### PR TITLE
feat(api): expose reputation fields in GraphQL AgentType

### DIFF
--- a/apps/api/src/graphql/resolvers/agent.resolver.ts
+++ b/apps/api/src/graphql/resolvers/agent.resolver.ts
@@ -1,5 +1,6 @@
-import { Args, ID, Query, Resolver } from "@nestjs/graphql";
+import { Args, ID, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 
+import { getReputationLevel, ReputationLevel } from "@openspawn/shared-types";
 import { OrgFromContext, validateOrgAccess } from "../../auth/decorators";
 import { AgentsService } from "../../agents";
 import { AgentType } from "../types";
@@ -37,5 +38,10 @@ export class AgentResolver {
     } catch {
       return null;
     }
+  }
+
+  @ResolveField(() => ReputationLevel)
+  reputationLevel(@Parent() agent: AgentType): ReputationLevel {
+    return getReputationLevel(agent.trustScore);
   }
 }

--- a/apps/api/src/graphql/types/agent.type.ts
+++ b/apps/api/src/graphql/types/agent.type.ts
@@ -1,10 +1,11 @@
 import { Field, ID, Int, ObjectType, registerEnumType } from "@nestjs/graphql";
 
-import { AgentRole, AgentStatus } from "@openspawn/shared-types";
+import { AgentRole, AgentStatus, ReputationLevel } from "@openspawn/shared-types";
 
 // Register enums
 registerEnumType(AgentRole, { name: "AgentRole" });
 registerEnumType(AgentStatus, { name: "AgentStatus" });
+registerEnumType(ReputationLevel, { name: "ReputationLevel" });
 
 @ObjectType()
 export class AgentType {
@@ -40,6 +41,27 @@ export class AgentType {
 
   @Field(() => Int)
   managementFeePct!: number;
+
+  // Trust & Reputation
+  @Field(() => Int)
+  trustScore!: number;
+
+  // reputationLevel is computed via @ResolveField in AgentResolver
+
+  @Field(() => Int)
+  tasksCompleted!: number;
+
+  @Field(() => Int)
+  tasksSuccessful!: number;
+
+  @Field({ nullable: true })
+  lastActivityAt?: Date | null;
+
+  @Field({ nullable: true })
+  lastPromotionAt?: Date | null;
+
+  @Field(() => ID, { nullable: true })
+  parentId?: string | null;
 
   @Field()
   createdAt!: Date;


### PR DESCRIPTION
## Summary
Exposes the trust & reputation fields in the GraphQL API so the dashboard can use real API responses instead of extended mock types.

## Changes
- **AgentType**: Added fields from the database entity:
  - `trustScore` (Int)
  - `tasksCompleted` (Int)
  - `tasksSuccessful` (Int)
  - `lastActivityAt` (DateTime, nullable)
  - `lastPromotionAt` (DateTime, nullable)
  - `parentId` (ID, nullable)

- **AgentResolver**: Added computed field:
  - `reputationLevel` - computed from `trustScore` using `getReputationLevel()`

- **ReputationLevel enum**: Registered in GraphQL schema

## Why
The demo was extending the API types with these fields. Now the API actually provides them, so the demo can accurately reflect production capabilities.

## Next Steps
After this merges, we can update the demo's mock-fetcher to remove the extended types and use the generated codegen types directly.