### PR TITLE
fix: add jekyll-seo-tag dependency

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 gem 'jekyll', '~> 4.3'
 gem 'jekyll-remote-theme'
+gem 'jekyll-seo-tag'
 gem 'webrick' # Required for Ruby 3.0+


### PR DESCRIPTION
The midnight theme requires jekyll-seo-tag. Adds it to Gemfile.