### PR TITLE
feat(api): add API versioning with /api/v1 prefix

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -6,6 +6,11 @@ import { AppModule } from "./app/app.module";
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  // Set global API version prefix
+  app.setGlobalPrefix('api/v1', {
+    exclude: ['/health', '/ready', '/metrics'],
+  });
+
   // Enable validation
   app.useGlobalPipes(
     new ValidationPipe({

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -11,7 +11,7 @@ const CONFIG_DIR = join(homedir(), ".openspawn");
 const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 
 const DEFAULT_CONFIG: CliConfig = {
-  apiUrl: "http://localhost:3000",
+  apiUrl: "http://localhost:3000/api/v1",
 };
 
 export function ensureConfigDir(): void {

--- a/apps/dashboard/src/graphql/fetcher.ts
+++ b/apps/dashboard/src/graphql/fetcher.ts
@@ -16,7 +16,7 @@ function getApiUrl(): string {
   // This ensures accessing from 192.168.x.x uses that IP, not localhost
   if (typeof window !== "undefined" && window.location?.hostname) {
     const { protocol, hostname } = window.location;
-    const url = `${protocol}//${hostname}:3000/graphql`;
+    const url = `${protocol}//${hostname}:3000/api/v1/graphql`;
     console.log("[GraphQL] Auto-detected API URL:", url);
     return url;
   }
@@ -27,7 +27,7 @@ function getApiUrl(): string {
     return import.meta.env.VITE_API_URL;
   }
 
-  return "http://localhost:3000/graphql";
+  return "http://localhost:3000/api/v1/graphql";
 }
 
 // Lazy initialization to ensure window.location is available

--- a/config/nginx.prod.conf
+++ b/config/nginx.prod.conf
@@ -70,11 +70,11 @@ http {
             add_header Content-Type text/plain;
         }
 
-        # API routes
-        location /api/ {
+        # API v1 routes (versioned API)
+        location /api/v1/ {
             limit_req zone=api burst=20 nodelay;
             
-            proxy_pass http://api_backend/;
+            proxy_pass http://api_backend/api/v1/;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -88,11 +88,16 @@ http {
             proxy_read_timeout 86400;
         }
 
-        # GraphQL endpoint
-        location /graphql {
+        # Legacy /api/ redirect to versioned endpoint
+        location /api/ {
+            return 301 /api/v1$request_uri;
+        }
+
+        # GraphQL endpoint (versioned)
+        location /api/v1/graphql {
             limit_req zone=api burst=20 nodelay;
             
-            proxy_pass http://api_backend/graphql;
+            proxy_pass http://api_backend/api/v1/graphql;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -101,6 +106,11 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
             proxy_read_timeout 86400;
+        }
+
+        # Legacy /graphql redirect to versioned endpoint
+        location /graphql {
+            return 301 /api/v1/graphql;
         }
 
         # MCP routes

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -68,7 +68,7 @@ services:
     container_name: openspawn-mcp
     restart: unless-stopped
     environment:
-      API_URL: http://api:3000
+      API_URL: http://api:3000/api/v1
       PORT: 3001
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:3001/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       dockerfile: apps/mcp/Dockerfile
     container_name: openspawn-mcp
     environment:
-      API_URL: http://api:3000
+      API_URL: http://api:3000/api/v1
       PORT: 3001
     ports:
       - "3001:3001"

--- a/docker/test-openclaw/docker-compose.yml
+++ b/docker/test-openclaw/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       context: ../..
       dockerfile: apps/mcp/Dockerfile
     environment:
-      API_URL: http://api:3000
+      API_URL: http://api:3000/api/v1
       PORT: 3001
     ports:
       - "3001:3001"
@@ -65,7 +65,7 @@ services:
     environment:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       OPENSPAWN_API_KEY: ${OPENSPAWN_API_KEY:-test-key}
-      OPENSPAWN_API_URL: http://api:3000
+      OPENSPAWN_API_URL: http://api:3000/api/v1
     ports:
       - "3333:3333"  # OpenClaw gateway port
     depends_on:


### PR DESCRIPTION
## Summary
Add versioned API routes with `/api/v1` prefix to enable backward-compatible API evolution.

## Changes

### API (NestJS)
- Add global prefix `api/v1` to all routes except health endpoints (`/health`, `/ready`, `/metrics`)

### CLI
- Update default API URL to `http://localhost:3000/api/v1`

### Dashboard
- Update GraphQL endpoint to use versioned path `/api/v1/graphql`

### Docker Compose
- Update MCP server `API_URL` environment variable in all compose files
- Update OpenClaw test instance `OPENSPAWN_API_URL`

### Nginx
- Add versioned API routes (`/api/v1/`)
- Add versioned GraphQL endpoint (`/api/v1/graphql`)
- Add legacy redirects for backward compatibility:
  - `/api/` → `/api/v1/`
  - `/graphql` → `/api/v1/graphql`

## Breaking Changes
All API routes now require `/api/v1` prefix. Legacy routes redirect to versioned endpoints for backward compatibility.

## Testing
- [ ] Verify API responds on `/api/v1/*` routes
- [ ] Verify health endpoints still work at root level
- [ ] Verify dashboard GraphQL queries work
- [ ] Verify CLI commands work with updated URL
- [ ] Verify legacy redirects work correctly