### PR TITLE
feat(dashboard): add phase chip indicator to pages

### DIFF
--- a/apps/dashboard/src/components/index.ts
+++ b/apps/dashboard/src/components/index.ts
@@ -16,3 +16,4 @@ export * from "./agent-efficiency";
 export * from "./model-usage";
 export * from "./agent-heartbeat";
 export { PhaseProgress } from './phase-progress';
+export { PhaseChip } from './phase-chip';

--- a/apps/dashboard/src/components/phase-chip.tsx
+++ b/apps/dashboard/src/components/phase-chip.tsx
@@ -1,0 +1,32 @@
+import { cn } from '../lib/utils';
+import type { PhaseInfo } from './phase-progress';
+
+interface PhaseChipProps {
+  phase: PhaseInfo;
+  className?: string;
+}
+
+/**
+ * Compact phase indicator for showing current project phase
+ * in page headers without being intrusive
+ */
+export function PhaseChip({ phase, className }: PhaseChipProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium",
+        "bg-blue-500/10 text-blue-400 border border-blue-500/20",
+        "transition-colors hover:bg-blue-500/15",
+        className
+      )}
+      title={`${phase.name}: ${phase.description}`}
+    >
+      <span>{phase.icon}</span>
+      <span>{phase.name}</span>
+      <span className="text-blue-400/60">•</span>
+      <span className="text-blue-400/80">{phase.week}</span>
+    </div>
+  );
+}
+
+export default PhaseChip;

--- a/apps/dashboard/src/hooks/index.ts
+++ b/apps/dashboard/src/hooks/index.ts
@@ -3,3 +3,4 @@ export { useAgents, type Agent } from "./use-agents";
 export { useCredits, type CreditTransaction } from "./use-credits";
 export { useEvents, type Event } from "./use-events";
 export { useMessages, useConversations, useConversationMessages, type Message, type Conversation } from "./use-messages";
+export { useCurrentPhase } from "./use-current-phase";

--- a/apps/dashboard/src/hooks/use-current-phase.ts
+++ b/apps/dashboard/src/hooks/use-current-phase.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { useDemo, PROJECT_PHASES } from '../demo/DemoProvider';
+
+/**
+ * Hook to get the current project phase for NovaTech scenario
+ * Returns null for non-NovaTech scenarios
+ */
+export function useCurrentPhase() {
+  const { scenario, isDemo } = useDemo();
+  
+  const currentPhase = useMemo(() => {
+    // Only show phase info for NovaTech scenario
+    if (!isDemo || scenario !== 'novatech') {
+      return null;
+    }
+    
+    // For demo purposes, we're in the Development phase
+    // In a real implementation, this would track based on task completion
+    const currentPhaseId = 'development';
+    return PROJECT_PHASES.find(p => p.id === currentPhaseId) || null;
+  }, [isDemo, scenario]);
+  
+  const phases = useMemo(() => {
+    if (!isDemo || scenario !== 'novatech') {
+      return [];
+    }
+    return PROJECT_PHASES;
+  }, [isDemo, scenario]);
+  
+  return {
+    currentPhase,
+    phases,
+    isNovaTech: scenario === 'novatech',
+  };
+}

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -23,7 +23,8 @@ import {
   DialogClose,
 } from "../components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs";
-import { useAgents } from "../hooks/use-agents";
+import { PhaseChip } from "../components/phase-chip";
+import { useAgents, useCurrentPhase } from "../hooks";
 import { AgentOnboarding } from "../components/agent-onboarding";
 import { BudgetManager } from "../components/budget-manager";
 import { CapabilityManager } from "../components/capability-manager";
@@ -556,6 +557,7 @@ function AdjustCreditsDialog({ agent, onClose }: { agent: Agent; onClose: () => 
 
 export function AgentsPage() {
   const { agents, loading, error } = useAgents();
+  const { currentPhase } = useCurrentPhase();
   const [selectedAgent, setSelectedAgent] = useState<Agent | null>(null);
   const [dialogMode, setDialogMode] = useState<DialogMode>(null);
   const [activeTab, setActiveTab] = useState("agents");
@@ -658,11 +660,14 @@ export function AgentsPage() {
     <div className="space-y-6">
       {/* Page header */}
       <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Agents</h1>
-          <p className="text-muted-foreground">
-            Manage your AI agents, onboarding, and budgets
-          </p>
+        <div className="flex items-center gap-3">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Agents</h1>
+            <p className="text-muted-foreground">
+              Manage your AI agents, onboarding, and budgets
+            </p>
+          </div>
+          {currentPhase && <PhaseChip phase={currentPhase} />}
         </div>
         <Button>
           <Plus className="mr-2 h-4 w-4" />

--- a/apps/dashboard/src/pages/messages.tsx
+++ b/apps/dashboard/src/pages/messages.tsx
@@ -19,7 +19,8 @@ import { ScrollArea } from '../components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { cn } from '../lib/utils';
 import { getAgentAvatarUrl } from '../lib/avatar';
-import { useMessages, useAgents, type Message } from '../hooks';
+import { PhaseChip } from '../components/phase-chip';
+import { useMessages, useAgents, useCurrentPhase, type Message } from '../hooks';
 
 const formatTime = (dateStr: string) => {
   const date = new Date(dateStr);
@@ -651,6 +652,7 @@ function ContextLinkedMessages({ messages, agents }: { messages: Message[]; agen
 export function MessagesPage() {
   const { messages, loading: messagesLoading } = useMessages(100);
   const { agents, loading: agentsLoading } = useAgents();
+  const { currentPhase } = useCurrentPhase();
 
   const loading = messagesLoading || agentsLoading;
 
@@ -668,9 +670,12 @@ export function MessagesPage() {
   return (
     <div className="p-3 md:p-6 space-y-4 md:space-y-6">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-        <div>
-          <h1 className="text-xl md:text-2xl font-bold">Agent Communications</h1>
-          <p className="text-slate-400 text-xs md:text-sm">Watch your agents coordinate in real-time</p>
+        <div className="flex items-center gap-3 flex-wrap">
+          <div>
+            <h1 className="text-xl md:text-2xl font-bold">Agent Communications</h1>
+            <p className="text-slate-400 text-xs md:text-sm">Watch your agents coordinate in real-time</p>
+          </div>
+          {currentPhase && <PhaseChip phase={currentPhase} className="hidden sm:inline-flex" />}
         </div>
         <Badge variant="outline" className="self-start sm:self-auto">{messages.length} messages</Badge>
       </div>

--- a/apps/dashboard/src/pages/tasks.tsx
+++ b/apps/dashboard/src/pages/tasks.tsx
@@ -6,7 +6,8 @@ import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs";
 import { ScrollArea } from "../components/ui/scroll-area";
-import { useTasks, type Task } from "../hooks/use-tasks";
+import { PhaseChip } from "../components/phase-chip";
+import { useTasks, type Task, useCurrentPhase } from "../hooks";
 
 const statusColumns = [
   { id: "BACKLOG", label: "Backlog", color: "bg-slate-500" },
@@ -410,6 +411,7 @@ function ListView({ tasks, onTaskClick }: { tasks: Task[]; onTaskClick: (task: T
 
 export function TasksPage() {
   const { tasks, loading, error } = useTasks();
+  const { currentPhase, isNovaTech } = useCurrentPhase();
   const [view, setView] = useState<"kanban" | "list">("kanban");
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
@@ -433,11 +435,14 @@ export function TasksPage() {
     <div className="space-y-6">
       {/* Page header */}
       <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Tasks</h1>
-          <p className="text-muted-foreground">
-            Manage and track agent tasks
-          </p>
+        <div className="flex items-center gap-3">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Tasks</h1>
+            <p className="text-muted-foreground">
+              Manage and track agent tasks
+            </p>
+          </div>
+          {currentPhase && <PhaseChip phase={currentPhase} />}
         </div>
         <div className="flex items-center gap-2">
           <Button variant="outline" size="icon">


### PR DESCRIPTION
## Changes

Adds a compact phase indicator (PhaseChip) to key pages when the NovaTech scenario is active:

- **Tasks page**: Shows current project phase next to title
- **Agents page**: Shows current project phase next to title  
- **Messages page**: Shows current project phase next to title (desktop only)

## Components Added

- `PhaseChip` - Compact pill showing phase icon, name, and week
- `useCurrentPhase` hook - Returns current phase info for NovaTech scenario

## UX Notes

- Only shows when NovaTech scenario is selected (not other scenarios)
- Non-intrusive: small chip that doesn't dominate the header
- Hover tooltip shows phase description
- Hidden on mobile for Messages page (space constraints)

## Screenshots

The chip appears as: `🔧 Development • Week 5-8`

---

Addresses the request to show phase/stage info across pages without being intrusive.