### PR TITLE
fix(docs): transform code blocks for Mermaid

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -33,6 +33,16 @@
   <!-- Mermaid.js for diagram rendering -->
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+    
+    // Transform code blocks to mermaid divs (Jekyll outputs <pre><code class="language-mermaid">)
+    document.querySelectorAll('code.language-mermaid').forEach((code) => {
+      const pre = code.parentElement;
+      const div = document.createElement('div');
+      div.className = 'mermaid';
+      div.textContent = code.textContent;
+      pre.parentNode.replaceChild(div, pre);
+    });
+    
     mermaid.initialize({ 
       startOnLoad: true,
       theme: 'dark',

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -33,6 +33,16 @@
   <!-- Mermaid.js for diagram rendering -->
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+    
+    // Transform code blocks to mermaid divs (Jekyll outputs <pre><code class="language-mermaid">)
+    document.querySelectorAll('code.language-mermaid').forEach((code) => {
+      const pre = code.parentElement;
+      const div = document.createElement('div');
+      div.className = 'mermaid';
+      div.textContent = code.textContent;
+      pre.parentNode.replaceChild(div, pre);
+    });
+    
     mermaid.initialize({ 
       startOnLoad: true,
       theme: 'dark',


### PR DESCRIPTION
Jekyll outputs mermaid as code blocks. This transforms them to divs before Mermaid renders.