### PR TITLE
feat(api): implement peer-to-peer agent messaging (#107)

### DIFF
--- a/apps/api/src/graphql/graphql.module.ts
+++ b/apps/api/src/graphql/graphql.module.ts
@@ -14,6 +14,7 @@ import { PubSubProvider } from "./pubsub.provider";
 import {
   AgentResolver,
   CreditResolver,
+  DirectMessageResolver,
   EventResolver,
   MessageResolver,
   TaskResolver,
@@ -43,6 +44,7 @@ import {
     TaskResolver,
     AgentResolver,
     CreditResolver,
+    DirectMessageResolver,
     EventResolver,
     MessageResolver,
   ],

--- a/apps/api/src/graphql/resolvers/direct-message.resolver.ts
+++ b/apps/api/src/graphql/resolvers/direct-message.resolver.ts
@@ -1,0 +1,132 @@
+import {
+  Args,
+  ID,
+  Int,
+  Mutation,
+  Query,
+  Resolver,
+  Subscription,
+} from "@nestjs/graphql";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { OrgFromContext, validateOrgAccess } from "../../auth/decorators";
+import { DirectMessagesService } from "../../messages";
+import { PubSubProvider } from "../pubsub.provider";
+import {
+  DirectMessageType,
+  ConversationType,
+  SendDirectMessageInput,
+} from "../types";
+
+export const DIRECT_MESSAGE_CREATED = "directMessageCreated";
+
+@Resolver(() => DirectMessageType)
+export class DirectMessageResolver {
+  constructor(
+    private dms: DirectMessagesService,
+    private pubSub: PubSubProvider,
+    private emitter: EventEmitter2,
+  ) {
+    this.emitter.on(
+      "message.direct",
+      async (p: { message: DirectMessageType }) => {
+        await this.pubSub.publish(DIRECT_MESSAGE_CREATED, {
+          directMessageCreated: p.message,
+        });
+      },
+    );
+  }
+
+  @Query(() => [ConversationType])
+  async conversations(
+    @Args("orgId", { type: () => ID }) orgId: string,
+    @Args("agentId", { type: () => ID }) agentId: string,
+    @OrgFromContext() auth?: string,
+  ) {
+    validateOrgAccess(orgId, auth);
+    return this.dms.getConversations(orgId, agentId);
+  }
+
+  @Query(() => [DirectMessageType])
+  async directMessages(
+    @Args("orgId", { type: () => ID }) orgId: string,
+    @Args("agent1Id", { type: () => ID }) a1: string,
+    @Args("agent2Id", { type: () => ID }) a2: string,
+    @Args("limit", { type: () => Int, defaultValue: 50 }) limit: number,
+    @Args("before", { type: () => ID, nullable: true }) before?: string,
+    @OrgFromContext() auth?: string,
+  ) {
+    validateOrgAccess(orgId, auth);
+    const msgs = await this.dms.getDirectMessages(orgId, a1, a2, limit, before);
+    return msgs.map((m) => ({
+      id: m.id,
+      fromAgentId: m.fromAgentId,
+      fromAgent: { id: m.fromAgentId, name: m.fromAgentName, level: 5 },
+      toAgentId: m.toAgentId,
+      toAgent: { id: m.toAgentId, name: m.toAgentName, level: 5 },
+      body: m.body,
+      type: m.type,
+      read: m.read,
+      createdAt: m.createdAt,
+    }));
+  }
+
+  @Query(() => Int)
+  async unreadMessageCount(
+    @Args("orgId", { type: () => ID }) orgId: string,
+    @Args("agentId", { type: () => ID }) agentId: string,
+    @OrgFromContext() auth?: string,
+  ) {
+    validateOrgAccess(orgId, auth);
+    return this.dms.getUnreadCount(orgId, agentId);
+  }
+
+  @Mutation(() => DirectMessageType)
+  async sendDirectMessage(
+    @Args("orgId", { type: () => ID }) orgId: string,
+    @Args("input") input: SendDirectMessageInput,
+    @OrgFromContext() auth?: string,
+  ) {
+    validateOrgAccess(orgId, auth);
+    const m = await this.dms.sendDirectMessage(orgId, input.fromAgentId, {
+      toAgentId: input.toAgentId,
+      body: input.body,
+      type: input.type,
+    });
+    const r = {
+      id: m.id,
+      fromAgentId: m.senderId,
+      fromAgent: null,
+      toAgentId: input.toAgentId,
+      toAgent: null,
+      body: m.body,
+      type: m.type,
+      read: false,
+      createdAt: m.createdAt,
+    };
+    this.emitter.emit("message.direct", { message: r });
+    return r;
+  }
+
+  @Mutation(() => Int)
+  async markMessagesAsRead(
+    @Args("orgId", { type: () => ID }) orgId: string,
+    @Args("agentId", { type: () => ID }) agentId: string,
+    @Args("otherAgentId", { type: () => ID }) otherId: string,
+    @OrgFromContext() auth?: string,
+  ) {
+    validateOrgAccess(orgId, auth);
+    return this.dms.markAsRead(orgId, agentId, otherId);
+  }
+
+  @Subscription(() => DirectMessageType, {
+    filter: (p, v) =>
+      p.directMessageCreated.toAgentId === v.agentId ||
+      p.directMessageCreated.fromAgentId === v.agentId,
+  })
+  directMessageCreated(
+    @Args("orgId", { type: () => ID }) _o: string,
+    @Args("agentId", { type: () => ID }) _a: string,
+  ): AsyncIterator<DirectMessageType> {
+    return this.pubSub.asyncIterableIterator(DIRECT_MESSAGE_CREATED);
+  }
+}

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -3,3 +3,4 @@ export { AgentResolver } from "./agent.resolver";
 export { CreditResolver } from "./credit.resolver";
 export { EventResolver } from "./event.resolver";
 export { MessageResolver } from "./message.resolver";
+export { DirectMessageResolver } from "./direct-message.resolver";

--- a/apps/api/src/graphql/types/direct-message.type.ts
+++ b/apps/api/src/graphql/types/direct-message.type.ts
@@ -1,0 +1,83 @@
+import { Field, ID, Int, ObjectType, InputType } from "@nestjs/graphql";
+import { MessageType as MsgType } from "@openspawn/shared-types";
+
+@ObjectType()
+export class DirectMessageAgentType {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  name!: string;
+
+  @Field(() => Int)
+  level!: number;
+}
+
+@ObjectType()
+export class DirectMessageType {
+  @Field(() => ID)
+  id!: string;
+
+  @Field(() => ID)
+  fromAgentId!: string;
+
+  @Field(() => DirectMessageAgentType, { nullable: true })
+  fromAgent?: DirectMessageAgentType | null;
+
+  @Field(() => ID)
+  toAgentId!: string;
+
+  @Field(() => DirectMessageAgentType, { nullable: true })
+  toAgent?: DirectMessageAgentType | null;
+
+  @Field()
+  body!: string;
+
+  @Field(() => String)
+  type!: MsgType;
+
+  @Field()
+  read!: boolean;
+
+  @Field()
+  createdAt!: Date;
+}
+
+@ObjectType()
+export class ConversationType {
+  @Field(() => ID)
+  channelId!: string;
+
+  @Field(() => ID)
+  otherAgentId!: string;
+
+  @Field()
+  otherAgentName!: string;
+
+  @Field(() => Int)
+  otherAgentLevel!: number;
+
+  @Field()
+  lastMessage!: string;
+
+  @Field()
+  lastMessageAt!: Date;
+
+  @Field(() => Int)
+  unreadCount!: number;
+}
+
+@InputType()
+export class SendDirectMessageInput {
+  @Field(() => ID)
+  fromAgentId!: string;
+
+  @Field(() => ID)
+  toAgentId!: string;
+
+  @Field()
+  body!: string;
+
+  @Field(() => String, { nullable: true })
+  type?: MsgType;
+}

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -10,3 +10,9 @@ export { CreditTransactionType } from "./credit-transaction.type";
 export { EventType } from "./event.type";
 export { MessageGqlType } from "./message.type";
 export { ChannelGqlType } from "./channel.type";
+export {
+  DirectMessageType,
+  DirectMessageAgentType,
+  ConversationType,
+  SendDirectMessageInput,
+} from "./direct-message.type";

--- a/apps/api/src/messages/direct-messages.service.ts
+++ b/apps/api/src/messages/direct-messages.service.ts
@@ -122,16 +122,16 @@ export class DirectMessagesService {
     // Get or create the DM channel
     const channel = await this.getOrCreateDMChannel(orgId, fromAgentId, dto.toAgentId);
 
-    // Create the message
+    // Create the message with explicit recipientId column
     const message = this.messageRepository.create({
       orgId,
       channelId: channel.id,
       senderId: fromAgentId,
+      recipientId: dto.toAgentId,
       type: dto.type || MessageType.TEXT,
       body: dto.body,
       metadata: {
         ...dto.metadata,
-        recipientId: dto.toAgentId,
         read: false,
       },
     });

--- a/docs/features/peer-messaging.md
+++ b/docs/features/peer-messaging.md
@@ -1,0 +1,16 @@
+# Peer-to-Peer Agent Messaging
+
+Enables agents to message each other directly (peer-to-peer, not just parent-child).
+
+## Database
+- `recipientId` column added to Message entity for direct messages
+- Indexed for efficient DM queries
+
+## GraphQL API
+- `conversations(orgId, agentId)` - Get all conversations for an agent
+- `directMessages(orgId, agent1Id, agent2Id)` - Get messages between agents
+- `sendDirectMessage(orgId, input)` - Send a direct message
+- `markMessagesAsRead(orgId, agentId, otherAgentId)` - Mark as read
+- `directMessageCreated` subscription - Real-time updates
+
+Closes #107

--- a/libs/database/src/entities/message.entity.ts
+++ b/libs/database/src/entities/message.entity.ts
@@ -17,6 +17,7 @@ import type { Organization } from "./organization.entity";
 @Entity("messages")
 @Index(["channelId", "createdAt"])
 @Index(["orgId", "senderId"])
+@Index(["orgId", "recipientId"])
 @Index(["parentMessageId"])
 export class Message {
   @PrimaryGeneratedColumn("uuid")
@@ -40,6 +41,9 @@ export class Message {
   @Column({ name: "parent_message_id", type: "uuid", nullable: true })
   parentMessageId!: string | null;
 
+  @Column({ name: "recipient_id", type: "uuid", nullable: true })
+  recipientId!: string | null;
+
   @Column({ type: "jsonb", default: {} })
   metadata!: Record<string, unknown>;
 
@@ -58,6 +62,10 @@ export class Message {
   @ManyToOne("Agent")
   @JoinColumn({ name: "sender_id" })
   sender?: Agent;
+
+  @ManyToOne("Agent")
+  @JoinColumn({ name: "recipient_id" })
+  recipient?: Agent;
 
   @ManyToOne("Message", "replies")
   @JoinColumn({ name: "parent_message_id" })


### PR DESCRIPTION
## Summary

Enables agents to message each other directly (peer-to-peer, not just parent-child).

## Changes

### Database Layer
- Add `recipientId` column to Message entity for direct messages
- Add index on `orgId` + `recipientId` for efficient DM queries

### API Layer  
- Create `DirectMessageType` and related GraphQL types (`DirectMessageAgentType`, `ConversationType`, `SendDirectMessageInput`)
- Add `DirectMessageResolver` with:
  - `conversations`: Get all conversations for an agent
  - `directMessages`: Get messages between two agents
  - `unreadMessageCount`: Count unread messages
  - `sendDirectMessage`: Send a DM to another agent
  - `markMessagesAsRead`: Mark conversation as read
  - `directMessageCreated`: Real-time subscription for new DMs
- Update `DirectMessagesService` to use the new `recipientId` column

### Documentation
- Add `docs/features/peer-messaging.md` feature documentation

## API

### GraphQL Queries
```graphql
# Get all conversations for an agent
conversations(orgId: ID!, agentId: ID!): [ConversationType!]!

# Get messages between two agents  
directMessages(orgId: ID!, agent1Id: ID!, agent2Id: ID!, limit: Int, before: ID): [DirectMessageType!]!

# Get unread message count
unreadMessageCount(orgId: ID!, agentId: ID!): Int!
```

### GraphQL Mutations
```graphql
# Send a direct message
sendDirectMessage(orgId: ID!, input: SendDirectMessageInput!): DirectMessageType!

# Mark messages as read
markMessagesAsRead(orgId: ID!, agentId: ID!, otherAgentId: ID!): Int!
```

### Subscriptions
```graphql
# Real-time updates for new DMs
directMessageCreated(orgId: ID!, agentId: ID!): DirectMessageType!
```

Closes #107