### PR TITLE
feat: add GoatCounter analytics

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -29,6 +29,10 @@
     <meta property="og:image" content="/og-image.png" />
     
     <link rel="stylesheet" href="/src/styles.css" />
+    
+    <!-- Analytics (GoatCounter - privacy-focused) -->
+    <script data-goatcounter="https://openspawn.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -9,6 +9,10 @@
   <link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  
+  <!-- Analytics (GoatCounter - privacy-focused) -->
+  <script data-goatcounter="https://openspawn.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
   <header>

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -9,6 +9,10 @@
   <link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  
+  <!-- Analytics (GoatCounter - privacy-focused) -->
+  <script data-goatcounter="https://openspawn.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
## What

Add privacy-focused analytics via [GoatCounter](https://www.goatcounter.com).

**Added to:**
- Dashboard (`apps/dashboard/index.html`)
- Docs site (`docs/_layouts/default.html`)
- Docs home (`docs/_layouts/home.html`)

## Why

Track page views to understand:
- How many people visit the demo
- Which pages are most popular
- Where traffic comes from

GoatCounter is:
- ✅ Privacy-focused (no cookies, GDPR compliant)
- ✅ Open source
- ✅ Free tier available
- ✅ Simple script tag

## Setup Required

After merging, register at https://www.goatcounter.com to claim:
```
https://openspawn.goatcounter.com
```

Dashboard: https://openspawn.goatcounter.com