### PR TITLE
feat(phase2): Agent Onboarding & Budget Management

### DIFF
--- a/apps/api/src/agents/agent-budget.service.ts
+++ b/apps/api/src/agents/agent-budget.service.ts
@@ -1,0 +1,328 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository, MoreThan } from "typeorm";
+
+import { Agent, CreditTransaction } from "@openspawn/database";
+import { AgentStatus, CreditType } from "@openspawn/shared-types";
+
+import { EventsService } from "../events";
+
+export interface SetBudgetDto {
+  budgetPeriodLimit: number;
+  resetCurrentPeriod?: boolean;
+}
+
+export interface TransferCreditsDto {
+  toAgentId: string;
+  amount: number;
+  reason?: string;
+}
+
+export interface BudgetStatus {
+  agentId: string;
+  currentBalance: number;
+  budgetPeriodLimit: number | null;
+  budgetPeriodSpent: number;
+  budgetRemaining: number | null;
+  budgetPeriodStart: Date | null;
+  utilizationPercent: number | null;
+}
+
+@Injectable()
+export class AgentBudgetService {
+  constructor(
+    @InjectRepository(Agent)
+    private readonly agentRepository: Repository<Agent>,
+    @InjectRepository(CreditTransaction)
+    private readonly transactionRepository: Repository<CreditTransaction>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  /**
+   * Get budget status for an agent
+   */
+  async getBudgetStatus(orgId: string, agentId: string): Promise<BudgetStatus> {
+    const agent = await this.agentRepository.findOne({
+      where: { id: agentId, orgId },
+    });
+
+    if (!agent) {
+      throw new NotFoundException("Agent not found");
+    }
+
+    const budgetRemaining = agent.budgetPeriodLimit
+      ? agent.budgetPeriodLimit - agent.budgetPeriodSpent
+      : null;
+
+    const utilizationPercent = agent.budgetPeriodLimit
+      ? Math.round((agent.budgetPeriodSpent / agent.budgetPeriodLimit) * 100)
+      : null;
+
+    return {
+      agentId: agent.id,
+      currentBalance: agent.currentBalance,
+      budgetPeriodLimit: agent.budgetPeriodLimit,
+      budgetPeriodSpent: agent.budgetPeriodSpent,
+      budgetRemaining,
+      budgetPeriodStart: agent.budgetPeriodStart,
+      utilizationPercent,
+    };
+  }
+
+  /**
+   * Set budget limit for an agent
+   * Only parent or L10 can set budgets
+   */
+  async setBudget(
+    orgId: string,
+    actorId: string,
+    targetAgentId: string,
+    dto: SetBudgetDto,
+  ): Promise<BudgetStatus> {
+    const [actor, target] = await Promise.all([
+      this.agentRepository.findOne({ where: { id: actorId } }),
+      this.agentRepository.findOne({ where: { id: targetAgentId, orgId } }),
+    ]);
+
+    if (!actor) {
+      throw new ForbiddenException("Actor not found");
+    }
+
+    if (!target) {
+      throw new NotFoundException("Target agent not found");
+    }
+
+    // Authorization: parent or L10
+    const isParent = target.parentId === actorId;
+    const isL10 = actor.level === 10;
+
+    if (!isParent && !isL10) {
+      throw new ForbiddenException(
+        "Only parent agent or L10 can set budgets"
+      );
+    }
+
+    if (dto.budgetPeriodLimit < 0) {
+      throw new BadRequestException("Budget limit cannot be negative");
+    }
+
+    target.budgetPeriodLimit = dto.budgetPeriodLimit;
+    
+    if (dto.resetCurrentPeriod) {
+      target.budgetPeriodSpent = 0;
+      target.budgetPeriodStart = new Date();
+    }
+
+    await this.agentRepository.save(target);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "agent.budget_set",
+      actorId,
+      entityType: "agent",
+      entityId: targetAgentId,
+      data: {
+        budgetPeriodLimit: dto.budgetPeriodLimit,
+        resetCurrentPeriod: dto.resetCurrentPeriod,
+      },
+    });
+
+    return this.getBudgetStatus(orgId, targetAgentId);
+  }
+
+  /**
+   * Transfer credits between agents
+   * Credits flow down the hierarchy (parent -> child)
+   */
+  async transferCredits(
+    orgId: string,
+    fromAgentId: string,
+    dto: TransferCreditsDto,
+  ): Promise<{ from: BudgetStatus; to: BudgetStatus }> {
+    const [fromAgent, toAgent] = await Promise.all([
+      this.agentRepository.findOne({ where: { id: fromAgentId, orgId } }),
+      this.agentRepository.findOne({ where: { id: dto.toAgentId, orgId } }),
+    ]);
+
+    if (!fromAgent) {
+      throw new NotFoundException("Source agent not found");
+    }
+
+    if (!toAgent) {
+      throw new NotFoundException("Target agent not found");
+    }
+
+    if (dto.amount <= 0) {
+      throw new BadRequestException("Transfer amount must be positive");
+    }
+
+    if (fromAgent.currentBalance < dto.amount) {
+      throw new BadRequestException(
+        `Insufficient balance (${fromAgent.currentBalance} < ${dto.amount})`
+      );
+    }
+
+    // Verify hierarchy: can only transfer to children or siblings
+    const isChild = toAgent.parentId === fromAgentId;
+    const isSibling = fromAgent.parentId && fromAgent.parentId === toAgent.parentId;
+    const isL10 = fromAgent.level === 10;
+
+    if (!isChild && !isSibling && !isL10) {
+      throw new ForbiddenException(
+        "Can only transfer credits to children or sibling agents"
+      );
+    }
+
+    // Perform transfer
+    fromAgent.currentBalance -= dto.amount;
+    toAgent.currentBalance += dto.amount;
+
+    await this.agentRepository.save([fromAgent, toAgent]);
+
+    // Record transactions
+    const now = new Date();
+    await this.transactionRepository.save([
+      {
+        orgId,
+        agentId: fromAgentId,
+        type: CreditType.DEBIT,
+        amount: dto.amount,
+        description: dto.reason || `Transfer to ${toAgent.name}`,
+        referenceType: "transfer",
+        referenceId: dto.toAgentId,
+        createdAt: now,
+      },
+      {
+        orgId,
+        agentId: dto.toAgentId,
+        type: CreditType.CREDIT,
+        amount: dto.amount,
+        description: dto.reason || `Transfer from ${fromAgent.name}`,
+        referenceType: "transfer",
+        referenceId: fromAgentId,
+        createdAt: now,
+      },
+    ]);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "credits.transferred",
+      actorId: fromAgentId,
+      entityType: "agent",
+      entityId: dto.toAgentId,
+      data: {
+        fromAgent: fromAgentId,
+        toAgent: dto.toAgentId,
+        amount: dto.amount,
+        reason: dto.reason,
+      },
+    });
+
+    return {
+      from: await this.getBudgetStatus(orgId, fromAgentId),
+      to: await this.getBudgetStatus(orgId, dto.toAgentId),
+    };
+  }
+
+  /**
+   * Check if an agent can spend a certain amount
+   */
+  async canSpend(orgId: string, agentId: string, amount: number): Promise<{
+    canSpend: boolean;
+    reason?: string;
+    currentBalance: number;
+    budgetRemaining: number | null;
+  }> {
+    const agent = await this.agentRepository.findOne({
+      where: { id: agentId, orgId },
+    });
+
+    if (!agent) {
+      return {
+        canSpend: false,
+        reason: "Agent not found",
+        currentBalance: 0,
+        budgetRemaining: null,
+      };
+    }
+
+    if (agent.status !== AgentStatus.ACTIVE) {
+      return {
+        canSpend: false,
+        reason: `Agent is not active (status: ${agent.status})`,
+        currentBalance: agent.currentBalance,
+        budgetRemaining: null,
+      };
+    }
+
+    // Check balance
+    if (agent.currentBalance < amount) {
+      return {
+        canSpend: false,
+        reason: `Insufficient balance (${agent.currentBalance} < ${amount})`,
+        currentBalance: agent.currentBalance,
+        budgetRemaining: null,
+      };
+    }
+
+    // Check budget limit
+    if (agent.budgetPeriodLimit !== null) {
+      const budgetRemaining = agent.budgetPeriodLimit - agent.budgetPeriodSpent;
+      if (amount > budgetRemaining) {
+        return {
+          canSpend: false,
+          reason: `Would exceed budget limit (remaining: ${budgetRemaining})`,
+          currentBalance: agent.currentBalance,
+          budgetRemaining,
+        };
+      }
+    }
+
+    return {
+      canSpend: true,
+      currentBalance: agent.currentBalance,
+      budgetRemaining: agent.budgetPeriodLimit
+        ? agent.budgetPeriodLimit - agent.budgetPeriodSpent
+        : null,
+    };
+  }
+
+  /**
+   * Get agents approaching budget limit (>80% used)
+   */
+  async getAgentsNearBudgetLimit(orgId: string): Promise<BudgetStatus[]> {
+    const agents = await this.agentRepository.find({
+      where: {
+        orgId,
+        status: AgentStatus.ACTIVE,
+        budgetPeriodLimit: MoreThan(0),
+      },
+    });
+
+    const statuses: BudgetStatus[] = [];
+
+    for (const agent of agents) {
+      if (agent.budgetPeriodLimit) {
+        const utilization = agent.budgetPeriodSpent / agent.budgetPeriodLimit;
+        if (utilization >= 0.8) {
+          statuses.push({
+            agentId: agent.id,
+            currentBalance: agent.currentBalance,
+            budgetPeriodLimit: agent.budgetPeriodLimit,
+            budgetPeriodSpent: agent.budgetPeriodSpent,
+            budgetRemaining: agent.budgetPeriodLimit - agent.budgetPeriodSpent,
+            budgetPeriodStart: agent.budgetPeriodStart,
+            utilizationPercent: Math.round(utilization * 100),
+          });
+        }
+      }
+    }
+
+    return statuses.sort((a, b) => (b.utilizationPercent || 0) - (a.utilizationPercent || 0));
+  }
+}

--- a/apps/api/src/agents/agent-onboarding.service.ts
+++ b/apps/api/src/agents/agent-onboarding.service.ts
@@ -1,0 +1,328 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { Agent } from "@openspawn/database";
+import { AgentStatus } from "@openspawn/shared-types";
+
+import { EventsService } from "../events";
+
+/**
+ * Capacity limits per agent level
+ * Higher level agents can manage more sub-agents
+ */
+const LEVEL_CAPACITY: Record<number, number> = {
+  1: 0,   // Workers can't spawn agents
+  2: 0,
+  3: 2,   // Team leads can have 2 workers
+  4: 3,
+  5: 5,   // Managers can have 5 reports
+  6: 8,
+  7: 12,  // Directors can have 12
+  8: 20,
+  9: 50,  // VPs can have 50
+  10: 100, // L10 (Founder) can have 100
+};
+
+export interface SpawnAgentDto {
+  agentId: string;
+  name: string;
+  level?: number;
+  model?: string;
+  budgetPeriodLimit?: number;
+  capabilities?: { capability: string; proficiency: string }[];
+}
+
+@Injectable()
+export class AgentOnboardingService {
+  constructor(
+    @InjectRepository(Agent)
+    private readonly agentRepository: Repository<Agent>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  /**
+   * Get the maximum number of children an agent can have based on level
+   */
+  getCapacityForLevel(level: number): number {
+    return LEVEL_CAPACITY[level] || 0;
+  }
+
+  /**
+   * Count current active children of an agent
+   */
+  async countChildren(agentId: string): Promise<number> {
+    return this.agentRepository.count({
+      where: {
+        parentId: agentId,
+        status: AgentStatus.ACTIVE,
+      },
+    });
+  }
+
+  /**
+   * Check if an agent can spawn more children
+   */
+  async canSpawnChild(parentId: string): Promise<{ canSpawn: boolean; reason?: string; current: number; max: number }> {
+    const parent = await this.agentRepository.findOne({ where: { id: parentId } });
+    if (!parent) {
+      return { canSpawn: false, reason: "Parent agent not found", current: 0, max: 0 };
+    }
+
+    const maxCapacity = parent.maxChildren || this.getCapacityForLevel(parent.level);
+    const currentChildren = await this.countChildren(parentId);
+
+    if (currentChildren >= maxCapacity) {
+      return {
+        canSpawn: false,
+        reason: `Agent at capacity (${currentChildren}/${maxCapacity})`,
+        current: currentChildren,
+        max: maxCapacity,
+      };
+    }
+
+    return { canSpawn: true, current: currentChildren, max: maxCapacity };
+  }
+
+  /**
+   * Spawn a new agent as a child of the parent
+   * New agents start in PENDING status until activated
+   */
+  async spawnAgent(
+    orgId: string,
+    parentId: string,
+    dto: SpawnAgentDto,
+    hmacSecretEnc: Buffer,
+  ): Promise<Agent> {
+    // Verify capacity
+    const capacityCheck = await this.canSpawnChild(parentId);
+    if (!capacityCheck.canSpawn) {
+      throw new ForbiddenException(capacityCheck.reason);
+    }
+
+    const parent = await this.agentRepository.findOne({ where: { id: parentId } });
+    if (!parent) {
+      throw new NotFoundException("Parent agent not found");
+    }
+
+    // Child level must be less than parent level
+    const childLevel = dto.level || parent.level - 1;
+    if (childLevel >= parent.level) {
+      throw new BadRequestException(
+        `Child level (${childLevel}) must be less than parent level (${parent.level})`
+      );
+    }
+
+    if (childLevel < 1) {
+      throw new BadRequestException("Agent level must be at least 1");
+    }
+
+    // Create the agent in PENDING status
+    const agent = this.agentRepository.create({
+      orgId,
+      agentId: dto.agentId,
+      name: dto.name,
+      level: childLevel,
+      model: dto.model || parent.model,
+      status: AgentStatus.PENDING,
+      parentId,
+      maxChildren: this.getCapacityForLevel(childLevel),
+      currentBalance: 0,
+      budgetPeriodSpent: 0,
+      budgetPeriodLimit: dto.budgetPeriodLimit,
+      hmacSecretEnc,
+      metadata: {},
+    });
+
+    const saved = await this.agentRepository.save(agent);
+
+    // Emit event
+    await this.eventsService.emit({
+      orgId,
+      type: "agent.spawned",
+      actorId: parentId,
+      entityType: "agent",
+      entityId: saved.id,
+      data: {
+        agentId: saved.agentId,
+        name: saved.name,
+        level: saved.level,
+        parentId,
+        status: AgentStatus.PENDING,
+      },
+    });
+
+    return saved;
+  }
+
+  /**
+   * Activate a pending agent
+   * Can only be done by the parent or L10
+   */
+  async activateAgent(
+    orgId: string,
+    actorId: string,
+    agentId: string,
+  ): Promise<Agent> {
+    const agent = await this.agentRepository.findOne({
+      where: { id: agentId, orgId },
+    });
+
+    if (!agent) {
+      throw new NotFoundException("Agent not found");
+    }
+
+    if (agent.status !== AgentStatus.PENDING) {
+      throw new BadRequestException(
+        `Agent is not pending activation (status: ${agent.status})`
+      );
+    }
+
+    // Check authorization: must be parent or L10
+    const actor = await this.agentRepository.findOne({ where: { id: actorId } });
+    if (!actor) {
+      throw new ForbiddenException("Actor not found");
+    }
+
+    const isParent = agent.parentId === actorId;
+    const isL10 = actor.level === 10;
+
+    if (!isParent && !isL10) {
+      throw new ForbiddenException(
+        "Only the parent agent or L10 can activate this agent"
+      );
+    }
+
+    // Activate
+    agent.status = AgentStatus.ACTIVE;
+    const saved = await this.agentRepository.save(agent);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "agent.activated",
+      actorId,
+      entityType: "agent",
+      entityId: agentId,
+      data: {
+        agentId: agent.agentId,
+        name: agent.name,
+        activatedBy: actorId,
+      },
+    });
+
+    return saved;
+  }
+
+  /**
+   * Reject a pending agent (delete it)
+   */
+  async rejectAgent(
+    orgId: string,
+    actorId: string,
+    agentId: string,
+    reason?: string,
+  ): Promise<void> {
+    const agent = await this.agentRepository.findOne({
+      where: { id: agentId, orgId },
+    });
+
+    if (!agent) {
+      throw new NotFoundException("Agent not found");
+    }
+
+    if (agent.status !== AgentStatus.PENDING) {
+      throw new BadRequestException("Can only reject pending agents");
+    }
+
+    // Check authorization
+    const actor = await this.agentRepository.findOne({ where: { id: actorId } });
+    if (!actor) {
+      throw new ForbiddenException("Actor not found");
+    }
+
+    const isParent = agent.parentId === actorId;
+    const isL10 = actor.level === 10;
+
+    if (!isParent && !isL10) {
+      throw new ForbiddenException(
+        "Only the parent agent or L10 can reject this agent"
+      );
+    }
+
+    await this.eventsService.emit({
+      orgId,
+      type: "agent.rejected",
+      actorId,
+      entityType: "agent",
+      entityId: agentId,
+      data: {
+        agentId: agent.agentId,
+        name: agent.name,
+        reason,
+      },
+    });
+
+    // Soft delete
+    await this.agentRepository.softDelete(agentId);
+  }
+
+  /**
+   * Get pending agents for an actor (their children or all if L10)
+   */
+  async getPendingAgents(orgId: string, actorId: string): Promise<Agent[]> {
+    const actor = await this.agentRepository.findOne({ where: { id: actorId } });
+    if (!actor) {
+      return [];
+    }
+
+    if (actor.level === 10) {
+      // L10 sees all pending agents
+      return this.agentRepository.find({
+        where: { orgId, status: AgentStatus.PENDING },
+        order: { createdAt: "ASC" },
+      });
+    }
+
+    // Others see only their pending children
+    return this.agentRepository.find({
+      where: { orgId, parentId: actorId, status: AgentStatus.PENDING },
+      order: { createdAt: "ASC" },
+    });
+  }
+
+  /**
+   * Get agent hierarchy (children and their children)
+   */
+  async getHierarchy(orgId: string, rootId: string, depth = 3): Promise<Agent & { children?: Agent[] }> {
+    const agent = await this.agentRepository.findOne({
+      where: { id: rootId, orgId },
+    });
+
+    if (!agent) {
+      throw new NotFoundException("Agent not found");
+    }
+
+    if (depth <= 0) {
+      return agent;
+    }
+
+    const children = await this.agentRepository.find({
+      where: { parentId: rootId, orgId },
+      order: { level: "DESC", name: "ASC" },
+    });
+
+    const childrenWithHierarchy = await Promise.all(
+      children.map((child) => this.getHierarchy(orgId, child.id, depth - 1))
+    );
+
+    return {
+      ...agent,
+      children: childrenWithHierarchy,
+    };
+  }
+}

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -1,16 +1,22 @@
-import { Body, Controller, Get, Param, Patch, Post } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from "@nestjs/common";
 
 import { AgentRole } from "@openspawn/shared-types";
 
 import { CurrentAgent, Roles, type AuthenticatedAgent } from "../auth";
 
 import { AgentsService } from "./agents.service";
+import { AgentOnboardingService, type SpawnAgentDto } from "./agent-onboarding.service";
+import { AgentBudgetService, type SetBudgetDto, type TransferCreditsDto } from "./agent-budget.service";
 import { CreateAgentDto } from "./dto/create-agent.dto";
 import { UpdateAgentDto } from "./dto/update-agent.dto";
 
 @Controller("agents")
 export class AgentsController {
-  constructor(private readonly agentsService: AgentsService) {}
+  constructor(
+    private readonly agentsService: AgentsService,
+    private readonly onboardingService: AgentOnboardingService,
+    private readonly budgetService: AgentBudgetService,
+  ) {}
 
   /**
    * Register a new agent - HR role only (Talent Agent)
@@ -102,5 +108,182 @@ export class AgentsController {
   async getBalance(@CurrentAgent() actor: AuthenticatedAgent, @Param("id") id: string) {
     const balance = await this.agentsService.getBalance(actor.orgId, id);
     return { data: balance };
+  }
+
+  // ============ Onboarding Endpoints ============
+
+  /**
+   * Spawn a new child agent (starts in PENDING status)
+   */
+  @Post("spawn")
+  async spawn(
+    @CurrentAgent() actor: AuthenticatedAgent,
+    @Body() dto: SpawnAgentDto & { hmacSecretEnc?: string },
+  ) {
+    // For now, generate a new secret (in production, might be passed in)
+    const { generateSigningSecret, encryptSecret } = await import("@openspawn/shared-types");
+    const plaintextSecret = generateSigningSecret();
+    const encryptionKey = process.env["ENCRYPTION_KEY"];
+    if (!encryptionKey) {
+      throw new Error("ENCRYPTION_KEY not configured");
+    }
+    const hmacSecretEnc = encryptSecret(plaintextSecret, encryptionKey);
+
+    const agent = await this.onboardingService.spawnAgent(
+      actor.orgId,
+      actor.id,
+      dto,
+      hmacSecretEnc,
+    );
+
+    return {
+      data: {
+        id: agent.id,
+        agentId: agent.agentId,
+        name: agent.name,
+        level: agent.level,
+        status: agent.status,
+        parentId: agent.parentId,
+      },
+      secret: plaintextSecret,
+      message: "Agent spawned in PENDING status. Parent or L10 must activate.",
+    };
+  }
+
+  /**
+   * Check spawn capacity
+   */
+  @Get("capacity")
+  async getCapacity(@CurrentAgent() actor: AuthenticatedAgent) {
+    const capacity = await this.onboardingService.canSpawnChild(actor.id);
+    return { data: capacity };
+  }
+
+  /**
+   * Get pending agents awaiting activation
+   */
+  @Get("pending")
+  async getPending(@CurrentAgent() actor: AuthenticatedAgent) {
+    const pending = await this.onboardingService.getPendingAgents(actor.orgId, actor.id);
+    return {
+      data: pending.map((a) => ({
+        id: a.id,
+        agentId: a.agentId,
+        name: a.name,
+        level: a.level,
+        parentId: a.parentId,
+        createdAt: a.createdAt,
+      })),
+    };
+  }
+
+  /**
+   * Activate a pending agent
+   */
+  @Post(":id/activate")
+  async activate(
+    @CurrentAgent() actor: AuthenticatedAgent,
+    @Param("id") id: string,
+  ) {
+    const agent = await this.onboardingService.activateAgent(actor.orgId, actor.id, id);
+    return {
+      data: { id: agent.id, status: agent.status },
+      message: "Agent activated successfully",
+    };
+  }
+
+  /**
+   * Reject a pending agent
+   */
+  @Delete(":id/reject")
+  async reject(
+    @CurrentAgent() actor: AuthenticatedAgent,
+    @Param("id") id: string,
+    @Body() body: { reason?: string },
+  ) {
+    await this.onboardingService.rejectAgent(actor.orgId, actor.id, id, body.reason);
+    return { message: "Agent rejected" };
+  }
+
+  /**
+   * Get agent hierarchy
+   */
+  @Get(":id/hierarchy")
+  async getHierarchy(
+    @CurrentAgent() actor: AuthenticatedAgent,
+    @Param("id") id: string,
+    @Query("depth") depth?: string,
+  ) {
+    const hierarchy = await this.onboardingService.getHierarchy(
+      actor.orgId,
+      id,
+      depth ? parseInt(depth, 10) : 3,
+    );
+    return { data: hierarchy };
+  }
+
+  // ============ Budget Endpoints ============
+
+  /**
+   * Get budget status for an agent
+   */
+  @Get(":id/budget")
+  async getBudgetStatus(
+    @CurrentAgent() actor: AuthenticatedAgent,
+    @Param("id") id: string,
+  ) {
+    const status = await this.budgetService.getBudgetStatus(actor.orgId, id);
+    return { data: status };
+  }
+
+  /**
+   * Set budget for an agent
+   */
+  @Patch(":id/budget")
+  async setBudget(
+    @CurrentAgent() actor: AuthenticatedAgent,
+    @Param("id") id: string,
+    @Body() dto: SetBudgetDto,
+  ) {
+    const status = await this.budgetService.setBudget(actor.orgId, actor.id, id, dto);
+    return { data: status };
+  }
+
+  /**
+   * Transfer credits to another agent
+   */
+  @Post("credits/transfer")
+  async transferCredits(
+    @CurrentAgent() actor: AuthenticatedAgent,
+    @Body() dto: TransferCreditsDto,
+  ) {
+    const result = await this.budgetService.transferCredits(actor.orgId, actor.id, dto);
+    return { data: result };
+  }
+
+  /**
+   * Check if an agent can spend an amount
+   */
+  @Get(":id/budget/can-spend")
+  async canSpend(
+    @CurrentAgent() actor: AuthenticatedAgent,
+    @Param("id") id: string,
+    @Query("amount") amount: string,
+  ) {
+    const result = await this.budgetService.canSpend(
+      actor.orgId,
+      id,
+      parseInt(amount, 10),
+    );
+    return { data: result };
+  }
+
+  /**
+   * Get agents near budget limit
+   */
+  @Get("budget/alerts")
+  async getBudgetAlerts(@CurrentAgent() actor: AuthenticatedAgent) {
+    const alerts = await this.budgetService.getAgentsNearBudgetLimit(actor.orgId);
+    return { data: alerts };
   }
 }

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -1,17 +1,22 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
-import { Agent, AgentCapability } from "@openspawn/database";
+import { Agent, AgentCapability, CreditTransaction } from "@openspawn/database";
 
 import { EventsModule } from "../events";
 
 import { AgentsController } from "./agents.controller";
 import { AgentsService } from "./agents.service";
+import { AgentOnboardingService } from "./agent-onboarding.service";
+import { AgentBudgetService } from "./agent-budget.service";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Agent, AgentCapability]), EventsModule],
+  imports: [
+    TypeOrmModule.forFeature([Agent, AgentCapability, CreditTransaction]),
+    EventsModule,
+  ],
   controllers: [AgentsController],
-  providers: [AgentsService],
-  exports: [AgentsService, TypeOrmModule],
+  providers: [AgentsService, AgentOnboardingService, AgentBudgetService],
+  exports: [AgentsService, AgentOnboardingService, AgentBudgetService, TypeOrmModule],
 })
 export class AgentsModule {}

--- a/apps/api/src/agents/index.ts
+++ b/apps/api/src/agents/index.ts
@@ -1,2 +1,4 @@
 export { AgentsModule } from "./agents.module";
 export { AgentsService } from "./agents.service";
+export { AgentOnboardingService, type SpawnAgentDto } from "./agent-onboarding.service";
+export { AgentBudgetService, type SetBudgetDto, type TransferCreditsDto, type BudgetStatus } from "./agent-budget.service";

--- a/apps/dashboard/src/components/agent-onboarding.tsx
+++ b/apps/dashboard/src/components/agent-onboarding.tsx
@@ -1,0 +1,205 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  UserPlus,
+  Check,
+  X,
+  Clock,
+  Users,
+  Loader2,
+  ChevronRight,
+} from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
+import { Button } from "./ui/button";
+import { Badge } from "./ui/badge";
+
+interface PendingAgent {
+  id: string;
+  agentId: string;
+  name: string;
+  level: number;
+  parentId: string | null;
+  createdAt: string;
+}
+
+interface CapacityInfo {
+  canSpawn: boolean;
+  current: number;
+  max: number;
+  reason?: string;
+}
+
+// Mock data for demo
+const MOCK_PENDING: PendingAgent[] = [
+  {
+    id: "pending-1",
+    agentId: "analyst-01",
+    name: "Data Analyst",
+    level: 2,
+    parentId: "agent-1",
+    createdAt: new Date(Date.now() - 3600000).toISOString(),
+  },
+  {
+    id: "pending-2",
+    agentId: "writer-03",
+    name: "Content Writer",
+    level: 1,
+    parentId: "agent-2",
+    createdAt: new Date(Date.now() - 7200000).toISOString(),
+  },
+];
+
+const MOCK_CAPACITY: CapacityInfo = {
+  canSpawn: true,
+  current: 3,
+  max: 5,
+};
+
+export function AgentOnboarding() {
+  const [pending, setPending] = useState<PendingAgent[]>(MOCK_PENDING);
+  const [capacity] = useState<CapacityInfo>(MOCK_CAPACITY);
+  const [activating, setActivating] = useState<string | null>(null);
+  const [rejecting, setRejecting] = useState<string | null>(null);
+
+  const handleActivate = async (id: string) => {
+    setActivating(id);
+    // TODO: Implement API call
+    await new Promise((r) => setTimeout(r, 1000));
+    setPending(pending.filter((p) => p.id !== id));
+    setActivating(null);
+  };
+
+  const handleReject = async (id: string) => {
+    setRejecting(id);
+    // TODO: Implement API call
+    await new Promise((r) => setTimeout(r, 1000));
+    setPending(pending.filter((p) => p.id !== id));
+    setRejecting(null);
+  };
+
+  const formatTime = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    return date.toLocaleDateString();
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Capacity Card */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Users className="h-5 w-5 text-primary" />
+              <CardTitle>Spawn Capacity</CardTitle>
+            </div>
+            <Badge variant={capacity.canSpawn ? "default" : "destructive"}>
+              {capacity.current}/{capacity.max}
+            </Badge>
+          </div>
+          <CardDescription>
+            {capacity.canSpawn
+              ? `You can spawn ${capacity.max - capacity.current} more agents`
+              : capacity.reason || "At capacity"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="h-2 w-full rounded-full bg-secondary">
+            <motion.div
+              className="h-2 rounded-full bg-primary"
+              initial={{ width: 0 }}
+              animate={{ width: `${(capacity.current / capacity.max) * 100}%` }}
+              transition={{ duration: 0.5 }}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Pending Agents */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Clock className="h-5 w-5 text-amber-500" />
+            <CardTitle>Pending Activation</CardTitle>
+          </div>
+          <CardDescription>
+            {pending.length} agent{pending.length !== 1 ? "s" : ""} awaiting your approval
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {pending.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-center">
+              <Check className="h-12 w-12 text-green-500/50 mb-4" />
+              <p className="text-muted-foreground">No pending agents</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <AnimatePresence mode="popLayout">
+                {pending.map((agent) => (
+                  <motion.div
+                    key={agent.id}
+                    layout
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, x: -100 }}
+                    className="flex items-center justify-between rounded-lg border border-border p-4"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-500/10">
+                        <UserPlus className="h-5 w-5 text-amber-500" />
+                      </div>
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">{agent.name}</span>
+                          <Badge variant="outline" className="text-xs">
+                            L{agent.level}
+                          </Badge>
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          {agent.agentId} · {formatTime(agent.createdAt)}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                        onClick={() => handleReject(agent.id)}
+                        disabled={rejecting === agent.id || activating === agent.id}
+                      >
+                        {rejecting === agent.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <X className="h-4 w-4" />
+                        )}
+                      </Button>
+                      <Button
+                        size="sm"
+                        onClick={() => handleActivate(agent.id)}
+                        disabled={activating === agent.id || rejecting === agent.id}
+                      >
+                        {activating === agent.id ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                          <Check className="mr-2 h-4 w-4" />
+                        )}
+                        Activate
+                      </Button>
+                    </div>
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/budget-manager.tsx
+++ b/apps/dashboard/src/components/budget-manager.tsx
@@ -1,0 +1,277 @@
+import { useState } from "react";
+import { motion } from "framer-motion";
+import {
+  Wallet,
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  ArrowRight,
+  Loader2,
+} from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
+import { Button } from "./ui/button";
+import { Badge } from "./ui/badge";
+import { Dialog, DialogPopup, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogTrigger } from "./ui/dialog";
+
+interface BudgetStatus {
+  agentId: string;
+  agentName: string;
+  currentBalance: number;
+  budgetPeriodLimit: number | null;
+  budgetPeriodSpent: number;
+  budgetRemaining: number | null;
+  utilizationPercent: number | null;
+}
+
+// Mock data
+const MOCK_BUDGETS: BudgetStatus[] = [
+  {
+    agentId: "agent-1",
+    agentName: "Research Lead",
+    currentBalance: 5000,
+    budgetPeriodLimit: 10000,
+    budgetPeriodSpent: 8500,
+    budgetRemaining: 1500,
+    utilizationPercent: 85,
+  },
+  {
+    agentId: "agent-2",
+    agentName: "Content Manager",
+    currentBalance: 3200,
+    budgetPeriodLimit: 5000,
+    budgetPeriodSpent: 4800,
+    budgetRemaining: 200,
+    utilizationPercent: 96,
+  },
+  {
+    agentId: "agent-3",
+    agentName: "Data Analyst",
+    currentBalance: 1500,
+    budgetPeriodLimit: 3000,
+    budgetPeriodSpent: 1200,
+    budgetRemaining: 1800,
+    utilizationPercent: 40,
+  },
+];
+
+export function BudgetManager() {
+  const [budgets] = useState<BudgetStatus[]>(MOCK_BUDGETS);
+  const [showTransfer, setShowTransfer] = useState(false);
+  const [transferring, setTransferring] = useState(false);
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  const [transferAmount, setTransferAmount] = useState("");
+  const [targetAgent, setTargetAgent] = useState("");
+
+  const alertBudgets = budgets.filter((b) => (b.utilizationPercent || 0) >= 80);
+  const healthyBudgets = budgets.filter((b) => (b.utilizationPercent || 0) < 80);
+
+  const handleTransfer = async () => {
+    setTransferring(true);
+    // TODO: Implement API call
+    await new Promise((r) => setTimeout(r, 1000));
+    setTransferring(false);
+    setShowTransfer(false);
+    setTransferAmount("");
+    setTargetAgent("");
+  };
+
+  const getUtilizationColor = (percent: number | null) => {
+    if (percent === null) return "bg-muted";
+    if (percent >= 90) return "bg-red-500";
+    if (percent >= 80) return "bg-amber-500";
+    if (percent >= 60) return "bg-yellow-500";
+    return "bg-green-500";
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Budget Alerts */}
+      {alertBudgets.length > 0 && (
+        <Card className="border-amber-500/50">
+          <CardHeader className="pb-3">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-500" />
+              <CardTitle className="text-amber-500">Budget Alerts</CardTitle>
+            </div>
+            <CardDescription>
+              {alertBudgets.length} agent{alertBudgets.length !== 1 ? "s" : ""} approaching budget limit
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {alertBudgets.map((budget) => (
+                <motion.div
+                  key={budget.agentId}
+                  initial={{ opacity: 0, x: -10 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  className="flex items-center justify-between rounded-lg border border-amber-500/30 bg-amber-500/5 p-3"
+                >
+                  <div>
+                    <p className="font-medium">{budget.agentName}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {budget.budgetRemaining?.toLocaleString()} credits remaining
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Badge
+                      variant="outline"
+                      className={budget.utilizationPercent! >= 90 ? "border-red-500 text-red-500" : "border-amber-500 text-amber-500"}
+                    >
+                      {budget.utilizationPercent}% used
+                    </Badge>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setSelectedAgent(budget.agentId);
+                        setShowTransfer(true);
+                      }}
+                    >
+                      <Wallet className="mr-2 h-4 w-4" />
+                      Top Up
+                    </Button>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* All Budgets */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Wallet className="h-5 w-5 text-primary" />
+              <CardTitle>Budget Overview</CardTitle>
+            </div>
+            <Dialog open={showTransfer} onOpenChange={setShowTransfer}>
+              <DialogTrigger asChild>
+                <Button variant="outline" size="sm">
+                  <ArrowRight className="mr-2 h-4 w-4" />
+                  Transfer Credits
+                </Button>
+              </DialogTrigger>
+              <DialogPopup>
+                <DialogHeader>
+                  <DialogTitle>Transfer Credits</DialogTitle>
+                  <DialogDescription>
+                    Move credits between agents in your hierarchy
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4 py-4">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">From Agent</label>
+                    <select
+                      value={selectedAgent || ""}
+                      onChange={(e) => setSelectedAgent(e.target.value)}
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    >
+                      <option value="">Select agent...</option>
+                      {budgets.map((b) => (
+                        <option key={b.agentId} value={b.agentId}>
+                          {b.agentName} ({b.currentBalance.toLocaleString()} available)
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">To Agent</label>
+                    <select
+                      value={targetAgent}
+                      onChange={(e) => setTargetAgent(e.target.value)}
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    >
+                      <option value="">Select agent...</option>
+                      {budgets
+                        .filter((b) => b.agentId !== selectedAgent)
+                        .map((b) => (
+                          <option key={b.agentId} value={b.agentId}>
+                            {b.agentName}
+                          </option>
+                        ))}
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Amount</label>
+                    <input
+                      type="number"
+                      value={transferAmount}
+                      onChange={(e) => setTransferAmount(e.target.value)}
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                      placeholder="Enter amount..."
+                    />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setShowTransfer(false)}>
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleTransfer}
+                    disabled={!selectedAgent || !targetAgent || !transferAmount || transferring}
+                  >
+                    {transferring ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <ArrowRight className="mr-2 h-4 w-4" />
+                    )}
+                    Transfer
+                  </Button>
+                </DialogFooter>
+              </DialogPopup>
+            </Dialog>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {budgets.map((budget) => (
+              <div key={budget.agentId} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{budget.agentName}</span>
+                    {budget.utilizationPercent !== null && (
+                      <Badge
+                        variant="outline"
+                        className={
+                          budget.utilizationPercent >= 80
+                            ? "border-amber-500 text-amber-500"
+                            : ""
+                        }
+                      >
+                        {budget.utilizationPercent}%
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-4 text-sm">
+                    <span className="flex items-center gap-1 text-green-500">
+                      <TrendingUp className="h-3 w-3" />
+                      {budget.currentBalance.toLocaleString()}
+                    </span>
+                    {budget.budgetPeriodLimit && (
+                      <span className="flex items-center gap-1 text-muted-foreground">
+                        <TrendingDown className="h-3 w-3" />
+                        {budget.budgetPeriodSpent.toLocaleString()}/{budget.budgetPeriodLimit.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                {budget.budgetPeriodLimit && (
+                  <div className="h-2 w-full rounded-full bg-secondary">
+                    <motion.div
+                      className={`h-2 rounded-full ${getUtilizationColor(budget.utilizationPercent)}`}
+                      initial={{ width: 0 }}
+                      animate={{ width: `${budget.utilizationPercent}%` }}
+                      transition={{ duration: 0.5 }}
+                    />
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/index.ts
+++ b/apps/dashboard/src/components/index.ts
@@ -2,3 +2,5 @@ export * from "./layout";
 export * from "./protected-route";
 export * from "./theme-provider";
 export * from "./theme-toggle";
+export * from "./agent-onboarding";
+export * from "./budget-manager";

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -1,6 +1,6 @@
-import { useState, useMemo, useRef, useEffect } from "react";
+import { useState, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Bot, MoreVertical, Plus, Coins, Edit, Eye, Ban, Filter, ArrowUpDown, Search } from "lucide-react";
+import { Bot, MoreVertical, Plus, Coins, Edit, Eye, Ban, Filter, ArrowUpDown, Search, Users, Wallet } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
@@ -21,7 +21,10 @@ import {
   DialogDescription,
   DialogClose,
 } from "../components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs";
 import { useAgents } from "../hooks/use-agents";
+import { AgentOnboarding } from "../components/agent-onboarding";
+import { BudgetManager } from "../components/budget-manager";
 
 interface Agent {
   id: string;
@@ -313,6 +316,7 @@ export function AgentsPage() {
   const { agents, loading, error } = useAgents();
   const [selectedAgent, setSelectedAgent] = useState<Agent | null>(null);
   const [dialogMode, setDialogMode] = useState<DialogMode>(null);
+  const [activeTab, setActiveTab] = useState("agents");
   
   // Filtering state
   const [searchQuery, setSearchQuery] = useState("");
@@ -415,15 +419,36 @@ export function AgentsPage() {
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Agents</h1>
           <p className="text-muted-foreground">
-            Manage your AI agents and their permissions
+            Manage your AI agents, onboarding, and budgets
           </p>
         </div>
         <Button>
           <Plus className="mr-2 h-4 w-4" />
-          Register Agent
+          Spawn Agent
         </Button>
       </div>
 
+      {/* Navigation Tabs */}
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="grid w-full grid-cols-3 lg:w-[400px]">
+          <TabsTrigger value="agents" className="flex items-center gap-2">
+            <Bot className="h-4 w-4" />
+            <span className="hidden sm:inline">All Agents</span>
+            <span className="sm:hidden">Agents</span>
+          </TabsTrigger>
+          <TabsTrigger value="onboarding" className="flex items-center gap-2">
+            <Users className="h-4 w-4" />
+            <span className="hidden sm:inline">Onboarding</span>
+            <span className="sm:hidden">Onboard</span>
+          </TabsTrigger>
+          <TabsTrigger value="budgets" className="flex items-center gap-2">
+            <Wallet className="h-4 w-4" />
+            Budgets
+          </TabsTrigger>
+        </TabsList>
+
+        {/* All Agents Tab */}
+        <TabsContent value="agents" className="space-y-6">
       {/* Filters and Search */}
       <div className="flex flex-wrap gap-3 items-center">
         {/* Search */}
@@ -683,6 +708,18 @@ export function AgentsPage() {
       {selectedAgent && dialogMode === "credits" && (
         <AdjustCreditsDialog agent={selectedAgent} onClose={handleCloseDialog} />
       )}
+        </TabsContent>
+
+        {/* Onboarding Tab */}
+        <TabsContent value="onboarding" className="space-y-6">
+          <AgentOnboarding />
+        </TabsContent>
+
+        {/* Budgets Tab */}
+        <TabsContent value="budgets" className="space-y-6">
+          <BudgetManager />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/libs/database/src/entities/agent.entity.ts
+++ b/libs/database/src/entities/agent.entity.ts
@@ -66,6 +66,12 @@ export class Agent {
   @Column({ name: "hmac_secret_enc", type: "bytea" })
   hmacSecretEnc!: Buffer;
 
+  @Column({ name: "parent_id", type: "uuid", nullable: true })
+  parentId!: string | null;
+
+  @Column({ name: "max_children", type: "smallint", default: 0 })
+  maxChildren!: number;
+
   @Column({ type: "jsonb", default: {} })
   metadata!: Record<string, unknown>;
 
@@ -82,6 +88,13 @@ export class Agent {
   @ManyToOne("Organization", "agents")
   @JoinColumn({ name: "org_id" })
   organization?: Organization;
+
+  @ManyToOne("Agent", "children")
+  @JoinColumn({ name: "parent_id" })
+  parent?: Agent;
+
+  @OneToMany("Agent", "parent")
+  children?: Agent[];
 
   @OneToMany("AgentCapability", "agent")
   capabilities?: AgentCapability[];

--- a/libs/demo-data/src/types.ts
+++ b/libs/demo-data/src/types.ts
@@ -18,8 +18,11 @@ export interface DemoAgent {
   currentBalance: number;
   lifetimeEarnings: number;
   createdAt: string;
-  parentId?: string; // Who spawned this agent
-  domain?: string;   // e.g., "Engineering", "Finance"
+  parentId?: string;          // Who spawned this agent
+  domain?: string;            // e.g., "Engineering", "Finance"
+  maxChildren?: number;       // Capacity for sub-agents
+  budgetPeriodLimit?: number; // Per-period spending limit
+  budgetPeriodSpent?: number; // Spent this period
 }
 
 export interface DemoTask {

--- a/libs/shared-types/src/enums/agent-status.enum.ts
+++ b/libs/shared-types/src/enums/agent-status.enum.ts
@@ -1,5 +1,6 @@
 export enum AgentStatus {
-  ACTIVE = "active",
-  SUSPENDED = "suspended",
-  REVOKED = "revoked",
+  PENDING = "pending",      // Awaiting activation by parent/L10
+  ACTIVE = "active",        // Fully operational
+  SUSPENDED = "suspended",  // Temporarily disabled
+  REVOKED = "revoked",      // Permanently disabled
 }


### PR DESCRIPTION
## Phase 2.1 — Agent Onboarding & Budget Management

### Agent Hierarchy
- Added `PENDING` status to AgentStatus enum
- Added `parentId` and `maxChildren` to Agent entity
- Parent-child relationships for hierarchical management

### Capacity Limits
| Level | Max Children |
|-------|--------------|
| L10 | 100 |
| L9 | 50 |
| L7-8 | 12-20 |
| L5-6 | 5-8 |
| L3-4 | 2-3 |
| L1-2 | 0 |

### AgentOnboardingService
- `spawnAgent`: Create child in PENDING status
- `activateAgent`: Parent or L10 activates
- `rejectAgent`: Soft-delete pending agent
- `canSpawnChild`: Check capacity
- `getHierarchy`: Get agent tree

### AgentBudgetService
- `getBudgetStatus`: Balance, limits, utilization %
- `setBudget`: Set period limits
- `transferCredits`: Move credits in hierarchy
- `canSpend`: Pre-check spending
- `getAgentsNearBudgetLimit`: >80% alerts

### Dashboard
- AgentOnboarding component
- BudgetManager component
- New tabs on Agents page