### PR TITLE
fix(auth): require authentication for HTTP requests

### DIFF
--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -7,6 +7,8 @@ import type { Request } from "express";
 import { IS_PUBLIC_KEY } from "./decorators/public.decorator";
 import { AuthService } from "./auth.service";
 import { ApiKeysService } from "./api-keys.service";
+import { TokensService } from "./tokens.service";
+import { UsersService } from "../users";
 import "./types"; // Extend Express.Request
 
 @Injectable()
@@ -14,6 +16,8 @@ export class AuthGuard implements CanActivate {
   constructor(
     private readonly authService: AuthService,
     private readonly apiKeysService: ApiKeysService,
+    private readonly tokensService: TokensService,
+    private readonly usersService: UsersService,
     private readonly reflector: Reflector,
   ) {}
 
@@ -38,13 +42,14 @@ export class AuthGuard implements CanActivate {
     }
 
     // If no request object (e.g., WebSocket subscription), skip auth for now
+    // TODO: Implement WebSocket authentication via connection params
+    // WebSocket subscriptions should validate auth during the connection handshake,
+    // not on each message. This requires changes to the GraphQL subscription setup.
     if (!request || !request.headers) {
-      // For subscriptions and dashboard queries, allow unauthenticated access
-      // TODO: Implement proper subscription auth
       return true;
     }
 
-    // Check for API key in Authorization header (Bearer token)
+    // Check for API key in Authorization header (Bearer osp_...)
     const authHeader = request.headers.authorization;
     if (authHeader?.startsWith("Bearer osp_")) {
       const key = authHeader.slice(7);
@@ -68,36 +73,65 @@ export class AuthGuard implements CanActivate {
     const nonce = request.headers["x-nonce"] as string | undefined;
     const signature = request.headers["x-signature"] as string | undefined;
 
-    // If no auth headers, allow unauthenticated access for dashboard
-    // TODO: Implement proper role-based access control for GraphQL
-    if (!agentId && !signature) {
+    // If agent headers are present, validate HMAC signature
+    if (agentId || signature) {
+      if (!agentId || !timestamp || !nonce || !signature) {
+        throw new UnauthorizedException("Missing authentication headers: x-agent-id, x-timestamp, x-nonce, and x-signature are all required");
+      }
+
+      // Get request body as string for signature verification
+      const body =
+        request.method === "GET" || request.method === "DELETE"
+          ? ""
+          : JSON.stringify(request.body || {});
+
+      // Validate the request
+      const agent = await this.authService.validateRequest(
+        agentId,
+        timestamp,
+        nonce,
+        signature,
+        request.method,
+        request.path,
+        body,
+      );
+
+      // Attach agent to request
+      request.agent = agent;
       return true;
     }
 
-    if (!agentId || !timestamp || !nonce || !signature) {
-      throw new UnauthorizedException("Missing authentication headers");
+    // No agent headers - check for JWT Bearer token (dashboard users)
+    if (authHeader?.startsWith("Bearer ")) {
+      const token = authHeader.slice(7);
+      try {
+        const payload = this.tokensService.verifyAccessToken(token);
+        
+        // Look up user to verify they still exist and get full info
+        const user = await this.usersService.findById(payload.sub);
+        if (!user) {
+          throw new UnauthorizedException("User not found");
+        }
+
+        request.jwtUser = {
+          id: user.id,
+          orgId: user.orgId,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+        };
+        return true;
+      } catch (error) {
+        if (error instanceof UnauthorizedException) {
+          throw error;
+        }
+        throw new UnauthorizedException("Invalid or expired JWT token");
+      }
     }
 
-    // Get request body as string for signature verification
-    const body =
-      request.method === "GET" || request.method === "DELETE"
-        ? ""
-        : JSON.stringify(request.body || {});
-
-    // Validate the request
-    const agent = await this.authService.validateRequest(
-      agentId,
-      timestamp,
-      nonce,
-      signature,
-      request.method,
-      request.path,
-      body,
+    // No valid authentication provided
+    throw new UnauthorizedException(
+      "Authentication required. Provide either a valid JWT Bearer token, API key (Bearer osp_...), or agent HMAC signature headers."
     );
-
-    // Attach agent to request
-    request.agent = agent;
-
-    return true;
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes a critical security vulnerability in the AuthGuard that allowed unauthenticated access to all GraphQL queries.

## Problem

The AuthGuard had two bypass conditions:

1. **Lines 37-39**: Returns `true` if no request/headers (WebSocket) - kept for now with detailed TODO
2. **Lines 60-63**: Returns `true` if no agent auth headers present - **SECURITY ISSUE**

This allowed anyone to access protected GraphQL endpoints by simply not including any authentication headers.

## Solution

For HTTP requests, the guard now requires one of:
- Valid agent HMAC signature (x-agent-id, x-timestamp, x-nonce, x-signature headers)
- Valid JWT Bearer token (for dashboard users)
- Valid API key (Bearer osp_...)
- Route marked with `@Public()` decorator

For WebSocket (no request/headers object), kept permissive with a detailed TODO explaining that WebSocket auth should be implemented at the connection handshake level, not per-message.

## Changes

- Inject `TokensService` and `UsersService` to validate JWT tokens
- Add proper JWT Bearer token validation for dashboard users
- Improve error messages to explain authentication requirements
- Add detailed TODO comment for WebSocket auth implementation

## Breaking Change

Unauthenticated HTTP requests to non-public routes will now receive 401 Unauthorized instead of being allowed through. Dashboard users must include their JWT token.

## Testing

- Verified TypeScript compilation passes
- Verified linting passes