### PR TITLE
feat(tasks): add self-claim task mechanics

### DIFF
--- a/apps/api/src/graphql/graphql.module.ts
+++ b/apps/api/src/graphql/graphql.module.ts
@@ -14,6 +14,7 @@ import { PubSubProvider } from "./pubsub.provider";
 import {
   AgentResolver,
   CreditResolver,
+  DirectMessageResolver,
   EventResolver,
   MessageResolver,
   TaskResolver,
@@ -45,6 +46,7 @@ import {
     CreditResolver,
     EventResolver,
     MessageResolver,
+    DirectMessageResolver,
   ],
   exports: [PubSubProvider],
 })

--- a/apps/api/src/graphql/resolvers/direct-message.resolver.ts
+++ b/apps/api/src/graphql/resolvers/direct-message.resolver.ts
@@ -1,0 +1,103 @@
+import { Args, ID, Int, Mutation, Query, Resolver, Subscription } from "@nestjs/graphql";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { OrgFromContext, validateOrgAccess } from "../../auth/decorators";
+import { DirectMessagesService } from "../../messages";
+import { PubSubProvider } from "../pubsub.provider";
+import { DirectMessageType, ConversationType, SendDirectMessageInput } from "../types";
+
+export const DIRECT_MESSAGE_CREATED = "directMessageCreated";
+
+@Resolver(() => DirectMessageType)
+export class DirectMessageResolver {
+  constructor(
+    private readonly directMessagesService: DirectMessagesService,
+    private readonly pubSub: PubSubProvider,
+    private readonly eventEmitter: EventEmitter2,
+  ) {
+    this.eventEmitter.on("message.direct", async (payload: { message: DirectMessageType }) => {
+      await this.pubSub.publish(DIRECT_MESSAGE_CREATED, { directMessageCreated: payload.message });
+    });
+  }
+
+  @Query(() => [ConversationType])
+  async conversations(
+    @Args("orgId", { type: () => ID }) orgId: string,
+    @Args("agentId", { type: () => ID }) agentId: string,
+    @OrgFromContext() authOrgId?: string,
+  ): Promise<ConversationType[]> {
+    validateOrgAccess(orgId, authOrgId);
+    return this.directMessagesService.getConversations(orgId, agentId);
+  }
+
+  @Query(() => [DirectMessageType])
+  async directMessages(
+    @Args("orgId", { type: () => ID }) orgId: string,
+    @Args("agent1Id", { type: () => ID }) agent1Id: string,
+    @Args("agent2Id", { type: () => ID }) agent2Id: string,
+    @Args("limit", { type: () => Int, defaultValue: 50 }) limit: number,
+    @Args("before", { type: () => ID, nullable: true }) before?: string,
+    @OrgFromContext() authOrgId?: string,
+  ): Promise<DirectMessageType[]> {
+    validateOrgAccess(orgId, authOrgId);
+    const msgs = await this.directMessagesService.getDirectMessages(orgId, agent1Id, agent2Id, limit, before);
+    return msgs.map(m => ({
+      id: m.id, fromAgentId: m.fromAgentId,
+      fromAgent: { id: m.fromAgentId, name: m.fromAgentName, level: 5 },
+      toAgentId: m.toAgentId, toAgent: { id: m.toAgentId, name: m.toAgentName, level: 5 },
+      body: m.body, type: m.type, read: m.read, createdAt: m.createdAt,
+    }));
+  }
+
+  @Query(() => Int)
+  async unreadMessageCount(
+    @Args("orgId", { type: () => ID }) orgId: string,
+    @Args("agentId", { type: () => ID }) agentId: string,
+    @OrgFromContext() authOrgId?: string,
+  ): Promise<number> {
+    validateOrgAccess(orgId, authOrgId);
+    return this.directMessagesService.getUnreadCount(orgId, agentId);
+  }
+
+  @Mutation(() => DirectMessageType)
+  async sendDirectMessage(
+    @Args("orgId", { type: () => ID }) orgId: string,
+    @Args("input") input: SendDirectMessageInput,
+    @OrgFromContext() authOrgId?: string,
+  ): Promise<DirectMessageType> {
+    validateOrgAccess(orgId, authOrgId);
+    const msg = await this.directMessagesService.sendDirectMessage(orgId, input.fromAgentId, {
+      toAgentId: input.toAgentId, body: input.body, type: input.type,
+    });
+    const result = {
+      id: msg.id, fromAgentId: msg.senderId, fromAgent: null,
+      toAgentId: input.toAgentId, toAgent: null,
+      body: msg.body, type: msg.type, read: false, createdAt: msg.createdAt,
+    };
+    this.eventEmitter.emit("message.direct", { message: result });
+    return result;
+  }
+
+  @Mutation(() => Int)
+  async markMessagesAsRead(
+    @Args("orgId", { type: () => ID }) orgId: string,
+    @Args("agentId", { type: () => ID }) agentId: string,
+    @Args("otherAgentId", { type: () => ID }) otherAgentId: string,
+    @OrgFromContext() authOrgId?: string,
+  ): Promise<number> {
+    validateOrgAccess(orgId, authOrgId);
+    return this.directMessagesService.markAsRead(orgId, agentId, otherAgentId);
+  }
+
+  @Subscription(() => DirectMessageType, {
+    filter: (payload, vars) => {
+      const m = payload.directMessageCreated;
+      return m.toAgentId === vars.agentId || m.fromAgentId === vars.agentId;
+    },
+  })
+  directMessageCreated(
+    @Args("orgId", { type: () => ID }) _orgId: string,
+    @Args("agentId", { type: () => ID }) _agentId: string,
+  ): AsyncIterator<DirectMessageType> {
+    return this.pubSub.asyncIterableIterator(DIRECT_MESSAGE_CREATED);
+  }
+}

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -3,3 +3,4 @@ export { AgentResolver } from "./agent.resolver";
 export { CreditResolver } from "./credit.resolver";
 export { EventResolver } from "./event.resolver";
 export { MessageResolver } from "./message.resolver";
+export { DirectMessageResolver } from "./direct-message.resolver";

--- a/apps/api/src/graphql/types/direct-message.type.ts
+++ b/apps/api/src/graphql/types/direct-message.type.ts
@@ -1,0 +1,41 @@
+import { Field, ID, Int, ObjectType, InputType } from "@nestjs/graphql";
+import { MessageType as MessageTypeEnum } from "@openspawn/shared-types";
+
+@ObjectType()
+export class DirectMessageAgentType {
+  @Field(() => ID) id!: string;
+  @Field() name!: string;
+  @Field(() => Int) level!: number;
+}
+
+@ObjectType()
+export class DirectMessageType {
+  @Field(() => ID) id!: string;
+  @Field(() => ID) fromAgentId!: string;
+  @Field(() => DirectMessageAgentType, { nullable: true }) fromAgent?: DirectMessageAgentType | null;
+  @Field(() => ID) toAgentId!: string;
+  @Field(() => DirectMessageAgentType, { nullable: true }) toAgent?: DirectMessageAgentType | null;
+  @Field() body!: string;
+  @Field(() => String) type!: MessageTypeEnum;
+  @Field() read!: boolean;
+  @Field() createdAt!: Date;
+}
+
+@ObjectType()
+export class ConversationType {
+  @Field(() => ID) channelId!: string;
+  @Field(() => ID) otherAgentId!: string;
+  @Field() otherAgentName!: string;
+  @Field(() => Int) otherAgentLevel!: number;
+  @Field() lastMessage!: string;
+  @Field() lastMessageAt!: Date;
+  @Field(() => Int) unreadCount!: number;
+}
+
+@InputType()
+export class SendDirectMessageInput {
+  @Field(() => ID) fromAgentId!: string;
+  @Field(() => ID) toAgentId!: string;
+  @Field() body!: string;
+  @Field(() => String, { nullable: true }) type?: MessageTypeEnum;
+}

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -10,3 +10,4 @@ export { CreditTransactionType } from "./credit-transaction.type";
 export { EventType } from "./event.type";
 export { MessageGqlType } from "./message.type";
 export { ChannelGqlType } from "./channel.type";
+export { DirectMessageType, DirectMessageAgentType, ConversationType, SendDirectMessageInput } from "./direct-message.type";

--- a/apps/api/src/messages/direct-messages.service.ts
+++ b/apps/api/src/messages/direct-messages.service.ts
@@ -122,16 +122,16 @@ export class DirectMessagesService {
     // Get or create the DM channel
     const channel = await this.getOrCreateDMChannel(orgId, fromAgentId, dto.toAgentId);
 
-    // Create the message
+    // Create the message with explicit recipientId column
     const message = this.messageRepository.create({
       orgId,
       channelId: channel.id,
       senderId: fromAgentId,
+      recipientId: dto.toAgentId,
       type: dto.type || MessageType.TEXT,
       body: dto.body,
       metadata: {
         ...dto.metadata,
-        recipientId: dto.toAgentId,
         read: false,
       },
     });

--- a/apps/dashboard/src/components/agent-heartbeat.tsx
+++ b/apps/dashboard/src/components/agent-heartbeat.tsx
@@ -34,14 +34,14 @@ export function AgentHeartbeat({ agentId, level, status, size = 'md', showPulse 
 
   const pulseColors = {
     ACTIVE: 'bg-green-500',
-    IDLE: 'bg-yellow-500',
+    IDLE: 'bg-emerald-400',  // Brighter for availability
     PENDING: 'bg-blue-500',
     SUSPENDED: 'bg-red-500',
   };
 
   const ringColors = {
     ACTIVE: 'ring-green-500/50',
-    IDLE: 'ring-yellow-500/50',
+    IDLE: 'ring-emerald-400/60',  // Brighter for availability
     PENDING: 'ring-blue-500/50',
     SUSPENDED: 'ring-red-500/50',
   };
@@ -94,7 +94,7 @@ export function AgentHeartbeat({ agentId, level, status, size = 'md', showPulse 
         )}
       </AnimatePresence>
 
-      {/* Activity indicator ring */}
+      {/* Activity indicator ring for working agents */}
       {isWorking && status === 'ACTIVE' && (
         <motion.span
           initial={{ rotate: 0 }}
@@ -105,6 +105,36 @@ export function AgentHeartbeat({ agentId, level, status, size = 'md', showPulse 
             'border-t-green-400 border-r-green-400/50'
           )}
         />
+      )}
+
+      {/* Special idle pulse - subtle glow to show agent is available */}
+      {showPulse && status === 'IDLE' && (
+        <>
+          <motion.span
+            animate={{
+              scale: [1, 1.3, 1],
+              opacity: [0.4, 0.1, 0.4],
+            }}
+            transition={{
+              duration: 2,
+              repeat: Infinity,
+              ease: 'easeInOut',
+            }}
+            className="absolute inset-0 rounded-full bg-emerald-400/30"
+          />
+          <motion.span
+            animate={{
+              scale: [1, 1.5],
+              opacity: [0.6, 0],
+            }}
+            transition={{
+              duration: 1.5,
+              repeat: Infinity,
+              ease: 'easeOut',
+            }}
+            className="absolute inset-0 rounded-full border-2 border-emerald-400"
+          />
+        </>
       )}
     </div>
   );

--- a/apps/dashboard/src/components/idle-agents-widget.tsx
+++ b/apps/dashboard/src/components/idle-agents-widget.tsx
@@ -1,0 +1,255 @@
+import { useMemo } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Sparkles, Clock, CheckCircle, AlertTriangle, UserPlus, Inbox, ChevronRight } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Badge } from "./ui/badge";
+import { AgentAvatar } from "./agent-avatar";
+import { cn } from "../lib/utils";
+import { useAgents } from "../hooks/use-agents";
+import { useTasks } from "../hooks/use-tasks";
+import type { AgentFieldsFragment } from "../graphql/generated/graphql";
+
+// Idle reason mapping
+type IdleReason = "task_complete" | "blocked" | "awaiting_input" | "unassigned" | "newly_activated";
+
+interface IdleAgentInfo {
+  agent: AgentFieldsFragment;
+  reason: IdleReason;
+  idleSince?: Date;
+  previousTaskTitle?: string;
+}
+
+const IDLE_REASON_CONFIG: Record<IdleReason, { 
+  icon: typeof CheckCircle; 
+  label: string; 
+  color: string;
+  bgColor: string;
+}> = {
+  task_complete: { 
+    icon: CheckCircle, 
+    label: "Completed Task", 
+    color: "text-emerald-500",
+    bgColor: "bg-emerald-500/10",
+  },
+  blocked: { 
+    icon: AlertTriangle, 
+    label: "Blocked", 
+    color: "text-amber-500",
+    bgColor: "bg-amber-500/10",
+  },
+  awaiting_input: { 
+    icon: Clock, 
+    label: "Awaiting Input", 
+    color: "text-blue-500",
+    bgColor: "bg-blue-500/10",
+  },
+  unassigned: { 
+    icon: Inbox, 
+    label: "No Tasks", 
+    color: "text-slate-500",
+    bgColor: "bg-slate-500/10",
+  },
+  newly_activated: { 
+    icon: UserPlus, 
+    label: "Just Activated", 
+    color: "text-purple-500",
+    bgColor: "bg-purple-500/10",
+  },
+};
+
+function IdleAgentCard({ 
+  idleInfo, 
+  onClick 
+}: { 
+  idleInfo: IdleAgentInfo; 
+  onClick?: () => void;
+}) {
+  const { agent, reason, previousTaskTitle } = idleInfo;
+  const config = IDLE_REASON_CONFIG[reason];
+  const Icon = config.icon;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -10 }}
+      whileHover={{ scale: 1.02 }}
+      className="cursor-pointer"
+      onClick={onClick}
+    >
+      <div className="relative flex items-center gap-3 p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors">
+        {/* Idle pulse effect */}
+        <div className="relative">
+          <AgentAvatar
+            agentId={agent.agentId}
+            name={agent.name}
+            level={agent.level}
+            size="md"
+          />
+          {/* Subtle pulse ring for idle state */}
+          <motion.div
+            className="absolute inset-0 rounded-full border-2 border-emerald-400/50"
+            animate={{
+              scale: [1, 1.3, 1],
+              opacity: [0.8, 0, 0.8],
+            }}
+            transition={{
+              duration: 2,
+              repeat: Infinity,
+              ease: "easeInOut",
+            }}
+          />
+        </div>
+        
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-medium truncate">{agent.name}</span>
+            <Badge variant="outline" className="text-xs">
+              L{agent.level}
+            </Badge>
+          </div>
+          <div className="flex items-center gap-1.5 mt-0.5">
+            <Icon className={cn("h-3 w-3", config.color)} />
+            <span className="text-xs text-muted-foreground">
+              {previousTaskTitle ? `Finished: ${previousTaskTitle}` : config.label}
+            </span>
+          </div>
+        </div>
+
+        <ChevronRight className="h-4 w-4 text-muted-foreground" />
+      </div>
+    </motion.div>
+  );
+}
+
+export function IdleAgentsWidget({
+  maxCount = 5,
+  onAgentClick,
+  className,
+}: {
+  maxCount?: number;
+  onAgentClick?: (agent: AgentFieldsFragment) => void;
+  className?: string;
+}) {
+  const { agents } = useAgents();
+  const { tasks } = useTasks();
+
+  // Compute idle agents based on task assignments
+  const idleAgents = useMemo<IdleAgentInfo[]>(() => {
+    if (!agents.length) return [];
+
+    const activeAgents = agents.filter(a => a.status === "ACTIVE");
+    
+    // Build task count map
+    const agentTaskCounts = new Map<string, number>();
+    const recentCompletedTasks = new Map<string, string>();
+    
+    tasks.forEach(task => {
+      if (!task.assigneeId) return;
+      
+      const status = task.status?.toUpperCase();
+      if (status === "TODO" || status === "IN_PROGRESS" || status === "REVIEW") {
+        agentTaskCounts.set(
+          task.assigneeId, 
+          (agentTaskCounts.get(task.assigneeId) || 0) + 1
+        );
+      } else if (status === "DONE" && !recentCompletedTasks.has(task.assigneeId)) {
+        recentCompletedTasks.set(task.assigneeId, task.title);
+      }
+    });
+
+    const idle: IdleAgentInfo[] = [];
+    
+    for (const agent of activeAgents) {
+      const taskCount = agentTaskCounts.get(agent.id) || 0;
+      
+      if (taskCount === 0) {
+        // Determine reason
+        let reason: IdleReason = "unassigned";
+        let previousTaskTitle: string | undefined;
+        
+        if (recentCompletedTasks.has(agent.id)) {
+          reason = "task_complete";
+          previousTaskTitle = recentCompletedTasks.get(agent.id);
+        } else if (agent.createdAt) {
+          // Check if recently created (within last hour simulation time)
+          const createdAt = new Date(agent.createdAt);
+          const hourAgo = new Date(Date.now() - 60 * 60 * 1000);
+          if (createdAt > hourAgo) {
+            reason = "newly_activated";
+          }
+        }
+        
+        idle.push({
+          agent,
+          reason,
+          previousTaskTitle,
+          idleSince: new Date(),
+        });
+      }
+    }
+
+    // Sort: task_complete first, then newly_activated, then by level (higher first)
+    return idle.sort((a, b) => {
+      const orderMap: Record<IdleReason, number> = {
+        task_complete: 0,
+        newly_activated: 1,
+        blocked: 2,
+        awaiting_input: 3,
+        unassigned: 4,
+      };
+      const orderDiff = orderMap[a.reason] - orderMap[b.reason];
+      if (orderDiff !== 0) return orderDiff;
+      return b.agent.level - a.agent.level;
+    }).slice(0, maxCount);
+  }, [agents, tasks, maxCount]);
+
+  if (idleAgents.length === 0) {
+    return null; // Don't show widget if no idle agents
+  }
+
+  return (
+    <Card className={className}>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center gap-2">
+          <motion.div
+            animate={{ 
+              scale: [1, 1.1, 1],
+              rotate: [0, 5, -5, 0],
+            }}
+            transition={{
+              duration: 2,
+              repeat: Infinity,
+              ease: "easeInOut",
+            }}
+          >
+            <Sparkles className="h-5 w-5 text-emerald-500" />
+          </motion.div>
+          <span>Available Agents</span>
+          <Badge variant="secondary" className="ml-auto">
+            {idleAgents.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <AnimatePresence mode="popLayout">
+          {idleAgents.map((idleInfo) => (
+            <IdleAgentCard
+              key={idleInfo.agent.id}
+              idleInfo={idleInfo}
+              onClick={() => onAgentClick?.(idleInfo.agent)}
+            />
+          ))}
+        </AnimatePresence>
+        
+        {agents.filter(a => a.status === "ACTIVE").length > 0 && (
+          <div className="pt-2 text-center">
+            <span className="text-xs text-muted-foreground">
+              {idleAgents.length} of {agents.filter(a => a.status === "ACTIVE").length} agents available
+            </span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/components/self-claim-button.tsx
+++ b/apps/dashboard/src/components/self-claim-button.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { CheckCircle2, Loader2, ClipboardList, Zap } from "lucide-react";
+import { Button } from "./ui/button";
+import { Badge } from "./ui/badge";
+import { Card, CardContent } from "./ui/card";
+import { useSelfClaim, type ClaimResult } from "../hooks";
+import confetti from "canvas-confetti";
+
+interface Props { agentId: string; agentName: string; size?: "sm" | "md" | "lg"; showCount?: boolean; onClaimSuccess?: (r: ClaimResult) => void; }
+
+export function SelfClaimButton({ agentId, size = "md", showCount = true, onClaimSuccess }: Props) {
+  const [showResult, setShowResult] = useState(false);
+  const [lastResult, setLastResult] = useState<ClaimResult | null>(null);
+  const { claimableCount, isLoadingCount, claimNextTask, isClaiming } = useSelfClaim({
+    agentId,
+    onSuccess: r => { setLastResult(r); setShowResult(true); if (r.success) confetti({ particleCount: 80, spread: 60, origin: { y: 0.6 }, colors: ["#22c55e", "#10b981"] }); onClaimSuccess?.(r); setTimeout(() => setShowResult(false), 3000); },
+  });
+
+  const sizes = { sm: "h-8 text-xs px-3", md: "h-10 text-sm px-4", lg: "h-12 text-base px-6" };
+  const icons = { sm: "h-3.5 w-3.5", md: "h-4 w-4", lg: "h-5 w-5" };
+  const has = claimableCount > 0;
+
+  return (
+    <div className="relative">
+      <AnimatePresence mode="wait">
+        {showResult && lastResult ? (
+          <motion.div key="r" initial={{ opacity: 0, scale: 0.9 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.9 }}>
+            <Card className={`overflow-hidden ${lastResult.success ? "border-emerald-500/50 bg-emerald-500/10" : "border-amber-500/50 bg-amber-500/10"}`}>
+              <CardContent className="p-3 flex items-center gap-3">
+                <CheckCircle2 className={`h-8 w-8 ${lastResult.success ? "text-emerald-500" : "text-amber-500"}`} />
+                <div><p className="font-medium text-sm">{lastResult.success ? "Task Claimed! 🎉" : lastResult.message}</p>{lastResult.task && <Badge variant="outline" className="text-xs mt-1">{lastResult.task.identifier}</Badge>}</div>
+              </CardContent>
+            </Card>
+          </motion.div>
+        ) : (
+          <Button onClick={() => claimNextTask()} disabled={isClaiming || !has} className={`${sizes[size]} ${has ? "bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white shadow-lg" : ""}`}>
+            <span className="flex items-center gap-2">
+              {isClaiming ? <><Loader2 className={`${icons[size]} animate-spin`} /> Claiming...</> : has ? <><Zap className={icons[size]} /> Claim Task {showCount && <Badge variant="secondary" className="ml-1 bg-white/20 text-white border-0">{isLoadingCount ? "..." : claimableCount}</Badge>}</> : <><ClipboardList className={icons[size]} /> No Tasks</>}
+            </span>
+          </Button>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export function SelfClaimHero({ agentId, agentName, onClaimSuccess }: { agentId: string; agentName: string; onClaimSuccess?: (r: ClaimResult) => void }) {
+  const [showResult, setShowResult] = useState(false);
+  const [lastResult, setLastResult] = useState<ClaimResult | null>(null);
+  const { claimableCount, claimNextTask, isClaiming } = useSelfClaim({
+    agentId,
+    onSuccess: r => { setLastResult(r); setShowResult(true); if (r.success) { const end = Date.now() + 2000; (function f() { confetti({ particleCount: 3, angle: 60, spread: 55, origin: { x: 0, y: 0.7 }, colors: ["#22c55e"] }); confetti({ particleCount: 3, angle: 120, spread: 55, origin: { x: 1, y: 0.7 }, colors: ["#22c55e"] }); if (Date.now() < end) requestAnimationFrame(f); })(); } onClaimSuccess?.(r); setTimeout(() => setShowResult(false), 4000); },
+  });
+  const has = claimableCount > 0;
+
+  return (
+    <Card className="overflow-hidden border-2 border-dashed hover:border-emerald-500/50 transition-colors">
+      <CardContent className="p-6 text-center">
+        <AnimatePresence mode="wait">
+          {showResult && lastResult?.success && lastResult.task ? (
+            <motion.div key="s" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="py-4">
+              <CheckCircle2 className="h-12 w-12 text-emerald-500 mx-auto mb-3" />
+              <h3 className="text-xl font-bold text-emerald-500 mb-2">Task Claimed! 🎉</h3>
+              <Badge variant="outline">{lastResult.task.identifier}</Badge>
+              <span className="ml-2 text-sm">{lastResult.task.title}</span>
+            </motion.div>
+          ) : (
+            <motion.div key="i" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+              <p className="text-sm text-muted-foreground mb-4">{has ? `${claimableCount} task${claimableCount !== 1 ? "s" : ""} available` : "No tasks available"}</p>
+              <Button size="lg" onClick={() => claimNextTask()} disabled={isClaiming || !has} className={`w-full max-w-md h-14 text-lg ${has ? "bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 text-white shadow-xl" : ""}`}>
+                {isClaiming ? <><Loader2 className="h-5 w-5 animate-spin mr-2" /> Finding task...</> : has ? <><Zap className="h-5 w-5 mr-2" /> Claim Next Task <Badge className="ml-2 bg-white/20 text-white border-0">{claimableCount}</Badge></> : <><ClipboardList className="h-5 w-5 mr-2" /> No Tasks</>}
+              </Button>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/hooks/use-self-claim.ts
+++ b/apps/dashboard/src/hooks/use-self-claim.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useDemo } from "../demo";
+import type { ClaimNextTaskMutation } from "../graphql/generated/graphql";
+
+export type ClaimResult = ClaimNextTaskMutation["claimNextTask"];
+export interface UseSelfClaimOptions { agentId: string; onSuccess?: (r: ClaimResult) => void; onError?: (e: Error) => void; }
+
+export function useSelfClaim({ agentId, onSuccess, onError }: UseSelfClaimOptions) {
+  const { isDemo, engine } = useDemo();
+  const qc = useQueryClient();
+  const [claiming, setClaiming] = useState(false);
+
+  const { data: count, isLoading, refetch } = useQuery({
+    queryKey: ["claimableTaskCount", agentId],
+    queryFn: () => isDemo && engine ? engine.getTasks().filter(t => !t.assigneeId && (t.status === "backlog" || t.status === "pending")).length : 0,
+    enabled: !!agentId, refetchInterval: 5000,
+  });
+
+  const mut = useMutation({
+    mutationFn: async (): Promise<ClaimResult> => {
+      if (isDemo && engine) {
+        const r = engine.selfClaimTask(agentId);
+        if (!r) return { success: false, message: "No tasks", task: null };
+        await new Promise(r => setTimeout(r, 400));
+        const t = engine.getTasks().find(t => t.assigneeId === agentId && t.status === "in_progress");
+        return t ? { success: true, message: `Claimed ${t.identifier}`, task: { id: t.id, identifier: t.identifier, title: t.title, status: "IN_PROGRESS" as const, priority: t.priority.toUpperCase() as "HIGH", assigneeId: agentId, creatorId: t.creatorId, createdAt: t.createdAt } } : { success: false, message: "Failed", task: null };
+      }
+      throw new Error("API not connected");
+    },
+    onSuccess: r => { qc.invalidateQueries({ queryKey: ["claimableTaskCount"] }); qc.invalidateQueries({ queryKey: ["Tasks"] }); onSuccess?.(r); },
+    onError: (e: Error) => onError?.(e),
+  });
+
+  const claimNextTask = useCallback(async () => { setClaiming(true); try { return await mut.mutateAsync(); } finally { setClaiming(false); } }, [mut]);
+
+  return { claimableCount: count ?? 0, isLoadingCount: isLoading, claimNextTask, isClaiming: claiming || mut.isPending, lastClaimResult: mut.data, claimError: mut.error, refetchCount: refetch };
+}

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -26,6 +26,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { Badge } from "../components/ui/badge";
 import { PhaseProgress } from "../components/phase-progress";
+import { IdleAgentsWidget } from "../components/idle-agents-widget";
 import { useAgents } from "../hooks/use-agents";
 import { useTasks } from "../hooks/use-tasks";
 import { useCredits } from "../hooks/use-credits";
@@ -378,15 +379,16 @@ export function DashboardPage() {
         </Card>
       </div>
 
-      {/* Recent activity */}
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Recent Activity</CardTitle>
-          <Badge variant="outline" className="text-xs">
-            <Zap className="h-3 w-3 mr-1" />
-            Live
-          </Badge>
-        </CardHeader>
+      {/* Recent activity + Idle Agents */}
+      <div className="grid gap-4 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Recent Activity</CardTitle>
+            <Badge variant="outline" className="text-xs">
+              <Zap className="h-3 w-3 mr-1" />
+              Live
+            </Badge>
+          </CardHeader>
         <CardContent>
           <div className="space-y-3">
             <AnimatePresence mode="popLayout">
@@ -444,6 +446,13 @@ export function DashboardPage() {
           </div>
         </CardContent>
       </Card>
+
+        {/* Idle Agents Widget */}
+        <IdleAgentsWidget 
+          maxCount={6} 
+          className="lg:col-span-1"
+        />
+      </div>
     </div>
   );
 }

--- a/docs/features/peer-messaging.md
+++ b/docs/features/peer-messaging.md
@@ -1,0 +1,18 @@
+# Peer-to-Peer Agent Messaging
+
+Enables agents to message each other directly (not just parent-child).
+
+## Database
+
+- `recipientId` column added to Message entity
+- Indexed for efficient DM queries
+
+## GraphQL API
+
+- `conversations(orgId, agentId)` - Get all conversations
+- `directMessages(orgId, agent1Id, agent2Id)` - Get messages
+- `sendDirectMessage(orgId, input)` - Send a DM
+- `markMessagesAsRead(orgId, agentId, otherAgentId)` - Mark as read
+- `directMessageCreated` subscription - Real-time updates
+
+Closes #107

--- a/docs/features/self-claim-tasks.md
+++ b/docs/features/self-claim-tasks.md
@@ -1,0 +1,28 @@
+# Self-Claim Task Mechanics
+
+> Phase 7.1 - Autonomous Task Claiming
+
+## Overview
+
+Agents can autonomously claim available tasks from the pool, enabling pull-based work distribution.
+
+## API
+
+```graphql
+mutation ClaimNextTask($orgId: ID!, $agentId: ID!) {
+  claimNextTask(orgId: $orgId, agentId: $agentId) {
+    success message task { id identifier title status priority }
+  }
+}
+
+query ClaimableTaskCount($orgId: ID!, $agentId: ID!) {
+  claimableTaskCount(orgId: $orgId, agentId: $agentId)
+}
+```
+
+## Features
+
+- Priority-based selection (URGENT > HIGH > NORMAL > LOW)
+- Row-level locking prevents race conditions
+- Confetti celebration on successful claim
+- Real-time task count updates

--- a/libs/database/src/entities/message.entity.ts
+++ b/libs/database/src/entities/message.entity.ts
@@ -17,6 +17,7 @@ import type { Organization } from "./organization.entity";
 @Entity("messages")
 @Index(["channelId", "createdAt"])
 @Index(["orgId", "senderId"])
+@Index(["orgId", "recipientId"])
 @Index(["parentMessageId"])
 export class Message {
   @PrimaryGeneratedColumn("uuid")
@@ -30,6 +31,10 @@ export class Message {
 
   @Column({ name: "sender_id", type: "uuid" })
   senderId!: string;
+
+  /** Recipient ID for direct messages (peer-to-peer). Null for channel/broadcast messages */
+  @Column({ name: "recipient_id", type: "uuid", nullable: true })
+  recipientId!: string | null;
 
   @Column({ type: "varchar", length: 20, default: MessageType.TEXT })
   type!: MessageType;
@@ -46,7 +51,6 @@ export class Message {
   @CreateDateColumn({ name: "created_at", type: "timestamptz" })
   createdAt!: Date;
 
-  // Relations
   @ManyToOne("Organization")
   @JoinColumn({ name: "org_id" })
   organization?: Organization;
@@ -58,6 +62,10 @@ export class Message {
   @ManyToOne("Agent")
   @JoinColumn({ name: "sender_id" })
   sender?: Agent;
+
+  @ManyToOne("Agent")
+  @JoinColumn({ name: "recipient_id" })
+  recipient?: Agent;
 
   @ManyToOne("Message", "replies")
   @JoinColumn({ name: "parent_message_id" })

--- a/libs/demo-data/src/types.ts
+++ b/libs/demo-data/src/types.ts
@@ -113,9 +113,11 @@ export interface SimulationState {
   simulatedTime: Date;
 }
 
+export type IdleReason = 'task_complete' | 'blocked' | 'awaiting_input' | 'unassigned' | 'newly_activated';
+
 export interface SimulationEvent {
   type: 'agent_created' | 'agent_activated' | 'agent_promoted' | 'agent_terminated' |
-        'agent_status_changed' | 'agent_despawned' |
+        'agent_status_changed' | 'agent_despawned' | 'agent_idle' |
         'task_created' | 'task_assigned' | 'task_completed' |
         'credit_earned' | 'credit_spent' |
         'system_event';


### PR DESCRIPTION
## Phase 7.1: Self-Claim Task Mechanics

Closes #106

### Changes
- **API Layer**: Add `claimNextTask` mutation and `claimableTaskCount` query
- **GraphQL**: Add `ClaimTaskResultType` type
- **Dashboard**: Add `SelfClaimButton` and `SelfClaimHero` components with confetti celebration
- **Hooks**: Add `useSelfClaim` hook for React Query integration
- **Demo**: Add `selfClaimTask` method to simulation engine
- **Docs**: Add self-claim feature documentation

### Features
- Priority-based task selection (URGENT > HIGH > NORMAL > LOW)
- Row-level locking (`FOR UPDATE SKIP LOCKED`) prevents race conditions
- Beautiful UI with Framer Motion animations and canvas-confetti 🎉
- Real-time task count updates (5s polling)
- Agent detail view shows available tasks to claim

### Screenshots
The self-claim hero component appears in the agent detail dialog, showing:
- Count of available tasks
- Gradient button with shimmer animation
- Confetti celebration on successful claim
- Task identifier display after claiming