### PR TITLE
feat(dashboard): customizable avatar styles

### DIFF
--- a/apps/dashboard/src/components/agent-avatar.tsx
+++ b/apps/dashboard/src/components/agent-avatar.tsx
@@ -3,9 +3,9 @@
  * Uses DiceBear to generate consistent avatars based on agent ID
  */
 
-import { useMemo } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
-import { getAgentAvatarUrl } from '../lib/avatar';
+import { getAgentAvatarUrl, getAvatarStyle, type AvatarStyleKey } from '../lib/avatar';
 import { Bot } from 'lucide-react';
 import { cn } from '../lib/utils';
 
@@ -50,10 +50,21 @@ export function AgentAvatar({
   const sizeConfig = SIZE_MAP[size];
   const levelColor = LEVEL_COLORS[level] || '#71717a';
   
-  // Memoize avatar generation to avoid recalculating on every render
+  // Track avatar style changes
+  const [avatarStyle, setAvatarStyle] = useState<AvatarStyleKey>(getAvatarStyle());
+  
+  useEffect(() => {
+    const handleStyleChange = (e: CustomEvent<AvatarStyleKey>) => {
+      setAvatarStyle(e.detail);
+    };
+    window.addEventListener('avatar-style-changed', handleStyleChange as EventListener);
+    return () => window.removeEventListener('avatar-style-changed', handleStyleChange as EventListener);
+  }, []);
+  
+  // Memoize avatar generation - regenerate when style changes
   const avatarUrl = useMemo(
     () => getAgentAvatarUrl(agentId, level, sizeConfig.px * 2), // 2x for retina
-    [agentId, level, sizeConfig.px]
+    [agentId, level, sizeConfig.px, avatarStyle]
   );
 
   return (

--- a/apps/dashboard/src/components/settings/appearance-settings.tsx
+++ b/apps/dashboard/src/components/settings/appearance-settings.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect } from "react";
+import { Check, Palette } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
+import { 
+  AVATAR_STYLES, 
+  type AvatarStyleKey, 
+  getAvatarStyle, 
+  setAvatarStyle,
+  generateStylePreview 
+} from "../../lib/avatar";
+
+export function AppearanceSettings() {
+  const [selectedStyle, setSelectedStyle] = useState<AvatarStyleKey>(getAvatarStyle());
+  const [previewSeed] = useState(() => `preview-${Date.now()}`);
+
+  // Listen for external changes
+  useEffect(() => {
+    const handleChange = (e: CustomEvent<AvatarStyleKey>) => {
+      setSelectedStyle(e.detail);
+    };
+    window.addEventListener('avatar-style-changed', handleChange as EventListener);
+    return () => window.removeEventListener('avatar-style-changed', handleChange as EventListener);
+  }, []);
+
+  function handleStyleSelect(style: AvatarStyleKey) {
+    setSelectedStyle(style);
+    setAvatarStyle(style);
+  }
+
+  // Group styles into categories
+  const styleCategories = {
+    "Robots & Tech": ["bottts", "botttsNeutral", "glass", "shapes", "rings", "identicon", "icons"],
+    "Pixel Art": ["pixelArt", "pixelArtNeutral", "miniavs"],
+    "Illustrated": ["lorelei", "loreleiNeutral", "notionists", "notionistsNeutral", "openPeeps", "personas", "dylan", "micah"],
+    "Fun & Playful": ["funEmoji", "thumbs", "bigSmile", "croodles", "croodlesNeutral"],
+    "Characters": ["adventurer", "adventurerNeutral", "bigEars", "bigEarsNeutral"],
+    "Simple": ["initials"],
+  } as const;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Palette className="h-5 w-5" />
+            Avatar Style
+          </CardTitle>
+          <CardDescription>
+            Choose a consistent avatar style for all agents. Each agent will still have a unique avatar based on their ID.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Current selection preview */}
+          <div className="flex items-center gap-4 p-4 bg-muted/50 rounded-lg">
+            <img 
+              src={generateStylePreview(selectedStyle, previewSeed)} 
+              alt="Current style preview"
+              className="w-16 h-16 rounded-full"
+            />
+            <div>
+              <p className="font-medium">{AVATAR_STYLES[selectedStyle].name}</p>
+              <p className="text-sm text-muted-foreground">{AVATAR_STYLES[selectedStyle].description}</p>
+            </div>
+          </div>
+
+          {/* Style categories */}
+          {Object.entries(styleCategories).map(([category, styles]) => (
+            <div key={category} className="space-y-3">
+              <h4 className="text-sm font-medium text-muted-foreground">{category}</h4>
+              <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-3">
+                {styles.map((styleKey) => {
+                  const styleInfo = AVATAR_STYLES[styleKey as AvatarStyleKey];
+                  if (!styleInfo) return null;
+                  const isSelected = selectedStyle === styleKey;
+                  
+                  return (
+                    <button
+                      key={styleKey}
+                      onClick={() => handleStyleSelect(styleKey as AvatarStyleKey)}
+                      className={`relative flex flex-col items-center gap-2 p-3 rounded-lg border-2 transition-all hover:bg-accent/50 ${
+                        isSelected 
+                          ? "border-primary bg-primary/10" 
+                          : "border-transparent bg-muted/30 hover:border-muted-foreground/20"
+                      }`}
+                      title={styleInfo.description}
+                    >
+                      {isSelected && (
+                        <div className="absolute -top-1 -right-1 w-5 h-5 bg-primary rounded-full flex items-center justify-center">
+                          <Check className="w-3 h-3 text-primary-foreground" />
+                        </div>
+                      )}
+                      <img 
+                        src={generateStylePreview(styleKey as AvatarStyleKey, previewSeed)} 
+                        alt={styleInfo.name}
+                        className="w-12 h-12 rounded-full"
+                      />
+                      <span className="text-[10px] font-medium text-center leading-tight">
+                        {styleInfo.name}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+
+          {/* Sample agents preview */}
+          <div className="pt-4 border-t">
+            <h4 className="text-sm font-medium mb-3">Preview with sample agents</h4>
+            <div className="flex gap-3 overflow-x-auto pb-2">
+              {["agent-dennis", "tech-talent", "marketing-lead", "code-reviewer", "data-analyst", "support-bot"].map((seed, i) => (
+                <div key={seed} className="flex flex-col items-center gap-1 shrink-0">
+                  <img 
+                    src={generateStylePreview(selectedStyle, seed)} 
+                    alt={seed}
+                    className="w-10 h-10 rounded-full"
+                  />
+                  <span className="text-[9px] text-muted-foreground">L{10 - i}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/settings/index.ts
+++ b/apps/dashboard/src/components/settings/index.ts
@@ -2,3 +2,4 @@ export { ProfileSettings } from "./profile-settings";
 export { SecuritySettings } from "./security-settings";
 export { ApiKeySettings } from "./api-key-settings";
 export { OrgSettings } from "./org-settings";
+export { AppearanceSettings } from "./appearance-settings";

--- a/apps/dashboard/src/lib/avatar.ts
+++ b/apps/dashboard/src/lib/avatar.ts
@@ -4,32 +4,95 @@
  */
 
 import { createAvatar } from '@dicebear/core';
-import { bottts, botttsNeutral, shapes, rings, glass, identicon } from '@dicebear/collection';
+import { 
+  bottts, 
+  botttsNeutral, 
+  shapes, 
+  rings, 
+  glass, 
+  identicon,
+  pixelArt,
+  pixelArtNeutral,
+  thumbs,
+  lorelei,
+  loreleiNeutral,
+  notionists,
+  notionistsNeutral,
+  openPeeps,
+  personas,
+  funEmoji,
+  dylan,
+  micah,
+  miniavs,
+  adventurer,
+  adventurerNeutral,
+  bigEars,
+  bigEarsNeutral,
+  bigSmile,
+  croodles,
+  croodlesNeutral,
+  icons,
+  initials,
+} from '@dicebear/collection';
 
-// Avatar style based on agent level
-const LEVEL_STYLES = {
-  // Leadership (L9-10): Premium glass style
-  leadership: glass,
-  // Managers (L7-8): Bottts neutral
-  manager: botttsNeutral,
-  // Seniors (L5-6): Bottts classic
-  senior: bottts,
-  // Workers (L3-4): Shapes
-  worker: shapes,
-  // Probation (L1-2): Rings
-  probation: rings,
-  // Fallback
-  default: identicon,
+// Available avatar styles with display names
+export const AVATAR_STYLES = {
+  bottts: { style: bottts, name: 'Bottts', description: 'Classic robot avatars' },
+  botttsNeutral: { style: botttsNeutral, name: 'Bottts Neutral', description: 'Neutral robot avatars' },
+  glass: { style: glass, name: 'Glass', description: 'Sleek glass orbs' },
+  shapes: { style: shapes, name: 'Shapes', description: 'Geometric shapes' },
+  rings: { style: rings, name: 'Rings', description: 'Colorful ring patterns' },
+  identicon: { style: identicon, name: 'Identicon', description: 'GitHub-style patterns' },
+  pixelArt: { style: pixelArt, name: 'Pixel Art', description: '8-bit style characters' },
+  pixelArtNeutral: { style: pixelArtNeutral, name: 'Pixel Neutral', description: 'Neutral pixel characters' },
+  thumbs: { style: thumbs, name: 'Thumbs', description: 'Thumbs up characters' },
+  lorelei: { style: lorelei, name: 'Lorelei', description: 'Illustrated portraits' },
+  loreleiNeutral: { style: loreleiNeutral, name: 'Lorelei Neutral', description: 'Neutral illustrated portraits' },
+  notionists: { style: notionists, name: 'Notionists', description: 'Notion-style avatars' },
+  notionistsNeutral: { style: notionistsNeutral, name: 'Notionists Neutral', description: 'Neutral Notion-style' },
+  openPeeps: { style: openPeeps, name: 'Open Peeps', description: 'Hand-drawn people' },
+  personas: { style: personas, name: 'Personas', description: 'Character personas' },
+  funEmoji: { style: funEmoji, name: 'Fun Emoji', description: 'Expressive emoji faces' },
+  dylan: { style: dylan, name: 'Dylan', description: 'Friendly illustrated faces' },
+  micah: { style: micah, name: 'Micah', description: 'Minimalist portraits' },
+  miniavs: { style: miniavs, name: 'Miniavs', description: 'Tiny cute avatars' },
+  adventurer: { style: adventurer, name: 'Adventurer', description: 'RPG-style characters' },
+  adventurerNeutral: { style: adventurerNeutral, name: 'Adventurer Neutral', description: 'Neutral RPG characters' },
+  bigEars: { style: bigEars, name: 'Big Ears', description: 'Cartoon characters' },
+  bigEarsNeutral: { style: bigEarsNeutral, name: 'Big Ears Neutral', description: 'Neutral cartoon characters' },
+  bigSmile: { style: bigSmile, name: 'Big Smile', description: 'Happy smiling faces' },
+  croodles: { style: croodles, name: 'Croodles', description: 'Doodle-style avatars' },
+  croodlesNeutral: { style: croodlesNeutral, name: 'Croodles Neutral', description: 'Neutral doodles' },
+  icons: { style: icons, name: 'Icons', description: 'Simple icon avatars' },
+  initials: { style: initials, name: 'Initials', description: 'Letter initials' },
 } as const;
 
-// Get avatar style based on level
-function getStyleForLevel(level: number) {
-  if (level >= 9) return LEVEL_STYLES.leadership;
-  if (level >= 7) return LEVEL_STYLES.manager;
-  if (level >= 5) return LEVEL_STYLES.senior;
-  if (level >= 3) return LEVEL_STYLES.worker;
-  if (level >= 1) return LEVEL_STYLES.probation;
-  return LEVEL_STYLES.default;
+export type AvatarStyleKey = keyof typeof AVATAR_STYLES;
+
+// LocalStorage key for avatar style preference
+const AVATAR_STYLE_KEY = 'openspawn-avatar-style';
+
+// Get saved avatar style or default
+export function getAvatarStyle(): AvatarStyleKey {
+  if (typeof window === 'undefined') return 'bottts';
+  const saved = localStorage.getItem(AVATAR_STYLE_KEY);
+  if (saved && saved in AVATAR_STYLES) {
+    return saved as AvatarStyleKey;
+  }
+  return 'bottts';
+}
+
+// Save avatar style preference
+export function setAvatarStyle(style: AvatarStyleKey): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(AVATAR_STYLE_KEY, style);
+  // Dispatch event so components can react
+  window.dispatchEvent(new CustomEvent('avatar-style-changed', { detail: style }));
+}
+
+// Get the DiceBear style object
+function getStyle(styleKey: AvatarStyleKey) {
+  return AVATAR_STYLES[styleKey]?.style || AVATAR_STYLES.bottts.style;
 }
 
 // Level-based background colors (matching the level color scheme)
@@ -50,17 +113,20 @@ export interface AvatarOptions {
   seed: string;
   level?: number;
   size?: number;
+  styleOverride?: AvatarStyleKey;
 }
 
 /**
  * Generate an SVG avatar for an agent
  * @param options.seed - Unique identifier (agent ID or name)
- * @param options.level - Agent level (1-10) for style selection
+ * @param options.level - Agent level (1-10) for background color
  * @param options.size - Avatar size in pixels
+ * @param options.styleOverride - Override the saved style preference
  * @returns SVG data URI
  */
-export function generateAgentAvatar({ seed, level = 5, size = 64 }: AvatarOptions): string {
-  const style = getStyleForLevel(level);
+export function generateAgentAvatar({ seed, level = 5, size = 64, styleOverride }: AvatarOptions): string {
+  const styleKey = styleOverride || getAvatarStyle();
+  const style = getStyle(styleKey);
   const backgrounds = LEVEL_BACKGROUNDS[level] || LEVEL_BACKGROUNDS[5];
   
   const avatar = createAvatar(style, {
@@ -80,4 +146,20 @@ export function generateAgentAvatar({ seed, level = 5, size = 64 }: AvatarOption
  */
 export function getAgentAvatarUrl(agentId: string, level: number = 5, size: number = 64): string {
   return generateAgentAvatar({ seed: agentId, level, size });
+}
+
+/**
+ * Generate a preview avatar for a specific style
+ */
+export function generateStylePreview(styleKey: AvatarStyleKey, seed: string = 'preview', size: number = 64): string {
+  const style = getStyle(styleKey);
+  
+  const avatar = createAvatar(style, {
+    seed,
+    size,
+    backgroundColor: ['c4b5fd', 'a78bfa', '8b5cf6'], // Purple gradient
+    backgroundType: ['gradientLinear'],
+  });
+
+  return avatar.toDataUri();
 }

--- a/apps/dashboard/src/pages/settings.tsx
+++ b/apps/dashboard/src/pages/settings.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { User, Shield, Key, Building2 } from "lucide-react";
+import { User, Shield, Key, Building2, Palette } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs";
 import { ProfileSettings } from "../components/settings/profile-settings";
 import { SecuritySettings } from "../components/settings/security-settings";
 import { ApiKeySettings } from "../components/settings/api-key-settings";
 import { OrgSettings } from "../components/settings/org-settings";
+import { AppearanceSettings } from "../components/settings/appearance-settings";
 
 export function SettingsPage() {
   const [activeTab, setActiveTab] = useState("profile");
@@ -20,10 +21,14 @@ export function SettingsPage() {
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-        <TabsList className="grid w-full grid-cols-4 lg:w-[600px]">
+        <TabsList className="grid w-full grid-cols-5 lg:w-[700px]">
           <TabsTrigger value="profile" className="flex items-center gap-2">
             <User className="h-4 w-4" />
             <span className="hidden sm:inline">Profile</span>
+          </TabsTrigger>
+          <TabsTrigger value="appearance" className="flex items-center gap-2">
+            <Palette className="h-4 w-4" />
+            <span className="hidden sm:inline">Appearance</span>
           </TabsTrigger>
           <TabsTrigger value="security" className="flex items-center gap-2">
             <Shield className="h-4 w-4" />
@@ -35,12 +40,16 @@ export function SettingsPage() {
           </TabsTrigger>
           <TabsTrigger value="organization" className="flex items-center gap-2">
             <Building2 className="h-4 w-4" />
-            <span className="hidden sm:inline">Organization</span>
+            <span className="hidden sm:inline">Org</span>
           </TabsTrigger>
         </TabsList>
 
         <TabsContent value="profile">
           <ProfileSettings />
+        </TabsContent>
+
+        <TabsContent value="appearance">
+          <AppearanceSettings />
         </TabsContent>
 
         <TabsContent value="security">


### PR DESCRIPTION
## Feature
Users can now pick their preferred avatar style from 25+ DiceBear styles in **Settings → Appearance**.

### Styles Available
- **Robots & Tech**: Bottts, Glass, Shapes, Rings, Identicon, Icons
- **Pixel Art**: Pixel Art, Pixel Neutral, Miniavs  
- **Illustrated**: Lorelei, Notionists, Open Peeps, Personas, Dylan, Micah
- **Fun & Playful**: Fun Emoji, Thumbs, Big Smile, Croodles
- **Characters**: Adventurer, Big Ears
- **Simple**: Initials

### UX
- Organized by category with visual preview grid
- Current selection shown at top with description
- "Sample agents" preview row shows variety
- Selection persists in localStorage
- All avatars update instantly across the app

### Technical
- Uses custom event `avatar-style-changed` for reactivity
- AgentAvatar component listens and re-renders
- Level-based background gradients still apply for visual hierarchy