### PR TITLE
fix(docs): add Jekyll front matter to guide pages

### DIFF
--- a/docs/openspawn/AGENT-LIFECYCLE.md
+++ b/docs/openspawn/AGENT-LIFECYCLE.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Agent Lifecycle - OpenSpawn
+---
+
 # Agent Lifecycle & Spawning Model
 
 > Autonomous agents spawning autonomous agents — with human oversight

--- a/docs/openspawn/API.md
+++ b/docs/openspawn/API.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: API Reference - OpenSpawn
+---
+
 # OpenSpawn — API Specification
 
 **Version:** 1.0  

--- a/docs/openspawn/ARCHITECTURE.md
+++ b/docs/openspawn/ARCHITECTURE.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Architecture - OpenSpawn
+---
+
 # OpenSpawn — Architecture Document
 
 **Version:** 1.0  

--- a/docs/openspawn/CREDITS.md
+++ b/docs/openspawn/CREDITS.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Credit System - OpenSpawn
+---
+
 # Credit System & Economy
 
 > Internal economy for AI agent accountability and cost control

--- a/docs/openspawn/PRD.md
+++ b/docs/openspawn/PRD.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Product Requirements - OpenSpawn
+---
+
 # OpenSpawn — Product Requirements Document
 
 **Version:** 1.0  

--- a/docs/openspawn/SCHEMA.md
+++ b/docs/openspawn/SCHEMA.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Database Schema - OpenSpawn
+---
+
 # OpenSpawn — Database Schema
 
 **Version:** 1.0  

--- a/docs/openspawn/TASK-WORKFLOW.md
+++ b/docs/openspawn/TASK-WORKFLOW.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Task Workflow - OpenSpawn
+---
+
 # Task Workflow & Templates
 
 > Structured task management with templates, routing, and intelligent assignment


### PR DESCRIPTION
## Problem
Guide pages in `docs/openspawn/` weren't being processed by Jekyll because they lacked front matter, causing 404 errors.

## Solution
Added Jekyll front matter (layout + title) to all guide pages:
- AGENT-LIFECYCLE.md
- API.md
- ARCHITECTURE.md
- CREDITS.md
- PRD.md
- SCHEMA.md
- TASK-WORKFLOW.md