### PR TITLE
feat(phase5): Trust & Reputation system

### DIFF
--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -1,7 +1,12 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
-import { Agent, AgentCapability, CreditTransaction } from "@openspawn/database";
+import {
+  Agent,
+  AgentCapability,
+  CreditTransaction,
+  ReputationEvent,
+} from "@openspawn/database";
 
 import { EventsModule } from "../events";
 
@@ -10,14 +15,33 @@ import { AgentsService } from "./agents.service";
 import { AgentOnboardingService } from "./agent-onboarding.service";
 import { AgentBudgetService } from "./agent-budget.service";
 import { AgentCapabilitiesService } from "./agent-capabilities.service";
+import { TrustService } from "./trust.service";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Agent, AgentCapability, CreditTransaction]),
+    TypeOrmModule.forFeature([
+      Agent,
+      AgentCapability,
+      CreditTransaction,
+      ReputationEvent,
+    ]),
     EventsModule,
   ],
   controllers: [AgentsController],
-  providers: [AgentsService, AgentOnboardingService, AgentBudgetService, AgentCapabilitiesService],
-  exports: [AgentsService, AgentOnboardingService, AgentBudgetService, AgentCapabilitiesService, TypeOrmModule],
+  providers: [
+    AgentsService,
+    AgentOnboardingService,
+    AgentBudgetService,
+    AgentCapabilitiesService,
+    TrustService,
+  ],
+  exports: [
+    AgentsService,
+    AgentOnboardingService,
+    AgentBudgetService,
+    AgentCapabilitiesService,
+    TrustService,
+    TypeOrmModule,
+  ],
 })
 export class AgentsModule {}

--- a/apps/api/src/agents/index.ts
+++ b/apps/api/src/agents/index.ts
@@ -3,3 +3,4 @@ export { AgentsService } from "./agents.service";
 export { AgentOnboardingService, type SpawnAgentDto } from "./agent-onboarding.service";
 export { AgentBudgetService, type SetBudgetDto, type TransferCreditsDto, type BudgetStatus } from "./agent-budget.service";
 export { AgentCapabilitiesService, type AddCapabilityDto, type UpdateCapabilityDto, type CapabilityMatch } from "./agent-capabilities.service";
+export { TrustService } from "./trust.service";

--- a/apps/api/src/agents/trust.service.ts
+++ b/apps/api/src/agents/trust.service.ts
@@ -1,0 +1,465 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository, LessThan, MoreThan } from "typeorm";
+
+import { Agent, ReputationEvent } from "@openspawn/database";
+import {
+  EventSeverity,
+  ReputationEventType,
+  ReputationLevel,
+  REPUTATION_IMPACT,
+  getReputationLevel,
+} from "@openspawn/shared-types";
+
+import { EventsService } from "../events";
+
+/** Promotion requirements by level */
+const PROMOTION_REQUIREMENTS: Record<
+  number,
+  { minTrustScore: number; minTasksCompleted: number }
+> = {
+  1: { minTrustScore: 55, minTasksCompleted: 3 },
+  2: { minTrustScore: 60, minTasksCompleted: 10 },
+  3: { minTrustScore: 65, minTasksCompleted: 25 },
+  4: { minTrustScore: 70, minTasksCompleted: 50 },
+  5: { minTrustScore: 75, minTasksCompleted: 100 },
+  6: { minTrustScore: 80, minTasksCompleted: 200 },
+  7: { minTrustScore: 85, minTasksCompleted: 400 },
+  8: { minTrustScore: 90, minTasksCompleted: 750 },
+  9: { minTrustScore: 95, minTasksCompleted: 1500 },
+};
+
+@Injectable()
+export class TrustService {
+  constructor(
+    @InjectRepository(Agent)
+    private readonly agentRepo: Repository<Agent>,
+    @InjectRepository(ReputationEvent)
+    private readonly reputationRepo: Repository<ReputationEvent>,
+    private readonly eventsService: EventsService
+  ) {}
+
+  /**
+   * Record a reputation event and update agent's trust score
+   */
+  async recordEvent(params: {
+    orgId: string;
+    agentId: string;
+    type: ReputationEventType;
+    taskId?: string;
+    triggeredBy?: string;
+    reason?: string;
+    customImpact?: number;
+  }): Promise<ReputationEvent> {
+    const agent = await this.agentRepo.findOneByOrFail({ id: params.agentId });
+    const impact = params.customImpact ?? REPUTATION_IMPACT[params.type];
+
+    const previousScore = agent.trustScore;
+    const newScore = Math.max(0, Math.min(100, previousScore + impact));
+
+    // Create the reputation event
+    const event = this.reputationRepo.create({
+      orgId: params.orgId,
+      agentId: params.agentId,
+      type: params.type,
+      impact,
+      previousScore,
+      newScore,
+      taskId: params.taskId ?? null,
+      triggeredBy: params.triggeredBy ?? null,
+      reason: params.reason ?? null,
+    });
+    await this.reputationRepo.save(event);
+
+    // Update agent trust score and activity timestamp
+    await this.agentRepo.update(params.agentId, {
+      trustScore: newScore,
+      lastActivityAt: new Date(),
+    });
+
+    // Log system event
+    await this.eventsService.emit({
+      orgId: params.orgId,
+      type: "reputation.changed",
+      actorId: params.triggeredBy ?? params.agentId,
+      severity: impact >= 0 ? EventSeverity.INFO : EventSeverity.WARNING,
+      entityType: "agent",
+      entityId: params.agentId,
+      data: {
+        agentId: params.agentId,
+        eventType: params.type,
+        impact,
+        previousScore,
+        newScore,
+        reputationLevel: getReputationLevel(newScore),
+      },
+    });
+
+    return event;
+  }
+
+  /**
+   * Record successful task completion
+   */
+  async recordTaskCompleted(params: {
+    orgId: string;
+    agentId: string;
+    taskId: string;
+    onTime: boolean;
+  }): Promise<void> {
+    // Record completion event
+    await this.recordEvent({
+      orgId: params.orgId,
+      agentId: params.agentId,
+      type: ReputationEventType.TASK_COMPLETED,
+      taskId: params.taskId,
+      reason: "Task completed successfully",
+    });
+
+    // Record on-time/late delivery
+    await this.recordEvent({
+      orgId: params.orgId,
+      agentId: params.agentId,
+      type: params.onTime
+        ? ReputationEventType.ON_TIME_DELIVERY
+        : ReputationEventType.LATE_DELIVERY,
+      taskId: params.taskId,
+    });
+
+    // Update task counters
+    await this.agentRepo.increment({ id: params.agentId }, "tasksCompleted", 1);
+    await this.agentRepo.increment({ id: params.agentId }, "tasksSuccessful", 1);
+
+    // Check for auto-promotion
+    await this.checkAutoPromotion(params.agentId);
+  }
+
+  /**
+   * Record task failure
+   */
+  async recordTaskFailed(params: {
+    orgId: string;
+    agentId: string;
+    taskId: string;
+    reason?: string;
+  }): Promise<void> {
+    await this.recordEvent({
+      orgId: params.orgId,
+      agentId: params.agentId,
+      type: ReputationEventType.TASK_FAILED,
+      taskId: params.taskId,
+      reason: params.reason,
+    });
+
+    // Increment completed but not successful
+    await this.agentRepo.increment({ id: params.agentId }, "tasksCompleted", 1);
+  }
+
+  /**
+   * Record task sent back for rework
+   */
+  async recordTaskRework(params: {
+    orgId: string;
+    agentId: string;
+    taskId: string;
+    triggeredBy: string;
+    reason?: string;
+  }): Promise<void> {
+    await this.recordEvent({
+      orgId: params.orgId,
+      agentId: params.agentId,
+      type: ReputationEventType.TASK_REWORK,
+      taskId: params.taskId,
+      triggeredBy: params.triggeredBy,
+      reason: params.reason,
+    });
+  }
+
+  /**
+   * Award quality bonus from supervisor
+   */
+  async awardQualityBonus(params: {
+    orgId: string;
+    agentId: string;
+    awardedBy: string;
+    reason: string;
+    bonusAmount?: number;
+  }): Promise<ReputationEvent> {
+    return this.recordEvent({
+      orgId: params.orgId,
+      agentId: params.agentId,
+      type: ReputationEventType.QUALITY_BONUS,
+      triggeredBy: params.awardedBy,
+      reason: params.reason,
+      customImpact: params.bonusAmount,
+    });
+  }
+
+  /**
+   * Apply quality penalty from supervisor
+   */
+  async applyQualityPenalty(params: {
+    orgId: string;
+    agentId: string;
+    appliedBy: string;
+    reason: string;
+    penaltyAmount?: number;
+  }): Promise<ReputationEvent> {
+    return this.recordEvent({
+      orgId: params.orgId,
+      agentId: params.agentId,
+      type: ReputationEventType.QUALITY_PENALTY,
+      triggeredBy: params.appliedBy,
+      reason: params.reason,
+      customImpact: params.penaltyAmount
+        ? -Math.abs(params.penaltyAmount)
+        : undefined,
+    });
+  }
+
+  /**
+   * Check if agent qualifies for automatic promotion
+   */
+  async checkAutoPromotion(agentId: string): Promise<boolean> {
+    const agent = await this.agentRepo.findOneByOrFail({ id: agentId });
+
+    // Can't auto-promote beyond L9
+    if (agent.level >= 9) return false;
+
+    const requirements = PROMOTION_REQUIREMENTS[agent.level];
+    if (!requirements) return false;
+
+    // Check if agent meets requirements
+    if (
+      agent.trustScore >= requirements.minTrustScore &&
+      agent.tasksCompleted >= requirements.minTasksCompleted
+    ) {
+      // Check cooldown (at least 7 days since last promotion)
+      if (agent.lastPromotionAt) {
+        const daysSincePromotion =
+          (Date.now() - agent.lastPromotionAt.getTime()) / (1000 * 60 * 60 * 24);
+        if (daysSincePromotion < 7) return false;
+      }
+
+      // Promote!
+      await this.promoteAgent(agent);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Promote an agent to the next level
+   */
+  async promoteAgent(agent: Agent): Promise<void> {
+    const newLevel = agent.level + 1;
+
+    await this.agentRepo.update(agent.id, {
+      level: newLevel,
+      lastPromotionAt: new Date(),
+    });
+
+    await this.recordEvent({
+      orgId: agent.orgId,
+      agentId: agent.id,
+      type: ReputationEventType.LEVEL_UP,
+      reason: `Automatically promoted from L${agent.level} to L${newLevel}`,
+    });
+
+    await this.eventsService.emit({
+      orgId: agent.orgId,
+      type: "agent.promoted",
+      actorId: agent.id,
+      severity: EventSeverity.INFO,
+      entityType: "agent",
+      entityId: agent.id,
+      data: {
+        agentId: agent.id,
+        previousLevel: agent.level,
+        newLevel,
+        trustScore: agent.trustScore,
+        tasksCompleted: agent.tasksCompleted,
+      },
+    });
+  }
+
+  /**
+   * Demote an agent (usually manual action)
+   */
+  async demoteAgent(params: {
+    agentId: string;
+    demotedBy: string;
+    reason: string;
+  }): Promise<void> {
+    const agent = await this.agentRepo.findOneByOrFail({ id: params.agentId });
+
+    if (agent.level <= 1) {
+      throw new Error("Cannot demote agent below level 1");
+    }
+
+    const newLevel = agent.level - 1;
+
+    await this.agentRepo.update(agent.id, { level: newLevel });
+
+    await this.recordEvent({
+      orgId: agent.orgId,
+      agentId: agent.id,
+      type: ReputationEventType.LEVEL_DOWN,
+      triggeredBy: params.demotedBy,
+      reason: params.reason,
+    });
+
+    await this.eventsService.emit({
+      orgId: agent.orgId,
+      type: "agent.demoted",
+      actorId: params.demotedBy,
+      severity: EventSeverity.WARNING,
+      entityType: "agent",
+      entityId: agent.id,
+      data: {
+        agentId: agent.id,
+        previousLevel: agent.level,
+        newLevel,
+        reason: params.reason,
+      },
+    });
+  }
+
+  /**
+   * Get agent's reputation summary
+   */
+  async getReputationSummary(agentId: string): Promise<{
+    trustScore: number;
+    reputationLevel: ReputationLevel;
+    tasksCompleted: number;
+    tasksSuccessful: number;
+    successRate: number;
+    lastActivityAt: Date | null;
+    promotionProgress: {
+      currentLevel: number;
+      nextLevel: number | null;
+      trustScoreRequired: number | null;
+      tasksRequired: number | null;
+      trustScoreProgress: number;
+      tasksProgress: number;
+    } | null;
+  }> {
+    const agent = await this.agentRepo.findOneByOrFail({ id: agentId });
+    const successRate =
+      agent.tasksCompleted > 0
+        ? Math.round((agent.tasksSuccessful / agent.tasksCompleted) * 100)
+        : 100;
+
+    let promotionProgress = null;
+    if (agent.level < 9) {
+      const requirements = PROMOTION_REQUIREMENTS[agent.level];
+      if (requirements) {
+        promotionProgress = {
+          currentLevel: agent.level,
+          nextLevel: agent.level + 1,
+          trustScoreRequired: requirements.minTrustScore,
+          tasksRequired: requirements.minTasksCompleted,
+          trustScoreProgress: Math.min(
+            100,
+            Math.round((agent.trustScore / requirements.minTrustScore) * 100)
+          ),
+          tasksProgress: Math.min(
+            100,
+            Math.round(
+              (agent.tasksCompleted / requirements.minTasksCompleted) * 100
+            )
+          ),
+        };
+      }
+    }
+
+    return {
+      trustScore: agent.trustScore,
+      reputationLevel: getReputationLevel(agent.trustScore),
+      tasksCompleted: agent.tasksCompleted,
+      tasksSuccessful: agent.tasksSuccessful,
+      successRate,
+      lastActivityAt: agent.lastActivityAt,
+      promotionProgress,
+    };
+  }
+
+  /**
+   * Get reputation history for an agent
+   */
+  async getReputationHistory(
+    agentId: string,
+    options?: { limit?: number; offset?: number }
+  ): Promise<{ events: ReputationEvent[]; total: number }> {
+    const [events, total] = await this.reputationRepo.findAndCount({
+      where: { agentId },
+      order: { createdAt: "DESC" },
+      take: options?.limit ?? 50,
+      skip: options?.offset ?? 0,
+    });
+
+    return { events, total };
+  }
+
+  /**
+   * Apply inactivity decay to all agents who haven't been active
+   * Run this as a scheduled task (e.g., weekly)
+   */
+  async applyInactivityDecay(daysThreshold: number = 14): Promise<number> {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - daysThreshold);
+
+    const inactiveAgents = await this.agentRepo.find({
+      where: {
+        lastActivityAt: LessThan(cutoffDate),
+        trustScore: MoreThan(30), // Don't decay below NEW level
+      },
+    });
+
+    for (const agent of inactiveAgents) {
+      await this.recordEvent({
+        orgId: agent.orgId,
+        agentId: agent.id,
+        type: ReputationEventType.INACTIVITY_DECAY,
+        reason: `No activity for ${daysThreshold}+ days`,
+      });
+    }
+
+    return inactiveAgents.length;
+  }
+
+  /**
+   * Get leaderboard of top agents by trust score
+   */
+  async getLeaderboard(
+    orgId: string,
+    limit: number = 10
+  ): Promise<
+    Array<{
+      id: string;
+      agentId: string;
+      name: string;
+      level: number;
+      trustScore: number;
+      reputationLevel: ReputationLevel;
+      tasksCompleted: number;
+    }>
+  > {
+    const agents = await this.agentRepo.find({
+      where: { orgId },
+      order: { trustScore: "DESC", tasksCompleted: "DESC" },
+      take: limit,
+    });
+
+    return agents.map((agent) => ({
+      id: agent.id,
+      agentId: agent.agentId,
+      name: agent.name,
+      level: agent.level,
+      trustScore: agent.trustScore,
+      reputationLevel: getReputationLevel(agent.trustScore),
+      tasksCompleted: agent.tasksCompleted,
+    }));
+  }
+}

--- a/libs/database/src/entities/agent.entity.ts
+++ b/libs/database/src/entities/agent.entity.ts
@@ -75,6 +75,22 @@ export class Agent {
   @Column({ type: "jsonb", default: {} })
   metadata!: Record<string, unknown>;
 
+  // Trust & Reputation fields
+  @Column({ name: "trust_score", type: "smallint", default: 50 })
+  trustScore!: number;
+
+  @Column({ name: "tasks_completed", type: "int", default: 0 })
+  tasksCompleted!: number;
+
+  @Column({ name: "tasks_successful", type: "int", default: 0 })
+  tasksSuccessful!: number;
+
+  @Column({ name: "last_activity_at", type: "timestamptz", nullable: true })
+  lastActivityAt!: Date | null;
+
+  @Column({ name: "last_promotion_at", type: "timestamptz", nullable: true })
+  lastPromotionAt!: Date | null;
+
   @DeleteDateColumn({ name: "deleted_at", type: "timestamptz", nullable: true })
   deletedAt!: Date | null;
 

--- a/libs/database/src/entities/index.ts
+++ b/libs/database/src/entities/index.ts
@@ -10,6 +10,7 @@ export { Message } from "./message.entity";
 export { Nonce } from "./nonce.entity";
 export { Organization } from "./organization.entity";
 export { RefreshToken } from "./refresh-token.entity";
+export { ReputationEvent } from "./reputation-event.entity";
 export { Task } from "./task.entity";
 export { TaskComment } from "./task-comment.entity";
 export { TaskDependency } from "./task-dependency.entity";

--- a/libs/database/src/entities/reputation-event.entity.ts
+++ b/libs/database/src/entities/reputation-event.entity.ts
@@ -1,0 +1,74 @@
+import { ReputationEventType } from "@openspawn/shared-types";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+import type { Agent } from "./agent.entity";
+import type { Organization } from "./organization.entity";
+
+/**
+ * Tracks events that affect an agent's trust score
+ * Append-only table for audit trail
+ */
+@Entity("reputation_events")
+@Index(["orgId", "agentId"])
+@Index(["orgId", "createdAt"])
+@Index(["agentId", "type"])
+export class ReputationEvent {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ name: "org_id", type: "uuid" })
+  orgId!: string;
+
+  @Column({ name: "agent_id", type: "uuid" })
+  agentId!: string;
+
+  @Column({ type: "varchar", length: 50 })
+  type!: ReputationEventType;
+
+  /** Score change (positive or negative) */
+  @Column({ type: "smallint" })
+  impact!: number;
+
+  /** Trust score before this event */
+  @Column({ name: "previous_score", type: "smallint" })
+  previousScore!: number;
+
+  /** Trust score after this event */
+  @Column({ name: "new_score", type: "smallint" })
+  newScore!: number;
+
+  /** Related task ID if applicable */
+  @Column({ name: "task_id", type: "uuid", nullable: true })
+  taskId!: string | null;
+
+  /** Who triggered this event (agent or system) */
+  @Column({ name: "triggered_by", type: "uuid", nullable: true })
+  triggeredBy!: string | null;
+
+  /** Additional context */
+  @Column({ type: "varchar", length: 500, nullable: true })
+  reason!: string | null;
+
+  @Column({ type: "jsonb", default: {} })
+  metadata!: Record<string, unknown>;
+
+  @CreateDateColumn({ name: "created_at", type: "timestamptz" })
+  createdAt!: Date;
+
+  // Relations
+  @ManyToOne("Organization")
+  @JoinColumn({ name: "org_id" })
+  organization?: Organization;
+
+  @ManyToOne("Agent")
+  @JoinColumn({ name: "agent_id" })
+  agent?: Agent;
+}

--- a/libs/shared-types/src/enums/index.ts
+++ b/libs/shared-types/src/enums/index.ts
@@ -6,5 +6,10 @@ export { CreditType } from "./credit-type.enum";
 export { EventSeverity } from "./event-severity.enum";
 export { MessageType } from "./message-type.enum";
 export { Proficiency } from "./proficiency.enum";
+export {
+  ReputationEventType,
+  REPUTATION_IMPACT,
+} from "./reputation-event-type.enum";
+export { ReputationLevel, getReputationLevel } from "./reputation-level.enum";
 export { TaskPriority } from "./task-priority.enum";
 export { TaskStatus } from "./task-status.enum";

--- a/libs/shared-types/src/enums/reputation-event-type.enum.ts
+++ b/libs/shared-types/src/enums/reputation-event-type.enum.ts
@@ -1,0 +1,44 @@
+/**
+ * Types of events that affect an agent's reputation/trust score
+ */
+export enum ReputationEventType {
+  /** Task completed successfully */
+  TASK_COMPLETED = "TASK_COMPLETED",
+  /** Task failed or cancelled after assignment */
+  TASK_FAILED = "TASK_FAILED",
+  /** Task sent back for rework */
+  TASK_REWORK = "TASK_REWORK",
+  /** Task delivered on time */
+  ON_TIME_DELIVERY = "ON_TIME_DELIVERY",
+  /** Task delivered late */
+  LATE_DELIVERY = "LATE_DELIVERY",
+  /** Quality bonus awarded by supervisor */
+  QUALITY_BONUS = "QUALITY_BONUS",
+  /** Quality penalty from supervisor */
+  QUALITY_PENALTY = "QUALITY_PENALTY",
+  /** Agent promoted to higher level */
+  LEVEL_UP = "LEVEL_UP",
+  /** Agent demoted to lower level */
+  LEVEL_DOWN = "LEVEL_DOWN",
+  /** Trust score decay from inactivity */
+  INACTIVITY_DECAY = "INACTIVITY_DECAY",
+  /** Manual trust adjustment by admin */
+  MANUAL_ADJUSTMENT = "MANUAL_ADJUSTMENT",
+}
+
+/**
+ * Default trust score impact for each event type
+ */
+export const REPUTATION_IMPACT: Record<ReputationEventType, number> = {
+  [ReputationEventType.TASK_COMPLETED]: 5,
+  [ReputationEventType.TASK_FAILED]: -10,
+  [ReputationEventType.TASK_REWORK]: -3,
+  [ReputationEventType.ON_TIME_DELIVERY]: 2,
+  [ReputationEventType.LATE_DELIVERY]: -5,
+  [ReputationEventType.QUALITY_BONUS]: 10,
+  [ReputationEventType.QUALITY_PENALTY]: -10,
+  [ReputationEventType.LEVEL_UP]: 5,
+  [ReputationEventType.LEVEL_DOWN]: -5,
+  [ReputationEventType.INACTIVITY_DECAY]: -1,
+  [ReputationEventType.MANUAL_ADJUSTMENT]: 0, // Variable
+};

--- a/libs/shared-types/src/enums/reputation-level.enum.ts
+++ b/libs/shared-types/src/enums/reputation-level.enum.ts
@@ -1,0 +1,26 @@
+/**
+ * Agent reputation levels based on trust score
+ */
+export enum ReputationLevel {
+  /** 0-30: New agent, limited trust */
+  NEW = "NEW",
+  /** 31-40: Under review, trust issues */
+  PROBATION = "PROBATION",
+  /** 41-70: Standard trust level */
+  TRUSTED = "TRUSTED",
+  /** 71-85: High trust, proven track record */
+  VETERAN = "VETERAN",
+  /** 86-100: Maximum trust, elite performer */
+  ELITE = "ELITE",
+}
+
+/**
+ * Get reputation level from trust score
+ */
+export function getReputationLevel(trustScore: number): ReputationLevel {
+  if (trustScore <= 30) return ReputationLevel.NEW;
+  if (trustScore <= 40) return ReputationLevel.PROBATION;
+  if (trustScore <= 70) return ReputationLevel.TRUSTED;
+  if (trustScore <= 85) return ReputationLevel.VETERAN;
+  return ReputationLevel.ELITE;
+}


### PR DESCRIPTION
## Phase 5: Trust & Reputation

### New Features

**Trust Score (0-100)**
- Starts at 50 for new agents
- Increases with successful task completion, on-time delivery, quality bonuses
- Decreases with failures, rework, penalties, inactivity

**Reputation Levels**
| Level | Score Range | Description |
|-------|-------------|-------------|
| NEW | 0-30 | Limited trust |
| PROBATION | 31-40 | Under review |
| TRUSTED | 41-70 | Standard trust |
| VETERAN | 71-85 | High trust |
| ELITE | 86-100 | Maximum trust |

**Auto-Promotion**
Agents automatically level up when they meet requirements:
- L1→L2: 55 trust, 3 tasks
- L2→L3: 60 trust, 10 tasks
- ...progressive up to L9

**Task Integration**
- Task → DONE: Records completion + on-time/late
- Task → CANCELLED: Records failure (if work started)
- REVIEW → IN_PROGRESS: Records rework needed

**New Endpoints**
- `GET /agents/:id/reputation` - Summary with promotion progress
- `GET /agents/:id/reputation/history` - Event log
- `POST /agents/:id/reputation/bonus` - Award bonus (L7+)
- `POST /agents/:id/reputation/penalty` - Apply penalty (L7+)
- `POST /agents/:id/demote` - Demote agent (L9+)
- `GET /agents/leaderboard/trust` - Top performers

**Dashboard Components**
- `ReputationCard` - Trust score, level, stats, promotion progress
- `ReputationHistory` - Event log with icons
- `TrustLeaderboard` - Ranked agent list

### Database
- Added trust fields to Agent entity (trustScore, tasksCompleted, tasksSuccessful, lastActivityAt, lastPromotionAt)
- New ReputationEvent entity for audit trail