### PR TITLE
fix(cli): resolve type errors for demo/real client union types

### DIFF
--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import pc from "picocolors";
-import { createClient } from "../lib/api.js";
+import { createClient, unwrap } from "../lib/api.js";
 import {
   output,
   outputError,
@@ -77,7 +77,7 @@ ${pc.cyan("Examples:")}
           return client.listAgents();
         });
 
-        let agentList = (data.data ?? data) as Agent[];
+        let agentList = unwrap(data) as Agent[];
 
         // Apply filters
         if (opts.status) {
@@ -134,7 +134,7 @@ ${pc.cyan("Examples:")}
           return client.getAgent(id);
         });
 
-        const agent = (data.data ?? data) as Agent;
+        const agent = unwrap(data) as Agent;
         formatAgent(agent);
       } catch (err) {
         outputError(
@@ -183,7 +183,7 @@ ${pc.cyan("Examples:")}
           { successText: `Agent ${pc.cyan(options.name)} created!` }
         );
 
-        const agent = (data.data ?? data) as Agent;
+        const agent = unwrap(data) as Agent;
         formatAgent(agent);
       } catch (err) {
         outputError(

--- a/apps/cli/src/commands/credits.ts
+++ b/apps/cli/src/commands/credits.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import pc from "picocolors";
-import { createClient } from "../lib/api.js";
+import { createClient, unwrap } from "../lib/api.js";
 import {
   output,
   outputError,
@@ -103,7 +103,7 @@ ${pc.cyan("Examples:")}
           }
         );
 
-        const balance = (data.data ?? data) as Balance;
+        const balance = unwrap(data) as Balance;
 
         console.log();
         console.log(`  ${icons.credit} ${pc.bold("Credit Balance")}`);

--- a/apps/cli/src/commands/messages.ts
+++ b/apps/cli/src/commands/messages.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import pc from "picocolors";
-import { createClient } from "../lib/api.js";
+import { createClient, unwrap } from "../lib/api.js";
 import {
   output,
   outputError,
@@ -118,7 +118,7 @@ ${pc.cyan("Examples:")}
           }
         );
 
-        const messageList = ((data.data ?? data) as Message[]) || [];
+        const messageList = (unwrap(data) as Message[]) || [];
 
         if (messageList.length === 0) {
           formatEmpty("No messages in this channel", "Send the first message!");
@@ -154,7 +154,7 @@ ${pc.cyan("Examples:")}
           return client.listChannels();
         });
 
-        const channels = ((data.data ?? data) as Channel[]) || [];
+        const channels = (unwrap(data) as Channel[]) || [];
 
         if (channels.length === 0) {
           formatEmpty("No channels found", "Channels are created automatically for tasks and DMs");

--- a/apps/cli/src/commands/tasks.ts
+++ b/apps/cli/src/commands/tasks.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import pc from "picocolors";
-import { createClient } from "../lib/api.js";
+import { createClient, unwrap } from "../lib/api.js";
 import {
   output,
   outputError,
@@ -105,7 +105,7 @@ ${pc.cyan("Examples:")}
           return client.listTasks({ status: opts.status });
         });
 
-        let taskList = ((data.data ?? data) as Task[]) || [];
+        let taskList = (unwrap(data) as Task[]) || [];
 
         // Apply filters
         if (opts.assignee) {
@@ -166,7 +166,7 @@ ${pc.cyan("Examples:")}
           return client.getTask(id);
         });
 
-        const task = (data.data ?? data) as Task;
+        const task = unwrap(data) as Task;
         formatTask(task);
       } catch (err) {
         outputError(err instanceof Error ? err.message : String(err));
@@ -207,7 +207,7 @@ ${pc.cyan("Examples:")}
           { successText: `Task created!` }
         );
 
-        const task = (data.data ?? data) as Task;
+        const task = unwrap(data) as Task;
         formatTask(task);
       } catch (err) {
         outputError(err instanceof Error ? err.message : String(err));

--- a/apps/cli/src/lib/api.ts
+++ b/apps/cli/src/lib/api.ts
@@ -1,17 +1,16 @@
 import { getApiKey, getApiUrl } from "./config.js";
 import { isDemoMode } from "./output.js";
 import { DemoClient } from "./demo-client.js";
+import type { ApiResponse, ApiError } from "./types.js";
 
-export interface ApiResponse<T = unknown> {
-  data?: T;
-  message?: string;
-  error?: string;
-  meta?: Record<string, unknown>;
-}
+export type { ApiResponse, ApiError };
 
-export interface ApiError {
-  message: string;
-  statusCode?: number;
+/** Unwrap API response data - throws if data is missing */
+export function unwrap<T>(response: ApiResponse<T>): T {
+  if (response.data === undefined) {
+    throw new Error(response.error ?? response.message ?? "No data in response");
+  }
+  return response.data;
 }
 
 export class OpenSpawnClient {

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared types for CLI clients
+ */
+
+export interface ApiResponse<T = unknown> {
+  data?: T;
+  message?: string;
+  error?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface ApiError {
+  message: string;
+  statusCode?: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true
+  },
+  "files": [],
+  "references": []
+}


### PR DESCRIPTION
## Summary

Fixes the CLI typecheck errors that were causing CI failures.

### Changes

**CLI Type System Improvements:**
- Add shared `types.ts` with `ApiResponse` interface to avoid circular imports
- Make `DemoClient` methods return `ApiResponse<T>` to match `OpenSpawnClient`
- Add `unwrap()` helper to safely extract data from API responses
- Update CLI commands to use `unwrap()` instead of `(data.data ?? data)`
- Add missing `DemoClient` methods: `assignTask`, `transitionTask`, `transferCredits`

**API Type Fix:**
- Fix `TasksService.claimNextTask` to always return `message` (required by `ClaimTaskResultType` GraphQL type)

**Config:**
- Add root `tsconfig.json` for Nx TypeScript sync

### Fixes

Resolves CLI typecheck errors from CI annotations:
- Property 'data' does not exist on type union errors
- Property 'transferCredits' does not exist on DemoClient  
- ClaimTaskResultType type mismatch

### Note

The API build has separate pre-existing issues with stale declaration files (TS6305 errors) that need investigation in a follow-up PR.