### PR TITLE
feat(phase5): add task integration + dashboard components

### DIFF
--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -1,8 +1,9 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { Agent, AgentCapability, Organization, Task, TaskComment, TaskDependency, TaskTag } from "@openspawn/database";
 
+import { AgentsModule } from "../agents";
 import { EventsModule } from "../events";
 
 import { TaskIdentifierService } from "./task-identifier.service";
@@ -24,6 +25,7 @@ import { TasksService } from "./tasks.service";
       TaskComment,
     ]),
     EventsModule,
+    forwardRef(() => AgentsModule),
   ],
   controllers: [TasksController],
   providers: [

--- a/apps/dashboard/src/components/index.ts
+++ b/apps/dashboard/src/components/index.ts
@@ -5,3 +5,6 @@ export * from "./theme-toggle";
 export * from "./agent-onboarding";
 export * from "./budget-manager";
 export * from "./capability-manager";
+export * from "./reputation-card";
+export * from "./reputation-history";
+export * from "./trust-leaderboard";

--- a/apps/dashboard/src/components/reputation-card.tsx
+++ b/apps/dashboard/src/components/reputation-card.tsx
@@ -1,0 +1,126 @@
+import { Badge } from "./ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Progress } from "./ui/progress";
+
+interface ReputationSummary {
+  trustScore: number;
+  reputationLevel: string;
+  tasksCompleted: number;
+  tasksSuccessful: number;
+  successRate: number;
+  lastActivityAt: string | null;
+  promotionProgress: {
+    currentLevel: number;
+    nextLevel: number | null;
+    trustScoreRequired: number | null;
+    tasksRequired: number | null;
+    trustScoreProgress: number;
+    tasksProgress: number;
+  } | null;
+}
+
+interface ReputationCardProps {
+  reputation: ReputationSummary;
+}
+
+const LEVEL_COLORS: Record<string, string> = {
+  NEW: "bg-gray-500",
+  PROBATION: "bg-orange-500",
+  TRUSTED: "bg-blue-500",
+  VETERAN: "bg-purple-500",
+  ELITE: "bg-yellow-500",
+};
+
+const LEVEL_EMOJI: Record<string, string> = {
+  NEW: "🆕",
+  PROBATION: "⚠️",
+  TRUSTED: "✅",
+  VETERAN: "🏆",
+  ELITE: "👑",
+};
+
+export function ReputationCard({ reputation }: ReputationCardProps) {
+  const levelColor = LEVEL_COLORS[reputation.reputationLevel] || "bg-gray-500";
+  const levelEmoji = LEVEL_EMOJI[reputation.reputationLevel] || "❓";
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center justify-between">
+          <span>Trust & Reputation</span>
+          <Badge className={levelColor}>
+            {levelEmoji} {reputation.reputationLevel}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Trust Score */}
+        <div>
+          <div className="flex justify-between text-sm mb-1">
+            <span className="text-muted-foreground">Trust Score</span>
+            <span className="font-semibold">{reputation.trustScore}/100</span>
+          </div>
+          <Progress value={reputation.trustScore} className="h-2" />
+        </div>
+
+        {/* Task Stats */}
+        <div className="grid grid-cols-3 gap-4 text-center">
+          <div>
+            <div className="text-2xl font-bold">{reputation.tasksCompleted}</div>
+            <div className="text-xs text-muted-foreground">Tasks Done</div>
+          </div>
+          <div>
+            <div className="text-2xl font-bold">{reputation.tasksSuccessful}</div>
+            <div className="text-xs text-muted-foreground">Successful</div>
+          </div>
+          <div>
+            <div className="text-2xl font-bold">{reputation.successRate}%</div>
+            <div className="text-xs text-muted-foreground">Success Rate</div>
+          </div>
+        </div>
+
+        {/* Promotion Progress */}
+        {reputation.promotionProgress && (
+          <div className="border-t pt-4">
+            <div className="text-sm font-medium mb-2">
+              Progress to Level {reputation.promotionProgress.nextLevel}
+            </div>
+            <div className="space-y-2">
+              <div>
+                <div className="flex justify-between text-xs mb-1">
+                  <span className="text-muted-foreground">Trust Score</span>
+                  <span>
+                    {reputation.trustScore} / {reputation.promotionProgress.trustScoreRequired}
+                  </span>
+                </div>
+                <Progress
+                  value={reputation.promotionProgress.trustScoreProgress}
+                  className="h-1.5"
+                />
+              </div>
+              <div>
+                <div className="flex justify-between text-xs mb-1">
+                  <span className="text-muted-foreground">Tasks Completed</span>
+                  <span>
+                    {reputation.tasksCompleted} / {reputation.promotionProgress.tasksRequired}
+                  </span>
+                </div>
+                <Progress
+                  value={reputation.promotionProgress.tasksProgress}
+                  className="h-1.5"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Last Activity */}
+        {reputation.lastActivityAt && (
+          <div className="text-xs text-muted-foreground text-right">
+            Last active: {new Date(reputation.lastActivityAt).toLocaleDateString()}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/components/reputation-history.tsx
+++ b/apps/dashboard/src/components/reputation-history.tsx
@@ -1,0 +1,120 @@
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { ScrollArea } from "./ui/scroll-area";
+
+interface ReputationEvent {
+  id: string;
+  type: string;
+  impact: number;
+  previousScore: number;
+  newScore: number;
+  reason: string | null;
+  createdAt: string;
+}
+
+interface ReputationHistoryProps {
+  events: ReputationEvent[];
+  title?: string;
+}
+
+const EVENT_ICONS: Record<string, string> = {
+  TASK_COMPLETED: "✅",
+  TASK_FAILED: "❌",
+  TASK_REWORK: "🔄",
+  ON_TIME_DELIVERY: "⏰",
+  LATE_DELIVERY: "⏳",
+  QUALITY_BONUS: "⭐",
+  QUALITY_PENALTY: "👎",
+  LEVEL_UP: "📈",
+  LEVEL_DOWN: "📉",
+  INACTIVITY_DECAY: "😴",
+  MANUAL_ADJUSTMENT: "✏️",
+};
+
+const EVENT_LABELS: Record<string, string> = {
+  TASK_COMPLETED: "Task Completed",
+  TASK_FAILED: "Task Failed",
+  TASK_REWORK: "Sent for Rework",
+  ON_TIME_DELIVERY: "On-Time Delivery",
+  LATE_DELIVERY: "Late Delivery",
+  QUALITY_BONUS: "Quality Bonus",
+  QUALITY_PENALTY: "Quality Penalty",
+  LEVEL_UP: "Promoted",
+  LEVEL_DOWN: "Demoted",
+  INACTIVITY_DECAY: "Inactivity Decay",
+  MANUAL_ADJUSTMENT: "Manual Adjustment",
+};
+
+function formatTimeAgo(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+export function ReputationHistory({
+  events,
+  title = "Reputation History",
+}: ReputationHistoryProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <span>📜</span>
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ScrollArea className="h-[300px] pr-4">
+          <div className="space-y-3">
+            {events.map((event) => (
+              <div
+                key={event.id}
+                className="flex items-start gap-3 p-2 rounded-lg bg-muted/50"
+              >
+                <div className="text-xl mt-0.5">
+                  {EVENT_ICONS[event.type] || "❓"}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between">
+                    <div className="font-medium text-sm">
+                      {EVENT_LABELS[event.type] || event.type}
+                    </div>
+                    <div
+                      className={`text-sm font-semibold ${
+                        event.impact >= 0 ? "text-green-500" : "text-red-500"
+                      }`}
+                    >
+                      {event.impact >= 0 ? "+" : ""}
+                      {event.impact}
+                    </div>
+                  </div>
+                  {event.reason && (
+                    <div className="text-xs text-muted-foreground truncate">
+                      {event.reason}
+                    </div>
+                  )}
+                  <div className="text-xs text-muted-foreground mt-1">
+                    {event.previousScore} → {event.newScore} · {formatTimeAgo(event.createdAt)}
+                  </div>
+                </div>
+              </div>
+            ))}
+            {events.length === 0 && (
+              <div className="text-center text-muted-foreground py-4">
+                No reputation events yet
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/components/trust-leaderboard.tsx
+++ b/apps/dashboard/src/components/trust-leaderboard.tsx
@@ -1,0 +1,81 @@
+import { Badge } from "./ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+
+interface LeaderboardEntry {
+  id: string;
+  agentId: string;
+  name: string;
+  level: number;
+  trustScore: number;
+  reputationLevel: string;
+  tasksCompleted: number;
+}
+
+interface TrustLeaderboardProps {
+  entries: LeaderboardEntry[];
+  title?: string;
+}
+
+const LEVEL_COLORS: Record<string, string> = {
+  NEW: "bg-gray-500",
+  PROBATION: "bg-orange-500",
+  TRUSTED: "bg-blue-500",
+  VETERAN: "bg-purple-500",
+  ELITE: "bg-yellow-500",
+};
+
+const RANK_EMOJI = ["🥇", "🥈", "🥉"];
+
+export function TrustLeaderboard({
+  entries,
+  title = "Trust Leaderboard",
+}: TrustLeaderboardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <span>🏆</span>
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {entries.map((entry, index) => (
+            <div
+              key={entry.id}
+              className="flex items-center justify-between p-2 rounded-lg bg-muted/50"
+            >
+              <div className="flex items-center gap-3">
+                <div className="w-8 text-center text-lg">
+                  {index < 3 ? RANK_EMOJI[index] : `#${index + 1}`}
+                </div>
+                <div>
+                  <div className="font-medium">{entry.name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    L{entry.level} · {entry.tasksCompleted} tasks
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="text-right">
+                  <div className="font-semibold">{entry.trustScore}</div>
+                  <div className="text-xs text-muted-foreground">trust</div>
+                </div>
+                <Badge
+                  className={`${LEVEL_COLORS[entry.reputationLevel] || "bg-gray-500"} text-xs`}
+                >
+                  {entry.reputationLevel}
+                </Badge>
+              </div>
+            </div>
+          ))}
+          {entries.length === 0 && (
+            <div className="text-center text-muted-foreground py-4">
+              No agents yet
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/components/ui/index.ts
+++ b/apps/dashboard/src/components/ui/index.ts
@@ -4,6 +4,7 @@ export * from "./button";
 export * from "./card";
 export * from "./dialog";
 export * from "./dropdown-menu";
+export * from "./progress";
 export * from "./scroll-area";
 export * from "./tabs";
 export * from "./tooltip";

--- a/apps/dashboard/src/components/ui/progress.tsx
+++ b/apps/dashboard/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+
+import { cn } from "../../lib/utils";
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.10
         version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3148,6 +3151,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.8':
+    resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -13447,6 +13463,16 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:


### PR DESCRIPTION
Follow-up to #37 — adds the task integration and dashboard UI.

## Task Integration
- TasksService now calls TrustService on transitions
- DONE → records completion + on-time/late delivery
- CANCELLED (after work) → records failure
- REVIEW → IN_PROGRESS → records rework

## Dashboard Components
- `ReputationCard` - Trust score, level, stats, promotion progress
- `ReputationHistory` - Event log with icons and time ago
- `TrustLeaderboard` - Top agents ranked by trust
- `Progress` UI component (radix-ui)