### PR TITLE
feat(messages): hook up Messages page to MSW demo pattern

### DIFF
--- a/apps/dashboard/src/hooks/index.ts
+++ b/apps/dashboard/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { useTasks, type Task } from "./use-tasks";
 export { useAgents, type Agent } from "./use-agents";
 export { useCredits, type CreditTransaction } from "./use-credits";
 export { useEvents, type Event } from "./use-events";
+export { useMessages, useConversations, useConversationMessages, type Message, type Conversation } from "./use-messages";

--- a/apps/dashboard/src/hooks/use-messages.ts
+++ b/apps/dashboard/src/hooks/use-messages.ts
@@ -1,0 +1,157 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetcher } from '../graphql/fetcher';
+
+// GraphQL queries for messages
+const MESSAGES_QUERY = `
+  query Messages($limit: Int) {
+    messages(limit: $limit) {
+      id
+      fromAgentId
+      toAgentId
+      fromAgent {
+        id
+        name
+        level
+      }
+      toAgent {
+        id
+        name
+        level
+      }
+      content
+      type
+      taskRef
+      read
+      createdAt
+    }
+  }
+`;
+
+const CONVERSATIONS_QUERY = `
+  query Conversations {
+    conversations {
+      id
+      agents {
+        id
+        name
+        level
+      }
+      messageCount
+      unreadCount
+      latestMessage {
+        id
+        content
+        type
+        createdAt
+      }
+      createdAt
+    }
+  }
+`;
+
+const CONVERSATION_MESSAGES_QUERY = `
+  query ConversationMessages($agent1Id: ID!, $agent2Id: ID!) {
+    conversationMessages(agent1Id: $agent1Id, agent2Id: $agent2Id) {
+      id
+      fromAgentId
+      toAgentId
+      fromAgent {
+        id
+        name
+        level
+      }
+      toAgent {
+        id
+        name
+        level
+      }
+      content
+      type
+      taskRef
+      read
+      createdAt
+    }
+  }
+`;
+
+export interface Message {
+  id: string;
+  fromAgentId: string;
+  toAgentId: string;
+  fromAgent: { id: string; name: string; level: number } | null;
+  toAgent: { id: string; name: string; level: number } | null;
+  content: string;
+  type: string;
+  taskRef: string | null;
+  read: boolean;
+  createdAt: string;
+}
+
+export interface Conversation {
+  id: string;
+  agents: { id: string; name: string; level: number }[];
+  messageCount: number;
+  unreadCount: number;
+  latestMessage: {
+    id: string;
+    content: string;
+    type: string;
+    createdAt: string;
+  };
+  createdAt: string;
+}
+
+export function useMessages(limit: number = 50) {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['messages', limit],
+    queryFn: fetcher<{ messages: Message[] }, { limit: number }>(
+      MESSAGES_QUERY,
+      { limit }
+    ),
+    refetchInterval: 10000, // Refetch every 10 seconds for real-time feel
+  });
+
+  return {
+    messages: data?.messages || [],
+    loading: isLoading,
+    error: error?.message,
+    refetch,
+  };
+}
+
+export function useConversations() {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['conversations'],
+    queryFn: fetcher<{ conversations: Conversation[] }, Record<string, never>>(
+      CONVERSATIONS_QUERY,
+      {}
+    ),
+    refetchInterval: 10000,
+  });
+
+  return {
+    conversations: data?.conversations || [],
+    loading: isLoading,
+    error: error?.message,
+    refetch,
+  };
+}
+
+export function useConversationMessages(agent1Id: string, agent2Id: string) {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['conversationMessages', agent1Id, agent2Id],
+    queryFn: fetcher<{ conversationMessages: Message[] }, { agent1Id: string; agent2Id: string }>(
+      CONVERSATION_MESSAGES_QUERY,
+      { agent1Id, agent2Id }
+    ),
+    enabled: Boolean(agent1Id && agent2Id),
+    refetchInterval: 5000,
+  });
+
+  return {
+    messages: data?.conversationMessages || [],
+    loading: isLoading,
+    error: error?.message,
+    refetch,
+  };
+}

--- a/apps/dashboard/src/pages/messages.tsx
+++ b/apps/dashboard/src/pages/messages.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   ReactFlow,
   Node,
@@ -14,95 +14,19 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
-import { Avatar } from '../components/ui/avatar';
 import { ScrollArea } from '../components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { cn } from '../lib/utils';
 import { getAgentAvatarUrl } from '../lib/avatar';
+import { useMessages, useConversations, useAgents, type Message } from '../hooks';
 
-// Demo data for messages
-const demoAgents = [
-  { id: 'talent-agent', name: 'Talent Agent', level: 10, status: 'ACTIVE', avatar: 'glass' },
-  { id: 'code-wizard', name: 'Code Wizard', level: 8, status: 'ACTIVE', avatar: 'botttsNeutral' },
-  { id: 'research-bot', name: 'Research Bot', level: 6, status: 'IDLE', avatar: 'bottts' },
-  { id: 'content-crafter', name: 'Content Crafter', level: 5, status: 'ACTIVE', avatar: 'bottts' },
-  { id: 'junior-helper', name: 'Junior Helper', level: 2, status: 'PENDING', avatar: 'shapes' },
-];
+// Helper to get agent by ID from messages
+const getAgentFromMessage = (msg: Message, which: 'from' | 'to') => {
+  return which === 'from' ? msg.fromAgent : msg.toAgent;
+};
 
-const demoMessages = [
-  {
-    id: 'm1',
-    from: 'talent-agent',
-    to: 'code-wizard',
-    content: 'API implementation is top priority. Need those endpoints by EOD.',
-    type: 'task',
-    timestamp: new Date(Date.now() - 120000),
-    taskRef: 'API-001',
-  },
-  {
-    id: 'm2',
-    from: 'code-wizard',
-    to: 'talent-agent',
-    content: 'On it. 80% done, just finishing up the auth guards.',
-    type: 'status',
-    timestamp: new Date(Date.now() - 60000),
-  },
-  {
-    id: 'm3',
-    from: 'research-bot',
-    to: 'talent-agent',
-    content: 'Competitor analysis complete. Found 3 key differentiators we should highlight.',
-    type: 'report',
-    timestamp: new Date(Date.now() - 300000),
-    taskRef: 'RES-007',
-  },
-  {
-    id: 'm4',
-    from: 'talent-agent',
-    to: 'content-crafter',
-    content: 'Start on the API docs once Code Wizard finishes the endpoints.',
-    type: 'task',
-    timestamp: new Date(Date.now() - 180000),
-    taskRef: 'DOC-042',
-  },
-  {
-    id: 'm5',
-    from: 'content-crafter',
-    to: 'talent-agent',
-    content: 'Will do! Already drafted the introduction section.',
-    type: 'status',
-    timestamp: new Date(Date.now() - 90000),
-  },
-  {
-    id: 'm6',
-    from: 'code-wizard',
-    to: 'research-bot',
-    content: 'Can you look into how competitors handle rate limiting?',
-    type: 'question',
-    timestamp: new Date(Date.now() - 45000),
-  },
-  {
-    id: 'm7',
-    from: 'talent-agent',
-    to: 'junior-helper',
-    content: 'Welcome to the team! Review the onboarding docs and shadow Code Wizard.',
-    type: 'task',
-    timestamp: new Date(Date.now() - 30000),
-    taskRef: 'ONB-003',
-  },
-  {
-    id: 'm8',
-    from: 'junior-helper',
-    to: 'talent-agent',
-    content: 'Thanks! Excited to learn. Starting the docs now.',
-    type: 'status',
-    timestamp: new Date(Date.now() - 15000),
-  },
-];
-
-const getAgent = (id: string) => demoAgents.find((a) => a.id === id);
-
-const formatTime = (date: Date) => {
+const formatTime = (dateStr: string) => {
+  const date = new Date(dateStr);
   const diff = Date.now() - date.getTime();
   if (diff < 60000) return 'just now';
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
@@ -110,34 +34,38 @@ const formatTime = (date: Date) => {
 };
 
 const typeColors: Record<string, string> = {
-  task: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-  status: 'bg-green-500/20 text-green-400 border-green-500/30',
-  report: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
-  question: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
-  escalation: 'bg-red-500/20 text-red-400 border-red-500/30',
+  TASK: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+  STATUS: 'bg-green-500/20 text-green-400 border-green-500/30',
+  REPORT: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
+  QUESTION: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
+  ESCALATION: 'bg-red-500/20 text-red-400 border-red-500/30',
+  GENERAL: 'bg-slate-500/20 text-slate-400 border-slate-500/30',
 };
 
 const typeIcons: Record<string, string> = {
-  task: '📋',
-  status: '✅',
-  report: '📊',
-  question: '❓',
-  escalation: '🚨',
+  TASK: '📋',
+  STATUS: '✅',
+  REPORT: '📊',
+  QUESTION: '❓',
+  ESCALATION: '🚨',
+  GENERAL: '💬',
 };
 
 // ============================================================
 // VIEW 1: Communication Graph
 // ============================================================
-function CommunicationGraph() {
+function CommunicationGraph({ messages, agents }: { messages: Message[]; agents: any[] }) {
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [selectedEdge, setSelectedEdge] = useState<string | null>(null);
   const [pulsingEdges, setPulsingEdges] = useState<Set<string>>(new Set());
 
   useEffect(() => {
+    if (agents.length === 0) return;
+
     // Create nodes from agents
-    const agentNodes: Node[] = demoAgents.map((agent, i) => {
-      const angle = (i / demoAgents.length) * 2 * Math.PI;
+    const agentNodes: Node[] = agents.slice(0, 8).map((agent, i) => {
+      const angle = (i / Math.min(agents.length, 8)) * 2 * Math.PI;
       const radius = 200;
       return {
         id: agent.id,
@@ -166,8 +94,8 @@ function CommunicationGraph() {
 
     // Create edges from message pairs
     const messagePairs = new Map<string, number>();
-    demoMessages.forEach((msg) => {
-      const key = [msg.from, msg.to].sort().join('-');
+    messages.forEach((msg) => {
+      const key = [msg.fromAgentId, msg.toAgentId].sort().join('-');
       messagePairs.set(key, (messagePairs.get(key) || 0) + 1);
     });
 
@@ -189,22 +117,23 @@ function CommunicationGraph() {
 
     setNodes(agentNodes);
     setEdges(edgeList);
-  }, [pulsingEdges]);
+  }, [agents, messages, pulsingEdges, setNodes, setEdges]);
 
   // Simulate live message flow
   useEffect(() => {
+    if (messages.length === 0) return;
     const interval = setInterval(() => {
-      const randomMsg = demoMessages[Math.floor(Math.random() * demoMessages.length)];
-      const key = [randomMsg.from, randomMsg.to].sort().join('-');
+      const randomMsg = messages[Math.floor(Math.random() * messages.length)];
+      const key = [randomMsg.fromAgentId, randomMsg.toAgentId].sort().join('-');
       setPulsingEdges(new Set([key]));
       setTimeout(() => setPulsingEdges(new Set()), 1000);
     }, 3000);
     return () => clearInterval(interval);
-  }, []);
+  }, [messages]);
 
   const selectedMessages = selectedEdge
-    ? demoMessages.filter((m) => {
-        const key = [m.from, m.to].sort().join('-');
+    ? messages.filter((m) => {
+        const key = [m.fromAgentId, m.toAgentId].sort().join('-');
         return key === selectedEdge;
       })
     : [];
@@ -237,13 +166,13 @@ function CommunicationGraph() {
             <ScrollArea className="h-[480px]">
               <div className="space-y-3">
                 {selectedMessages.map((msg) => {
-                  const sender = getAgent(msg.from);
+                  const sender = msg.fromAgent;
                   return (
                     <div key={msg.id} className="p-2 rounded-lg bg-slate-700/50">
                       <div className="flex items-center gap-2 mb-1">
-                        <img src={getAgentAvatarUrl(msg.from, sender?.level || 1)} className="w-5 h-5 rounded-full" />
-                        <span className="text-xs font-medium">{sender?.name}</span>
-                        <span className="text-[10px] text-slate-500">{formatTime(msg.timestamp)}</span>
+                        <img src={getAgentAvatarUrl(msg.fromAgentId, sender?.level || 5)} className="w-5 h-5 rounded-full" />
+                        <span className="text-xs font-medium">{sender?.name || 'Unknown'}</span>
+                        <span className="text-[10px] text-slate-500">{formatTime(msg.createdAt)}</span>
                       </div>
                       <p className="text-sm text-slate-300">{msg.content}</p>
                     </div>
@@ -261,36 +190,8 @@ function CommunicationGraph() {
 // ============================================================
 // VIEW 2: Mission Control Feed
 // ============================================================
-function MissionControlFeed() {
-  const [messages, setMessages] = useState(demoMessages);
+function MissionControlFeed({ messages }: { messages: Message[] }) {
   const [filter, setFilter] = useState<string | null>(null);
-
-  // Simulate new messages coming in
-  useEffect(() => {
-    const interval = setInterval(() => {
-      const agents = ['talent-agent', 'code-wizard', 'research-bot', 'content-crafter'];
-      const types = ['task', 'status', 'report', 'question'];
-      const contents = [
-        'Making good progress on this.',
-        'Need clarification on the requirements.',
-        'Task complete, moving to next item.',
-        'Found an issue, investigating.',
-        'Ready for review.',
-      ];
-      
-      const newMsg = {
-        id: `m${Date.now()}`,
-        from: agents[Math.floor(Math.random() * agents.length)],
-        to: agents[Math.floor(Math.random() * agents.length)],
-        content: contents[Math.floor(Math.random() * contents.length)],
-        type: types[Math.floor(Math.random() * types.length)],
-        timestamp: new Date(),
-      };
-      
-      setMessages((prev) => [newMsg, ...prev].slice(0, 20));
-    }, 5000);
-    return () => clearInterval(interval);
-  }, []);
 
   const filtered = filter ? messages.filter((m) => m.type === filter) : messages;
 
@@ -311,7 +212,7 @@ function MissionControlFeed() {
             size="sm"
             onClick={() => setFilter(type)}
           >
-            {typeIcons[type]} {type}
+            {typeIcons[type]} {type.toLowerCase()}
           </Button>
         ))}
       </div>
@@ -320,9 +221,9 @@ function MissionControlFeed() {
         <div className="absolute left-6 top-0 bottom-0 w-px bg-gradient-to-b from-indigo-500 via-purple-500 to-pink-500 opacity-30" />
         
         <AnimatePresence mode="popLayout">
-          {filtered.map((msg, i) => {
-            const sender = getAgent(msg.from);
-            const receiver = getAgent(msg.to);
+          {filtered.slice(0, 20).map((msg, i) => {
+            const sender = msg.fromAgent;
+            const receiver = msg.toAgent;
             return (
               <motion.div
                 key={msg.id}
@@ -336,26 +237,26 @@ function MissionControlFeed() {
                 
                 <Card className={cn(
                   "flex-1 bg-slate-800/50 border-l-4",
-                  msg.type === 'task' && 'border-l-blue-500',
-                  msg.type === 'status' && 'border-l-green-500',
-                  msg.type === 'report' && 'border-l-purple-500',
-                  msg.type === 'question' && 'border-l-yellow-500',
-                  msg.type === 'escalation' && 'border-l-red-500',
+                  msg.type === 'TASK' && 'border-l-blue-500',
+                  msg.type === 'STATUS' && 'border-l-green-500',
+                  msg.type === 'REPORT' && 'border-l-purple-500',
+                  msg.type === 'QUESTION' && 'border-l-yellow-500',
+                  msg.type === 'ESCALATION' && 'border-l-red-500',
                 )}>
                   <CardContent className="p-3">
                     <div className="flex items-center justify-between mb-2">
                       <div className="flex items-center gap-2">
-                        <img src={getAgentAvatarUrl(msg.from, sender?.level || 1)} className="w-6 h-6 rounded-full" />
-                        <span className="font-medium text-sm">{sender?.name}</span>
+                        <img src={getAgentAvatarUrl(msg.fromAgentId, sender?.level || 5)} className="w-6 h-6 rounded-full" />
+                        <span className="font-medium text-sm">{sender?.name || 'Unknown'}</span>
                         <span className="text-slate-500">→</span>
-                        <img src={getAgentAvatarUrl(msg.to, receiver?.level || 1)} className="w-6 h-6 rounded-full" />
-                        <span className="font-medium text-sm">{receiver?.name}</span>
+                        <img src={getAgentAvatarUrl(msg.toAgentId, receiver?.level || 5)} className="w-6 h-6 rounded-full" />
+                        <span className="font-medium text-sm">{receiver?.name || 'Unknown'}</span>
                       </div>
                       <div className="flex items-center gap-2">
-                        <Badge variant="outline" className={cn("text-[10px]", typeColors[msg.type])}>
-                          {typeIcons[msg.type]} {msg.type}
+                        <Badge variant="outline" className={cn("text-[10px]", typeColors[msg.type] || typeColors.GENERAL)}>
+                          {typeIcons[msg.type] || '💬'} {msg.type?.toLowerCase()}
                         </Badge>
-                        <span className="text-xs text-slate-500">{formatTime(msg.timestamp)}</span>
+                        <span className="text-xs text-slate-500">{formatTime(msg.createdAt)}</span>
                       </div>
                     </div>
                     <p className="text-sm text-slate-300">{msg.content}</p>
@@ -378,30 +279,32 @@ function MissionControlFeed() {
 // ============================================================
 // VIEW 3: Conversation Cards
 // ============================================================
-function ConversationCards() {
+function ConversationCards({ messages }: { messages: Message[] }) {
   const [selectedConvo, setSelectedConvo] = useState<string | null>(null);
 
   // Group messages by conversation
-  const conversations = demoMessages.reduce((acc, msg) => {
-    const key = [msg.from, msg.to].sort().join('-');
-    if (!acc[key]) acc[key] = [];
-    acc[key].push(msg);
-    return acc;
-  }, {} as Record<string, typeof demoMessages>);
+  const conversations = useMemo(() => {
+    const groups = messages.reduce((acc, msg) => {
+      const key = [msg.fromAgentId, msg.toAgentId].sort().join('-');
+      if (!acc[key]) acc[key] = [];
+      acc[key].push(msg);
+      return acc;
+    }, {} as Record<string, Message[]>);
 
-  const sortedConvos = Object.entries(conversations).sort((a, b) => {
-    const aLatest = Math.max(...a[1].map((m) => m.timestamp.getTime()));
-    const bLatest = Math.max(...b[1].map((m) => m.timestamp.getTime()));
-    return bLatest - aLatest;
-  });
+    return Object.entries(groups).sort((a, b) => {
+      const aLatest = Math.max(...a[1].map((m) => new Date(m.createdAt).getTime()));
+      const bLatest = Math.max(...b[1].map((m) => new Date(m.createdAt).getTime()));
+      return bLatest - aLatest;
+    });
+  }, [messages]);
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {sortedConvos.map(([key, msgs]) => {
+      {conversations.map(([key, msgs]) => {
         const [agent1Id, agent2Id] = key.split('-');
-        const agent1 = getAgent(agent1Id);
-        const agent2 = getAgent(agent2Id);
-        const latestMsg = msgs.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())[0];
+        const agent1 = msgs.find(m => m.fromAgentId === agent1Id)?.fromAgent || msgs.find(m => m.toAgentId === agent1Id)?.toAgent;
+        const agent2 = msgs.find(m => m.fromAgentId === agent2Id)?.fromAgent || msgs.find(m => m.toAgentId === agent2Id)?.toAgent;
+        const latestMsg = msgs.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
         const isExpanded = selectedConvo === key;
 
         return (
@@ -417,16 +320,16 @@ function ConversationCards() {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <div className="flex -space-x-2">
-                      <img src={getAgentAvatarUrl(agent1Id, agent1?.level || 1)} className="w-8 h-8 rounded-full border-2 border-slate-800" />
-                      <img src={getAgentAvatarUrl(agent2Id, agent2?.level || 1)} className="w-8 h-8 rounded-full border-2 border-slate-800" />
+                      <img src={getAgentAvatarUrl(agent1Id, agent1?.level || 5)} className="w-8 h-8 rounded-full border-2 border-slate-800" />
+                      <img src={getAgentAvatarUrl(agent2Id, agent2?.level || 5)} className="w-8 h-8 rounded-full border-2 border-slate-800" />
                     </div>
                     <div>
-                      <p className="text-sm font-medium">{agent1?.name} ↔ {agent2?.name}</p>
+                      <p className="text-sm font-medium">{agent1?.name || 'Unknown'} ↔ {agent2?.name || 'Unknown'}</p>
                       <p className="text-xs text-slate-500">{msgs.length} messages</p>
                     </div>
                   </div>
                   <Badge variant="outline" className="text-[10px]">
-                    {formatTime(latestMsg.timestamp)}
+                    {formatTime(latestMsg.createdAt)}
                   </Badge>
                 </div>
               </CardHeader>
@@ -439,9 +342,9 @@ function ConversationCards() {
                 ) : (
                   <ScrollArea className="h-64 mt-2">
                     <div className="space-y-3">
-                      {msgs.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime()).map((msg) => {
-                        const sender = getAgent(msg.from);
-                        const isAgent1 = msg.from === agent1Id;
+                      {msgs.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()).map((msg) => {
+                        const sender = msg.fromAgent;
+                        const isAgent1 = msg.fromAgentId === agent1Id;
                         return (
                           <div
                             key={msg.id}
@@ -450,7 +353,7 @@ function ConversationCards() {
                               isAgent1 ? "flex-row" : "flex-row-reverse"
                             )}
                           >
-                            <img src={getAgentAvatarUrl(msg.from, sender?.level || 1)} className="w-6 h-6 rounded-full" />
+                            <img src={getAgentAvatarUrl(msg.fromAgentId, sender?.level || 5)} className="w-6 h-6 rounded-full" />
                             <div
                               className={cn(
                                 "max-w-[80%] p-2 rounded-lg text-sm",
@@ -458,7 +361,7 @@ function ConversationCards() {
                               )}
                             >
                               {msg.content}
-                              <p className="text-[10px] text-slate-500 mt-1">{formatTime(msg.timestamp)}</p>
+                              <p className="text-[10px] text-slate-500 mt-1">{formatTime(msg.createdAt)}</p>
                             </div>
                           </div>
                         );
@@ -478,14 +381,19 @@ function ConversationCards() {
 // ============================================================
 // VIEW 4: Context-Linked Messages
 // ============================================================
-function ContextLinkedMessages() {
+function ContextLinkedMessages({ messages, agents }: { messages: Message[]; agents: any[] }) {
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
   const [selectedTask, setSelectedTask] = useState<string | null>(null);
 
-  const tasks = ['API-001', 'DOC-042', 'RES-007', 'ONB-003'];
+  // Get unique task refs from messages
+  const tasks = useMemo(() => {
+    const refs = new Set<string>();
+    messages.forEach(m => { if (m.taskRef) refs.add(m.taskRef); });
+    return Array.from(refs);
+  }, [messages]);
 
-  const filteredMessages = demoMessages.filter((msg) => {
-    if (selectedAgent && msg.from !== selectedAgent && msg.to !== selectedAgent) return false;
+  const filteredMessages = messages.filter((msg) => {
+    if (selectedAgent && msg.fromAgentId !== selectedAgent && msg.toAgentId !== selectedAgent) return false;
     if (selectedTask && msg.taskRef !== selectedTask) return false;
     return true;
   });
@@ -507,7 +415,7 @@ function ContextLinkedMessages() {
             >
               All Agents
             </Button>
-            {demoAgents.map((agent) => (
+            {agents.slice(0, 10).map((agent) => (
               <Button
                 key={agent.id}
                 variant={selectedAgent === agent.id ? 'default' : 'ghost'}
@@ -558,7 +466,7 @@ function ContextLinkedMessages() {
           </span>
           {selectedAgent && (
             <Badge variant="outline" className="text-xs">
-              Agent: {getAgent(selectedAgent)?.name}
+              Agent: {agents.find(a => a.id === selectedAgent)?.name}
             </Badge>
           )}
           {selectedTask && (
@@ -574,25 +482,25 @@ function ContextLinkedMessages() {
               <p className="text-slate-400">No messages match the current filters</p>
             </Card>
           ) : (
-            filteredMessages.map((msg) => {
-              const sender = getAgent(msg.from);
-              const receiver = getAgent(msg.to);
+            filteredMessages.slice(0, 20).map((msg) => {
+              const sender = msg.fromAgent;
+              const receiver = msg.toAgent;
               return (
                 <Card key={msg.id} className="bg-slate-800/50 border-slate-700">
                   <CardContent className="p-3">
                     <div className="flex items-start gap-3">
-                      <img src={getAgentAvatarUrl(msg.from, sender?.level || 1)} className="w-10 h-10 rounded-full" />
+                      <img src={getAgentAvatarUrl(msg.fromAgentId, sender?.level || 5)} className="w-10 h-10 rounded-full" />
                       <div className="flex-1">
                         <div className="flex items-center gap-2 mb-1">
-                          <span className="font-medium">{sender?.name}</span>
+                          <span className="font-medium">{sender?.name || 'Unknown'}</span>
                           <span className="text-slate-500">→</span>
-                          <span className="font-medium">{receiver?.name}</span>
-                          <span className="text-xs text-slate-500 ml-auto">{formatTime(msg.timestamp)}</span>
+                          <span className="font-medium">{receiver?.name || 'Unknown'}</span>
+                          <span className="text-xs text-slate-500 ml-auto">{formatTime(msg.createdAt)}</span>
                         </div>
                         <p className="text-slate-300">{msg.content}</p>
                         <div className="flex gap-2 mt-2">
-                          <Badge variant="outline" className={cn("text-[10px]", typeColors[msg.type])}>
-                            {typeIcons[msg.type]} {msg.type}
+                          <Badge variant="outline" className={cn("text-[10px]", typeColors[msg.type] || typeColors.GENERAL)}>
+                            {typeIcons[msg.type] || '💬'} {msg.type?.toLowerCase()}
                           </Badge>
                           {msg.taskRef && (
                             <Badge
@@ -624,6 +532,22 @@ function ContextLinkedMessages() {
 // MAIN COMPONENT
 // ============================================================
 export function MessagesPage() {
+  const { messages, loading: messagesLoading } = useMessages(100);
+  const { agents, loading: agentsLoading } = useAgents();
+
+  const loading = messagesLoading || agentsLoading;
+
+  if (loading && messages.length === 0) {
+    return (
+      <div className="p-6 flex items-center justify-center h-[400px]">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto" />
+          <p className="mt-4 text-muted-foreground">Loading messages...</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
@@ -631,6 +555,7 @@ export function MessagesPage() {
           <h1 className="text-2xl font-bold">Agent Communications</h1>
           <p className="text-slate-400">Watch your agents coordinate in real-time</p>
         </div>
+        <Badge variant="outline">{messages.length} messages</Badge>
       </div>
 
       <Tabs defaultValue="graph" className="w-full">
@@ -646,16 +571,16 @@ export function MessagesPage() {
             <p className="text-sm text-slate-400 mb-4">
               <strong>Communication Graph:</strong> Click on an edge to see the conversation. Edges pulse green when messages flow.
             </p>
-            <CommunicationGraph />
+            <CommunicationGraph messages={messages} agents={agents} />
           </Card>
         </TabsContent>
 
         <TabsContent value="feed">
           <Card className="bg-slate-800/30 border-slate-700 p-4">
             <p className="text-sm text-slate-400 mb-4">
-              <strong>Mission Control Feed:</strong> Real-time stream of all agent communications. New messages appear automatically.
+              <strong>Mission Control Feed:</strong> Real-time stream of all agent communications.
             </p>
-            <MissionControlFeed />
+            <MissionControlFeed messages={messages} />
           </Card>
         </TabsContent>
 
@@ -664,7 +589,7 @@ export function MessagesPage() {
             <p className="text-sm text-slate-400 mb-4">
               <strong>Conversation Cards:</strong> Click a card to expand the full conversation thread.
             </p>
-            <ConversationCards />
+            <ConversationCards messages={messages} />
           </Card>
         </TabsContent>
 
@@ -673,7 +598,7 @@ export function MessagesPage() {
             <p className="text-sm text-slate-400 mb-4">
               <strong>Context-Linked:</strong> Filter messages by agent or task to see related discussions.
             </p>
-            <ContextLinkedMessages />
+            <ContextLinkedMessages messages={messages} agents={agents} />
           </Card>
         </TabsContent>
       </Tabs>

--- a/libs/demo-data/src/fixtures/index.ts
+++ b/libs/demo-data/src/fixtures/index.ts
@@ -2,3 +2,4 @@ export * from './agents.js';
 export * from './tasks.js';
 export * from './credits.js';
 export * from './events.js';
+export * from './messages.js';

--- a/libs/demo-data/src/fixtures/messages.ts
+++ b/libs/demo-data/src/fixtures/messages.ts
@@ -1,0 +1,147 @@
+import type { DemoMessage, MessageType } from '../types.js';
+
+// Message templates by type
+const MESSAGE_TEMPLATES: Record<MessageType, string[]> = {
+  task: [
+    'Working on {taskRef} now. Should have it done by EOD.',
+    'Just started {taskRef}. Initial analysis looks straightforward.',
+    'Need your input on {taskRef} - can we sync?',
+    'Completed the first phase of {taskRef}.',
+    '{taskRef} is blocked - waiting on external dependencies.',
+  ],
+  status: [
+    'Making good progress today. 3 tasks completed.',
+    'All clear on my end. Ready for new assignments.',
+    'Running behind schedule - will need to prioritize.',
+    'Just wrapped up the morning batch. Taking a short break.',
+    'Systems nominal. All processes running smoothly.',
+  ],
+  report: [
+    'Competitor analysis complete. Key findings: they focus on enterprise.',
+    'Weekly metrics: 47 tasks completed, 98% success rate.',
+    'Performance report ready for review.',
+    'Cost analysis shows 15% efficiency improvement.',
+    'Audit complete. No critical issues found.',
+  ],
+  question: [
+    'What priority level should I assign to the new requests?',
+    'Can you clarify the requirements for the API integration?',
+    'Should I escalate this to the manager?',
+    'Is there a deadline for the documentation update?',
+    'Who should I coordinate with on the security review?',
+  ],
+  escalation: [
+    'URGENT: Production issue detected. Need immediate attention.',
+    'Escalating: Budget threshold exceeded by 20%.',
+    'Critical: Agent unresponsive for 2 hours.',
+    'Alert: Unusual activity pattern detected.',
+    'Priority escalation: Customer-facing issue reported.',
+  ],
+  general: [
+    'Good morning team! Ready for another productive day.',
+    'Thanks for the quick turnaround on that request.',
+    'Great work on the release yesterday!',
+    'Reminder: Team sync in 30 minutes.',
+    'FYI - I\'ll be offline for maintenance at 3 PM.',
+  ],
+};
+
+// Helper to generate UUID
+function uuid(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+// Random element from array
+function randomFrom<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+/**
+ * Generate a random message between two agents
+ */
+export function generateMessage(
+  fromAgentId: string,
+  toAgentId: string,
+  options?: {
+    type?: MessageType;
+    taskRef?: string;
+    hoursAgo?: number;
+  }
+): DemoMessage {
+  const type = options?.type || randomFrom<MessageType>(['task', 'status', 'general', 'question']);
+  const templates = MESSAGE_TEMPLATES[type];
+  let content = randomFrom(templates);
+  
+  // Replace {taskRef} placeholder
+  if (content.includes('{taskRef}')) {
+    const taskRef = options?.taskRef || `TASK-${Math.floor(Math.random() * 1000).toString().padStart(3, '0')}`;
+    content = content.replace('{taskRef}', taskRef);
+  }
+
+  const hoursAgo = options?.hoursAgo ?? Math.random() * 48;
+  const createdAt = new Date(Date.now() - hoursAgo * 60 * 60 * 1000);
+
+  return {
+    id: `msg-${uuid()}`,
+    fromAgentId,
+    toAgentId,
+    content,
+    type,
+    taskRef: options?.taskRef,
+    read: Math.random() > 0.3, // 70% read
+    createdAt: createdAt.toISOString(),
+  };
+}
+
+/**
+ * Generate a conversation between two agents (back and forth)
+ */
+export function generateConversation(
+  agent1Id: string,
+  agent2Id: string,
+  messageCount: number = 4,
+  taskRef?: string
+): DemoMessage[] {
+  const messages: DemoMessage[] = [];
+  const types: MessageType[] = ['task', 'status', 'question', 'general'];
+  
+  for (let i = 0; i < messageCount; i++) {
+    const fromAgent = i % 2 === 0 ? agent1Id : agent2Id;
+    const toAgent = i % 2 === 0 ? agent2Id : agent1Id;
+    const hoursAgo = (messageCount - i) * 0.5; // Most recent last
+    
+    messages.push(generateMessage(fromAgent, toAgent, {
+      type: types[i % types.length],
+      taskRef: i === 0 ? taskRef : undefined,
+      hoursAgo,
+    }));
+  }
+  
+  return messages;
+}
+
+/**
+ * Generate initial messages for a scenario
+ */
+export function generateInitialMessages(agentIds: string[], taskIds: string[]): DemoMessage[] {
+  const messages: DemoMessage[] = [];
+  
+  // Generate some conversations between agents
+  for (let i = 0; i < agentIds.length; i++) {
+    for (let j = i + 1; j < agentIds.length; j++) {
+      // ~60% chance of conversation between any two agents
+      if (Math.random() < 0.6) {
+        const taskRef = taskIds.length > 0 && Math.random() > 0.5
+          ? randomFrom(taskIds)
+          : undefined;
+        messages.push(...generateConversation(agentIds[i], agentIds[j], 2 + Math.floor(Math.random() * 4), taskRef));
+      }
+    }
+  }
+  
+  return messages;
+}

--- a/libs/demo-data/src/scenarios/enterprise.ts
+++ b/libs/demo-data/src/scenarios/enterprise.ts
@@ -3,6 +3,7 @@ import { agents, AGENT_IDS, generateRandomAgent } from '../fixtures/agents.js';
 import { tasks, generateRandomTask } from '../fixtures/tasks.js';
 import { creditTransactions, generateCreditTransaction } from '../fixtures/credits.js';
 import { events, generateEvent } from '../fixtures/events.js';
+import { generateInitialMessages } from '../fixtures/messages.js';
 
 // Additional domains for enterprise scale
 const ENTERPRISE_DOMAINS = ['Engineering', 'Finance', 'Marketing', 'Sales', 'Support', 'Research', 'Legal', 'HR'];
@@ -138,6 +139,10 @@ const enterpriseTasks = generateEnterpriseTasks();
 const enterpriseCredits = generateEnterpriseCredits(enterpriseAgents);
 const enterpriseEvents = generateEnterpriseEvents(enterpriseAgents);
 
+// Build combined agent and task lists
+const allEnterpriseAgents = [...agents, ...enterpriseAgents];
+const allEnterpriseTasks = [...tasks, ...enterpriseTasks];
+
 /**
  * Enterprise Scenario: Large organization
  * - 50+ agents across 8 domains
@@ -147,10 +152,14 @@ const enterpriseEvents = generateEnterpriseEvents(enterpriseAgents);
 export const enterpriseScenario: DemoScenario = {
   name: 'enterprise',
   description: 'Large organization - 50+ agents, 8 domains, complex hierarchy',
-  agents: [...agents, ...enterpriseAgents],
-  tasks: [...tasks, ...enterpriseTasks],
+  agents: allEnterpriseAgents,
+  tasks: allEnterpriseTasks,
   credits: [...creditTransactions, ...enterpriseCredits],
   events: [...events, ...enterpriseEvents],
+  messages: generateInitialMessages(
+    allEnterpriseAgents.map(a => a.id),
+    allEnterpriseTasks.map(t => t.identifier)
+  ),
 };
 
 export default enterpriseScenario;

--- a/libs/demo-data/src/scenarios/fresh.ts
+++ b/libs/demo-data/src/scenarios/fresh.ts
@@ -26,6 +26,9 @@ export const freshScenario: DemoScenario = {
   
   // No events yet
   events: [],
+  
+  // No messages yet
+  messages: [],
 };
 
 export default freshScenario;

--- a/libs/demo-data/src/scenarios/growth.ts
+++ b/libs/demo-data/src/scenarios/growth.ts
@@ -3,6 +3,7 @@ import { agents } from '../fixtures/agents.js';
 import { tasks } from '../fixtures/tasks.js';
 import { creditTransactions } from '../fixtures/credits.js';
 import { events } from '../fixtures/events.js';
+import { generateInitialMessages } from '../fixtures/messages.js';
 
 /**
  * Growth Scenario: Scaling team
@@ -19,6 +20,10 @@ export const growthScenario: DemoScenario = {
   tasks: [...tasks],
   credits: [...creditTransactions],
   events: [...events],
+  messages: generateInitialMessages(
+    agents.map(a => a.id),
+    tasks.map(t => t.identifier)
+  ),
 };
 
 export default growthScenario;

--- a/libs/demo-data/src/scenarios/startup.ts
+++ b/libs/demo-data/src/scenarios/startup.ts
@@ -3,6 +3,7 @@ import { agents, AGENT_IDS, generateRandomAgent } from '../fixtures/agents.js';
 import { tasks, generateRandomTask } from '../fixtures/tasks.js';
 import { creditTransactions } from '../fixtures/credits.js';
 import { events } from '../fixtures/events.js';
+import { generateInitialMessages } from '../fixtures/messages.js';
 
 /**
  * Startup Scenario: Small team, early stage
@@ -34,6 +35,12 @@ export const startupScenario: DemoScenario = {
     !e.agentId || 
     [AGENT_IDS.agentDennis, AGENT_IDS.techTalent, AGENT_IDS.marketingTalent,
      AGENT_IDS.codeReviewer, AGENT_IDS.copywriter].includes(e.agentId as any)
+  ),
+  
+  messages: generateInitialMessages(
+    [AGENT_IDS.agentDennis, AGENT_IDS.techTalent, AGENT_IDS.marketingTalent,
+     AGENT_IDS.codeReviewer, AGENT_IDS.copywriter],
+    tasks.slice(0, 10).map(t => t.identifier)
   ),
 };
 

--- a/libs/demo-data/src/simulation/engine.ts
+++ b/libs/demo-data/src/simulation/engine.ts
@@ -6,10 +6,11 @@ import type {
   DemoTask,
   DemoCreditTransaction,
   DemoEvent,
+  DemoMessage,
   TaskStatus,
   AgentStatus,
 } from '../types.js';
-import { generateRandomAgent, generateRandomTask, generateCreditTransaction, generateEvent } from '../fixtures/index.js';
+import { generateRandomAgent, generateRandomTask, generateCreditTransaction, generateEvent, generateMessage } from '../fixtures/index.js';
 
 // Probability distributions for different events (per tick)
 const PROBABILITIES = {
@@ -152,6 +153,10 @@ export class SimulationEngine {
   
   getEvents(): DemoEvent[] {
     return this.deepClone(this.state.scenario.events);
+  }
+  
+  getMessages(): DemoMessage[] {
+    return this.deepClone(this.state.scenario.messages || []);
   }
   
   // Playback controls

--- a/libs/demo-data/src/types.ts
+++ b/libs/demo-data/src/types.ts
@@ -81,6 +81,19 @@ export interface DemoEvent {
   taskId?: string;
 }
 
+export type MessageType = 'task' | 'status' | 'report' | 'question' | 'escalation' | 'general';
+
+export interface DemoMessage {
+  id: string;
+  fromAgentId: string;
+  toAgentId: string;
+  content: string;
+  type: MessageType;
+  taskRef?: string;
+  read: boolean;
+  createdAt: string;
+}
+
 export interface DemoScenario {
   name: string;
   description: string;
@@ -88,6 +101,7 @@ export interface DemoScenario {
   tasks: DemoTask[];
   credits: DemoCreditTransaction[];
   events: DemoEvent[];
+  messages: DemoMessage[];
 }
 
 export interface SimulationState {


### PR DESCRIPTION
## Summary

The Messages page now follows the same demo pattern as other pages — data comes from the simulation engine via the mock-fetcher, not hardcoded.

## Changes

### demo-data lib
- Added `DemoMessage` type with from/to agents, content, type, taskRef
- Added `messages.ts` fixture with generators
- Added `messages: []` to all scenarios
- Added `getMessages()` to SimulationEngine

### mock-fetcher
- Added `Messages` query handler
- Added `Conversations` query (groups messages by agent pair)
- Added `ConversationMessages` query (thread between two agents)

### Dashboard
- Created `use-messages.ts` hook with `useMessages()`, `useConversations()`
- Refactored Messages page to use hooks instead of inline demo data
- Messages now update when the simulation ticks

## Testing

```bash
pnpm dev
# → http://localhost:4200/messages?demo=true
```

The graph, feed, cards, and context views all work with the simulation data.