### PR TITLE
docs(readme): remove --demo CTA, focus on real usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@
 [![Docs](https://img.shields.io/badge/📚_Docs-Read-22c55e?style=for-the-badge)](https://openspawn.github.io/openspawn/)
 [![Discord](https://img.shields.io/badge/💬_Discord-Join-5865f2?style=for-the-badge)](https://discord.gg/openspawn)
 
-<br />
-
-```bash
-npx openspawn --demo
-```
-
 </div>
 
 ---


### PR DESCRIPTION
Removes the `npx openspawn --demo` call-to-action from the hero section.

**Why:** The CLI demo mode is for marketing materials (GIF, screenshots) only. Real users should:
1. Try the **live dashboard demo** (button still there)
2. Or set up the full stack for real usage

The GIF still shows the CLI in action — demo mode is baked into the recording wrapper so it's invisible.