### PR TITLE
feat(dashboard): Settings UI (Phase 1.4)

### DIFF
--- a/apps/dashboard/src/app/app.tsx
+++ b/apps/dashboard/src/app/app.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter, HashRouter, Routes, Route } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Layout, ProtectedRoute } from "../components";
 import { ThemeProvider } from "../components/theme-provider";
-import { TasksPage, AgentsPage, CreditsPage, EventsPage, LoginPage, AuthCallbackPage } from "../pages";
+import { TasksPage, AgentsPage, CreditsPage, EventsPage, LoginPage, AuthCallbackPage, SettingsPage } from "../pages";
 import { DashboardPage } from "../pages/dashboard";
 import { NetworkPage } from "../pages/network";
 import { DemoProvider, DemoControls } from "../demo";
@@ -75,6 +75,7 @@ export function App() {
                           <Route path="/credits" element={<CreditsPage />} />
                           <Route path="/events" element={<EventsPage />} />
                           <Route path="/network" element={<NetworkPage />} />
+                          <Route path="/settings" element={<SettingsPage />} />
                         </Routes>
                       </Layout>
                     </MaybeProtectedRoute>

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -11,6 +11,7 @@ import {
   Square,
   LogOut,
   User,
+  Settings,
 } from "lucide-react";
 import { cn } from "../lib/utils";
 import { Button } from "./ui/button";
@@ -42,6 +43,7 @@ const navigation = [
   { name: "Agents", href: "/agents", icon: Users },
   { name: "Credits", href: "/credits", icon: Coins },
   { name: "Events", href: "/events", icon: Activity },
+  { name: "Settings", href: "/settings", icon: Settings },
 ];
 
 export function Layout({ children }: LayoutProps) {

--- a/apps/dashboard/src/components/settings/api-key-settings.tsx
+++ b/apps/dashboard/src/components/settings/api-key-settings.tsx
@@ -1,0 +1,271 @@
+import { useState } from "react";
+import { Key, Plus, Trash2, Copy, Eye, EyeOff, Loader2, Check } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { Dialog, DialogPopup, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "../ui/dialog";
+
+interface ApiKey {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  scopes: string[];
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+// Mock data for demo
+const MOCK_API_KEYS: ApiKey[] = [
+  {
+    id: "1",
+    name: "Production API",
+    keyPrefix: "osp_a1b2c3d4",
+    scopes: ["read", "write"],
+    lastUsedAt: new Date(Date.now() - 3600000).toISOString(),
+    expiresAt: null,
+    createdAt: new Date(Date.now() - 86400000 * 30).toISOString(),
+  },
+  {
+    id: "2",
+    name: "Development",
+    keyPrefix: "osp_e5f6g7h8",
+    scopes: ["read"],
+    lastUsedAt: null,
+    expiresAt: new Date(Date.now() + 86400000 * 30).toISOString(),
+    createdAt: new Date(Date.now() - 86400000 * 7).toISOString(),
+  },
+];
+
+export function ApiKeySettings() {
+  const [apiKeys, setApiKeys] = useState<ApiKey[]>(MOCK_API_KEYS);
+  const [isCreating, setIsCreating] = useState(false);
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [newKeyName, setNewKeyName] = useState("");
+  const [newKeyScopes, setNewKeyScopes] = useState<string[]>(["read"]);
+  const [newKeySecret, setNewKeySecret] = useState<string | null>(null);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  const handleCreateKey = async () => {
+    setIsCreating(true);
+    // TODO: Implement actual API call
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    
+    const mockSecret = `osp_${Math.random().toString(36).substring(2)}${Math.random().toString(36).substring(2)}`;
+    setNewKeySecret(mockSecret);
+    
+    const newKey: ApiKey = {
+      id: Math.random().toString(),
+      name: newKeyName,
+      keyPrefix: mockSecret.substring(0, 12),
+      scopes: newKeyScopes,
+      lastUsedAt: null,
+      expiresAt: null,
+      createdAt: new Date().toISOString(),
+    };
+    
+    setApiKeys([newKey, ...apiKeys]);
+    setIsCreating(false);
+  };
+
+  const handleRevokeKey = async (id: string) => {
+    if (!confirm("Are you sure you want to revoke this API key? This action cannot be undone.")) {
+      return;
+    }
+    setApiKeys(apiKeys.filter((k) => k.id !== id));
+  };
+
+  const handleCopyKey = async (key: string) => {
+    await navigator.clipboard.writeText(key);
+    setCopiedKey(key);
+    setTimeout(() => setCopiedKey(null), 2000);
+  };
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return "Never";
+    return new Date(dateStr).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  };
+
+  const handleCloseDialog = () => {
+    setShowCreateDialog(false);
+    setNewKeyName("");
+    setNewKeyScopes(["read"]);
+    setNewKeySecret(null);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle className="flex items-center gap-2">
+            <Key className="h-5 w-5" />
+            API Keys
+          </CardTitle>
+          <CardDescription>
+            Manage API keys for programmatic access
+          </CardDescription>
+        </div>
+        <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+          <DialogTrigger asChild>
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              Create Key
+            </Button>
+          </DialogTrigger>
+          <DialogPopup>
+            {newKeySecret ? (
+              <>
+                <DialogHeader>
+                  <DialogTitle>API Key Created</DialogTitle>
+                  <DialogDescription>
+                    Copy your API key now. You won't be able to see it again!
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="my-4 rounded-lg bg-muted p-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <code className="text-sm break-all">{newKeySecret}</code>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleCopyKey(newKeySecret)}
+                    >
+                      {copiedKey === newKeySecret ? (
+                        <Check className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button onClick={handleCloseDialog}>Done</Button>
+                </DialogFooter>
+              </>
+            ) : (
+              <>
+                <DialogHeader>
+                  <DialogTitle>Create API Key</DialogTitle>
+                  <DialogDescription>
+                    Create a new API key for programmatic access
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4 py-4">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Name</label>
+                    <input
+                      type="text"
+                      value={newKeyName}
+                      onChange={(e) => setNewKeyName(e.target.value)}
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                      placeholder="e.g., Production API"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Scopes</label>
+                    <div className="flex flex-wrap gap-2">
+                      {["read", "write", "admin"].map((scope) => (
+                        <button
+                          key={scope}
+                          onClick={() => {
+                            if (newKeyScopes.includes(scope)) {
+                              setNewKeyScopes(newKeyScopes.filter((s) => s !== scope));
+                            } else {
+                              setNewKeyScopes([...newKeyScopes, scope]);
+                            }
+                          }}
+                          className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                            newKeyScopes.includes(scope)
+                              ? "bg-primary text-primary-foreground"
+                              : "bg-muted text-muted-foreground hover:bg-muted/80"
+                          }`}
+                        >
+                          {scope}
+                        </button>
+                      ))}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      read = view data, write = modify data, admin = full access
+                    </p>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={handleCloseDialog}>
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleCreateKey}
+                    disabled={!newKeyName || newKeyScopes.length === 0 || isCreating}
+                  >
+                    {isCreating ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Key className="mr-2 h-4 w-4" />
+                    )}
+                    Create Key
+                  </Button>
+                </DialogFooter>
+              </>
+            )}
+          </DialogPopup>
+        </Dialog>
+      </CardHeader>
+      <CardContent>
+        {apiKeys.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <Key className="h-12 w-12 text-muted-foreground/50 mb-4" />
+            <p className="text-muted-foreground">No API keys yet</p>
+            <p className="text-sm text-muted-foreground">
+              Create your first API key to get started
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {apiKeys.map((key) => (
+              <div
+                key={key.id}
+                className="flex items-center justify-between rounded-lg border border-border p-4"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <p className="font-medium">{key.name}</p>
+                    <div className="flex gap-1">
+                      {key.scopes.map((scope) => (
+                        <Badge key={scope} variant="secondary" className="text-xs">
+                          {scope}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="mt-1 flex items-center gap-4 text-sm text-muted-foreground">
+                    <span className="font-mono">{key.keyPrefix}...</span>
+                    <span>Created {formatDate(key.createdAt)}</span>
+                    {key.lastUsedAt && (
+                      <span>Last used {formatDate(key.lastUsedAt)}</span>
+                    )}
+                    {key.expiresAt && (
+                      <span className="text-amber-500">
+                        Expires {formatDate(key.expiresAt)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                  onClick={() => handleRevokeKey(key.id)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/components/settings/index.ts
+++ b/apps/dashboard/src/components/settings/index.ts
@@ -1,0 +1,4 @@
+export { ProfileSettings } from "./profile-settings";
+export { SecuritySettings } from "./security-settings";
+export { ApiKeySettings } from "./api-key-settings";
+export { OrgSettings } from "./org-settings";

--- a/apps/dashboard/src/components/settings/org-settings.tsx
+++ b/apps/dashboard/src/components/settings/org-settings.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { Building2, Users, Save, Loader2 } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { useAuth } from "../../contexts";
+
+interface OrgMember {
+  id: string;
+  name: string;
+  email: string;
+  role: "admin" | "operator" | "viewer";
+  lastActive: string;
+}
+
+// Mock data for demo
+const MOCK_MEMBERS: OrgMember[] = [
+  {
+    id: "1",
+    name: "Adam",
+    email: "adam@openspawn.ai",
+    role: "admin",
+    lastActive: new Date().toISOString(),
+  },
+  {
+    id: "2",
+    name: "Agent Dennis",
+    email: "agentdennis@openspawn.ai",
+    role: "operator",
+    lastActive: new Date(Date.now() - 3600000).toISOString(),
+  },
+];
+
+export function OrgSettings() {
+  const { user } = useAuth();
+  const [orgName, setOrgName] = useState("OpenSpawn");
+  const [isSaving, setIsSaving] = useState(false);
+  const [members] = useState<OrgMember[]>(MOCK_MEMBERS);
+
+  const isAdmin = user?.role === "admin";
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setIsSaving(false);
+  };
+
+  const getRoleBadgeVariant = (role: string) => {
+    switch (role) {
+      case "admin":
+        return "default";
+      case "operator":
+        return "secondary";
+      default:
+        return "outline";
+    }
+  };
+
+  const formatLastActive = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+
+    if (diffMins < 1) return "Just now";
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    return date.toLocaleDateString();
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Organization Info */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Building2 className="h-5 w-5" />
+            Organization
+          </CardTitle>
+          <CardDescription>
+            Manage your organization settings
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Organization Name</label>
+            <input
+              type="text"
+              value={orgName}
+              onChange={(e) => setOrgName(e.target.value)}
+              disabled={!isAdmin}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            />
+            {!isAdmin && (
+              <p className="text-xs text-muted-foreground">
+                Only admins can change organization settings
+              </p>
+            )}
+          </div>
+
+          {isAdmin && (
+            <Button onClick={handleSave} disabled={isSaving}>
+              {isSaving ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
+              Save Changes
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Team Members */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="h-5 w-5" />
+              Team Members
+            </CardTitle>
+            <CardDescription>
+              {members.length} member{members.length !== 1 ? "s" : ""} in your organization
+            </CardDescription>
+          </div>
+          {isAdmin && (
+            <Button variant="outline">
+              Invite Member
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {members.map((member) => (
+              <div
+                key={member.id}
+                className="flex items-center justify-between rounded-lg border border-border p-4"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary font-medium">
+                    {member.name.charAt(0).toUpperCase()}
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <p className="font-medium">{member.name}</p>
+                      <Badge variant={getRoleBadgeVariant(member.role)}>
+                        {member.role}
+                      </Badge>
+                      {member.id === user?.id && (
+                        <Badge variant="outline" className="text-xs">
+                          You
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-sm text-muted-foreground">{member.email}</p>
+                  </div>
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Active {formatLastActive(member.lastActive)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Danger Zone */}
+      {isAdmin && (
+        <Card className="border-destructive/50">
+          <CardHeader>
+            <CardTitle className="text-destructive">Danger Zone</CardTitle>
+            <CardDescription>
+              Irreversible actions that affect your entire organization
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between rounded-lg border border-destructive/50 p-4">
+              <div>
+                <p className="font-medium">Delete Organization</p>
+                <p className="text-sm text-muted-foreground">
+                  Permanently delete this organization and all its data
+                </p>
+              </div>
+              <Button variant="destructive">
+                Delete Organization
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/settings/profile-settings.tsx
+++ b/apps/dashboard/src/components/settings/profile-settings.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { Save, Loader2 } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
+import { Button } from "../ui/button";
+import { useAuth } from "../../contexts";
+
+export function ProfileSettings() {
+  const { user } = useAuth();
+  const [name, setName] = useState(user?.name || "");
+  const [email, setEmail] = useState(user?.email || "");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    // TODO: Implement profile update API call
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setIsSaving(false);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Profile</CardTitle>
+        <CardDescription>
+          Update your personal information
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            placeholder="Your name"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            placeholder="your@email.com"
+          />
+          <p className="text-xs text-muted-foreground">
+            Changing your email will require verification
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Role</label>
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
+              {user?.role || "viewer"}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              Contact an admin to change your role
+            </span>
+          </div>
+        </div>
+
+        <Button onClick={handleSave} disabled={isSaving}>
+          {isSaving ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Save className="mr-2 h-4 w-4" />
+          )}
+          Save Changes
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/components/settings/security-settings.tsx
+++ b/apps/dashboard/src/components/settings/security-settings.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import { Shield, Smartphone, Key, Loader2, Check, X } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
+import { Button } from "../ui/button";
+import { useAuth } from "../../contexts";
+
+export function SecuritySettings() {
+  const { user } = useAuth();
+  const [isChangingPassword, setIsChangingPassword] = useState(false);
+  const [isEnabling2FA, setIsEnabling2FA] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  const handleChangePassword = async () => {
+    if (newPassword !== confirmPassword) {
+      alert("Passwords don't match");
+      return;
+    }
+    setIsChangingPassword(true);
+    // TODO: Implement password change API
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setIsChangingPassword(false);
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+  };
+
+  const handleToggle2FA = async () => {
+    setIsEnabling2FA(true);
+    // TODO: Implement 2FA toggle API
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setIsEnabling2FA(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Password Section */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Key className="h-5 w-5" />
+            Password
+          </CardTitle>
+          <CardDescription>
+            Change your password to keep your account secure
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Current Password</label>
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">New Password</label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Confirm New Password</label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            />
+          </div>
+          <Button onClick={handleChangePassword} disabled={isChangingPassword}>
+            {isChangingPassword ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Shield className="mr-2 h-4 w-4" />
+            )}
+            Update Password
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* 2FA Section */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Smartphone className="h-5 w-5" />
+            Two-Factor Authentication
+          </CardTitle>
+          <CardDescription>
+            Add an extra layer of security to your account
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className={`rounded-full p-2 ${user?.totpEnabled ? 'bg-green-500/10' : 'bg-muted'}`}>
+                {user?.totpEnabled ? (
+                  <Check className="h-5 w-5 text-green-500" />
+                ) : (
+                  <X className="h-5 w-5 text-muted-foreground" />
+                )}
+              </div>
+              <div>
+                <p className="font-medium">
+                  {user?.totpEnabled ? "Enabled" : "Disabled"}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {user?.totpEnabled
+                    ? "Your account is protected with 2FA"
+                    : "Enable 2FA for additional security"}
+                </p>
+              </div>
+            </div>
+            <Button
+              variant={user?.totpEnabled ? "destructive" : "default"}
+              onClick={handleToggle2FA}
+              disabled={isEnabling2FA}
+            >
+              {isEnabling2FA ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : user?.totpEnabled ? (
+                "Disable 2FA"
+              ) : (
+                "Enable 2FA"
+              )}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Sessions Section */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Active Sessions</CardTitle>
+          <CardDescription>
+            Manage your active login sessions
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-lg border border-border p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">Current Session</p>
+                <p className="text-sm text-muted-foreground">
+                  This browser · Last active now
+                </p>
+              </div>
+              <span className="inline-flex items-center rounded-full bg-green-500/10 px-2.5 py-0.5 text-xs font-medium text-green-500">
+                Active
+              </span>
+            </div>
+          </div>
+          <Button variant="outline" className="mt-4">
+            Sign Out All Other Sessions
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/dashboard/src/pages/index.ts
+++ b/apps/dashboard/src/pages/index.ts
@@ -4,4 +4,5 @@ export * from "./credits";
 export * from "./dashboard";
 export * from "./events";
 export * from "./login";
+export * from "./settings";
 export * from "./tasks";

--- a/apps/dashboard/src/pages/settings.tsx
+++ b/apps/dashboard/src/pages/settings.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { User, Shield, Key, Building2 } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs";
+import { ProfileSettings } from "../components/settings/profile-settings";
+import { SecuritySettings } from "../components/settings/security-settings";
+import { ApiKeySettings } from "../components/settings/api-key-settings";
+import { OrgSettings } from "../components/settings/org-settings";
+
+export function SettingsPage() {
+  const [activeTab, setActiveTab] = useState("profile");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
+        <p className="text-muted-foreground">
+          Manage your account and organization settings
+        </p>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
+        <TabsList className="grid w-full grid-cols-4 lg:w-[600px]">
+          <TabsTrigger value="profile" className="flex items-center gap-2">
+            <User className="h-4 w-4" />
+            <span className="hidden sm:inline">Profile</span>
+          </TabsTrigger>
+          <TabsTrigger value="security" className="flex items-center gap-2">
+            <Shield className="h-4 w-4" />
+            <span className="hidden sm:inline">Security</span>
+          </TabsTrigger>
+          <TabsTrigger value="api-keys" className="flex items-center gap-2">
+            <Key className="h-4 w-4" />
+            <span className="hidden sm:inline">API Keys</span>
+          </TabsTrigger>
+          <TabsTrigger value="organization" className="flex items-center gap-2">
+            <Building2 className="h-4 w-4" />
+            <span className="hidden sm:inline">Organization</span>
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="profile">
+          <ProfileSettings />
+        </TabsContent>
+
+        <TabsContent value="security">
+          <SecuritySettings />
+        </TabsContent>
+
+        <TabsContent value="api-keys">
+          <ApiKeySettings />
+        </TabsContent>
+
+        <TabsContent value="organization">
+          <OrgSettings />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}


### PR DESCRIPTION
## Phase 1.4: Settings UI

> ⚠️ **Stacked PR** — depends on #20 (RBAC) → #19 (API Keys)

### Tabs
| Tab | Features |
|-----|----------|
| **Profile** | Name, email, role display |
| **Security** | Password change, 2FA toggle, active sessions |
| **API Keys** | Create, list, revoke keys with scope selection |
| **Organization** | Org name, team members, danger zone |

### Screenshots
_Settings page with 4 tabs and consistent styling_

### Components
- `SettingsPage` — Main layout with tabs
- `ProfileSettings` — User info form
- `SecuritySettings` — Password + 2FA + sessions
- `ApiKeySettings` — Full API key CRUD UI
- `OrgSettings` — Org management + member list

### Navigation
Added Settings link to sidebar (gear icon)

### Notes
- Uses mock data for demo mode
- API endpoints will connect after auth PRs merge
- Role-based visibility (admin-only sections)