### PR TITLE
fix: use pnpm version from package.json

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Removes hardcoded pnpm v9 from workflow — uses packageManager field from package.json (v10.6.1) instead.