### PR TITLE
ci: add codegen verification step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify codegen is up to date
+        run: |
+          pnpm run codegen
+          if ! git diff --quiet apps/dashboard/src/graphql/generated/ schema.gql; then
+            echo "❌ Generated files are out of date. Run 'pnpm run codegen' and commit the changes."
+            git diff --stat apps/dashboard/src/graphql/generated/ schema.gql
+            exit 1
+          fi
+          echo "✅ Codegen files are up to date"
+
       - name: Lint
         run: pnpm exec nx run-many -t lint --parallel=3
         continue-on-error: true  # Don't fail on lint for now


### PR DESCRIPTION
Adds a CI step to verify that GraphQL codegen files are up to date.

**What it does:**
- Runs `pnpm run codegen`
- Checks if there are any changes to generated files
- Fails CI if generated files differ from committed code

**Why:**
- Ensures schema changes are accompanied by codegen updates
- Prevents drift between `schema.gql` and generated types
- Catches forgotten codegen runs before merge

**Developer workflow:**
After changing GraphQL schema/operations:
```bash
pnpm run codegen
git add apps/dashboard/src/graphql/generated/ schema.gql
```