### PR TITLE
feat: add webhooks system and CLI tool

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { EventsModule } from "../events";
 import { GraphqlModule } from "../graphql";
 import { MessagesModule } from "../messages";
 import { TasksModule } from "../tasks";
+import { WebhooksModule } from "../webhooks";
 
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
@@ -41,6 +42,7 @@ import { AppService } from "./app.service";
     TasksModule,
     CreditsModule,
     MessagesModule,
+    WebhooksModule,
 
     // GraphQL
     GraphqlModule,

--- a/apps/api/src/webhooks/dto/create-webhook.dto.ts
+++ b/apps/api/src/webhooks/dto/create-webhook.dto.ts
@@ -1,0 +1,17 @@
+import { IsString, IsUrl, IsArray, IsOptional, ArrayMinSize } from "class-validator";
+
+export class CreateWebhookDto {
+  @IsString()
+  name!: string;
+
+  @IsUrl()
+  url!: string;
+
+  @IsOptional()
+  @IsString()
+  secret?: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  events!: string[];
+}

--- a/apps/api/src/webhooks/dto/update-webhook.dto.ts
+++ b/apps/api/src/webhooks/dto/update-webhook.dto.ts
@@ -1,0 +1,24 @@
+import { IsString, IsUrl, IsArray, IsOptional, IsBoolean } from "class-validator";
+
+export class UpdateWebhookDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsUrl()
+  url?: string;
+
+  @IsOptional()
+  @IsString()
+  secret?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  events?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/apps/api/src/webhooks/index.ts
+++ b/apps/api/src/webhooks/index.ts
@@ -1,0 +1,5 @@
+export { WebhooksModule } from "./webhooks.module";
+export { WebhooksService } from "./webhooks.service";
+export { WebhooksController } from "./webhooks.controller";
+export { CreateWebhookDto } from "./dto/create-webhook.dto";
+export { UpdateWebhookDto } from "./dto/update-webhook.dto";

--- a/apps/api/src/webhooks/webhooks.controller.ts
+++ b/apps/api/src/webhooks/webhooks.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  NotFoundException,
+} from "@nestjs/common";
+import { WebhooksService } from "./webhooks.service";
+import { CreateWebhookDto } from "./dto/create-webhook.dto";
+import { UpdateWebhookDto } from "./dto/update-webhook.dto";
+import { JwtAuthGuard, CurrentUser, type JwtUser } from "../auth";
+
+@Controller("webhooks")
+@UseGuards(JwtAuthGuard)
+export class WebhooksController {
+  constructor(private readonly webhooksService: WebhooksService) {}
+
+  @Post()
+  async create(@CurrentUser() user: JwtUser, @Body() dto: CreateWebhookDto) {
+    return this.webhooksService.create(user.orgId, dto);
+  }
+
+  @Get()
+  async list(@CurrentUser() user: JwtUser) {
+    return this.webhooksService.findByOrg(user.orgId);
+  }
+
+  @Get(":id")
+  async get(@CurrentUser() user: JwtUser, @Param("id") id: string) {
+    const webhook = await this.webhooksService.findById(user.orgId, id);
+    if (!webhook) {
+      throw new NotFoundException("Webhook not found");
+    }
+    return webhook;
+  }
+
+  @Patch(":id")
+  async update(
+    @CurrentUser() user: JwtUser,
+    @Param("id") id: string,
+    @Body() dto: UpdateWebhookDto,
+  ) {
+    const webhook = await this.webhooksService.update(user.orgId, id, dto);
+    if (!webhook) {
+      throw new NotFoundException("Webhook not found");
+    }
+    return webhook;
+  }
+
+  @Delete(":id")
+  async delete(@CurrentUser() user: JwtUser, @Param("id") id: string) {
+    const deleted = await this.webhooksService.delete(user.orgId, id);
+    if (!deleted) {
+      throw new NotFoundException("Webhook not found");
+    }
+    return { success: true };
+  }
+
+  @Post(":id/test")
+  async test(@CurrentUser() user: JwtUser, @Param("id") id: string) {
+    return this.webhooksService.sendTestEvent(user.orgId, id);
+  }
+}

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Webhook } from "@openspawn/database";
+import { WebhooksController } from "./webhooks.controller";
+import { WebhooksService } from "./webhooks.service";
+import { AuthModule } from "../auth";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Webhook]), AuthModule],
+  controllers: [WebhooksController],
+  providers: [WebhooksService],
+  exports: [WebhooksService],
+})
+export class WebhooksModule {}

--- a/apps/api/src/webhooks/webhooks.service.ts
+++ b/apps/api/src/webhooks/webhooks.service.ts
@@ -1,0 +1,180 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { OnEvent } from "@nestjs/event-emitter";
+import { Repository } from "typeorm";
+import { Webhook, Event } from "@openspawn/database";
+import * as crypto from "node:crypto";
+
+export interface WebhookPayload {
+  event: string;
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+
+@Injectable()
+export class WebhooksService {
+  private readonly logger = new Logger(WebhooksService.name);
+
+  constructor(
+    @InjectRepository(Webhook)
+    private readonly webhookRepo: Repository<Webhook>,
+  ) {}
+
+  async create(
+    orgId: string,
+    data: { name: string; url: string; secret?: string; events: string[] },
+  ): Promise<Webhook> {
+    const webhook = this.webhookRepo.create({
+      orgId,
+      name: data.name,
+      url: data.url,
+      secret: data.secret,
+      events: data.events,
+      enabled: true,
+    });
+    return this.webhookRepo.save(webhook);
+  }
+
+  async findByOrg(orgId: string): Promise<Webhook[]> {
+    return this.webhookRepo.find({
+      where: { orgId },
+      order: { createdAt: "DESC" },
+    });
+  }
+
+  async findById(orgId: string, id: string): Promise<Webhook | null> {
+    return this.webhookRepo.findOne({ where: { id, orgId } });
+  }
+
+  async update(
+    orgId: string,
+    id: string,
+    data: Partial<{ name: string; url: string; secret: string; events: string[]; enabled: boolean }>,
+  ): Promise<Webhook | null> {
+    const webhook = await this.findById(orgId, id);
+    if (!webhook) return null;
+
+    Object.assign(webhook, data);
+    return this.webhookRepo.save(webhook);
+  }
+
+  async delete(orgId: string, id: string): Promise<boolean> {
+    const result = await this.webhookRepo.delete({ id, orgId });
+    return (result.affected ?? 0) > 0;
+  }
+
+  async dispatchEvent(orgId: string, eventType: string, data: Record<string, unknown>): Promise<void> {
+    const webhooks = await this.webhookRepo.find({
+      where: { orgId, enabled: true },
+    });
+
+    const payload: WebhookPayload = {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      data,
+    };
+
+    const matchingWebhooks = webhooks.filter(
+      (w) => w.events.length === 0 || w.events.includes(eventType) || w.events.includes("*"),
+    );
+
+    await Promise.allSettled(
+      matchingWebhooks.map((webhook) => this.sendWebhook(webhook, payload)),
+    );
+  }
+
+  private async sendWebhook(webhook: Webhook, payload: WebhookPayload): Promise<void> {
+    const body = JSON.stringify(payload);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-OpenSpawn-Event": payload.event,
+      "X-OpenSpawn-Delivery": crypto.randomUUID(),
+    };
+
+    if (webhook.secret) {
+      const signature = crypto
+        .createHmac("sha256", webhook.secret)
+        .update(body)
+        .digest("hex");
+      headers["X-OpenSpawn-Signature"] = `sha256=${signature}`;
+    }
+
+    try {
+      const response = await fetch(webhook.url, {
+        method: "POST",
+        headers,
+        body,
+        signal: AbortSignal.timeout(10000),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      await this.webhookRepo.update(webhook.id, {
+        lastTriggeredAt: new Date(),
+        failureCount: 0,
+        lastError: undefined,
+      });
+
+      this.logger.debug(`Webhook ${webhook.id} delivered: ${payload.event}`);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Webhook ${webhook.id} failed: ${errorMessage}`);
+
+      await this.webhookRepo.update(webhook.id, {
+        failureCount: webhook.failureCount + 1,
+        lastError: errorMessage,
+      });
+
+      // Disable after 10 consecutive failures
+      if (webhook.failureCount >= 9) {
+        await this.webhookRepo.update(webhook.id, { enabled: false });
+        this.logger.warn(`Webhook ${webhook.id} disabled after 10 failures`);
+      }
+    }
+  }
+
+  async sendTestEvent(orgId: string, id: string): Promise<{ success: boolean; error?: string }> {
+    const webhook = await this.findById(orgId, id);
+    if (!webhook) {
+      return { success: false, error: "Webhook not found" };
+    }
+
+    const payload: WebhookPayload = {
+      event: "test",
+      timestamp: new Date().toISOString(),
+      data: { message: "This is a test webhook from OpenSpawn" },
+    };
+
+    try {
+      await this.sendWebhook(webhook, payload);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /**
+   * Listen for all events and dispatch to registered webhooks
+   */
+  @OnEvent("event.created")
+  async handleEventCreated(event: Event): Promise<void> {
+    try {
+      await this.dispatchEvent(event.orgId, event.type, {
+        id: event.id,
+        actorId: event.actorId,
+        entityType: event.entityType,
+        entityId: event.entityId,
+        severity: event.severity,
+        data: event.data,
+        createdAt: event.createdAt,
+      });
+    } catch (error) {
+      this.logger.error(`Failed to dispatch webhooks for event ${event.id}:`, error);
+    }
+  }
+}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@openspawn/cli",
+  "version": "0.1.0",
+  "description": "OpenSpawn CLI for agent interaction",
+  "type": "module",
+  "main": "./dist/main.js",
+  "bin": {
+    "openspawn": "./dist/main.js"
+  },
+  "dependencies": {
+    "commander": "^12.1.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/apps/cli/project.json
+++ b/apps/cli/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "cli",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/cli/src",
+  "projectType": "application",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc -p apps/cli/tsconfig.json"
+      },
+      "outputs": ["{workspaceRoot}/dist/apps/cli"]
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsx apps/cli/src/main.ts"
+      }
+    }
+  }
+}

--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -1,0 +1,72 @@
+import { Command } from "commander";
+import { createClient } from "../lib/api.js";
+import { output, outputError, outputTable } from "../lib/output.js";
+
+interface Agent {
+  id: string;
+  agentId: string;
+  name: string;
+  role: string;
+  level: number;
+  status: string;
+  currentBalance: number;
+}
+
+export function createAgentsCommand(): Command {
+  const agents = new Command("agents").description("Agent management commands");
+
+  agents.command("list").description("List all agents").action(async () => {
+    try {
+      const client = createClient();
+      const response = await client.listAgents();
+      const agentList = (response.data as Agent[]) ?? [];
+      outputTable(
+        ["ID", "Agent ID", "Name", "Role", "Level", "Status", "Balance"],
+        agentList.map((a) => [a.id.substring(0, 8), a.agentId, a.name, a.role, String(a.level), a.status, String(a.currentBalance)])
+      );
+    } catch (err) {
+      outputError(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  });
+
+  agents.command("get <id>").description("Get agent details").action(async (id: string) => {
+    try {
+      const client = createClient();
+      const response = await client.getAgent(id);
+      output(response.data);
+    } catch (err) {
+      outputError(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  });
+
+  agents
+    .command("create")
+    .description("Create a new agent")
+    .requiredOption("--name <name>", "Agent name")
+    .requiredOption("--level <level>", "Agent level (1-10)", parseInt)
+    .option("--agent-id <id>", "Custom agent identifier")
+    .option("--role <role>", "Agent role", "worker")
+    .action(async (options: { name: string; level: number; agentId?: string; role?: string }) => {
+      try {
+        if (options.level < 1 || options.level > 10) {
+          outputError("Level must be between 1 and 10");
+          process.exit(1);
+        }
+        const client = createClient();
+        const response = await client.createAgent({
+          name: options.name,
+          agentId: options.agentId ?? options.name.toLowerCase().replace(/\s+/g, "-"),
+          level: options.level,
+          role: options.role,
+        });
+        output(response);
+      } catch (err) {
+        outputError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  return agents;
+}

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -1,0 +1,53 @@
+import { Command } from "commander";
+import { getApiKey, getApiUrl, setApiKey, setApiUrl } from "../lib/config.js";
+import { output, outputError, outputSuccess } from "../lib/output.js";
+import { OpenSpawnClient } from "../lib/api.js";
+
+export function createAuthCommand(): Command {
+  const auth = new Command("auth").description("Authentication commands");
+
+  auth
+    .command("login")
+    .description("Configure API credentials")
+    .requiredOption("--api-key <key>", "API key (osp_...)")
+    .option("--api-url <url>", "API URL (default: http://localhost:3000)")
+    .action((options: { apiKey: string; apiUrl?: string }) => {
+      if (!options.apiKey.startsWith("osp_")) {
+        outputError("API key must start with 'osp_'");
+        process.exit(1);
+      }
+      setApiKey(options.apiKey);
+      if (options.apiUrl) setApiUrl(options.apiUrl);
+      outputSuccess("Credentials saved to ~/.openspawn/config.json");
+    });
+
+  auth
+    .command("whoami")
+    .description("Show current authentication status")
+    .action(async () => {
+      const apiKey = getApiKey();
+      const apiUrl = getApiUrl();
+      if (!apiKey) {
+        outputError("Not logged in. Run: openspawn auth login --api-key <key>");
+        process.exit(1);
+      }
+      try {
+        const client = new OpenSpawnClient(apiKey, apiUrl);
+        await client.whoami();
+        output({ status: "authenticated", apiUrl, apiKeyPrefix: apiKey.substring(0, 12) + "..." });
+      } catch (err) {
+        output({ status: "invalid", apiUrl, error: err instanceof Error ? err.message : "Unknown error" });
+        process.exit(1);
+      }
+    });
+
+  auth
+    .command("logout")
+    .description("Remove stored credentials")
+    .action(() => {
+      setApiKey("");
+      outputSuccess("Credentials removed");
+    });
+
+  return auth;
+}

--- a/apps/cli/src/commands/credits.ts
+++ b/apps/cli/src/commands/credits.ts
@@ -1,0 +1,44 @@
+import { Command } from "commander";
+import { createClient } from "../lib/api.js";
+import { output, outputError } from "../lib/output.js";
+
+export function createCreditsCommand(): Command {
+  const credits = new Command("credits").description("Manage credits");
+
+  credits
+    .command("balance [agentId]")
+    .description("Get credit balance for an agent")
+    .action(async (agentId) => {
+      try {
+        const client = createClient();
+        const response = await client.getBalance(agentId);
+        output(response);
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  credits
+    .command("transfer")
+    .description("Transfer credits between agents")
+    .requiredOption("--from <id>", "Source agent ID")
+    .requiredOption("--to <id>", "Destination agent ID")
+    .requiredOption("--amount <n>", "Amount to transfer")
+    .action(async (opts) => {
+      try {
+        const client = createClient();
+        const response = await client.transferCredits(
+          opts.from,
+          opts.to,
+          parseInt(opts.amount, 10),
+        );
+        output(response);
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  return credits;
+}

--- a/apps/cli/src/commands/index.ts
+++ b/apps/cli/src/commands/index.ts
@@ -1,0 +1,5 @@
+export { createAuthCommand } from "./auth.js";
+export { createAgentsCommand } from "./agents.js";
+export { createTasksCommand } from "./tasks.js";
+export { createCreditsCommand } from "./credits.js";
+export { createMessagesCommand } from "./messages.js";

--- a/apps/cli/src/commands/messages.ts
+++ b/apps/cli/src/commands/messages.ts
@@ -1,0 +1,54 @@
+import { Command } from "commander";
+import { createClient } from "../lib/api.js";
+import { output, outputError } from "../lib/output.js";
+
+export function createMessagesCommand(): Command {
+  const messages = new Command("messages").description("Manage messages");
+
+  messages
+    .command("send")
+    .description("Send a direct message to an agent")
+    .requiredOption("--to <agentId>", "Recipient agent ID")
+    .requiredOption("--content <text>", "Message content")
+    .action(async (opts) => {
+      try {
+        const client = createClient();
+        const response = await client.sendMessage(opts.to, opts.content);
+        output(response);
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  messages
+    .command("list")
+    .description("List messages in a channel")
+    .requiredOption("--channel <id>", "Channel ID")
+    .action(async (opts) => {
+      try {
+        const client = createClient();
+        const response = await client.listMessages(opts.channel);
+        output(response);
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  messages
+    .command("channels")
+    .description("List available channels")
+    .action(async () => {
+      try {
+        const client = createClient();
+        const response = await client.listChannels();
+        output(response);
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  return messages;
+}

--- a/apps/cli/src/commands/tasks.ts
+++ b/apps/cli/src/commands/tasks.ts
@@ -1,0 +1,89 @@
+import { Command } from "commander";
+import { createClient } from "../lib/api.js";
+import { output, outputError } from "../lib/output.js";
+
+export function createTasksCommand(): Command {
+  const tasks = new Command("tasks").description("Manage tasks");
+
+  tasks
+    .command("list")
+    .description("List tasks")
+    .option("--status <status>", "Filter by status")
+    .action(async (opts) => {
+      try {
+        const client = createClient();
+        const response = await client.listTasks({ status: opts.status });
+        output(response);
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  tasks
+    .command("get <id>")
+    .description("Get task details")
+    .action(async (id) => {
+      try {
+        const client = createClient();
+        const response = await client.getTask(id);
+        output(response);
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  tasks
+    .command("create")
+    .description("Create a new task")
+    .requiredOption("--title <title>", "Task title")
+    .option("--description <desc>", "Task description")
+    .option("--priority <priority>", "Priority (low|medium|high|critical)", "medium")
+    .action(async (opts) => {
+      try {
+        const client = createClient();
+        const response = await client.createTask({
+          title: opts.title,
+          description: opts.description,
+          priority: opts.priority.toUpperCase(),
+        });
+        output(response);
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  tasks
+    .command("assign <taskId>")
+    .description("Assign task to agent")
+    .requiredOption("--to <agentId>", "Agent ID to assign to")
+    .action(async (taskId, opts) => {
+      try {
+        const client = createClient();
+        const response = await client.assignTask(taskId, opts.to);
+        output(response);
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  tasks
+    .command("transition <taskId>")
+    .description("Transition task to new status")
+    .requiredOption("--status <status>", "New status")
+    .action(async (taskId, opts) => {
+      try {
+        const client = createClient();
+        const response = await client.transitionTask(taskId, opts.status.toUpperCase());
+        output(response);
+      } catch (error) {
+        outputError(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  return tasks;
+}

--- a/apps/cli/src/lib/api.ts
+++ b/apps/cli/src/lib/api.ts
@@ -1,0 +1,147 @@
+import { getApiKey, getApiUrl } from "./config.js";
+
+export interface ApiResponse<T = unknown> {
+  data?: T;
+  message?: string;
+  error?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface ApiError {
+  message: string;
+  statusCode?: number;
+}
+
+export class OpenSpawnClient {
+  private baseUrl: string;
+  private apiKey: string;
+
+  constructor(apiKey?: string, baseUrl?: string) {
+    this.baseUrl = baseUrl ?? getApiUrl();
+    this.apiKey = apiKey ?? getApiKey() ?? "";
+
+    if (!this.apiKey) {
+      throw new Error(
+        "No API key configured. Run: openspawn auth login --api-key <key>",
+      );
+    }
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json",
+    };
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      const error: ApiError = {
+        message: data.message ?? data.error ?? "Request failed",
+        statusCode: response.status,
+      };
+      throw error;
+    }
+
+    return data as T;
+  }
+
+  async whoami(): Promise<ApiResponse> {
+    return this.request("GET", "/agents");
+  }
+
+  async listAgents(): Promise<ApiResponse> {
+    return this.request("GET", "/agents");
+  }
+
+  async getAgent(id: string): Promise<ApiResponse> {
+    return this.request("GET", `/agents/${id}`);
+  }
+
+  async createAgent(data: {
+    name: string;
+    agentId: string;
+    level: number;
+    role?: string;
+  }): Promise<ApiResponse> {
+    return this.request("POST", "/agents/register", data);
+  }
+
+  async listTasks(params?: { status?: string }): Promise<ApiResponse> {
+    const query = params?.status ? `?status=${params.status}` : "";
+    return this.request("GET", `/tasks${query}`);
+  }
+
+  async getTask(id: string): Promise<ApiResponse> {
+    return this.request("GET", `/tasks/${id}`);
+  }
+
+  async createTask(data: {
+    title: string;
+    priority: string;
+    description?: string;
+  }): Promise<ApiResponse> {
+    return this.request("POST", "/tasks", data);
+  }
+
+  async assignTask(taskId: string, assigneeId: string): Promise<ApiResponse> {
+    return this.request("POST", `/tasks/${taskId}/assign`, { assigneeId });
+  }
+
+  async transitionTask(taskId: string, status: string): Promise<ApiResponse> {
+    return this.request("POST", `/tasks/${taskId}/transition`, { status });
+  }
+
+  async getBalance(agentId?: string): Promise<ApiResponse> {
+    if (agentId) {
+      return this.request("GET", `/agents/${agentId}/credits/balance`);
+    }
+    return this.request("GET", "/credits/balance");
+  }
+
+  async transferCredits(
+    fromId: string,
+    toId: string,
+    amount: number,
+  ): Promise<ApiResponse> {
+    return this.request("POST", "/agents/credits/transfer", {
+      fromAgentId: fromId,
+      toAgentId: toId,
+      amount,
+    });
+  }
+
+  async listMessages(channelId: string): Promise<ApiResponse> {
+    return this.request("GET", `/messages?channelId=${channelId}`);
+  }
+
+  async sendMessage(
+    recipientId: string,
+    content: string,
+  ): Promise<ApiResponse> {
+    return this.request("POST", "/dm", {
+      recipientId,
+      body: content,
+    });
+  }
+
+  async listChannels(): Promise<ApiResponse> {
+    return this.request("GET", "/channels");
+  }
+}
+
+export function createClient(): OpenSpawnClient {
+  return new OpenSpawnClient();
+}

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -1,0 +1,62 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface CliConfig {
+  apiUrl: string;
+  apiKey?: string;
+}
+
+const CONFIG_DIR = join(homedir(), ".openspawn");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+
+const DEFAULT_CONFIG: CliConfig = {
+  apiUrl: "http://localhost:3000",
+};
+
+export function ensureConfigDir(): void {
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true });
+  }
+}
+
+export function loadConfig(): CliConfig {
+  ensureConfigDir();
+
+  if (!existsSync(CONFIG_FILE)) {
+    return DEFAULT_CONFIG;
+  }
+
+  try {
+    const content = readFileSync(CONFIG_FILE, "utf-8");
+    const config = JSON.parse(content) as Partial<CliConfig>;
+    return { ...DEFAULT_CONFIG, ...config };
+  } catch {
+    return DEFAULT_CONFIG;
+  }
+}
+
+export function saveConfig(config: CliConfig): void {
+  ensureConfigDir();
+  writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+}
+
+export function getApiKey(): string | undefined {
+  return loadConfig().apiKey;
+}
+
+export function setApiKey(key: string): void {
+  const config = loadConfig();
+  config.apiKey = key;
+  saveConfig(config);
+}
+
+export function setApiUrl(url: string): void {
+  const config = loadConfig();
+  config.apiUrl = url;
+  saveConfig(config);
+}
+
+export function getApiUrl(): string {
+  return loadConfig().apiUrl;
+}

--- a/apps/cli/src/lib/index.ts
+++ b/apps/cli/src/lib/index.ts
@@ -1,0 +1,3 @@
+export * from "./config.js";
+export * from "./api.js";
+export * from "./output.js";

--- a/apps/cli/src/lib/output.ts
+++ b/apps/cli/src/lib/output.ts
@@ -1,0 +1,63 @@
+let outputJson = false;
+
+export function setJsonOutput(enabled: boolean): void {
+  outputJson = enabled;
+}
+
+export function isJsonOutput(): boolean {
+  return outputJson;
+}
+
+export function output(data: unknown): void {
+  if (outputJson) {
+    console.log(JSON.stringify(data, null, 2));
+  } else if (typeof data === "string") {
+    console.log(data);
+  } else {
+    console.log(JSON.stringify(data, null, 2));
+  }
+}
+
+export function outputTable(headers: string[], rows: string[][]): void {
+  if (outputJson) {
+    const data = rows.map((row) => {
+      const obj: Record<string, string> = {};
+      headers.forEach((h, i) => {
+        obj[h.toLowerCase().replace(/\s+/g, "_")] = row[i] ?? "";
+      });
+      return obj;
+    });
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)),
+  );
+
+  const headerLine = headers.map((h, i) => h.padEnd(widths[i] ?? 0)).join("  ");
+  console.log(headerLine);
+  console.log("-".repeat(headerLine.length));
+
+  for (const row of rows) {
+    console.log(
+      row.map((cell, i) => (cell ?? "").padEnd(widths[i] ?? 0)).join("  "),
+    );
+  }
+}
+
+export function outputError(message: string): void {
+  if (outputJson) {
+    console.error(JSON.stringify({ error: message }));
+  } else {
+    console.error(`Error: ${message}`);
+  }
+}
+
+export function outputSuccess(message: string): void {
+  if (outputJson) {
+    console.log(JSON.stringify({ success: true, message }));
+  } else {
+    console.log(`✓ ${message}`);
+  }
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+
+import {
+  createAgentsCommand,
+  createAuthCommand,
+  createCreditsCommand,
+  createMessagesCommand,
+  createTasksCommand,
+} from "./commands/index.js";
+import { setJsonOutput } from "./lib/output.js";
+
+const program = new Command();
+
+program
+  .name("openspawn")
+  .description("OpenSpawn CLI - Multi-agent coordination platform")
+  .version("0.1.0")
+  .option("--json", "Output in JSON format")
+  .hook("preAction", (thisCommand) => {
+    const opts = thisCommand.opts();
+    if (opts.json) {
+      setJsonOutput(true);
+    }
+  });
+
+program.addCommand(createAuthCommand());
+program.addCommand(createAgentsCommand());
+program.addCommand(createTasksCommand());
+program.addCommand(createCreditsCommand());
+program.addCommand(createMessagesCommand());
+
+program.parse();

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/apps/cli",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/libs/database/src/data-source.ts
+++ b/libs/database/src/data-source.ts
@@ -5,19 +5,24 @@ import {
   AgentCapability,
   ApiKey,
   Channel,
+  ConsensusRequest,
+  ConsensusVote,
   CreditRateConfig,
   CreditTransaction,
+  Escalation,
   Event,
   IdempotencyKey,
   Message,
   Nonce,
   Organization,
   RefreshToken,
+  ReputationEvent,
   Task,
   TaskComment,
   TaskDependency,
   TaskTag,
   User,
+  Webhook,
 } from "./entities";
 
 export const entities = [
@@ -38,6 +43,11 @@ export const entities = [
   Event,
   IdempotencyKey,
   Nonce,
+  ReputationEvent,
+  Escalation,
+  ConsensusRequest,
+  ConsensusVote,
+  Webhook,
 ];
 
 export function createDataSourceOptions(

--- a/libs/database/src/entities/index.ts
+++ b/libs/database/src/entities/index.ts
@@ -19,3 +19,4 @@ export { TaskComment } from "./task-comment.entity";
 export { TaskDependency } from "./task-dependency.entity";
 export { TaskTag } from "./task-tag.entity";
 export { User, UserRole } from "./user.entity";
+export { Webhook } from "./webhook.entity";

--- a/libs/database/src/entities/webhook.entity.ts
+++ b/libs/database/src/entities/webhook.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from "typeorm";
+import { Organization } from "./organization.entity.js";
+
+@Entity("webhooks")
+export class Webhook {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ name: "org_id" })
+  orgId!: string;
+
+  @ManyToOne(() => Organization)
+  @JoinColumn({ name: "org_id" })
+  organization!: Organization;
+
+  @Column()
+  name!: string;
+
+  @Column()
+  url!: string;
+
+  @Column({ nullable: true })
+  secret?: string;
+
+  @Column("simple-array", { default: "" })
+  events!: string[];
+
+  @Column({ default: true })
+  enabled!: boolean;
+
+  @Column({ name: "failure_count", default: 0 })
+  failureCount!: number;
+
+  @Column({ name: "last_triggered_at", nullable: true })
+  lastTriggeredAt?: Date;
+
+  @Column({ name: "last_error", nullable: true })
+  lastError?: string;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt!: Date;
+}


### PR DESCRIPTION
## Summary

Two major features in one PR:

### 📡 Webhooks System
Push events to external systems (Slack, Discord, custom endpoints).

**New Entity:** `webhook.entity.ts`
- URL, secret (HMAC signing), event filters
- Failure tracking with auto-disable after 10 failures

**Endpoints:**
- `POST /webhooks` — Create webhook
- `GET /webhooks` — List webhooks
- `GET /webhooks/:id` — Get webhook
- `PATCH /webhooks/:id` — Update webhook
- `DELETE /webhooks/:id` — Delete webhook
- `POST /webhooks/:id/test` — Send test event

**Features:**
- HMAC-SHA256 signing via `X-OpenSpawn-Signature` header
- Subscribes to `event.created` via EventEmitter2
- Automatic retry tracking and disable after failures

### 🖥️ CLI Tool (`openspawn`)
Agent interaction without HTTP clients.

**Commands:**
```bash
openspawn auth login --api-key <key>
openspawn auth whoami
openspawn auth logout

openspawn agents list
openspawn agents get <id>
openspawn agents create --name <name> --level <1-10>

openspawn tasks list [--status <status>]
openspawn tasks create --title <title> --priority <priority>
openspawn tasks assign <taskId> --to <agentId>
openspawn tasks transition <taskId> --status <status>

openspawn credits balance [agentId]
openspawn credits transfer --from <id> --to <id> --amount <n>

openspawn messages send --to <agentId> --content <text>
openspawn messages list --channel <id>
openspawn messages channels
```

**Features:**
- Config stored in `~/.openspawn/config.json`
- `--json` flag for machine-readable output
- Table formatting for list commands

### Testing
- `pnpm build` ✅