### PR TITLE
fix: rebrand remaining OpenSpawn → BikiniBottom in dashboard

### DIFF
--- a/apps/dashboard/src/components/settings/github-settings.tsx
+++ b/apps/dashboard/src/components/settings/github-settings.tsx
@@ -240,7 +240,7 @@ export function GitHubSettings() {
               <div>
                 <CardTitle>GitHub Integration</CardTitle>
                 <CardDescription>
-                  Bidirectional sync between GitHub issues/PRs and OpenSpawn tasks
+                  Bidirectional sync between GitHub issues/PRs and BikiniBottom tasks
                 </CardDescription>
               </div>
             </div>
@@ -471,7 +471,7 @@ export function GitHubSettings() {
               Linked Items
             </CardTitle>
             <CardDescription>
-              Active links between GitHub and OpenSpawn
+              Active links between GitHub and BikiniBottom
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/apps/dashboard/src/components/settings/inbound-webhooks-settings.tsx
+++ b/apps/dashboard/src/components/settings/inbound-webhooks-settings.tsx
@@ -336,7 +336,7 @@ export function InboundWebhooksSettings() {
               Inbound Webhooks
             </CardTitle>
             <CardDescription>
-              Allow external services to create tasks in OpenSpawn via HTTP POST
+              Allow external services to create tasks in BikiniBottom via HTTP POST
             </CardDescription>
           </div>
           <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
@@ -664,7 +664,7 @@ export function InboundWebhooksSettings() {
                           <div className="pt-2 border-t">
                             <Button variant="link" size="sm" asChild>
                               <a
-                                href="https://docs.openspawn.com/features/inbound-webhooks"
+                                href="https://github.com/openspawn/openspawn/blob/main/docs/features/inbound-webhooks.md"
                                 target="_blank"
                                 rel="noopener noreferrer"
                               >

--- a/apps/dashboard/src/components/settings/org-settings.tsx
+++ b/apps/dashboard/src/components/settings/org-settings.tsx
@@ -33,7 +33,7 @@ const MOCK_MEMBERS: OrgMember[] = [
 
 export function OrgSettings() {
   const { user } = useAuth();
-  const [orgName, setOrgName] = useState("OpenSpawn");
+  const [orgName, setOrgName] = useState("BikiniBottom");
   const [isSaving, setIsSaving] = useState(false);
   const [members] = useState<OrgMember[]>(MOCK_MEMBERS);
 

--- a/apps/dashboard/src/lib/confetti.ts
+++ b/apps/dashboard/src/lib/confetti.ts
@@ -1,5 +1,5 @@
 /**
- * Confetti celebration effects for OpenSpawn dashboard
+ * Confetti celebration effects for BikiniBottom dashboard
  * Uses canvas-confetti for lightweight, performant animations
  */
 

--- a/apps/dashboard/src/pages/login.tsx
+++ b/apps/dashboard/src/pages/login.tsx
@@ -47,7 +47,7 @@ export function LoginPage() {
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl">Welcome to OpenSpawn</CardTitle>
+          <CardTitle className="text-2xl">Welcome to BikiniBottom</CardTitle>
           <CardDescription>
             Sign in to access your agent dashboard
           </CardDescription>


### PR DESCRIPTION
Renames visible OpenSpawn references in settings pages, login, org settings, and confetti comments.