### PR TITLE
feat: PR4 - Credits + Messaging

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -8,7 +8,9 @@ import { AgentsModule } from "../agents";
 import { AuthModule } from "../auth";
 import { CommonModule } from "../common/common.module";
 import { OrgScopeMiddleware } from "../common/middleware/org-scope.middleware";
+import { CreditsModule } from "../credits";
 import { EventsModule } from "../events";
+import { MessagesModule } from "../messages";
 import { TasksModule } from "../tasks";
 
 import { AppController } from "./app.controller";
@@ -36,6 +38,8 @@ import { AppService } from "./app.service";
     // Domain modules
     AgentsModule,
     TasksModule,
+    CreditsModule,
+    MessagesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/credits/budget-reset.task.ts
+++ b/apps/api/src/credits/budget-reset.task.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { InjectRepository } from "@nestjs/typeorm";
+import { IsNull, Not, Repository } from "typeorm";
+
+import { Agent } from "@openspawn/database";
+
+import { EventsService } from "../events";
+
+@Injectable()
+export class BudgetResetTask {
+  private readonly logger = new Logger(BudgetResetTask.name);
+
+  constructor(
+    @InjectRepository(Agent)
+    private readonly agentRepository: Repository<Agent>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  /**
+   * Reset budget period spent at midnight UTC daily
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async handleBudgetReset() {
+    // Find agents with budget limits who have spent something
+    const agents = await this.agentRepository.find({
+      where: {
+        budgetPeriodLimit: Not(IsNull()),
+        budgetPeriodSpent: Not(0),
+      },
+    });
+
+    if (agents.length === 0) {
+      return;
+    }
+
+    for (const agent of agents) {
+      const previousSpent = agent.budgetPeriodSpent;
+
+      // Reset the budget
+      await this.agentRepository.update(agent.id, {
+        budgetPeriodSpent: 0,
+      });
+
+      // Emit event
+      await this.eventsService.emit({
+        orgId: agent.orgId,
+        type: "credit.budget_reset",
+        actorId: "system",
+        entityType: "agent",
+        entityId: agent.id,
+        data: {
+          previousSpent,
+          budgetLimit: agent.budgetPeriodLimit,
+        },
+      });
+    }
+
+    this.logger.log(`Reset budget for ${agents.length} agents`);
+  }
+}

--- a/apps/api/src/credits/credit-earning.service.ts
+++ b/apps/api/src/credits/credit-earning.service.ts
@@ -1,0 +1,115 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { OnEvent } from "@nestjs/event-emitter";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { Agent, CreditRateConfig, Task } from "@openspawn/database";
+import { CreditType, TaskStatus } from "@openspawn/shared-types";
+
+import { CreditsService } from "./credits.service";
+
+interface TaskTransitionedEvent {
+  task: Task;
+  from: TaskStatus;
+  to: TaskStatus;
+  actorId: string;
+}
+
+@Injectable()
+export class CreditEarningService {
+  private readonly logger = new Logger(CreditEarningService.name);
+
+  constructor(
+    @InjectRepository(Agent)
+    private readonly agentRepository: Repository<Agent>,
+    @InjectRepository(CreditRateConfig)
+    private readonly rateConfigRepository: Repository<CreditRateConfig>,
+    private readonly creditsService: CreditsService,
+  ) {}
+
+  @OnEvent("task.transitioned")
+  async handleTaskTransitioned(event: TaskTransitionedEvent) {
+    const { task, to } = event;
+
+    // Only award credits when task is completed
+    if (to !== TaskStatus.DONE) {
+      return;
+    }
+
+    if (!task.assigneeId) {
+      this.logger.warn(`Task ${task.identifier} completed without assignee`);
+      return;
+    }
+
+    try {
+      // Get rate config for task completion
+      const rateConfig = await this.rateConfigRepository.findOne({
+        where: { orgId: task.orgId, triggerType: "task.done", direction: CreditType.CREDIT },
+      });
+
+      const baseCredits = rateConfig?.amount ?? 10;
+
+      // Award credits to assignee
+      await this.creditsService.earn({
+        orgId: task.orgId,
+        agentId: task.assigneeId,
+        amount: baseCredits,
+        reason: `Task completed: ${task.identifier}`,
+        triggerType: "task.done",
+        sourceTaskId: task.id,
+      });
+
+      this.logger.log(
+        `Awarded ${baseCredits} credits to ${task.assigneeId} for ${task.identifier}`,
+      );
+
+      // Check for management fee
+      if (task.creatorId && task.creatorId !== task.assigneeId) {
+        const creator = await this.agentRepository.findOne({
+          where: { id: task.creatorId },
+        });
+
+        if (creator && creator.managementFeePct > 0) {
+          const fee = Math.floor((baseCredits * creator.managementFeePct) / 100);
+
+          if (fee > 0) {
+            await this.creditsService.earn({
+              orgId: task.orgId,
+              agentId: creator.id,
+              amount: fee,
+              reason: `Management fee: ${task.identifier}`,
+              triggerType: "management_fee",
+              sourceTaskId: task.id,
+            });
+
+            this.logger.log(
+              `Awarded ${fee} management fee to ${creator.id} for ${task.identifier}`,
+            );
+          }
+        }
+
+        // Award delegation credits
+        const delegationConfig = await this.rateConfigRepository.findOne({
+          where: { orgId: task.orgId, triggerType: "task.delegated", direction: CreditType.CREDIT },
+        });
+
+        if (delegationConfig && delegationConfig.amount !== null && delegationConfig.amount > 0) {
+          await this.creditsService.earn({
+            orgId: task.orgId,
+            agentId: task.creatorId,
+            amount: delegationConfig.amount,
+            reason: `Task delegated: ${task.identifier}`,
+            triggerType: "task.delegated",
+            sourceTaskId: task.id,
+          });
+
+          this.logger.log(
+            `Awarded ${delegationConfig.amount} delegation credits to ${task.creatorId}`,
+          );
+        }
+      }
+    } catch (error) {
+      this.logger.error(`Failed to process credit earning for task ${task.id}`, error);
+    }
+  }
+}

--- a/apps/api/src/credits/credits.controller.ts
+++ b/apps/api/src/credits/credits.controller.ts
@@ -1,0 +1,85 @@
+import { Body, Controller, Get, Post, Query } from "@nestjs/common";
+
+import { AgentRole } from "@openspawn/shared-types";
+
+import { CurrentAgent, Public, Roles, type AuthenticatedAgent } from "../auth";
+
+import { CreditsService } from "./credits.service";
+import { AdjustCreditsDto } from "./dto/adjust-credits.dto";
+import { LiteLLMCallbackDto } from "./dto/litellm-callback.dto";
+import { SpendCreditsDto } from "./dto/spend-credits.dto";
+
+@Controller("credits")
+export class CreditsController {
+  constructor(private readonly creditsService: CreditsService) {}
+
+  @Get("balance")
+  async getBalance(@CurrentAgent() agent: AuthenticatedAgent) {
+    const balance = await this.creditsService.getBalance(agent.orgId, agent.id);
+    return { data: balance };
+  }
+
+  @Post("spend")
+  async spend(@CurrentAgent() agent: AuthenticatedAgent, @Body() dto: SpendCreditsDto) {
+    const transaction = await this.creditsService.spend({
+      orgId: agent.orgId,
+      agentId: agent.id,
+      amount: dto.amount,
+      reason: dto.reason,
+      triggerType: dto.triggerType,
+      sourceTaskId: dto.sourceTaskId,
+      sourceAgentId: dto.sourceAgentId,
+    });
+    return { data: transaction };
+  }
+
+  @Get("history")
+  async getHistory(
+    @CurrentAgent() agent: AuthenticatedAgent,
+    @Query("limit") limit?: number,
+    @Query("offset") offset?: number,
+  ) {
+    const { transactions, total } = await this.creditsService.getHistory(
+      agent.orgId,
+      agent.id,
+      limit || 50,
+      offset || 0,
+    );
+    return {
+      data: transactions,
+      meta: { total, limit: limit || 50, offset: offset || 0 },
+    };
+  }
+
+  @Post("adjust")
+  @Roles(AgentRole.HR, AgentRole.ADMIN)
+  async adjust(@CurrentAgent() actor: AuthenticatedAgent, @Body() dto: AdjustCreditsDto) {
+    const transaction = await this.creditsService.adjust({
+      orgId: actor.orgId,
+      agentId: dto.agentId,
+      amount: dto.amount,
+      type: dto.type,
+      reason: dto.reason,
+      actorId: actor.id,
+    });
+    return { data: transaction };
+  }
+
+  /**
+   * LiteLLM callback endpoint - internal use only
+   * In production, this should be secured with a shared secret
+   */
+  @Public()
+  @Post("litellm-callback")
+  async litellmCallback(@Body() dto: LiteLLMCallbackDto, @Query("orgId") orgId: string) {
+    const transaction = await this.creditsService.processLiteLLMCallback(
+      orgId,
+      dto.agentId,
+      dto.model,
+      dto.inputTokens,
+      dto.outputTokens,
+      dto.callId,
+    );
+    return { data: transaction, message: transaction ? "Charged" : "No charge" };
+  }
+}

--- a/apps/api/src/credits/credits.module.ts
+++ b/apps/api/src/credits/credits.module.ts
@@ -1,0 +1,22 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+import { Agent, CreditRateConfig, CreditTransaction, Task } from "@openspawn/database";
+
+import { EventsModule } from "../events";
+
+import { BudgetResetTask } from "./budget-reset.task";
+import { CreditEarningService } from "./credit-earning.service";
+import { CreditsController } from "./credits.controller";
+import { CreditsService } from "./credits.service";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Agent, CreditTransaction, CreditRateConfig, Task]),
+    EventsModule,
+  ],
+  controllers: [CreditsController],
+  providers: [CreditsService, CreditEarningService, BudgetResetTask],
+  exports: [CreditsService],
+})
+export class CreditsModule {}

--- a/apps/api/src/credits/credits.service.ts
+++ b/apps/api/src/credits/credits.service.ts
@@ -1,0 +1,306 @@
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { DataSource, Repository } from "typeorm";
+
+import { Agent, CreditRateConfig, CreditTransaction } from "@openspawn/database";
+import { CreditType } from "@openspawn/shared-types";
+
+import { EventsService } from "../events";
+
+export interface SpendParams {
+  orgId: string;
+  agentId: string;
+  amount: number;
+  reason: string;
+  triggerType?: string;
+  sourceTaskId?: string;
+  sourceAgentId?: string;
+  idempotencyKey?: string;
+}
+
+export interface EarnParams {
+  orgId: string;
+  agentId: string;
+  amount: number;
+  reason: string;
+  triggerType?: string;
+  sourceTaskId?: string;
+  sourceAgentId?: string;
+}
+
+export interface AdjustParams {
+  orgId: string;
+  agentId: string;
+  amount: number;
+  type: CreditType;
+  reason: string;
+  actorId: string;
+}
+
+@Injectable()
+export class CreditsService {
+  constructor(
+    private readonly dataSource: DataSource,
+    @InjectRepository(Agent)
+    private readonly agentRepository: Repository<Agent>,
+    @InjectRepository(CreditTransaction)
+    private readonly transactionRepository: Repository<CreditTransaction>,
+    @InjectRepository(CreditRateConfig)
+    private readonly rateConfigRepository: Repository<CreditRateConfig>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  /**
+   * Get agent's current balance
+   */
+  async getBalance(
+    orgId: string,
+    agentId: string,
+  ): Promise<{ balance: number; budgetPeriodSpent: number; budgetPeriodLimit: number | null }> {
+    const agent = await this.agentRepository.findOne({
+      where: { id: agentId, orgId },
+    });
+
+    if (!agent) {
+      throw new NotFoundException("Agent not found");
+    }
+
+    return {
+      balance: agent.currentBalance,
+      budgetPeriodSpent: agent.budgetPeriodSpent,
+      budgetPeriodLimit: agent.budgetPeriodLimit,
+    };
+  }
+
+  /**
+   * Spend credits (debit) - atomic transaction
+   */
+  async spend(params: SpendParams): Promise<CreditTransaction> {
+    const { orgId, agentId, amount, reason, triggerType, sourceTaskId, sourceAgentId } = params;
+
+    if (amount <= 0) {
+      throw new BadRequestException("Amount must be positive");
+    }
+
+    return this.dataSource.transaction(async (manager) => {
+      // Lock agent row for update
+      const agent = await manager
+        .getRepository(Agent)
+        .createQueryBuilder("agent")
+        .setLock("pessimistic_write")
+        .where("agent.id = :id AND agent.org_id = :orgId", { id: agentId, orgId })
+        .getOne();
+
+      if (!agent) {
+        throw new NotFoundException("Agent not found");
+      }
+
+      // Check balance
+      if (agent.currentBalance < amount) {
+        throw new BadRequestException("Insufficient balance");
+      }
+
+      // Check budget limit if set
+      if (agent.budgetPeriodLimit !== null) {
+        if (agent.budgetPeriodSpent + amount > agent.budgetPeriodLimit) {
+          throw new BadRequestException("Budget limit exceeded");
+        }
+      }
+
+      // Create transaction record
+      const transaction = manager.getRepository(CreditTransaction).create({
+        orgId,
+        agentId,
+        type: CreditType.DEBIT,
+        amount,
+        reason,
+        balanceAfter: agent.currentBalance - amount,
+        triggerType,
+        sourceTaskId,
+        sourceAgentId,
+      });
+
+      const savedTransaction = await manager.getRepository(CreditTransaction).save(transaction);
+
+      // Update agent balance
+      await manager.getRepository(Agent).update(agentId, {
+        currentBalance: agent.currentBalance - amount,
+        budgetPeriodSpent: agent.budgetPeriodSpent + amount,
+      });
+
+      return savedTransaction;
+    });
+  }
+
+  /**
+   * Earn credits (credit) - atomic transaction
+   */
+  async earn(params: EarnParams): Promise<CreditTransaction> {
+    const { orgId, agentId, amount, reason, triggerType, sourceTaskId, sourceAgentId } = params;
+
+    if (amount <= 0) {
+      throw new BadRequestException("Amount must be positive");
+    }
+
+    return this.dataSource.transaction(async (manager) => {
+      // Lock agent row for update
+      const agent = await manager
+        .getRepository(Agent)
+        .createQueryBuilder("agent")
+        .setLock("pessimistic_write")
+        .where("agent.id = :id AND agent.org_id = :orgId", { id: agentId, orgId })
+        .getOne();
+
+      if (!agent) {
+        throw new NotFoundException("Agent not found");
+      }
+
+      // Create transaction record
+      const transaction = manager.getRepository(CreditTransaction).create({
+        orgId,
+        agentId,
+        type: CreditType.CREDIT,
+        amount,
+        reason,
+        balanceAfter: agent.currentBalance + amount,
+        triggerType,
+        sourceTaskId,
+        sourceAgentId,
+      });
+
+      const savedTransaction = await manager.getRepository(CreditTransaction).save(transaction);
+
+      // Update agent balance
+      await manager.getRepository(Agent).update(agentId, {
+        currentBalance: agent.currentBalance + amount,
+      });
+
+      return savedTransaction;
+    });
+  }
+
+  /**
+   * Admin adjustment (credit or debit)
+   */
+  async adjust(params: AdjustParams): Promise<CreditTransaction> {
+    const { orgId, agentId, amount, type, reason, actorId } = params;
+
+    if (amount <= 0) {
+      throw new BadRequestException("Amount must be positive");
+    }
+
+    return this.dataSource.transaction(async (manager) => {
+      const agent = await manager
+        .getRepository(Agent)
+        .createQueryBuilder("agent")
+        .setLock("pessimistic_write")
+        .where("agent.id = :id AND agent.org_id = :orgId", { id: agentId, orgId })
+        .getOne();
+
+      if (!agent) {
+        throw new NotFoundException("Agent not found");
+      }
+
+      const newBalance =
+        type === CreditType.CREDIT ? agent.currentBalance + amount : agent.currentBalance - amount;
+
+      if (newBalance < 0) {
+        throw new BadRequestException("Adjustment would result in negative balance");
+      }
+
+      const transaction = manager.getRepository(CreditTransaction).create({
+        orgId,
+        agentId,
+        type,
+        amount,
+        reason: `[Admin] ${reason}`,
+        balanceAfter: newBalance,
+        triggerType: "admin_adjustment",
+        sourceAgentId: actorId,
+      });
+
+      const savedTransaction = await manager.getRepository(CreditTransaction).save(transaction);
+
+      await manager.getRepository(Agent).update(agentId, {
+        currentBalance: newBalance,
+      });
+
+      await this.eventsService.emit({
+        orgId,
+        type: "credit.adjusted",
+        actorId,
+        entityType: "agent",
+        entityId: agentId,
+        data: { amount, type, reason },
+      });
+
+      return savedTransaction;
+    });
+  }
+
+  /**
+   * Get transaction history
+   */
+  async getHistory(
+    orgId: string,
+    agentId: string,
+    limit = 50,
+    offset = 0,
+  ): Promise<{ transactions: CreditTransaction[]; total: number }> {
+    const [transactions, total] = await this.transactionRepository.findAndCount({
+      where: { orgId, agentId },
+      order: { createdAt: "DESC" },
+      take: limit,
+      skip: offset,
+    });
+
+    return { transactions, total };
+  }
+
+  /**
+   * Get rate config for a specific trigger type
+   */
+  async getRateConfig(orgId: string, triggerType: string): Promise<CreditRateConfig | null> {
+    return this.rateConfigRepository.findOne({
+      where: { orgId, triggerType },
+    });
+  }
+
+  /**
+   * Process LiteLLM callback for usage-based billing
+   */
+  async processLiteLLMCallback(
+    orgId: string,
+    agentId: string,
+    model: string,
+    inputTokens: number,
+    outputTokens: number,
+    callId: string,
+  ): Promise<CreditTransaction | null> {
+    // Get rate config for the model
+    const rateConfig = await this.getRateConfig(orgId, `llm.${model}`);
+
+    if (!rateConfig || rateConfig.amount === null) {
+      // No rate config = free
+      return null;
+    }
+
+    // Calculate cost based on tokens
+    // Rate is stored as credits per 1M tokens
+    const totalTokens = inputTokens + outputTokens;
+    const cost = Math.ceil((totalTokens / 1_000_000) * rateConfig.amount);
+
+    if (cost <= 0) {
+      return null;
+    }
+
+    return this.spend({
+      orgId,
+      agentId,
+      amount: cost,
+      reason: `LLM usage: ${model} (${totalTokens} tokens)`,
+      triggerType: "llm_call",
+      idempotencyKey: callId,
+    });
+  }
+}

--- a/apps/api/src/credits/dto/adjust-credits.dto.ts
+++ b/apps/api/src/credits/dto/adjust-credits.dto.ts
@@ -1,0 +1,18 @@
+import { IsEnum, IsInt, IsString, IsUUID, Min } from "class-validator";
+
+import { CreditType } from "@openspawn/shared-types";
+
+export class AdjustCreditsDto {
+  @IsUUID()
+  agentId!: string;
+
+  @IsInt()
+  @Min(1)
+  amount!: number;
+
+  @IsEnum(CreditType)
+  type!: CreditType;
+
+  @IsString()
+  reason!: string;
+}

--- a/apps/api/src/credits/dto/litellm-callback.dto.ts
+++ b/apps/api/src/credits/dto/litellm-callback.dto.ts
@@ -1,0 +1,20 @@
+import { IsInt, IsString, Min } from "class-validator";
+
+export class LiteLLMCallbackDto {
+  @IsString()
+  callId!: string;
+
+  @IsString()
+  agentId!: string;
+
+  @IsString()
+  model!: string;
+
+  @IsInt()
+  @Min(0)
+  inputTokens!: number;
+
+  @IsInt()
+  @Min(0)
+  outputTokens!: number;
+}

--- a/apps/api/src/credits/dto/spend-credits.dto.ts
+++ b/apps/api/src/credits/dto/spend-credits.dto.ts
@@ -1,0 +1,22 @@
+import { IsInt, IsOptional, IsString, IsUUID, Min } from "class-validator";
+
+export class SpendCreditsDto {
+  @IsInt()
+  @Min(1)
+  amount!: number;
+
+  @IsString()
+  reason!: string;
+
+  @IsOptional()
+  @IsString()
+  triggerType?: string;
+
+  @IsOptional()
+  @IsUUID()
+  sourceTaskId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  sourceAgentId?: string;
+}

--- a/apps/api/src/credits/index.ts
+++ b/apps/api/src/credits/index.ts
@@ -1,0 +1,2 @@
+export { CreditsModule } from "./credits.module";
+export { CreditsService } from "./credits.service";

--- a/apps/api/src/messages/channels.service.ts
+++ b/apps/api/src/messages/channels.service.ts
@@ -1,0 +1,103 @@
+import { ConflictException, Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { Channel } from "@openspawn/database";
+import { ChannelType } from "@openspawn/shared-types";
+
+import { EventsService } from "../events";
+
+export interface CreateChannelParams {
+  orgId: string;
+  name: string;
+  type: ChannelType;
+  taskId?: string;
+  actorId: string;
+  metadata?: Record<string, unknown>;
+}
+
+@Injectable()
+export class ChannelsService {
+  constructor(
+    @InjectRepository(Channel)
+    private readonly channelRepository: Repository<Channel>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  async create(params: CreateChannelParams): Promise<Channel> {
+    const { orgId, name, type, taskId, actorId, metadata } = params;
+
+    // Check for duplicate name in org
+    const existing = await this.channelRepository.findOne({
+      where: { orgId, name },
+    });
+
+    if (existing) {
+      throw new ConflictException(`Channel "${name}" already exists`);
+    }
+
+    const channel = this.channelRepository.create({
+      orgId,
+      name,
+      type,
+      taskId,
+      metadata: metadata || {},
+    });
+
+    const saved = await this.channelRepository.save(channel);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "channel.created",
+      actorId,
+      entityType: "channel",
+      entityId: saved.id,
+      data: { name, type, taskId },
+    });
+
+    return saved;
+  }
+
+  async findAll(orgId: string): Promise<Channel[]> {
+    return this.channelRepository.find({
+      where: { orgId },
+      order: { createdAt: "DESC" },
+    });
+  }
+
+  async findOne(orgId: string, id: string): Promise<Channel> {
+    const channel = await this.channelRepository.findOne({
+      where: { id, orgId },
+    });
+
+    if (!channel) {
+      throw new NotFoundException("Channel not found");
+    }
+
+    return channel;
+  }
+
+  async findByTask(orgId: string, taskId: string): Promise<Channel | null> {
+    return this.channelRepository.findOne({
+      where: { orgId, taskId },
+    });
+  }
+
+  /**
+   * Create a task-specific channel (auto-called when task is created)
+   */
+  async createTaskChannel(
+    orgId: string,
+    taskId: string,
+    taskIdentifier: string,
+    actorId: string,
+  ): Promise<Channel> {
+    return this.create({
+      orgId,
+      name: `#${taskIdentifier.toLowerCase()}`,
+      type: ChannelType.TASK,
+      taskId,
+      actorId,
+    });
+  }
+}

--- a/apps/api/src/messages/dto/create-channel.dto.ts
+++ b/apps/api/src/messages/dto/create-channel.dto.ts
@@ -1,0 +1,20 @@
+import { IsEnum, IsObject, IsOptional, IsString, IsUUID, MaxLength } from "class-validator";
+
+import { ChannelType } from "@openspawn/shared-types";
+
+export class CreateChannelDto {
+  @IsString()
+  @MaxLength(100)
+  name!: string;
+
+  @IsEnum(ChannelType)
+  type!: ChannelType;
+
+  @IsOptional()
+  @IsUUID()
+  taskId?: string;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/apps/api/src/messages/dto/send-message.dto.ts
+++ b/apps/api/src/messages/dto/send-message.dto.ts
@@ -1,0 +1,22 @@
+import { IsEnum, IsObject, IsOptional, IsString, IsUUID } from "class-validator";
+
+import { MessageType } from "@openspawn/shared-types";
+
+export class SendMessageDto {
+  @IsUUID()
+  channelId!: string;
+
+  @IsEnum(MessageType)
+  type!: MessageType;
+
+  @IsString()
+  body!: string;
+
+  @IsOptional()
+  @IsUUID()
+  parentMessageId?: string;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/apps/api/src/messages/index.ts
+++ b/apps/api/src/messages/index.ts
@@ -1,0 +1,3 @@
+export { MessagesModule } from "./messages.module";
+export { MessagesService } from "./messages.service";
+export { ChannelsService } from "./channels.service";

--- a/apps/api/src/messages/messages.controller.ts
+++ b/apps/api/src/messages/messages.controller.ts
@@ -1,0 +1,85 @@
+import { Body, Controller, Get, Param, Post, Query } from "@nestjs/common";
+
+import { CurrentAgent, type AuthenticatedAgent } from "../auth";
+
+import { ChannelsService } from "./channels.service";
+import { CreateChannelDto } from "./dto/create-channel.dto";
+import { SendMessageDto } from "./dto/send-message.dto";
+import { MessagesService } from "./messages.service";
+
+@Controller()
+export class MessagesController {
+  constructor(
+    private readonly messagesService: MessagesService,
+    private readonly channelsService: ChannelsService,
+  ) {}
+
+  // Channel endpoints
+  @Post("channels")
+  async createChannel(@CurrentAgent() agent: AuthenticatedAgent, @Body() dto: CreateChannelDto) {
+    const channel = await this.channelsService.create({
+      orgId: agent.orgId,
+      name: dto.name,
+      type: dto.type,
+      taskId: dto.taskId,
+      actorId: agent.id,
+      metadata: dto.metadata,
+    });
+    return { data: channel };
+  }
+
+  @Get("channels")
+  async listChannels(@CurrentAgent() agent: AuthenticatedAgent) {
+    const channels = await this.channelsService.findAll(agent.orgId);
+    return { data: channels };
+  }
+
+  @Get("channels/:id")
+  async getChannel(@CurrentAgent() agent: AuthenticatedAgent, @Param("id") id: string) {
+    const channel = await this.channelsService.findOne(agent.orgId, id);
+    return { data: channel };
+  }
+
+  // Message endpoints
+  @Post("messages")
+  async sendMessage(@CurrentAgent() agent: AuthenticatedAgent, @Body() dto: SendMessageDto) {
+    const message = await this.messagesService.send({
+      orgId: agent.orgId,
+      channelId: dto.channelId,
+      senderId: agent.id,
+      type: dto.type,
+      body: dto.body,
+      parentMessageId: dto.parentMessageId,
+      metadata: dto.metadata,
+    });
+    return { data: message };
+  }
+
+  @Get("messages")
+  async listMessages(
+    @CurrentAgent() agent: AuthenticatedAgent,
+    @Query("channelId") channelId: string,
+    @Query("limit") limit?: number,
+    @Query("before") before?: string,
+  ) {
+    const messages = await this.messagesService.findByChannel(
+      agent.orgId,
+      channelId,
+      limit || 50,
+      before,
+    );
+    return { data: messages };
+  }
+
+  @Get("messages/:id")
+  async getMessage(@CurrentAgent() agent: AuthenticatedAgent, @Param("id") id: string) {
+    const message = await this.messagesService.findOne(agent.orgId, id);
+    return { data: message };
+  }
+
+  @Get("messages/:id/thread")
+  async getThread(@CurrentAgent() agent: AuthenticatedAgent, @Param("id") id: string) {
+    const messages = await this.messagesService.getThread(agent.orgId, id);
+    return { data: messages };
+  }
+}

--- a/apps/api/src/messages/messages.module.ts
+++ b/apps/api/src/messages/messages.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+import { Channel, Message } from "@openspawn/database";
+
+import { EventsModule } from "../events";
+
+import { ChannelsService } from "./channels.service";
+import { MessagesController } from "./messages.controller";
+import { MessagesService } from "./messages.service";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Channel, Message]), EventsModule],
+  controllers: [MessagesController],
+  providers: [MessagesService, ChannelsService],
+  exports: [MessagesService, ChannelsService],
+})
+export class MessagesModule {}

--- a/apps/api/src/messages/messages.service.ts
+++ b/apps/api/src/messages/messages.service.ts
@@ -1,0 +1,110 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { Message } from "@openspawn/database";
+import { MessageType } from "@openspawn/shared-types";
+
+import { EventsService } from "../events";
+
+export interface SendMessageParams {
+  orgId: string;
+  channelId: string;
+  senderId: string;
+  type: MessageType;
+  body: string;
+  parentMessageId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+@Injectable()
+export class MessagesService {
+  constructor(
+    @InjectRepository(Message)
+    private readonly messageRepository: Repository<Message>,
+    private readonly eventsService: EventsService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async send(params: SendMessageParams): Promise<Message> {
+    const { orgId, channelId, senderId, type, body, parentMessageId, metadata } = params;
+
+    const message = this.messageRepository.create({
+      orgId,
+      channelId,
+      senderId,
+      type,
+      body,
+      parentMessageId,
+      metadata: metadata || {},
+    });
+
+    const saved = await this.messageRepository.save(message);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "message.sent",
+      actorId: senderId,
+      entityType: "message",
+      entityId: saved.id,
+      data: {
+        channelId,
+        type,
+        hasParent: !!parentMessageId,
+      },
+    });
+
+    // Emit for real-time subscriptions
+    this.eventEmitter.emit("message.created", saved);
+
+    return saved;
+  }
+
+  async findByChannel(
+    orgId: string,
+    channelId: string,
+    limit = 50,
+    before?: string,
+  ): Promise<Message[]> {
+    const query = this.messageRepository
+      .createQueryBuilder("message")
+      .where("message.org_id = :orgId", { orgId })
+      .andWhere("message.channel_id = :channelId", { channelId })
+      .orderBy("message.created_at", "DESC")
+      .take(limit);
+
+    if (before) {
+      const beforeMessage = await this.messageRepository.findOne({
+        where: { id: before },
+      });
+      if (beforeMessage) {
+        query.andWhere("message.created_at < :beforeTime", {
+          beforeTime: beforeMessage.createdAt,
+        });
+      }
+    }
+
+    const messages = await query.getMany();
+    return messages.reverse(); // Return in chronological order
+  }
+
+  async findOne(orgId: string, id: string): Promise<Message> {
+    const message = await this.messageRepository.findOne({
+      where: { id, orgId },
+    });
+
+    if (!message) {
+      throw new NotFoundException("Message not found");
+    }
+
+    return message;
+  }
+
+  async getThread(orgId: string, parentId: string): Promise<Message[]> {
+    return this.messageRepository.find({
+      where: { orgId, parentMessageId: parentId },
+      order: { createdAt: "ASC" },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Credit economy and messaging infrastructure.

### Credits Module
- Atomic credit transactions with row-level locking (SELECT FOR UPDATE)
- `GET /credits/balance` - current balance + budget info
- `POST /credits/spend` - debit credits with balance/budget validation
- `GET /credits/history` - paginated transaction history
- `POST /credits/adjust` - admin credit adjustment (HR/Admin only)
- `POST /credits/litellm-callback` - LLM usage-based billing endpoint

### Credit Earning Service
- `@OnEvent('task.transitioned')` listener
- Awards credits when task transitions to DONE
- Management fee calculation (% to task creator)
- Delegation credits (when creator != assignee)

### Budget Reset Task
- Cron job: daily at midnight UTC
- Resets `budget_period_spent` for all agents with budgets
- Emits `credit.budget_reset` event

### Messaging Module
- `POST /channels` - create channel
- `GET /channels` - list channels
- `GET /channels/:id` - get channel details
- `POST /messages` - send message (supports threading via parentMessageId)
- `GET /messages` - list by channel with cursor pagination
- `GET /messages/:id` - get single message
- `GET /messages/:id/thread` - get thread replies