### PR TITLE
fix(dashboard): Tone down confetti celebrations

### DIFF
--- a/apps/dashboard/src/demo/DemoProvider.tsx
+++ b/apps/dashboard/src/demo/DemoProvider.tsx
@@ -110,33 +110,28 @@ export function DemoProvider({
     };
   }, []); // Only run once on mount
 
-  // Trigger confetti based on event type
+  // Cooldown tracking for confetti (prevent spam)
+  const lastConfettiRef = useRef<number>(0);
+  const CONFETTI_COOLDOWN_MS = 8000; // 8 seconds between confetti
+
+  // Trigger confetti based on event type (toned down - only major events)
   const triggerCelebration = useCallback((event: SimulationEvent) => {
-    switch (event.type) {
-      case 'task_completed':
-        // Task completed - small celebration
-        celebrateSparkle();
-        break;
-      case 'agent_promoted':
-        // Agent promoted - level up celebration
-        celebrateLevelUp();
-        break;
-      case 'agent_activated':
-        // New agent activated - welcome burst
-        celebrate('burst');
-        break;
-      case 'agent_created':
-        // Agent spawned - subtle sparkle (agent still pending)
-        // No celebration until activated
-        break;
-      default:
-        // Other events don't trigger celebrations
-        break;
+    // Check cooldown before firing confetti
+    const now = Date.now();
+    if (now - lastConfettiRef.current < CONFETTI_COOLDOWN_MS) {
+      return; // Skip if on cooldown
+    }
+
+    // Only celebrate promotions (rare, meaningful events)
+    if (event.type === 'agent_promoted') {
+      lastConfettiRef.current = now;
+      celebrateLevelUp();
     }
     
-    // Special celebration for elite reputation
+    // Special celebration for elite + 100 trust (very rare)
     const payload = event.payload as { agent?: { reputationLevel?: string; trustScore?: number } };
     if (payload?.agent?.reputationLevel === 'ELITE' && payload?.agent?.trustScore === 100) {
+      lastConfettiRef.current = now;
       celebrateElite();
     }
   }, []);

--- a/apps/dashboard/src/lib/confetti.ts
+++ b/apps/dashboard/src/lib/confetti.ts
@@ -19,8 +19,8 @@ const LEVEL_UP_COLORS = ['#a78bfa', '#c4b5fd', '#ffd700', '#ffec8b', '#f472b6'];
  */
 export function celebrateBurst() {
   confetti({
-    particleCount: 100,
-    spread: 70,
+    particleCount: 50,
+    spread: 60,
     origin: { y: 0.6 },
     colors: THEME_COLORS,
   });
@@ -56,36 +56,18 @@ export function celebrateCannons() {
 }
 
 /**
- * Level up / promotion celebration (stars + confetti)
+ * Level up / promotion celebration (stars + confetti) - subtle version
  */
 export function celebrateLevelUp() {
-  const duration = 1500;
-  const end = Date.now() + duration;
-
-  (function frame() {
-    confetti({
-      particleCount: 2,
-      angle: 60,
-      spread: 55,
-      origin: { x: 0 },
-      colors: LEVEL_UP_COLORS,
-      shapes: ['star'],
-      scalar: 1.2,
-    });
-    confetti({
-      particleCount: 2,
-      angle: 120,
-      spread: 55,
-      origin: { x: 1 },
-      colors: LEVEL_UP_COLORS,
-      shapes: ['star'],
-      scalar: 1.2,
-    });
-
-    if (Date.now() < end) {
-      requestAnimationFrame(frame);
-    }
-  })();
+  // Single burst instead of continuous animation
+  confetti({
+    particleCount: 40,
+    spread: 70,
+    origin: { y: 0.6 },
+    colors: LEVEL_UP_COLORS,
+    shapes: ['star', 'circle'],
+    scalar: 1.1,
+  });
 }
 
 /**
@@ -140,32 +122,20 @@ export function celebrateSparkle() {
 }
 
 /**
- * Elite agent celebration (gold rain)
+ * Elite agent celebration (gold burst) - subtle version
  */
 export function celebrateElite() {
-  const duration = 1000;
-  const end = Date.now() + duration;
   const colors = ['#ffd700', '#ffec8b', '#daa520', '#b8860b'];
-
-  (function frame() {
-    confetti({
-      particleCount: 5,
-      startVelocity: 0,
-      ticks: 200,
-      gravity: 0.5,
-      origin: {
-        x: Math.random(),
-        y: 0,
-      },
-      colors,
-      shapes: ['circle'],
-      scalar: 1.5,
-    });
-
-    if (Date.now() < end) {
-      requestAnimationFrame(frame);
-    }
-  })();
+  
+  // Single elegant gold burst
+  confetti({
+    particleCount: 60,
+    spread: 80,
+    origin: { y: 0.5 },
+    colors,
+    shapes: ['circle', 'star'],
+    scalar: 1.2,
+  });
 }
 
 // Celebration types mapped to functions


### PR DESCRIPTION
## The Problem
Confetti was firing too frequently and was overwhelming 🎉🎉🎉

## The Fix
- **8 second cooldown** between confetti bursts
- **Promotions only** — removed triggers for task_completed, agent_activated  
- **Reduced particles** — 50 instead of 100
- **Single bursts** — no more continuous animations

### Before
- Every task completion → sparkle
- Every agent activation → burst  
- Every promotion → 1.5 second animation loop

### After
- Only promotions → single burst (max every 8 sec)
- Elite 100 trust → gold burst (very rare)

Keeps confetti special, not spammy ✨

### Testing
- `pnpm build` ✅