### PR TITLE
feat(dashboard): Guided tour for first-time users

### DIFF
--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -37,13 +37,13 @@ interface LayoutProps {
 }
 
 const navigation = [
-  { name: "Dashboard", href: "/", icon: LayoutDashboard },
-  { name: "Network", href: "/network", icon: Network },
-  { name: "Tasks", href: "/tasks", icon: CheckSquare },
-  { name: "Agents", href: "/agents", icon: Users },
-  { name: "Credits", href: "/credits", icon: Coins },
-  { name: "Events", href: "/events", icon: Activity },
-  { name: "Settings", href: "/settings", icon: Settings },
+  { name: "Dashboard", href: "/", icon: LayoutDashboard, tourId: "dashboard-link" },
+  { name: "Network", href: "/network", icon: Network, tourId: "network-link" },
+  { name: "Tasks", href: "/tasks", icon: CheckSquare, tourId: "tasks-link" },
+  { name: "Agents", href: "/agents", icon: Users, tourId: "agents-link" },
+  { name: "Credits", href: "/credits", icon: Coins, tourId: "credits-link" },
+  { name: "Events", href: "/events", icon: Activity, tourId: "events-link" },
+  { name: "Settings", href: "/settings", icon: Settings, tourId: "settings-link" },
 ];
 
 export function Layout({ children }: LayoutProps) {
@@ -81,7 +81,7 @@ export function Layout({ children }: LayoutProps) {
     <TooltipProvider>
       <div className="flex h-screen bg-background">
         {/* Sidebar */}
-        <aside className="hidden w-64 flex-shrink-0 flex-col border-r border-border lg:flex">
+        <aside className="hidden w-64 flex-shrink-0 flex-col border-r border-border lg:flex" data-tour="sidebar">
           {/* Logo */}
           <div className="flex h-16 items-center gap-2 border-b border-border px-6">
             <Bot className="h-6 w-6 text-primary" />
@@ -94,7 +94,7 @@ export function Layout({ children }: LayoutProps) {
               {navigation.map((item) => {
                 const isActive = location.pathname === item.href;
                 return (
-                  <Link key={item.name} to={item.href}>
+                  <Link key={item.name} to={item.href} data-tour={item.tourId}>
                     <Button
                       variant={isActive ? "secondary" : "ghost"}
                       className={cn(
@@ -132,7 +132,7 @@ export function Layout({ children }: LayoutProps) {
               )}
             </Button>
             {isDemo && (
-              <div className="mt-2">
+              <div className="mt-2" data-tour="demo-controls">
                 <DemoControls compact />
               </div>
             )}
@@ -185,7 +185,9 @@ export function Layout({ children }: LayoutProps) {
             ) : null}
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>v0.1.0</span>
-              <ThemeToggle />
+              <div data-tour="theme-toggle">
+                <ThemeToggle />
+              </div>
             </div>
           </div>
         </aside>

--- a/apps/dashboard/src/demo/DemoWelcome.tsx
+++ b/apps/dashboard/src/demo/DemoWelcome.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Play, Sparkles, Network, LayoutDashboard, Coins, CheckSquare } from 'lucide-react';
+import { X, Play, Sparkles, Network, LayoutDashboard, Coins, CheckSquare, HelpCircle } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { useDemo } from './DemoProvider';
+import { startTour, markTourCompleted } from '../lib/tour';
 
 const STORAGE_KEY = 'openspawn-demo-welcomed';
 
@@ -107,6 +108,19 @@ export function DemoWelcome() {
               >
                 <Play className="mr-2 h-4 w-4" />
                 Start Exploring
+              </Button>
+              <Button
+                onClick={() => {
+                  handleDismiss();
+                  markTourCompleted(); // Prevent auto-tour since user chose manual
+                  setTimeout(() => startTour(), 300); // Small delay for modal close
+                }}
+                variant="outline"
+                size="lg"
+                className="w-full"
+              >
+                <HelpCircle className="mr-2 h-4 w-4" />
+                Take a Guided Tour
               </Button>
               <p className="text-center text-xs text-muted-foreground">
                 This is a live simulation — watch agents work in real-time

--- a/apps/dashboard/src/lib/tour.ts
+++ b/apps/dashboard/src/lib/tour.ts
@@ -1,0 +1,144 @@
+/**
+ * Guided tour configuration using driver.js
+ * Walks users through the key features of OpenSpawn
+ */
+
+import { driver, type DriveStep } from 'driver.js';
+import 'driver.js/dist/driver.css';
+
+// Storage key for tour completion
+const TOUR_COMPLETED_KEY = 'openspawn-tour-completed';
+
+// Check if user has completed the tour
+export function hasTourCompleted(): boolean {
+  return localStorage.getItem(TOUR_COMPLETED_KEY) === 'true';
+}
+
+// Mark tour as completed
+export function markTourCompleted(): void {
+  localStorage.setItem(TOUR_COMPLETED_KEY, 'true');
+}
+
+// Reset tour (for testing)
+export function resetTour(): void {
+  localStorage.removeItem(TOUR_COMPLETED_KEY);
+}
+
+// Tour steps
+const tourSteps: DriveStep[] = [
+  {
+    popover: {
+      title: '👋 Welcome to OpenSpawn!',
+      description: 'Let\'s take a quick tour of your multi-agent coordination platform. This will only take a minute!',
+      side: 'over',
+      align: 'center',
+    },
+  },
+  {
+    element: '[data-tour="sidebar"]',
+    popover: {
+      title: '🧭 Navigation',
+      description: 'Use the sidebar to navigate between different sections: Dashboard, Tasks, Agents, Credits, and more.',
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="dashboard-stats"]',
+    popover: {
+      title: '📊 Dashboard Overview',
+      description: 'Get a quick overview of your system: active agents, pending tasks, credit flow, and recent activity.',
+      side: 'bottom',
+      align: 'center',
+    },
+  },
+  {
+    element: '[data-tour="agents-link"]',
+    popover: {
+      title: '🤖 Agents',
+      description: 'Manage your AI agents here. View their status, capabilities, trust scores, and budgets.',
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="tasks-link"]',
+    popover: {
+      title: '📋 Tasks',
+      description: 'Track work across your agent swarm. Tasks flow through: Backlog → Todo → In Progress → Review → Done.',
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="credits-link"]',
+    popover: {
+      title: '💰 Credits',
+      description: 'Monitor credit spending and earnings. Agents earn credits by completing tasks and spend them on model usage.',
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="network-link"]',
+    popover: {
+      title: '🕸️ Network View',
+      description: 'Visualize your agent hierarchy. See relationships between agents and who manages whom.',
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="demo-controls"]',
+    popover: {
+      title: '🎮 Demo Controls',
+      description: 'In demo mode, use these controls to play/pause the simulation, adjust speed, and switch scenarios.',
+      side: 'top',
+      align: 'end',
+    },
+  },
+  {
+    element: '[data-tour="theme-toggle"]',
+    popover: {
+      title: '🌓 Theme',
+      description: 'Toggle between light and dark mode to suit your preference.',
+      side: 'bottom',
+      align: 'end',
+    },
+  },
+  {
+    popover: {
+      title: '🚀 You\'re all set!',
+      description: 'Start exploring! Try clicking on agents, tasks, or the network view. Hit Play in the demo controls to see the simulation in action.',
+      side: 'over',
+      align: 'center',
+    },
+  },
+];
+
+// Create and start the tour
+export function startTour(onComplete?: () => void): void {
+  const driverObj = driver({
+    showProgress: true,
+    steps: tourSteps,
+    nextBtnText: 'Next →',
+    prevBtnText: '← Back',
+    doneBtnText: 'Get Started!',
+    onDestroyStarted: () => {
+      markTourCompleted();
+      driverObj.destroy();
+      onComplete?.();
+    },
+    popoverClass: 'openspawn-tour-popover',
+  });
+
+  driverObj.drive();
+}
+
+// Start tour if not completed (for first-time users)
+export function maybeStartTour(onComplete?: () => void): void {
+  if (!hasTourCompleted()) {
+    // Small delay to let the page render
+    setTimeout(() => startTour(onComplete), 500);
+  }
+}

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -191,7 +191,7 @@ export function DashboardPage() {
       </div>
 
       {/* Stats grid */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4" data-tour="dashboard-stats">
         <StatCard
           title="Active Agents"
           value={activeAgents}

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -101,3 +101,61 @@
     height: 0;
   }
 }
+
+/* Driver.js tour customization */
+.driver-popover {
+  background-color: hsl(var(--card)) !important;
+  color: hsl(var(--foreground)) !important;
+  border: 1px solid hsl(var(--border)) !important;
+  box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25) !important;
+}
+
+.driver-popover-title {
+  color: hsl(var(--foreground)) !important;
+  font-weight: 600 !important;
+}
+
+.driver-popover-description {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.driver-popover-progress-text {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.driver-popover-prev-btn,
+.driver-popover-next-btn {
+  background-color: hsl(var(--primary)) !important;
+  color: hsl(var(--primary-foreground)) !important;
+  border: none !important;
+  border-radius: var(--radius) !important;
+  padding: 0.5rem 1rem !important;
+  font-weight: 500 !important;
+}
+
+.driver-popover-prev-btn:hover,
+.driver-popover-next-btn:hover {
+  opacity: 0.9 !important;
+}
+
+.driver-popover-close-btn {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.driver-popover-close-btn:hover {
+  color: hsl(var(--foreground)) !important;
+}
+
+.driver-popover-arrow-side-left,
+.driver-popover-arrow-side-right,
+.driver-popover-arrow-side-top,
+.driver-popover-arrow-side-bottom {
+  border-color: hsl(var(--border)) !important;
+}
+
+.driver-popover-arrow-side-left::after,
+.driver-popover-arrow-side-right::after,
+.driver-popover-arrow-side-top::after,
+.driver-popover-arrow-side-bottom::after {
+  border-color: hsl(var(--card)) !important;
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "class-validator": "^0.14.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "driver.js": "^1.4.0",
     "elkjs": "^0.11.0",
     "express": "^5.2.1",
     "framer-motion": "^12.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      driver.js:
+        specifier: ^1.4.0
+        version: 1.4.0
       elkjs:
         specifier: ^0.11.0
         version: 0.11.0
@@ -5797,6 +5800,9 @@ packages:
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
+
+  driver.js@1.4.0:
+    resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
 
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
@@ -16315,6 +16321,8 @@ snapshots:
   dotenv@16.4.7: {}
 
   dotenv@16.6.1: {}
+
+  driver.js@1.4.0: {}
 
   dset@3.1.4: {}
 


### PR DESCRIPTION
## Summary
Adds an interactive guided tour using driver.js to help first-time users discover features.

### Tour Stops
1. 👋 Welcome splash
2. 🧭 Sidebar navigation
3. 📊 Dashboard stats overview
4. 🤖 Agents page
5. 📋 Tasks page  
6. 💰 Credits page
7. 🕸️ Network view
8. 🎮 Demo controls
9. 🌓 Theme toggle
10. 🚀 Get started!

### How to Trigger
- **Welcome Modal**: 'Take a Guided Tour' button
- **Programmatic**: `startTour()` from `lib/tour.ts`

### Styling
- Custom CSS matching our dark/light theme
- Smooth animations and transitions
- Progress indicator shows current step

### Dependencies
- `driver.js`: ~7KB gzipped

### Stacked On
- #44 (Activity Toasts)
- #43 (Confetti)
- #42 (Avatars)

### Testing
- `pnpm build` ✅