### PR TITLE
feat(dashboard): add real-time updates infrastructure

### DIFF
--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -33,6 +33,7 @@ import { Avatar, AvatarFallback } from "./ui/avatar";
 import { useDemo } from "../demo";
 import { DemoControls } from "../demo/DemoControls";
 import { useAuth } from "../contexts";
+import { useRealtime, useIsRealtime } from "../hooks/use-realtime";
 import type { ReactNode } from "react";
 
 interface LayoutProps {
@@ -61,6 +62,10 @@ export function Layout({ children }: LayoutProps) {
   useEffect(() => {
     setMobileMenuOpen(false);
   }, [location.pathname]);
+
+  // Enable real-time updates
+  useRealtime();
+  const isRealtime = useIsRealtime();
 
   const handleLogout = async () => {
     await logout();

--- a/apps/dashboard/src/graphql/subscriptions.ts
+++ b/apps/dashboard/src/graphql/subscriptions.ts
@@ -1,0 +1,75 @@
+import { graphql } from "./generated";
+
+// Subscriptions for real-time updates
+
+export const EventCreatedSubscription = graphql(`
+  subscription EventCreated($orgId: ID!) {
+    eventCreated(orgId: $orgId) {
+      id
+      type
+      actorId
+      actor {
+        id
+        name
+      }
+      entityType
+      entityId
+      severity
+      reasoning
+      createdAt
+    }
+  }
+`);
+
+export const TaskUpdatedSubscription = graphql(`
+  subscription TaskUpdated($orgId: ID!) {
+    taskUpdated(orgId: $orgId) {
+      id
+      identifier
+      title
+      description
+      status
+      priority
+      assigneeId
+      assignee {
+        id
+        name
+      }
+      creatorId
+      approvalRequired
+      dueDate
+      completedAt
+      createdAt
+    }
+  }
+`);
+
+export const CreditUpdatedSubscription = graphql(`
+  subscription CreditUpdated($orgId: ID!) {
+    creditUpdated(orgId: $orgId) {
+      id
+      agentId
+      type
+      amount
+      balanceAfter
+      reason
+      triggerType
+      sourceTaskId
+      createdAt
+    }
+  }
+`);
+
+export const MessageCreatedSubscription = graphql(`
+  subscription MessageCreated($orgId: ID!, $channelId: ID!) {
+    messageCreated(orgId: $orgId, channelId: $channelId) {
+      id
+      channelId
+      senderId
+      type
+      body
+      parentMessageId
+      createdAt
+    }
+  }
+`);

--- a/apps/dashboard/src/hooks/index.ts
+++ b/apps/dashboard/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { useTasks, type Task } from "./use-tasks";
 export { useAgents, type Agent } from "./use-agents";
 export { useCredits, type CreditTransaction } from "./use-credits";
 export { useEvents, type Event } from "./use-events";
+export { useRealtime, useAutoRefresh, useIsRealtime } from "./use-realtime";

--- a/apps/dashboard/src/hooks/use-realtime.ts
+++ b/apps/dashboard/src/hooks/use-realtime.ts
@@ -1,0 +1,92 @@
+import { useEffect, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useDemo } from "../demo";
+
+/**
+ * Hook to enable real-time updates for queries
+ * 
+ * In demo mode: Listens to simulation engine events
+ * In prod mode: Sets up polling (WebSocket support coming later)
+ */
+export function useRealtime() {
+  const queryClient = useQueryClient();
+  const demo = useDemo();
+  const isDemo = demo.isDemo;
+
+  // Invalidate queries when simulation events occur
+  const handleDemoEvent = useCallback(
+    (event: { type: string; payload: unknown }) => {
+      // Invalidate relevant queries based on event type
+      if (event.type.startsWith("agent")) {
+        queryClient.invalidateQueries({ queryKey: ["agents"] });
+      }
+      if (event.type.startsWith("task")) {
+        queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      }
+      if (event.type.startsWith("credit")) {
+        queryClient.invalidateQueries({ queryKey: ["credits"] });
+        queryClient.invalidateQueries({ queryKey: ["agents"] }); // Balance updates
+      }
+      if (event.type.startsWith("event") || event.type === "system.started") {
+        queryClient.invalidateQueries({ queryKey: ["events"] });
+      }
+    },
+    [queryClient]
+  );
+
+  useEffect(() => {
+    if (!isDemo) {
+      // In production mode, set up polling for real-time updates
+      // Polling interval: 30 seconds
+      const interval = setInterval(() => {
+        queryClient.invalidateQueries();
+      }, 30000);
+
+      return () => clearInterval(interval);
+    }
+
+    // In demo mode, listen to simulation events
+    // The demo provider handles this via its own state updates
+    // We just need to ensure queries refetch when state changes
+  }, [isDemo, queryClient]);
+
+  // Subscribe to demo events for more granular updates
+  useEffect(() => {
+    if (!isDemo || !demo.recentEvents) return;
+
+    // When recentEvents changes, invalidate relevant queries
+    const latestEvent = demo.recentEvents[0];
+    if (latestEvent) {
+      handleDemoEvent(latestEvent);
+    }
+  }, [isDemo, demo.recentEvents, handleDemoEvent]);
+}
+
+/**
+ * Hook to set up auto-refresh for a specific query
+ */
+export function useAutoRefresh(queryKey: string[], intervalMs = 10000) {
+  const queryClient = useQueryClient();
+  const demo = useDemo();
+
+  useEffect(() => {
+    // In demo mode, simulation handles updates
+    if (demo.isDemo) return;
+
+    const interval = setInterval(() => {
+      queryClient.invalidateQueries({ queryKey });
+    }, intervalMs);
+
+    return () => clearInterval(interval);
+  }, [queryClient, queryKey, intervalMs, demo.isDemo]);
+}
+
+/**
+ * Hook that returns whether real-time updates are active
+ */
+export function useIsRealtime(): boolean {
+  const demo = useDemo();
+  // In demo mode, real-time = simulation is playing
+  // In prod mode, real-time = always true (via polling)
+  return demo.isDemo ? demo.isPlaying : true;
+}


### PR DESCRIPTION
## Summary

Adds infrastructure for real-time updates to the dashboard.

### New Files

**`graphql/subscriptions.ts`** — GraphQL subscription definitions:
- `EventCreated` — New events
- `TaskUpdated` — Task changes
- `CreditUpdated` — Credit transactions
- `MessageCreated` — New messages

**`hooks/use-realtime.ts`** — Real-time update hooks:
- `useRealtime()` — Enables auto-refresh for all queries
- `useAutoRefresh(queryKey, interval)` — Per-query polling
- `useIsRealtime()` — Check if real-time updates are active

### Behavior

**Demo Mode:**
- Listens to simulation engine events
- Invalidates relevant queries based on event type
- No network polling (simulation is the source of truth)

**Production Mode:**
- 30-second polling for all queries
- WebSocket subscriptions can be added later

### Integration
- Layout component calls `useRealtime()` for global updates
- Queries automatically refetch when simulation events fire

### Future Work
- Add WebSocket client (graphql-ws) for true real-time in production
- Add visual indicator when updates are live

Stacked on: #57