### PR TITLE
feat(phase2): Capability Management & Matching

### DIFF
--- a/apps/api/src/agents/agent-capabilities.service.ts
+++ b/apps/api/src/agents/agent-capabilities.service.ts
@@ -1,0 +1,430 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository, In } from "typeorm";
+
+import { Agent, AgentCapability } from "@openspawn/database";
+import { AgentStatus, Proficiency } from "@openspawn/shared-types";
+
+import { EventsService } from "../events";
+
+export interface AddCapabilityDto {
+  capability: string;
+  proficiency?: Proficiency;
+}
+
+export interface UpdateCapabilityDto {
+  proficiency: Proficiency;
+}
+
+export interface CapabilityMatch {
+  agentId: string;
+  agentName: string;
+  level: number;
+  status: AgentStatus;
+  capability: string;
+  proficiency: Proficiency;
+  score: number; // Match score based on proficiency
+}
+
+// Proficiency score weights for matching
+const PROFICIENCY_SCORES: Record<Proficiency, number> = {
+  [Proficiency.BASIC]: 1,
+  [Proficiency.STANDARD]: 2,
+  [Proficiency.EXPERT]: 3,
+};
+
+@Injectable()
+export class AgentCapabilitiesService {
+  constructor(
+    @InjectRepository(Agent)
+    private readonly agentRepository: Repository<Agent>,
+    @InjectRepository(AgentCapability)
+    private readonly capabilityRepository: Repository<AgentCapability>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  /**
+   * Get all capabilities for an agent
+   */
+  async getAgentCapabilities(orgId: string, agentId: string): Promise<AgentCapability[]> {
+    return this.capabilityRepository.find({
+      where: { orgId, agentId },
+      order: { capability: "ASC" },
+    });
+  }
+
+  /**
+   * Add a capability to an agent
+   */
+  async addCapability(
+    orgId: string,
+    actorId: string,
+    agentId: string,
+    dto: AddCapabilityDto,
+  ): Promise<AgentCapability> {
+    // Verify authorization: self, parent, or L10
+    const [actor, agent] = await Promise.all([
+      this.agentRepository.findOne({ where: { id: actorId } }),
+      this.agentRepository.findOne({ where: { id: agentId, orgId } }),
+    ]);
+
+    if (!actor) {
+      throw new ForbiddenException("Actor not found");
+    }
+
+    if (!agent) {
+      throw new NotFoundException("Agent not found");
+    }
+
+    const isSelf = actorId === agentId;
+    const isParent = agent.parentId === actorId;
+    const isL10 = actor.level === 10;
+
+    if (!isSelf && !isParent && !isL10) {
+      throw new ForbiddenException(
+        "Only the agent, their parent, or L10 can modify capabilities"
+      );
+    }
+
+    // Normalize capability name
+    const capability = dto.capability.toLowerCase().trim();
+
+    // Check if capability already exists
+    const existing = await this.capabilityRepository.findOne({
+      where: { orgId, agentId, capability },
+    });
+
+    if (existing) {
+      throw new BadRequestException(`Agent already has capability: ${capability}`);
+    }
+
+    const cap = this.capabilityRepository.create({
+      orgId,
+      agentId,
+      capability,
+      proficiency: dto.proficiency || Proficiency.STANDARD,
+    });
+
+    const saved = await this.capabilityRepository.save(cap);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "agent.capability_added",
+      actorId,
+      entityType: "agent",
+      entityId: agentId,
+      data: {
+        capability: saved.capability,
+        proficiency: saved.proficiency,
+      },
+    });
+
+    return saved;
+  }
+
+  /**
+   * Update a capability's proficiency level
+   */
+  async updateCapability(
+    orgId: string,
+    actorId: string,
+    capabilityId: string,
+    dto: UpdateCapabilityDto,
+  ): Promise<AgentCapability> {
+    const cap = await this.capabilityRepository.findOne({
+      where: { id: capabilityId, orgId },
+    });
+
+    if (!cap) {
+      throw new NotFoundException("Capability not found");
+    }
+
+    // Verify authorization
+    const [actor, agent] = await Promise.all([
+      this.agentRepository.findOne({ where: { id: actorId } }),
+      this.agentRepository.findOne({ where: { id: cap.agentId, orgId } }),
+    ]);
+
+    if (!actor || !agent) {
+      throw new ForbiddenException("Actor or agent not found");
+    }
+
+    const isSelf = actorId === cap.agentId;
+    const isParent = agent.parentId === actorId;
+    const isL10 = actor.level === 10;
+
+    if (!isSelf && !isParent && !isL10) {
+      throw new ForbiddenException("Insufficient permissions");
+    }
+
+    const oldProficiency = cap.proficiency;
+    cap.proficiency = dto.proficiency;
+    const saved = await this.capabilityRepository.save(cap);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "agent.capability_updated",
+      actorId,
+      entityType: "agent",
+      entityId: cap.agentId,
+      data: {
+        capability: cap.capability,
+        oldProficiency,
+        newProficiency: dto.proficiency,
+      },
+    });
+
+    return saved;
+  }
+
+  /**
+   * Remove a capability from an agent
+   */
+  async removeCapability(
+    orgId: string,
+    actorId: string,
+    capabilityId: string,
+  ): Promise<void> {
+    const cap = await this.capabilityRepository.findOne({
+      where: { id: capabilityId, orgId },
+    });
+
+    if (!cap) {
+      throw new NotFoundException("Capability not found");
+    }
+
+    // Verify authorization
+    const [actor, agent] = await Promise.all([
+      this.agentRepository.findOne({ where: { id: actorId } }),
+      this.agentRepository.findOne({ where: { id: cap.agentId, orgId } }),
+    ]);
+
+    if (!actor || !agent) {
+      throw new ForbiddenException("Actor or agent not found");
+    }
+
+    const isParent = agent.parentId === actorId;
+    const isL10 = actor.level === 10;
+
+    // Self can't remove their own capabilities (only parent/L10 can)
+    if (!isParent && !isL10) {
+      throw new ForbiddenException("Only parent or L10 can remove capabilities");
+    }
+
+    await this.capabilityRepository.delete(capabilityId);
+
+    await this.eventsService.emit({
+      orgId,
+      type: "agent.capability_removed",
+      actorId,
+      entityType: "agent",
+      entityId: cap.agentId,
+      data: {
+        capability: cap.capability,
+      },
+    });
+  }
+
+  /**
+   * Find agents with specific capabilities
+   * Returns agents sorted by match score (best matches first)
+   */
+  async findAgentsWithCapabilities(
+    orgId: string,
+    requiredCapabilities: string[],
+    options?: {
+      minProficiency?: Proficiency;
+      onlyActive?: boolean;
+      excludeAgentIds?: string[];
+    },
+  ): Promise<CapabilityMatch[]> {
+    const normalized = requiredCapabilities.map((c) => c.toLowerCase().trim());
+
+    // Find all matching capabilities
+    const caps = await this.capabilityRepository.find({
+      where: {
+        orgId,
+        capability: In(normalized),
+      },
+    });
+
+    // Get unique agent IDs
+    const agentIds = [...new Set(caps.map((c) => c.agentId))];
+
+    if (agentIds.length === 0) {
+      return [];
+    }
+
+    // Get agent details
+    const agents = await this.agentRepository.find({
+      where: { id: In(agentIds), orgId },
+    });
+
+    const agentMap = new Map(agents.map((a) => [a.id, a]));
+
+    // Filter and score
+    const results: CapabilityMatch[] = [];
+
+    for (const cap of caps) {
+      const agent = agentMap.get(cap.agentId);
+      if (!agent) continue;
+
+      // Filter by status
+      if (options?.onlyActive && agent.status !== AgentStatus.ACTIVE) {
+        continue;
+      }
+
+      // Filter excluded agents
+      if (options?.excludeAgentIds?.includes(cap.agentId)) {
+        continue;
+      }
+
+      // Filter by min proficiency
+      if (options?.minProficiency) {
+        const minScore = PROFICIENCY_SCORES[options.minProficiency];
+        const capScore = PROFICIENCY_SCORES[cap.proficiency];
+        if (capScore < minScore) {
+          continue;
+        }
+      }
+
+      results.push({
+        agentId: agent.id,
+        agentName: agent.name,
+        level: agent.level,
+        status: agent.status as AgentStatus,
+        capability: cap.capability,
+        proficiency: cap.proficiency,
+        score: PROFICIENCY_SCORES[cap.proficiency],
+      });
+    }
+
+    // Sort by score (descending), then level (descending)
+    return results.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return b.level - a.level;
+    });
+  }
+
+  /**
+   * Get the best agent match for a set of required capabilities
+   * Returns the agent that best covers all requirements
+   */
+  async findBestMatch(
+    orgId: string,
+    requiredCapabilities: string[],
+    options?: {
+      minProficiency?: Proficiency;
+      onlyActive?: boolean;
+      excludeAgentIds?: string[];
+    },
+  ): Promise<{
+    agentId: string;
+    agentName: string;
+    level: number;
+    matchedCapabilities: { capability: string; proficiency: Proficiency }[];
+    coveragePercent: number;
+    totalScore: number;
+  } | null> {
+    const matches = await this.findAgentsWithCapabilities(
+      orgId,
+      requiredCapabilities,
+      options,
+    );
+
+    if (matches.length === 0) {
+      return null;
+    }
+
+    // Group by agent and calculate coverage
+    const agentScores = new Map<
+      string,
+      {
+        agent: { id: string; name: string; level: number };
+        capabilities: { capability: string; proficiency: Proficiency }[];
+        totalScore: number;
+      }
+    >();
+
+    for (const match of matches) {
+      const existing = agentScores.get(match.agentId);
+      if (existing) {
+        existing.capabilities.push({
+          capability: match.capability,
+          proficiency: match.proficiency,
+        });
+        existing.totalScore += match.score;
+      } else {
+        agentScores.set(match.agentId, {
+          agent: {
+            id: match.agentId,
+            name: match.agentName,
+            level: match.level,
+          },
+          capabilities: [
+            { capability: match.capability, proficiency: match.proficiency },
+          ],
+          totalScore: match.score,
+        });
+      }
+    }
+
+    // Find best coverage
+    let best: {
+      agentId: string;
+      agentName: string;
+      level: number;
+      matchedCapabilities: { capability: string; proficiency: Proficiency }[];
+      coveragePercent: number;
+      totalScore: number;
+    } | null = null;
+
+    for (const [agentId, data] of agentScores) {
+      const coveragePercent = Math.round(
+        (data.capabilities.length / requiredCapabilities.length) * 100
+      );
+
+      if (
+        !best ||
+        coveragePercent > best.coveragePercent ||
+        (coveragePercent === best.coveragePercent &&
+          data.totalScore > best.totalScore)
+      ) {
+        best = {
+          agentId,
+          agentName: data.agent.name,
+          level: data.agent.level,
+          matchedCapabilities: data.capabilities,
+          coveragePercent,
+          totalScore: data.totalScore,
+        };
+      }
+    }
+
+    return best;
+  }
+
+  /**
+   * Get all unique capabilities in the organization
+   */
+  async getOrgCapabilities(orgId: string): Promise<{ capability: string; count: number }[]> {
+    const result = await this.capabilityRepository
+      .createQueryBuilder("cap")
+      .select("cap.capability", "capability")
+      .addSelect("COUNT(*)", "count")
+      .where("cap.org_id = :orgId", { orgId })
+      .groupBy("cap.capability")
+      .orderBy("count", "DESC")
+      .getRawMany();
+
+    return result.map((r) => ({
+      capability: r.capability,
+      count: parseInt(r.count, 10),
+    }));
+  }
+}

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -9,6 +9,7 @@ import { AgentsController } from "./agents.controller";
 import { AgentsService } from "./agents.service";
 import { AgentOnboardingService } from "./agent-onboarding.service";
 import { AgentBudgetService } from "./agent-budget.service";
+import { AgentCapabilitiesService } from "./agent-capabilities.service";
 
 @Module({
   imports: [
@@ -16,7 +17,7 @@ import { AgentBudgetService } from "./agent-budget.service";
     EventsModule,
   ],
   controllers: [AgentsController],
-  providers: [AgentsService, AgentOnboardingService, AgentBudgetService],
-  exports: [AgentsService, AgentOnboardingService, AgentBudgetService, TypeOrmModule],
+  providers: [AgentsService, AgentOnboardingService, AgentBudgetService, AgentCapabilitiesService],
+  exports: [AgentsService, AgentOnboardingService, AgentBudgetService, AgentCapabilitiesService, TypeOrmModule],
 })
 export class AgentsModule {}

--- a/apps/api/src/agents/index.ts
+++ b/apps/api/src/agents/index.ts
@@ -2,3 +2,4 @@ export { AgentsModule } from "./agents.module";
 export { AgentsService } from "./agents.service";
 export { AgentOnboardingService, type SpawnAgentDto } from "./agent-onboarding.service";
 export { AgentBudgetService, type SetBudgetDto, type TransferCreditsDto, type BudgetStatus } from "./agent-budget.service";
+export { AgentCapabilitiesService, type AddCapabilityDto, type UpdateCapabilityDto, type CapabilityMatch } from "./agent-capabilities.service";

--- a/apps/dashboard/src/components/capability-manager.tsx
+++ b/apps/dashboard/src/components/capability-manager.tsx
@@ -1,0 +1,363 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  Zap,
+  Plus,
+  Trash2,
+  Search,
+  TrendingUp,
+  Users,
+  Loader2,
+  Star,
+} from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
+import { Button } from "./ui/button";
+import { Badge } from "./ui/badge";
+import { Dialog, DialogPopup, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogTrigger } from "./ui/dialog";
+
+type Proficiency = "basic" | "standard" | "expert";
+
+interface Capability {
+  id: string;
+  capability: string;
+  proficiency: Proficiency;
+  agentId: string;
+}
+
+interface OrgCapability {
+  capability: string;
+  count: number;
+}
+
+interface CapabilityMatch {
+  agentId: string;
+  agentName: string;
+  level: number;
+  capability: string;
+  proficiency: Proficiency;
+  score: number;
+}
+
+// Mock data
+const MOCK_ORG_CAPABILITIES: OrgCapability[] = [
+  { capability: "code-review", count: 5 },
+  { capability: "data-analysis", count: 4 },
+  { capability: "writing", count: 6 },
+  { capability: "research", count: 3 },
+  { capability: "testing", count: 4 },
+  { capability: "debugging", count: 3 },
+  { capability: "documentation", count: 2 },
+];
+
+const MOCK_AGENT_CAPABILITIES: Capability[] = [
+  { id: "cap-1", capability: "code-review", proficiency: "expert", agentId: "agent-1" },
+  { id: "cap-2", capability: "debugging", proficiency: "standard", agentId: "agent-1" },
+  { id: "cap-3", capability: "testing", proficiency: "basic", agentId: "agent-1" },
+];
+
+const MOCK_MATCHES: CapabilityMatch[] = [
+  { agentId: "agent-1", agentName: "Code Reviewer", level: 6, capability: "code-review", proficiency: "expert", score: 3 },
+  { agentId: "agent-2", agentName: "Senior Dev", level: 5, capability: "code-review", proficiency: "standard", score: 2 },
+  { agentId: "agent-3", agentName: "Bug Hunter", level: 4, capability: "code-review", proficiency: "basic", score: 1 },
+];
+
+const proficiencyColors: Record<Proficiency, string> = {
+  basic: "bg-gray-500",
+  standard: "bg-blue-500",
+  expert: "bg-purple-500",
+};
+
+const proficiencyLabels: Record<Proficiency, string> = {
+  basic: "Basic",
+  standard: "Standard",
+  expert: "Expert",
+};
+
+export function CapabilityManager({ agentId }: { agentId?: string }) {
+  const [orgCapabilities] = useState<OrgCapability[]>(MOCK_ORG_CAPABILITIES);
+  const [agentCapabilities, setAgentCapabilities] = useState<Capability[]>(MOCK_AGENT_CAPABILITIES);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showAddDialog, setShowAddDialog] = useState(false);
+  const [showMatchDialog, setShowMatchDialog] = useState(false);
+  const [newCapability, setNewCapability] = useState("");
+  const [newProficiency, setNewProficiency] = useState<Proficiency>("standard");
+  const [matchQuery, setMatchQuery] = useState("");
+  const [matches, setMatches] = useState<CapabilityMatch[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [removing, setRemoving] = useState<string | null>(null);
+
+  const filteredOrgCaps = orgCapabilities.filter((c) =>
+    c.capability.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const handleAddCapability = async () => {
+    if (!newCapability.trim()) return;
+    
+    // TODO: Implement API call
+    const newCap: Capability = {
+      id: `cap-${Date.now()}`,
+      capability: newCapability.toLowerCase().trim(),
+      proficiency: newProficiency,
+      agentId: agentId || "agent-1",
+    };
+    
+    setAgentCapabilities([...agentCapabilities, newCap]);
+    setNewCapability("");
+    setNewProficiency("standard");
+    setShowAddDialog(false);
+  };
+
+  const handleRemoveCapability = async (id: string) => {
+    setRemoving(id);
+    // TODO: Implement API call
+    await new Promise((r) => setTimeout(r, 500));
+    setAgentCapabilities(agentCapabilities.filter((c) => c.id !== id));
+    setRemoving(null);
+  };
+
+  const handleSearch = async () => {
+    if (!matchQuery.trim()) return;
+    
+    setSearching(true);
+    // TODO: Implement API call
+    await new Promise((r) => setTimeout(r, 800));
+    setMatches(MOCK_MATCHES);
+    setSearching(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Organization Capabilities Overview */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Zap className="h-5 w-5 text-primary" />
+              <CardTitle>Organization Capabilities</CardTitle>
+            </div>
+            <Dialog open={showMatchDialog} onOpenChange={setShowMatchDialog}>
+              <DialogTrigger asChild>
+                <Button variant="outline" size="sm">
+                  <Search className="mr-2 h-4 w-4" />
+                  Find Agents
+                </Button>
+              </DialogTrigger>
+              <DialogPopup>
+                <DialogHeader>
+                  <DialogTitle>Find Agents by Capabilities</DialogTitle>
+                  <DialogDescription>
+                    Search for agents that match required capabilities
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4 py-4">
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={matchQuery}
+                      onChange={(e) => setMatchQuery(e.target.value)}
+                      placeholder="e.g., code-review, testing"
+                      className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    />
+                    <Button onClick={handleSearch} disabled={searching}>
+                      {searching ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Search className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                  
+                  {matches.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-sm text-muted-foreground">
+                        Found {matches.length} matching agent{matches.length !== 1 ? "s" : ""}
+                      </p>
+                      {matches.map((match) => (
+                        <div
+                          key={`${match.agentId}-${match.capability}`}
+                          className="flex items-center justify-between rounded-lg border border-border p-3"
+                        >
+                          <div className="flex items-center gap-3">
+                            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
+                              <span className="text-xs font-bold">L{match.level}</span>
+                            </div>
+                            <div>
+                              <p className="font-medium">{match.agentName}</p>
+                              <div className="flex items-center gap-2">
+                                <Badge variant="outline">{match.capability}</Badge>
+                                <Badge className={proficiencyColors[match.proficiency]}>
+                                  {proficiencyLabels[match.proficiency]}
+                                </Badge>
+                              </div>
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            {Array.from({ length: match.score }).map((_, i) => (
+                              <Star key={i} className="h-4 w-4 fill-yellow-500 text-yellow-500" />
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setShowMatchDialog(false)}>
+                    Close
+                  </Button>
+                </DialogFooter>
+              </DialogPopup>
+            </Dialog>
+          </div>
+          <CardDescription>
+            {orgCapabilities.length} unique capabilities across your agents
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="relative mb-4">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Filter capabilities..."
+              className="w-full pl-9 pr-3 py-2 rounded-md border border-input bg-background text-sm"
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {filteredOrgCaps.map((cap) => (
+              <motion.div
+                key={cap.capability}
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                className="flex items-center gap-2 rounded-full border border-border px-3 py-1.5"
+              >
+                <Zap className="h-3 w-3 text-primary" />
+                <span className="text-sm font-medium">{cap.capability}</span>
+                <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <Users className="h-3 w-3" />
+                  {cap.count}
+                </span>
+              </motion.div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Agent Capabilities (if viewing specific agent) */}
+      {agentId && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <TrendingUp className="h-5 w-5 text-green-500" />
+                <CardTitle>Agent Capabilities</CardTitle>
+              </div>
+              <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
+                <DialogTrigger asChild>
+                  <Button size="sm">
+                    <Plus className="mr-2 h-4 w-4" />
+                    Add Capability
+                  </Button>
+                </DialogTrigger>
+                <DialogPopup>
+                  <DialogHeader>
+                    <DialogTitle>Add Capability</DialogTitle>
+                    <DialogDescription>
+                      Add a new capability to this agent
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="space-y-4 py-4">
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium">Capability</label>
+                      <input
+                        type="text"
+                        value={newCapability}
+                        onChange={(e) => setNewCapability(e.target.value)}
+                        placeholder="e.g., code-review, data-analysis"
+                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium">Proficiency</label>
+                      <div className="flex gap-2">
+                        {(["basic", "standard", "expert"] as Proficiency[]).map((p) => (
+                          <Button
+                            key={p}
+                            variant={newProficiency === p ? "default" : "outline"}
+                            size="sm"
+                            onClick={() => setNewProficiency(p)}
+                            className="flex-1 capitalize"
+                          >
+                            {p}
+                          </Button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                  <DialogFooter>
+                    <Button variant="outline" onClick={() => setShowAddDialog(false)}>
+                      Cancel
+                    </Button>
+                    <Button onClick={handleAddCapability} disabled={!newCapability.trim()}>
+                      Add Capability
+                    </Button>
+                  </DialogFooter>
+                </DialogPopup>
+              </Dialog>
+            </div>
+            <CardDescription>
+              {agentCapabilities.length} capabilities assigned
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {agentCapabilities.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-8 text-center">
+                <Zap className="h-12 w-12 text-muted-foreground/50 mb-4" />
+                <p className="text-muted-foreground">No capabilities assigned yet</p>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <AnimatePresence mode="popLayout">
+                  {agentCapabilities.map((cap) => (
+                    <motion.div
+                      key={cap.id}
+                      layout
+                      initial={{ opacity: 0, x: -10 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: 10 }}
+                      className="flex items-center justify-between rounded-lg border border-border p-3"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Zap className="h-5 w-5 text-primary" />
+                        <div>
+                          <p className="font-medium">{cap.capability}</p>
+                          <Badge className={`${proficiencyColors[cap.proficiency]} text-white`}>
+                            {proficiencyLabels[cap.proficiency]}
+                          </Badge>
+                        </div>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                        onClick={() => handleRemoveCapability(cap.id)}
+                        disabled={removing === cap.id}
+                      >
+                        {removing === cap.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/index.ts
+++ b/apps/dashboard/src/components/index.ts
@@ -4,3 +4,4 @@ export * from "./theme-provider";
 export * from "./theme-toggle";
 export * from "./agent-onboarding";
 export * from "./budget-manager";
+export * from "./capability-manager";

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Bot, MoreVertical, Plus, Coins, Edit, Eye, Ban, Filter, ArrowUpDown, Search, Users, Wallet } from "lucide-react";
+import { Bot, MoreVertical, Plus, Coins, Edit, Eye, Ban, Filter, ArrowUpDown, Search, Users, Wallet, Zap } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
@@ -25,6 +25,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs"
 import { useAgents } from "../hooks/use-agents";
 import { AgentOnboarding } from "../components/agent-onboarding";
 import { BudgetManager } from "../components/budget-manager";
+import { CapabilityManager } from "../components/capability-manager";
 
 interface Agent {
   id: string;
@@ -430,7 +431,7 @@ export function AgentsPage() {
 
       {/* Navigation Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="grid w-full grid-cols-3 lg:w-[400px]">
+        <TabsList className="grid w-full grid-cols-4 lg:w-[500px]">
           <TabsTrigger value="agents" className="flex items-center gap-2">
             <Bot className="h-4 w-4" />
             <span className="hidden sm:inline">All Agents</span>
@@ -440,6 +441,11 @@ export function AgentsPage() {
             <Users className="h-4 w-4" />
             <span className="hidden sm:inline">Onboarding</span>
             <span className="sm:hidden">Onboard</span>
+          </TabsTrigger>
+          <TabsTrigger value="capabilities" className="flex items-center gap-2">
+            <Zap className="h-4 w-4" />
+            <span className="hidden sm:inline">Capabilities</span>
+            <span className="sm:hidden">Skills</span>
           </TabsTrigger>
           <TabsTrigger value="budgets" className="flex items-center gap-2">
             <Wallet className="h-4 w-4" />
@@ -713,6 +719,11 @@ export function AgentsPage() {
         {/* Onboarding Tab */}
         <TabsContent value="onboarding" className="space-y-6">
           <AgentOnboarding />
+        </TabsContent>
+
+        {/* Capabilities Tab */}
+        <TabsContent value="capabilities" className="space-y-6">
+          <CapabilityManager />
         </TabsContent>
 
         {/* Budgets Tab */}


### PR DESCRIPTION
## Phase 2.2 — Capability Management

### AgentCapabilitiesService
- `addCapability`: Add skill with proficiency
- `updateCapability`: Change proficiency level
- `removeCapability`: Parent or L10 only
- `getAgentCapabilities`: List agent's skills
- `getOrgCapabilities`: Org-wide summary
- `findAgentsWithCapabilities`: Search by skills
- `findBestMatch`: Best agent for requirements

### Proficiency Scoring
| Level | Score |
|-------|-------|
| BASIC | 1 |
| STANDARD | 2 |
| EXPERT | 3 |

### REST Endpoints
```
GET    /agents/capabilities           - Org summary
GET    /agents/capabilities/match     - Find matching agents
GET    /agents/capabilities/best-match - Best match
GET    /agents/:id/capabilities       - Agent's skills
POST   /agents/:id/capabilities       - Add skill
PATCH  /agents/capabilities/:id       - Update proficiency
DELETE /agents/capabilities/:id       - Remove skill
```

### Dashboard
- CapabilityManager component
- Find Agents dialog
- Capabilities tab on Agents page

**Depends on:** #25