### PR TITLE
feat: PR3 - Agents + Tasks

### DIFF
--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -1,0 +1,106 @@
+import { Body, Controller, Get, Param, Patch, Post } from "@nestjs/common";
+
+import { AgentRole } from "@openspawn/shared-types";
+
+import { CurrentAgent, Roles, type AuthenticatedAgent } from "../auth";
+
+import { AgentsService } from "./agents.service";
+import { CreateAgentDto } from "./dto/create-agent.dto";
+import { UpdateAgentDto } from "./dto/update-agent.dto";
+
+@Controller("agents")
+export class AgentsController {
+  constructor(private readonly agentsService: AgentsService) {}
+
+  /**
+   * Register a new agent - HR role only (Talent Agent)
+   * Returns the plaintext secret ONCE
+   */
+  @Post("register")
+  @Roles(AgentRole.HR)
+  async register(@CurrentAgent() actor: AuthenticatedAgent, @Body() dto: CreateAgentDto) {
+    const { agent, secret } = await this.agentsService.register(actor.orgId, actor.id, dto);
+
+    return {
+      data: {
+        id: agent.id,
+        agentId: agent.agentId,
+        name: agent.name,
+        role: agent.role,
+        level: agent.level,
+        model: agent.model,
+      },
+      secret,
+      message: "IMPORTANT: Save this secret securely. It cannot be recovered.",
+    };
+  }
+
+  @Get()
+  async findAll(@CurrentAgent() agent: AuthenticatedAgent) {
+    const agents = await this.agentsService.findAll(agent.orgId);
+    return {
+      data: agents.map((a) => ({
+        id: a.id,
+        agentId: a.agentId,
+        name: a.name,
+        role: a.role,
+        level: a.level,
+        model: a.model,
+        status: a.status,
+        currentBalance: a.currentBalance,
+        createdAt: a.createdAt,
+      })),
+    };
+  }
+
+  @Get(":id")
+  async findOne(@CurrentAgent() actor: AuthenticatedAgent, @Param("id") id: string) {
+    const agent = await this.agentsService.findOne(actor.orgId, id);
+    return {
+      data: {
+        id: agent.id,
+        agentId: agent.agentId,
+        name: agent.name,
+        role: agent.role,
+        level: agent.level,
+        model: agent.model,
+        status: agent.status,
+        currentBalance: agent.currentBalance,
+        managementFeePct: agent.managementFeePct,
+        budgetPeriodLimit: agent.budgetPeriodLimit,
+        budgetPeriodSpent: agent.budgetPeriodSpent,
+        capabilities: agent.capabilities,
+        metadata: agent.metadata,
+        createdAt: agent.createdAt,
+        updatedAt: agent.updatedAt,
+      },
+    };
+  }
+
+  @Patch(":id")
+  @Roles(AgentRole.HR)
+  async update(
+    @CurrentAgent() actor: AuthenticatedAgent,
+    @Param("id") id: string,
+    @Body() dto: UpdateAgentDto,
+  ) {
+    const agent = await this.agentsService.update(actor.orgId, actor.id, id, dto);
+    return { data: agent };
+  }
+
+  @Post(":id/revoke")
+  @Roles(AgentRole.HR)
+  async revoke(@CurrentAgent() actor: AuthenticatedAgent, @Param("id") id: string) {
+    const agent = await this.agentsService.revoke(actor.orgId, actor.id, id);
+    return {
+      data: { id: agent.id, status: agent.status },
+      message: "Agent has been revoked",
+    };
+  }
+
+  @Get(":id/credits/balance")
+  async getBalance(@CurrentAgent() actor: AuthenticatedAgent, @Param("id") id: string) {
+    const balance = await this.agentsService.getBalance(actor.orgId, id);
+    return { data: balance };
+  }
+}

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -1,0 +1,17 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+import { Agent, AgentCapability } from "@openspawn/database";
+
+import { EventsModule } from "../events";
+
+import { AgentsController } from "./agents.controller";
+import { AgentsService } from "./agents.service";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Agent, AgentCapability]), EventsModule],
+  controllers: [AgentsController],
+  providers: [AgentsService],
+  exports: [AgentsService],
+})
+export class AgentsModule {}

--- a/apps/api/src/agents/agents.service.ts
+++ b/apps/api/src/agents/agents.service.ts
@@ -1,0 +1,191 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { Agent, AgentCapability } from "@openspawn/database";
+import {
+  AgentRole,
+  AgentStatus,
+  encryptSecret,
+  generateSigningSecret,
+} from "@openspawn/shared-types";
+
+import { EventsService } from "../events";
+
+import { CreateAgentDto } from "./dto/create-agent.dto";
+import { UpdateAgentDto } from "./dto/update-agent.dto";
+
+@Injectable()
+export class AgentsService {
+  constructor(
+    @InjectRepository(Agent)
+    private readonly agentRepository: Repository<Agent>,
+    @InjectRepository(AgentCapability)
+    private readonly capabilityRepository: Repository<AgentCapability>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  /**
+   * Register a new agent (HR role only)
+   * Returns the plaintext secret ONCE - it cannot be recovered after this.
+   */
+  async register(
+    orgId: string,
+    actorId: string,
+    dto: CreateAgentDto,
+  ): Promise<{ agent: Agent; secret: string }> {
+    // Check if agent_id already exists
+    const existing = await this.agentRepository.findOne({
+      where: { orgId, agentId: dto.agentId },
+    });
+
+    if (existing) {
+      throw new ConflictException(`Agent with ID "${dto.agentId}" already exists`);
+    }
+
+    // Generate and encrypt secret
+    const plaintextSecret = generateSigningSecret();
+    const encryptionKey = process.env["ENCRYPTION_KEY"];
+    if (!encryptionKey) {
+      throw new Error("ENCRYPTION_KEY not configured");
+    }
+    const encryptedSecret = encryptSecret(plaintextSecret, encryptionKey);
+
+    // Create agent
+    const agent = this.agentRepository.create({
+      orgId,
+      agentId: dto.agentId,
+      name: dto.name,
+      level: dto.level || 1,
+      model: dto.model || "sonnet",
+      status: AgentStatus.ACTIVE,
+      role: dto.role || AgentRole.WORKER,
+      managementFeePct: dto.managementFeePct || 0,
+      currentBalance: 0,
+      budgetPeriodSpent: 0,
+      budgetPeriodLimit: dto.budgetPeriodLimit,
+      hmacSecretEnc: encryptedSecret,
+      metadata: dto.metadata || {},
+    });
+
+    const saved = await this.agentRepository.save(agent);
+
+    // Add capabilities if provided
+    if (dto.capabilities?.length) {
+      const capabilities = dto.capabilities.map((cap) =>
+        this.capabilityRepository.create({
+          orgId,
+          agentId: saved.id,
+          capability: cap.capability,
+          proficiency: cap.proficiency,
+        }),
+      );
+      await this.capabilityRepository.save(capabilities);
+    }
+
+    // Emit event
+    await this.eventsService.emit({
+      orgId,
+      type: "agent.registered",
+      actorId,
+      entityType: "agent",
+      entityId: saved.id,
+      data: {
+        agentId: saved.agentId,
+        name: saved.name,
+        role: saved.role,
+        level: saved.level,
+      },
+    });
+
+    return { agent: saved, secret: plaintextSecret };
+  }
+
+  async findAll(orgId: string): Promise<Agent[]> {
+    return this.agentRepository.find({
+      where: { orgId },
+      order: { createdAt: "DESC" },
+    });
+  }
+
+  async findOne(orgId: string, id: string): Promise<Agent> {
+    const agent = await this.agentRepository.findOne({
+      where: { id, orgId },
+      relations: ["capabilities"],
+    });
+
+    if (!agent) {
+      throw new NotFoundException("Agent not found");
+    }
+
+    return agent;
+  }
+
+  async findByAgentId(orgId: string, agentId: string): Promise<Agent | null> {
+    return this.agentRepository.findOne({
+      where: { orgId, agentId },
+    });
+  }
+
+  async update(orgId: string, actorId: string, id: string, dto: UpdateAgentDto): Promise<Agent> {
+    const agent = await this.findOne(orgId, id);
+
+    // Update allowed fields
+    if (dto.name !== undefined) agent.name = dto.name;
+    if (dto.level !== undefined) agent.level = dto.level;
+    if (dto.model !== undefined) agent.model = dto.model;
+    if (dto.managementFeePct !== undefined) agent.managementFeePct = dto.managementFeePct;
+    if (dto.budgetPeriodLimit !== undefined) agent.budgetPeriodLimit = dto.budgetPeriodLimit;
+    if (dto.metadata !== undefined) agent.metadata = dto.metadata;
+
+    const saved = await this.agentRepository.save(agent);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "agent.updated",
+      actorId,
+      entityType: "agent",
+      entityId: id,
+      data: { changes: dto },
+    });
+
+    return saved;
+  }
+
+  async revoke(orgId: string, actorId: string, id: string): Promise<Agent> {
+    const agent = await this.findOne(orgId, id);
+
+    if (agent.status === AgentStatus.REVOKED) {
+      throw new ConflictException("Agent is already revoked");
+    }
+
+    // Prevent self-revocation
+    if (agent.id === actorId) {
+      throw new ForbiddenException("Cannot revoke yourself");
+    }
+
+    agent.status = AgentStatus.REVOKED;
+    const saved = await this.agentRepository.save(agent);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "agent.revoked",
+      actorId,
+      entityType: "agent",
+      entityId: id,
+      data: { previousStatus: AgentStatus.ACTIVE },
+    });
+
+    return saved;
+  }
+
+  async getBalance(orgId: string, id: string): Promise<{ balance: number }> {
+    const agent = await this.findOne(orgId, id);
+    return { balance: agent.currentBalance };
+  }
+}

--- a/apps/api/src/agents/dto/create-agent.dto.ts
+++ b/apps/api/src/agents/dto/create-agent.dto.ts
@@ -1,0 +1,71 @@
+import {
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from "class-validator";
+import { Type } from "class-transformer";
+
+import { AgentRole, Proficiency } from "@openspawn/shared-types";
+
+export class CapabilityDto {
+  @IsString()
+  @MaxLength(100)
+  capability!: string;
+
+  @IsOptional()
+  @IsEnum(Proficiency)
+  proficiency?: Proficiency;
+}
+
+export class CreateAgentDto {
+  @IsString()
+  @MaxLength(100)
+  agentId!: string;
+
+  @IsString()
+  @MaxLength(255)
+  name!: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  level?: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  model?: string;
+
+  @IsOptional()
+  @IsEnum(AgentRole)
+  role?: AgentRole;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(50)
+  managementFeePct?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  budgetPeriodLimit?: number;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CapabilityDto)
+  capabilities?: CapabilityDto[];
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/apps/api/src/agents/dto/update-agent.dto.ts
+++ b/apps/api/src/agents/dto/update-agent.dto.ts
@@ -1,0 +1,34 @@
+import { IsInt, IsObject, IsOptional, IsString, Max, MaxLength, Min } from "class-validator";
+
+export class UpdateAgentDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  name?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  level?: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  model?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(50)
+  managementFeePct?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  budgetPeriodLimit?: number;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/apps/api/src/agents/index.ts
+++ b/apps/api/src/agents/index.ts
@@ -1,0 +1,2 @@
+export { AgentsModule } from "./agents.module";
+export { AgentsService } from "./agents.service";

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -4,10 +4,12 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { entities } from "@openspawn/database";
 
+import { AgentsModule } from "../agents";
 import { AuthModule } from "../auth";
 import { CommonModule } from "../common/common.module";
 import { OrgScopeMiddleware } from "../common/middleware/org-scope.middleware";
 import { EventsModule } from "../events";
+import { TasksModule } from "../tasks";
 
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
@@ -30,6 +32,10 @@ import { AppService } from "./app.service";
     CommonModule,
     AuthModule,
     EventsModule,
+
+    // Domain modules
+    AgentsModule,
+    TasksModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { Agent, Nonce } from "@openspawn/database";
 
 import { AuthGuard } from "./auth.guard";
 import { AuthService } from "./auth.service";
+import { RolesGuard } from "./roles.guard";
 
 @Module({
   imports: [TypeOrmModule.forFeature([Agent, Nonce])],
@@ -14,6 +15,10 @@ import { AuthService } from "./auth.service";
     {
       provide: APP_GUARD,
       useClass: AuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: RolesGuard,
     },
   ],
   exports: [AuthService],

--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -1,4 +1,5 @@
 export { AuthModule } from "./auth.module";
 export { AuthService, type AuthenticatedAgent } from "./auth.service";
 export { AuthGuard } from "./auth.guard";
+export { RolesGuard } from "./roles.guard";
 export * from "./decorators";

--- a/apps/api/src/auth/roles.guard.ts
+++ b/apps/api/src/auth/roles.guard.ts
@@ -1,0 +1,40 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+
+import type { Request } from "express";
+
+import type { AgentRole } from "@openspawn/shared-types";
+
+import { ROLES_KEY } from "./decorators/roles.decorator";
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<AgentRole[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    // No roles required = allow
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const agent = request.agent;
+
+    if (!agent) {
+      throw new ForbiddenException("Authentication required");
+    }
+
+    const hasRole = requiredRoles.some((role) => agent.role === role);
+
+    if (!hasRole) {
+      throw new ForbiddenException(`Requires one of roles: ${requiredRoles.join(", ")}`);
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/tasks/dto/add-comment.dto.ts
+++ b/apps/api/src/tasks/dto/add-comment.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString, IsUUID } from "class-validator";
+
+export class AddCommentDto {
+  @IsString()
+  body!: string;
+
+  @IsOptional()
+  @IsUUID()
+  parentCommentId?: string;
+}

--- a/apps/api/src/tasks/dto/add-dependency.dto.ts
+++ b/apps/api/src/tasks/dto/add-dependency.dto.ts
@@ -1,0 +1,10 @@
+import { IsBoolean, IsOptional, IsUUID } from "class-validator";
+
+export class AddDependencyDto {
+  @IsUUID()
+  dependsOnId!: string;
+
+  @IsOptional()
+  @IsBoolean()
+  blocking?: boolean;
+}

--- a/apps/api/src/tasks/dto/assign-task.dto.ts
+++ b/apps/api/src/tasks/dto/assign-task.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from "class-validator";
+
+export class AssignTaskDto {
+  @IsUUID()
+  assigneeId!: string;
+}

--- a/apps/api/src/tasks/dto/create-task.dto.ts
+++ b/apps/api/src/tasks/dto/create-task.dto.ts
@@ -1,0 +1,52 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from "class-validator";
+
+import { TaskPriority } from "@openspawn/shared-types";
+
+export class CreateTaskDto {
+  @IsString()
+  @MaxLength(255)
+  title!: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsEnum(TaskPriority)
+  priority?: TaskPriority;
+
+  @IsOptional()
+  @IsUUID()
+  assigneeId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  parentTaskId?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  approvalRequired?: boolean;
+
+  @IsOptional()
+  @IsDateString()
+  dueAt?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/apps/api/src/tasks/dto/transition-task.dto.ts
+++ b/apps/api/src/tasks/dto/transition-task.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum, IsOptional, IsString } from "class-validator";
+
+import { TaskStatus } from "@openspawn/shared-types";
+
+export class TransitionTaskDto {
+  @IsEnum(TaskStatus)
+  status!: TaskStatus;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/apps/api/src/tasks/index.ts
+++ b/apps/api/src/tasks/index.ts
@@ -1,0 +1,3 @@
+export { TasksModule } from "./tasks.module";
+export { TasksService } from "./tasks.service";
+export { TaskTransitionService } from "./task-transition.service";

--- a/apps/api/src/tasks/task-identifier.service.ts
+++ b/apps/api/src/tasks/task-identifier.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { Organization } from "@openspawn/database";
+
+@Injectable()
+export class TaskIdentifierService {
+  constructor(
+    @InjectRepository(Organization)
+    private readonly orgRepository: Repository<Organization>,
+  ) {}
+
+  /**
+   * Generate the next task identifier for an organization
+   * Atomically increments next_task_number
+   */
+  async generateIdentifier(orgId: string): Promise<string> {
+    // Atomic increment using raw query
+    const result = await this.orgRepository
+      .createQueryBuilder()
+      .update(Organization)
+      .set({
+        nextTaskNumber: () => "next_task_number + 1",
+      })
+      .where("id = :orgId", { orgId })
+      .returning(["task_prefix", "next_task_number"])
+      .execute();
+
+    const updated = result.raw[0] as { task_prefix: string; next_task_number: number };
+
+    // Format: PREFIX-NUMBER (e.g., TASK-42)
+    return `${updated.task_prefix}-${updated.next_task_number}`;
+  }
+}

--- a/apps/api/src/tasks/task-transition.service.ts
+++ b/apps/api/src/tasks/task-transition.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, UnprocessableEntityException } from "@nestjs/common";
+
+import { TaskStatus } from "@openspawn/shared-types";
+
+/**
+ * Valid state transitions for tasks
+ */
+const TRANSITION_MAP: Record<TaskStatus, TaskStatus[]> = {
+  [TaskStatus.BACKLOG]: [TaskStatus.TODO, TaskStatus.CANCELLED],
+  [TaskStatus.TODO]: [TaskStatus.IN_PROGRESS, TaskStatus.BLOCKED, TaskStatus.CANCELLED],
+  [TaskStatus.IN_PROGRESS]: [TaskStatus.REVIEW, TaskStatus.BLOCKED, TaskStatus.CANCELLED],
+  [TaskStatus.REVIEW]: [TaskStatus.DONE, TaskStatus.IN_PROGRESS, TaskStatus.CANCELLED],
+  [TaskStatus.BLOCKED]: [TaskStatus.TODO, TaskStatus.IN_PROGRESS, TaskStatus.CANCELLED],
+  [TaskStatus.DONE]: [], // Terminal state
+  [TaskStatus.CANCELLED]: [], // Terminal state
+};
+
+@Injectable()
+export class TaskTransitionService {
+  /**
+   * Check if a transition is valid
+   */
+  isValidTransition(from: TaskStatus, to: TaskStatus): boolean {
+    const validTargets = TRANSITION_MAP[from];
+    return validTargets?.includes(to) ?? false;
+  }
+
+  /**
+   * Validate transition, throw if invalid
+   */
+  validateTransition(from: TaskStatus, to: TaskStatus): void {
+    if (!this.isValidTransition(from, to)) {
+      throw new UnprocessableEntityException(`Invalid transition: ${from} → ${to}`);
+    }
+  }
+
+  /**
+   * Get valid transitions from a status
+   */
+  getValidTransitions(from: TaskStatus): TaskStatus[] {
+    return TRANSITION_MAP[from] || [];
+  }
+
+  /**
+   * Check if status is terminal
+   */
+  isTerminal(status: TaskStatus): boolean {
+    return status === TaskStatus.DONE || status === TaskStatus.CANCELLED;
+  }
+}

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -1,0 +1,120 @@
+import { Body, Controller, Delete, Get, Param, Post, Query } from "@nestjs/common";
+
+import { TaskStatus } from "@openspawn/shared-types";
+
+import { CurrentAgent, type AuthenticatedAgent } from "../auth";
+
+import { AddCommentDto } from "./dto/add-comment.dto";
+import { AddDependencyDto } from "./dto/add-dependency.dto";
+import { AssignTaskDto } from "./dto/assign-task.dto";
+import { CreateTaskDto } from "./dto/create-task.dto";
+import { TransitionTaskDto } from "./dto/transition-task.dto";
+import { TasksService } from "./tasks.service";
+
+@Controller("tasks")
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Post()
+  async create(@CurrentAgent() agent: AuthenticatedAgent, @Body() dto: CreateTaskDto) {
+    const task = await this.tasksService.create(agent.orgId, agent.id, dto);
+    return { data: task };
+  }
+
+  @Get()
+  async findAll(
+    @CurrentAgent() agent: AuthenticatedAgent,
+    @Query("status") status?: TaskStatus,
+    @Query("assigneeId") assigneeId?: string,
+    @Query("creatorId") creatorId?: string,
+    @Query("parentTaskId") parentTaskId?: string,
+  ) {
+    const tasks = await this.tasksService.findAll(agent.orgId, {
+      status,
+      assigneeId,
+      creatorId,
+      parentTaskId,
+    });
+    return { data: tasks };
+  }
+
+  @Get(":id")
+  async findOne(@CurrentAgent() agent: AuthenticatedAgent, @Param("id") id: string) {
+    const task = await this.tasksService.findOne(agent.orgId, id);
+    return { data: task };
+  }
+
+  @Post(":id/transition")
+  async transition(
+    @CurrentAgent() agent: AuthenticatedAgent,
+    @Param("id") id: string,
+    @Body() dto: TransitionTaskDto,
+  ) {
+    const task = await this.tasksService.transition(agent.orgId, agent.id, id, dto);
+    return { data: task };
+  }
+
+  @Post(":id/approve")
+  async approve(@CurrentAgent() agent: AuthenticatedAgent, @Param("id") id: string) {
+    const task = await this.tasksService.approve(agent.orgId, agent.id, id);
+    return { data: task };
+  }
+
+  @Post(":id/assign")
+  async assign(
+    @CurrentAgent() agent: AuthenticatedAgent,
+    @Param("id") id: string,
+    @Body() dto: AssignTaskDto,
+  ) {
+    const task = await this.tasksService.assign(agent.orgId, agent.id, id, dto.assigneeId);
+    return { data: task };
+  }
+
+  @Post(":id/dependencies")
+  async addDependency(
+    @CurrentAgent() agent: AuthenticatedAgent,
+    @Param("id") id: string,
+    @Body() dto: AddDependencyDto,
+  ) {
+    const dependency = await this.tasksService.addDependency(
+      agent.orgId,
+      agent.id,
+      id,
+      dto.dependsOnId,
+      dto.blocking,
+    );
+    return { data: dependency };
+  }
+
+  @Delete(":id/dependencies/:depId")
+  async removeDependency(
+    @CurrentAgent() agent: AuthenticatedAgent,
+    @Param("id") id: string,
+    @Param("depId") depId: string,
+  ) {
+    await this.tasksService.removeDependency(agent.orgId, agent.id, id, depId);
+    return { message: "Dependency removed" };
+  }
+
+  @Post(":id/comments")
+  async addComment(
+    @CurrentAgent() agent: AuthenticatedAgent,
+    @Param("id") id: string,
+    @Body() dto: AddCommentDto,
+  ) {
+    const comment = await this.tasksService.addComment(
+      agent.orgId,
+      agent.id,
+      id,
+      dto.body,
+      dto.parentCommentId,
+    );
+    return { data: comment };
+  }
+
+  @Get(":id/comments")
+  async getComments(@CurrentAgent() agent: AuthenticatedAgent, @Param("id") id: string) {
+    const comments = await this.tasksService.getComments(agent.orgId, id);
+    return { data: comments };
+  }
+}

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -1,0 +1,22 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+import { Organization, Task, TaskComment, TaskDependency, TaskTag } from "@openspawn/database";
+
+import { EventsModule } from "../events";
+
+import { TaskIdentifierService } from "./task-identifier.service";
+import { TaskTransitionService } from "./task-transition.service";
+import { TasksController } from "./tasks.controller";
+import { TasksService } from "./tasks.service";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Organization, Task, TaskDependency, TaskTag, TaskComment]),
+    EventsModule,
+  ],
+  controllers: [TasksController],
+  providers: [TasksService, TaskIdentifierService, TaskTransitionService],
+  exports: [TasksService, TaskTransitionService],
+})
+export class TasksModule {}

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -1,0 +1,383 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { Task, TaskComment, TaskDependency, TaskTag } from "@openspawn/database";
+import { TaskStatus } from "@openspawn/shared-types";
+
+import { EventsService } from "../events";
+
+import { CreateTaskDto } from "./dto/create-task.dto";
+import { TransitionTaskDto } from "./dto/transition-task.dto";
+import { TaskIdentifierService } from "./task-identifier.service";
+import { TaskTransitionService } from "./task-transition.service";
+
+@Injectable()
+export class TasksService {
+  constructor(
+    @InjectRepository(Task)
+    private readonly taskRepository: Repository<Task>,
+    @InjectRepository(TaskDependency)
+    private readonly dependencyRepository: Repository<TaskDependency>,
+    @InjectRepository(TaskTag)
+    private readonly tagRepository: Repository<TaskTag>,
+    @InjectRepository(TaskComment)
+    private readonly commentRepository: Repository<TaskComment>,
+    private readonly taskIdentifierService: TaskIdentifierService,
+    private readonly taskTransitionService: TaskTransitionService,
+    private readonly eventsService: EventsService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async create(orgId: string, actorId: string, dto: CreateTaskDto): Promise<Task> {
+    // Generate task identifier
+    const identifier = await this.taskIdentifierService.generateIdentifier(orgId);
+
+    const task = this.taskRepository.create({
+      orgId,
+      identifier,
+      title: dto.title,
+      description: dto.description,
+      status: TaskStatus.BACKLOG,
+      priority: dto.priority,
+      creatorId: actorId,
+      assigneeId: dto.assigneeId,
+      parentTaskId: dto.parentTaskId,
+      approvalRequired: dto.approvalRequired ?? false,
+      dueDate: dto.dueAt ? new Date(dto.dueAt) : undefined,
+      metadata: dto.metadata || {},
+    });
+
+    const saved = await this.taskRepository.save(task);
+
+    // Add tags if provided
+    if (dto.tags?.length) {
+      const tags = dto.tags.map((tag) =>
+        this.tagRepository.create({
+          orgId,
+          taskId: saved.id,
+          tag,
+        }),
+      );
+      await this.tagRepository.save(tags);
+    }
+
+    await this.eventsService.emit({
+      orgId,
+      type: "task.created",
+      actorId,
+      entityType: "task",
+      entityId: saved.id,
+      data: {
+        identifier: saved.identifier,
+        title: saved.title,
+        priority: saved.priority,
+        assigneeId: saved.assigneeId,
+      },
+    });
+
+    return this.findOne(orgId, saved.id);
+  }
+
+  async findAll(
+    orgId: string,
+    filters?: {
+      status?: TaskStatus;
+      assigneeId?: string;
+      creatorId?: string;
+      parentTaskId?: string;
+    },
+  ): Promise<Task[]> {
+    const query = this.taskRepository
+      .createQueryBuilder("task")
+      .where("task.org_id = :orgId", { orgId })
+      .leftJoinAndSelect("task.tags", "tags")
+      .orderBy("task.created_at", "DESC");
+
+    if (filters?.status) {
+      query.andWhere("task.status = :status", { status: filters.status });
+    }
+    if (filters?.assigneeId) {
+      query.andWhere("task.assignee_id = :assigneeId", {
+        assigneeId: filters.assigneeId,
+      });
+    }
+    if (filters?.creatorId) {
+      query.andWhere("task.creator_id = :creatorId", {
+        creatorId: filters.creatorId,
+      });
+    }
+    if (filters?.parentTaskId) {
+      query.andWhere("task.parent_task_id = :parentTaskId", {
+        parentTaskId: filters.parentTaskId,
+      });
+    }
+
+    return query.getMany();
+  }
+
+  async findOne(orgId: string, id: string): Promise<Task> {
+    const task = await this.taskRepository.findOne({
+      where: { id, orgId },
+      relations: ["tags", "dependencies", "dependents"],
+    });
+
+    if (!task) {
+      throw new NotFoundException("Task not found");
+    }
+
+    return task;
+  }
+
+  async transition(
+    orgId: string,
+    actorId: string,
+    id: string,
+    dto: TransitionTaskDto,
+  ): Promise<Task> {
+    const task = await this.findOne(orgId, id);
+
+    // Validate transition
+    this.taskTransitionService.validateTransition(task.status, dto.status);
+
+    // Check blocking dependencies for moving to done
+    if (dto.status === TaskStatus.DONE) {
+      const blockingDeps = await this.dependencyRepository.find({
+        where: { taskId: id, blocking: true },
+        relations: ["dependsOn"],
+      });
+
+      const incomplete = blockingDeps.filter((dep) => dep.dependsOn?.status !== TaskStatus.DONE);
+
+      if (incomplete.length > 0) {
+        throw new ConflictException(
+          `Cannot complete: ${incomplete.length} blocking dependencies not done`,
+        );
+      }
+
+      // Check approval gate
+      if (task.approvalRequired && !task.approvedAt) {
+        throw new ForbiddenException("Task requires approval before completion");
+      }
+
+      task.completedAt = new Date();
+    }
+
+    const previousStatus = task.status;
+    task.status = dto.status;
+
+    const saved = await this.taskRepository.save(task);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "task.transitioned",
+      actorId,
+      entityType: "task",
+      entityId: id,
+      data: {
+        from: previousStatus,
+        to: dto.status,
+        reason: dto.reason,
+      },
+    });
+
+    // Emit for credit system to pick up
+    this.eventEmitter.emit("task.transitioned", {
+      task: saved,
+      from: previousStatus,
+      to: dto.status,
+      actorId,
+    });
+
+    return saved;
+  }
+
+  async approve(orgId: string, actorId: string, id: string): Promise<Task> {
+    const task = await this.findOne(orgId, id);
+
+    if (!task.approvalRequired) {
+      throw new ConflictException("Task does not require approval");
+    }
+
+    if (task.approvedAt) {
+      throw new ConflictException("Task is already approved");
+    }
+
+    task.approvedAt = new Date();
+    task.approvedBy = actorId;
+
+    const saved = await this.taskRepository.save(task);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "task.approved",
+      actorId,
+      entityType: "task",
+      entityId: id,
+      data: { identifier: task.identifier },
+    });
+
+    return saved;
+  }
+
+  async assign(orgId: string, actorId: string, id: string, assigneeId: string): Promise<Task> {
+    const task = await this.findOne(orgId, id);
+    const previousAssignee = task.assigneeId;
+
+    task.assigneeId = assigneeId;
+    const saved = await this.taskRepository.save(task);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "task.assigned",
+      actorId,
+      entityType: "task",
+      entityId: id,
+      data: {
+        previousAssignee,
+        newAssignee: assigneeId,
+      },
+    });
+
+    return saved;
+  }
+
+  async addDependency(
+    orgId: string,
+    actorId: string,
+    taskId: string,
+    dependsOnId: string,
+    blocking = true,
+  ): Promise<TaskDependency> {
+    // Check both tasks exist
+    await this.findOne(orgId, taskId);
+    await this.findOne(orgId, dependsOnId);
+
+    // Prevent self-dependency
+    if (taskId === dependsOnId) {
+      throw new ConflictException("Task cannot depend on itself");
+    }
+
+    // Check for circular dependency using BFS
+    const visited = new Set<string>();
+    const queue = [dependsOnId];
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (current === taskId) {
+        throw new ConflictException("Circular dependency detected");
+      }
+
+      if (visited.has(current)) continue;
+      visited.add(current);
+
+      const deps = await this.dependencyRepository.find({
+        where: { taskId: current },
+      });
+
+      for (const dep of deps) {
+        queue.push(dep.dependsOnId);
+      }
+    }
+
+    // Check if dependency already exists
+    const existing = await this.dependencyRepository.findOne({
+      where: { taskId, dependsOnId },
+    });
+
+    if (existing) {
+      throw new ConflictException("Dependency already exists");
+    }
+
+    const dependency = this.dependencyRepository.create({
+      orgId,
+      taskId,
+      dependsOnId,
+      blocking,
+    });
+
+    const saved = await this.dependencyRepository.save(dependency);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "task.dependency.added",
+      actorId,
+      entityType: "task",
+      entityId: taskId,
+      data: { dependsOnId, blocking },
+    });
+
+    return saved;
+  }
+
+  async removeDependency(
+    orgId: string,
+    actorId: string,
+    taskId: string,
+    dependsOnId: string,
+  ): Promise<void> {
+    const result = await this.dependencyRepository.delete({
+      taskId,
+      dependsOnId,
+    });
+
+    if (result.affected === 0) {
+      throw new NotFoundException("Dependency not found");
+    }
+
+    await this.eventsService.emit({
+      orgId,
+      type: "task.dependency.removed",
+      actorId,
+      entityType: "task",
+      entityId: taskId,
+      data: { dependsOnId },
+    });
+  }
+
+  async addComment(
+    orgId: string,
+    actorId: string,
+    taskId: string,
+    body: string,
+    parentCommentId?: string,
+  ): Promise<TaskComment> {
+    await this.findOne(orgId, taskId);
+
+    const comment = this.commentRepository.create({
+      orgId,
+      taskId,
+      authorId: actorId,
+      body,
+      parentCommentId,
+    });
+
+    const saved = await this.commentRepository.save(comment);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "task.comment.added",
+      actorId,
+      entityType: "task",
+      entityId: taskId,
+      data: { commentId: saved.id },
+    });
+
+    return saved;
+  }
+
+  async getComments(orgId: string, taskId: string): Promise<TaskComment[]> {
+    await this.findOne(orgId, taskId);
+
+    return this.commentRepository.find({
+      where: { taskId },
+      order: { createdAt: "ASC" },
+    });
+  }
+}

--- a/libs/database/src/entities/task-dependency.entity.ts
+++ b/libs/database/src/entities/task-dependency.entity.ts
@@ -12,9 +12,9 @@ import type { Organization } from "./organization.entity";
 import type { Task } from "./task.entity";
 
 @Entity("task_dependencies")
-@Index(["blockingTaskId", "blockedTaskId"], { unique: true })
-@Index(["blockedTaskId"])
-@Index(["blockingTaskId"])
+@Index(["taskId", "dependsOnId"], { unique: true })
+@Index(["taskId"])
+@Index(["dependsOnId"])
 export class TaskDependency {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
@@ -22,11 +22,14 @@ export class TaskDependency {
   @Column({ name: "org_id", type: "uuid" })
   orgId!: string;
 
-  @Column({ name: "blocking_task_id", type: "uuid" })
-  blockingTaskId!: string;
+  @Column({ name: "task_id", type: "uuid" })
+  taskId!: string;
 
-  @Column({ name: "blocked_task_id", type: "uuid" })
-  blockedTaskId!: string;
+  @Column({ name: "depends_on_id", type: "uuid" })
+  dependsOnId!: string;
+
+  @Column({ name: "blocking", type: "boolean", default: true })
+  blocking!: boolean;
 
   @CreateDateColumn({ name: "created_at", type: "timestamptz" })
   createdAt!: Date;
@@ -36,11 +39,11 @@ export class TaskDependency {
   @JoinColumn({ name: "org_id" })
   organization?: Organization;
 
-  @ManyToOne("Task", "blockedDependencies")
-  @JoinColumn({ name: "blocking_task_id" })
-  blockingTask?: Task;
+  @ManyToOne("Task", "dependencies")
+  @JoinColumn({ name: "task_id" })
+  task?: Task;
 
-  @ManyToOne("Task", "blockingDependencies")
-  @JoinColumn({ name: "blocked_task_id" })
-  blockedTask?: Task;
+  @ManyToOne("Task", "dependents")
+  @JoinColumn({ name: "depends_on_id" })
+  dependsOn?: Task;
 }

--- a/libs/database/src/entities/task.entity.ts
+++ b/libs/database/src/entities/task.entity.ts
@@ -109,9 +109,9 @@ export class Task {
   @OneToMany("TaskComment", "task")
   comments?: TaskComment[];
 
-  @OneToMany("TaskDependency", "blockedTask")
-  blockingDependencies?: TaskDependency[];
+  @OneToMany("TaskDependency", "task")
+  dependencies?: TaskDependency[];
 
-  @OneToMany("TaskDependency", "blockingTask")
-  blockedDependencies?: TaskDependency[];
+  @OneToMany("TaskDependency", "dependsOn")
+  dependents?: TaskDependency[];
 }

--- a/scripts/sync-db.mjs
+++ b/scripts/sync-db.mjs
@@ -101,10 +101,11 @@ try {
     CREATE TABLE IF NOT EXISTS task_dependencies (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       org_id UUID NOT NULL REFERENCES organizations(id),
-      blocking_task_id UUID NOT NULL REFERENCES tasks(id),
-      blocked_task_id UUID NOT NULL REFERENCES tasks(id),
+      task_id UUID NOT NULL REFERENCES tasks(id),
+      depends_on_id UUID NOT NULL REFERENCES tasks(id),
+      blocking BOOLEAN NOT NULL DEFAULT true,
       created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      UNIQUE(blocking_task_id, blocked_task_id)
+      UNIQUE(task_id, depends_on_id)
     );
 
     -- Task Tags


### PR DESCRIPTION
## Summary

Core domain modules for agent management and task tracking.

### Agents Module
- `POST /agents/register` - HR role only, returns HMAC secret ONCE
- `GET /agents` - list all agents
- `GET /agents/:id` - get agent details with capabilities
- `PATCH /agents/:id` - HR role only, update agent settings
- `POST /agents/:id/revoke` - HR role only, revoke agent access
- `GET /agents/:id/credits/balance` - get agent credit balance

### Tasks Module
- `POST /tasks` - create task with auto-generated identifier (PREFIX-N)
- `GET /tasks` - list with status/assignee/creator/parent filters
- `GET /tasks/:id` - get task with tags and dependencies
- `POST /tasks/:id/transition` - validated state machine transitions
- `POST /tasks/:id/approve` - for approval-gated tasks
- `POST /tasks/:id/assign` - assign task to agent
- `POST /tasks/:id/dependencies` - add dependency with circular detection
- `DELETE /tasks/:id/dependencies/:depId` - remove dependency
- `POST /tasks/:id/comments` - add comment (supports threading)
- `GET /tasks/:id/comments` - get task comments

### Task State Machine
```
backlog → todo, cancelled
todo → in_progress, blocked, cancelled
in_progress → review, blocked, cancelled
review → done (may require approval), in_progress, cancelled
blocked → todo, in_progress, cancelled
done → (terminal)
cancelled → (terminal)
```

### Supporting
- RolesGuard for role-based access control
- TaskTransitionService for state machine validation
- TaskIdentifierService with atomic counter increment