### PR TITLE
feat(mcp): Add trust, reputation, and escalation tools

### DIFF
--- a/apps/mcp/src/api-client.ts
+++ b/apps/mcp/src/api-client.ts
@@ -129,4 +129,52 @@ export class ApiClient {
     // Returns the current agent based on auth headers
     return this.request("GET", "/health");
   }
+
+  // Trust & Reputation operations
+  async getAgentReputation(agentId: string): Promise<{ data: unknown }> {
+    return this.request("GET", `/agents/${agentId}/reputation`);
+  }
+
+  async getReputationHistory(agentId: string, limit = 20): Promise<{ data: unknown[] }> {
+    return this.request("GET", `/agents/${agentId}/reputation/history?limit=${limit}`);
+  }
+
+  async getTrustLeaderboard(limit = 10): Promise<{ data: unknown[] }> {
+    return this.request("GET", `/agents/leaderboard/trust?limit=${limit}`);
+  }
+
+  async applyReputationBonus(agentId: string, amount: number, reason: string): Promise<{ data: unknown }> {
+    return this.request("POST", `/agents/${agentId}/reputation/bonus`, { amount, reason });
+  }
+
+  async applyReputationPenalty(agentId: string, amount: number, reason: string): Promise<{ data: unknown }> {
+    return this.request("POST", `/agents/${agentId}/reputation/penalty`, { amount, reason });
+  }
+
+  // Escalation operations
+  async createEscalation(taskId: string, reason: string, targetAgentId: string): Promise<{ data: unknown }> {
+    return this.request("POST", `/tasks/${taskId}/escalate`, { reason, targetAgentId });
+  }
+
+  async getEscalations(taskId?: string): Promise<{ data: unknown[] }> {
+    const query = taskId ? `?taskId=${taskId}` : "";
+    return this.request("GET", `/escalations${query}`);
+  }
+
+  async resolveEscalation(escalationId: string, resolution: string): Promise<{ data: unknown }> {
+    return this.request("POST", `/escalations/${escalationId}/resolve`, { resolution });
+  }
+
+  // Consensus operations
+  async requestConsensus(taskId: string, question: string, voterIds: string[]): Promise<{ data: unknown }> {
+    return this.request("POST", `/tasks/${taskId}/consensus`, { question, voterIds });
+  }
+
+  async submitVote(consensusId: string, vote: "approve" | "reject", reason?: string): Promise<{ data: unknown }> {
+    return this.request("POST", `/consensus/${consensusId}/vote`, { vote, reason });
+  }
+
+  async getConsensusStatus(consensusId: string): Promise<{ data: unknown }> {
+    return this.request("GET", `/consensus/${consensusId}`);
+  }
 }

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -4,8 +4,10 @@ import { ApiClient } from "./api-client.js";
 import {
   registerAgentTools,
   registerCreditTools,
+  registerEscalationTools,
   registerMessageTools,
   registerTaskTools,
+  registerTrustTools,
 } from "./tools/index.js";
 
 export function createMcpServer(): McpServer {
@@ -26,6 +28,8 @@ export function createMcpServer(): McpServer {
   registerCreditTools(server, apiClient);
   registerMessageTools(server, apiClient);
   registerAgentTools(server, apiClient);
+  registerTrustTools(server, apiClient);
+  registerEscalationTools(server, apiClient);
 
   return server;
 }

--- a/apps/mcp/src/tools/escalation-tools.ts
+++ b/apps/mcp/src/tools/escalation-tools.ts
@@ -1,0 +1,91 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import type { ApiClient } from "../api-client.js";
+
+export function registerEscalationTools(server: McpServer, client: ApiClient) {
+  // Create escalation
+  server.tool(
+    "escalation_create",
+    "Escalate a task to a higher-level agent",
+    {
+      taskId: z.string().describe("The task ID to escalate"),
+      reason: z.string().describe("Reason for escalation (e.g., 'blocked', 'needs_approval', 'out_of_scope')"),
+      targetAgentId: z.string().describe("Agent ID to escalate to (must be higher level)"),
+    },
+    async ({ taskId, reason, targetAgentId }) => {
+      const result = await client.createEscalation(taskId, reason, targetAgentId);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+
+  // List escalations
+  server.tool(
+    "escalation_list",
+    "List escalations, optionally filtered by task",
+    {
+      taskId: z.string().optional().describe("Filter by task ID"),
+    },
+    async ({ taskId }) => {
+      const result = await client.getEscalations(taskId);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+
+  // Resolve escalation
+  server.tool(
+    "escalation_resolve",
+    "Resolve an escalation with a resolution note",
+    {
+      escalationId: z.string().describe("The escalation ID to resolve"),
+      resolution: z.string().describe("How the escalation was resolved"),
+    },
+    async ({ escalationId, resolution }) => {
+      const result = await client.resolveEscalation(escalationId, resolution);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+
+  // Request consensus
+  server.tool(
+    "consensus_request",
+    "Request a consensus vote from multiple agents",
+    {
+      taskId: z.string().describe("The task ID requiring consensus"),
+      question: z.string().describe("The question to vote on"),
+      voterIds: z.array(z.string()).describe("List of agent IDs who should vote"),
+    },
+    async ({ taskId, question, voterIds }) => {
+      const result = await client.requestConsensus(taskId, question, voterIds);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+
+  // Submit vote
+  server.tool(
+    "consensus_vote",
+    "Submit your vote on a consensus request",
+    {
+      consensusId: z.string().describe("The consensus request ID"),
+      vote: z.enum(["approve", "reject"]).describe("Your vote"),
+      reason: z.string().optional().describe("Optional reason for your vote"),
+    },
+    async ({ consensusId, vote, reason }) => {
+      const result = await client.submitVote(consensusId, vote, reason);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+
+  // Get consensus status
+  server.tool(
+    "consensus_status",
+    "Check the status of a consensus request",
+    {
+      consensusId: z.string().describe("The consensus request ID"),
+    },
+    async ({ consensusId }) => {
+      const result = await client.getConsensusStatus(consensusId);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+}

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -2,3 +2,5 @@ export { registerTaskTools } from "./task-tools.js";
 export { registerCreditTools } from "./credit-tools.js";
 export { registerMessageTools } from "./message-tools.js";
 export { registerAgentTools } from "./agent-tools.js";
+export { registerTrustTools } from "./trust-tools.js";
+export { registerEscalationTools } from "./escalation-tools.js";

--- a/apps/mcp/src/tools/trust-tools.ts
+++ b/apps/mcp/src/tools/trust-tools.ts
@@ -1,0 +1,76 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import type { ApiClient } from "../api-client.js";
+
+export function registerTrustTools(server: McpServer, client: ApiClient) {
+  // Get agent reputation
+  server.tool(
+    "trust_get_reputation",
+    "Get trust score and reputation details for an agent",
+    {
+      agentId: z.string().describe("The agent ID to get reputation for"),
+    },
+    async ({ agentId }) => {
+      const result = await client.getAgentReputation(agentId);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+
+  // Get reputation history
+  server.tool(
+    "trust_get_history",
+    "Get reputation change history for an agent",
+    {
+      agentId: z.string().describe("The agent ID"),
+      limit: z.number().optional().describe("Max events to return (default 20)"),
+    },
+    async ({ agentId, limit }) => {
+      const result = await client.getReputationHistory(agentId, limit);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+
+  // Get trust leaderboard
+  server.tool(
+    "trust_leaderboard",
+    "Get top agents ranked by trust score",
+    {
+      limit: z.number().optional().describe("Number of agents to return (default 10)"),
+    },
+    async ({ limit }) => {
+      const result = await client.getTrustLeaderboard(limit);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+
+  // Apply reputation bonus (requires HR role)
+  server.tool(
+    "trust_bonus",
+    "Award a reputation bonus to an agent (requires HR role)",
+    {
+      agentId: z.string().describe("The agent ID to reward"),
+      amount: z.number().min(1).max(20).describe("Bonus amount (1-20)"),
+      reason: z.string().describe("Reason for the bonus"),
+    },
+    async ({ agentId, amount, reason }) => {
+      const result = await client.applyReputationBonus(agentId, amount, reason);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+
+  // Apply reputation penalty (requires HR role)
+  server.tool(
+    "trust_penalty",
+    "Apply a reputation penalty to an agent (requires HR role)",
+    {
+      agentId: z.string().describe("The agent ID to penalize"),
+      amount: z.number().min(1).max(20).describe("Penalty amount (1-20)"),
+      reason: z.string().describe("Reason for the penalty"),
+    },
+    async ({ agentId, amount, reason }) => {
+      const result = await client.applyReputationPenalty(agentId, amount, reason);
+      return { content: [{ type: "text", text: JSON.stringify(result.data, null, 2) }] };
+    }
+  );
+}


### PR DESCRIPTION
## Summary
Adds Phase 5-6 capabilities to the MCP server.

### New Tools (11 total)

#### Trust & Reputation (5)
| Tool | Description |
|------|-------------|
| `trust_get_reputation` | Get agent trust score and details |
| `trust_get_history` | View reputation change history |
| `trust_leaderboard` | Top agents by trust score |
| `trust_bonus` | Award reputation bonus (HR role) |
| `trust_penalty` | Apply reputation penalty (HR role) |

#### Escalation & Consensus (6)
| Tool | Description |
|------|-------------|
| `escalation_create` | Escalate task to higher-level agent |
| `escalation_list` | List escalations |
| `escalation_resolve` | Resolve an escalation |
| `consensus_request` | Request multi-agent vote |
| `consensus_vote` | Submit vote on consensus request |
| `consensus_status` | Check consensus status |

### Usage Example
```typescript
// Check your reputation
await mcp.call('trust_get_reputation', { agentId: 'my-agent' });

// Escalate a blocked task
await mcp.call('escalation_create', {
  taskId: 'task-123',
  reason: 'blocked',
  targetAgentId: 'manager-agent'
});

// Request consensus vote
await mcp.call('consensus_request', {
  taskId: 'task-456',
  question: 'Should we proceed with approach A?',
  voterIds: ['agent-1', 'agent-2', 'agent-3']
});
```

### Stacked On
- #48 (Screenshots)

### Testing
- `pnpm build` ✅