### PR TITLE
fix(docs): remove duplicate title from layout

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -23,7 +23,6 @@
   </header>
   
   <main>
-    <h1>{{ page.title }}</h1>
     {{ content }}
   </main>
   


### PR DESCRIPTION
The layout was rendering page.title as H1, but the markdown content already has its own H1. Removed the duplicate.