### PR TITLE
feat(dashboard): add beautiful empty states with ocean-themed illustrations #174

### DIFF
--- a/apps/dashboard/src/components/ui/empty-state.tsx
+++ b/apps/dashboard/src/components/ui/empty-state.tsx
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import { Network, LayoutDashboard, Users, Coins } from 'lucide-react';
 import { Button } from './button';
 
@@ -10,10 +11,20 @@ const ICONS = {
 
 interface EmptyStateProps {
   variant?: keyof typeof ICONS;
+=======
+import { motion } from "framer-motion";
+import { Button } from "./button";
+
+type EmptyStateVariant = "agents" | "tasks" | "messages" | "events" | "credits" | "network" | "generic";
+
+interface EmptyStateProps {
+  variant?: EmptyStateVariant;
+>>>>>>> 63941bb (feat(dashboard): add EmptyState component with ocean-themed illustrations #174)
   title: string;
   description: string;
   ctaLabel?: string;
   onCta?: () => void;
+<<<<<<< HEAD
 }
 
 export function EmptyState({ variant = 'dashboard', title, description, ctaLabel, onCta }: EmptyStateProps) {
@@ -32,5 +43,148 @@ export function EmptyState({ variant = 'dashboard', title, description, ctaLabel
         </Button>
       )}
     </div>
+=======
+  compact?: boolean;
+}
+
+function Bubbles({ compact }: { compact?: boolean }) {
+  const bubbles = compact
+    ? [
+        { cx: 20, cy: 40, r: 3, delay: 0 },
+        { cx: 80, cy: 30, r: 2, delay: 0.5 },
+        { cx: 60, cy: 50, r: 4, delay: 1 },
+      ]
+    : [
+        { cx: 30, cy: 80, r: 4, delay: 0 },
+        { cx: 70, cy: 60, r: 3, delay: 0.4 },
+        { cx: 110, cy: 90, r: 5, delay: 0.8 },
+        { cx: 50, cy: 40, r: 2.5, delay: 1.2 },
+        { cx: 90, cy: 70, r: 3.5, delay: 0.6 },
+      ];
+
+  return (
+    <>
+      {bubbles.map((b, i) => (
+        <motion.circle
+          key={i}
+          cx={b.cx}
+          cy={b.cy}
+          r={b.r}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={0.8}
+          opacity={0.4}
+          animate={{ y: [0, -8, 0], opacity: [0.3, 0.6, 0.3] }}
+          transition={{ duration: 3, delay: b.delay, repeat: Infinity, ease: "easeInOut" }}
+        />
+      ))}
+    </>
+  );
+}
+
+const illustrations: Record<EmptyStateVariant, (compact?: boolean) => React.ReactNode> = {
+  agents: (compact) => (
+    <svg viewBox="0 0 120 100" className="w-full h-full text-cyan-500">
+      <Bubbles compact={compact} />
+      <motion.g animate={{ x: [0, 6, 0] }} transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}>
+        <ellipse cx="60" cy="50" rx="14" ry="8" fill="currentColor" opacity={0.2} />
+        <ellipse cx="60" cy="50" rx="14" ry="8" stroke="currentColor" strokeWidth={1} fill="none" />
+        <circle cx="68" cy="48" r="1.5" fill="currentColor" opacity={0.6} />
+        <path d="M44 50 L38 44 L38 56 Z" fill="currentColor" opacity={0.3} />
+      </motion.g>
+      <path d="M15 95 Q18 80 20 70 Q22 60 25 70 Q28 80 30 95" stroke="currentColor" strokeWidth={1.5} fill="none" opacity={0.25} />
+      <path d="M90 95 Q93 82 96 75 Q99 82 102 95" stroke="currentColor" strokeWidth={1.5} fill="none" opacity={0.2} />
+    </svg>
+  ),
+  tasks: (compact) => (
+    <svg viewBox="0 0 120 100" className="w-full h-full text-cyan-500">
+      <Bubbles compact={compact} />
+      <motion.g animate={{ rotate: [-2, 2, -2] }} transition={{ duration: 5, repeat: Infinity, ease: "easeInOut" }} style={{ transformOrigin: "60px 55px" }}>
+        <rect x="42" y="35" width="36" height="40" rx="4" stroke="currentColor" strokeWidth={1.2} fill="currentColor" fillOpacity={0.08} />
+        <line x1="50" y1="48" x2="70" y2="48" stroke="currentColor" strokeWidth={1} opacity={0.4} />
+        <line x1="50" y1="55" x2="65" y2="55" stroke="currentColor" strokeWidth={1} opacity={0.3} />
+        <line x1="50" y1="62" x2="68" y2="62" stroke="currentColor" strokeWidth={1} opacity={0.2} />
+      </motion.g>
+    </svg>
+  ),
+  messages: (compact) => (
+    <svg viewBox="0 0 120 100" className="w-full h-full text-cyan-500">
+      <Bubbles compact={compact} />
+      <motion.g animate={{ y: [0, -3, 0] }} transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}>
+        <rect x="30" y="35" width="35" height="22" rx="8" stroke="currentColor" strokeWidth={1} fill="currentColor" fillOpacity={0.1} />
+        <path d="M40 57 L35 65 L45 57" fill="currentColor" fillOpacity={0.1} stroke="currentColor" strokeWidth={1} />
+      </motion.g>
+      <motion.g animate={{ y: [0, -3, 0] }} transition={{ duration: 3, delay: 1.5, repeat: Infinity, ease: "easeInOut" }}>
+        <rect x="55" y="50" width="35" height="22" rx="8" stroke="currentColor" strokeWidth={1} fill="currentColor" fillOpacity={0.15} />
+        <path d="M80 72 L85 80 L75 72" fill="currentColor" fillOpacity={0.15} stroke="currentColor" strokeWidth={1} />
+      </motion.g>
+    </svg>
+  ),
+  events: (compact) => (
+    <svg viewBox="0 0 120 100" className="w-full h-full text-cyan-500">
+      <Bubbles compact={compact} />
+      <motion.path
+        d="M20 55 L35 55 L40 40 L50 65 L60 45 L70 60 L75 55 L100 55"
+        stroke="currentColor" strokeWidth={1.5} fill="none" opacity={0.5}
+        animate={{ pathLength: [0, 1], opacity: [0.2, 0.6] }}
+        transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
+      />
+    </svg>
+  ),
+  credits: (compact) => (
+    <svg viewBox="0 0 120 100" className="w-full h-full text-cyan-500">
+      <Bubbles compact={compact} />
+      <motion.g animate={{ rotateY: [0, 180, 360] }} transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }} style={{ transformOrigin: "60px 50px" }}>
+        <circle cx="60" cy="50" r="18" stroke="currentColor" strokeWidth={1.5} fill="currentColor" fillOpacity={0.1} />
+        <text x="60" y="56" textAnchor="middle" fill="currentColor" fontSize="16" opacity={0.5}>¢</text>
+      </motion.g>
+    </svg>
+  ),
+  network: (compact) => (
+    <svg viewBox="0 0 120 100" className="w-full h-full text-cyan-500">
+      <Bubbles compact={compact} />
+      <motion.g animate={{ scale: [1, 1.05, 1] }} transition={{ duration: 3, repeat: Infinity }}>
+        <line x1="40" y1="40" x2="80" y2="40" stroke="currentColor" strokeWidth={0.8} opacity={0.3} />
+        <line x1="60" y1="40" x2="60" y2="70" stroke="currentColor" strokeWidth={0.8} opacity={0.3} />
+        <line x1="40" y1="40" x2="60" y2="70" stroke="currentColor" strokeWidth={0.8} opacity={0.2} />
+        <line x1="80" y1="40" x2="60" y2="70" stroke="currentColor" strokeWidth={0.8} opacity={0.2} />
+        <circle cx="40" cy="40" r="5" fill="currentColor" opacity={0.3} />
+        <circle cx="80" cy="40" r="5" fill="currentColor" opacity={0.3} />
+        <circle cx="60" cy="70" r="5" fill="currentColor" opacity={0.3} />
+      </motion.g>
+    </svg>
+  ),
+  generic: (compact) => (
+    <svg viewBox="0 0 120 100" className="w-full h-full text-cyan-500">
+      <Bubbles compact={compact} />
+      <motion.g animate={{ rotate: [0, 15, 0] }} transition={{ duration: 6, repeat: Infinity, ease: "easeInOut" }} style={{ transformOrigin: "60px 55px" }}>
+        <circle cx="60" cy="55" r="12" stroke="currentColor" strokeWidth={1} fill="currentColor" fillOpacity={0.1} />
+      </motion.g>
+    </svg>
+  ),
+};
+
+export function EmptyState({ variant = "generic", title, description, ctaLabel, onCta, compact = false }: EmptyStateProps) {
+  const illustrationSize = compact ? "w-20 h-16" : "w-32 h-24";
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, ease: "easeOut" }}
+      className={`flex flex-col items-center justify-center text-center ${compact ? "py-8" : "py-16"}`}
+    >
+      <div className={illustrationSize}>
+        {illustrations[variant]?.(compact) ?? illustrations.generic(compact)}
+      </div>
+      <h3 className={`font-semibold mt-4 ${compact ? "text-base" : "text-lg"}`}>{title}</h3>
+      <p className={`text-muted-foreground max-w-sm mt-1 ${compact ? "text-xs" : "text-sm"}`}>{description}</p>
+      {ctaLabel && onCta && (
+        <Button onClick={onCta} className="mt-4 bg-cyan-600 hover:bg-cyan-700" size={compact ? "sm" : "default"}>
+          {ctaLabel}
+        </Button>
+      )}
+    </motion.div>
+>>>>>>> 63941bb (feat(dashboard): add EmptyState component with ocean-themed illustrations #174)
   );
 }

--- a/apps/dashboard/src/pages/messages.tsx
+++ b/apps/dashboard/src/pages/messages.tsx
@@ -19,6 +19,7 @@ import { Button } from '../components/ui/button';
 import { ScrollArea } from '../components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { cn } from '../lib/utils';
+import { EmptyState } from '../components/ui/empty-state';
 import { getAgentAvatarUrl } from '../lib/avatar';
 import { PhaseChip } from '../components/phase-chip';
 import { useMessages, useAgents, useCurrentPhase, type Message } from '../hooks';
@@ -714,6 +715,26 @@ export function MessagesPage() {
   const { currentPhase } = useCurrentPhase();
 
   const loading = messagesLoading || agentsLoading;
+
+  if (!loading && messages.length === 0) {
+    return (
+      <div className="p-3 md:p-6 space-y-4 md:space-y-6">
+        <div>
+          <h1 className="text-xl md:text-2xl font-bold">Agent Communications</h1>
+          <p className="text-slate-400 text-xs md:text-sm">Watch your agents coordinate in real-time</p>
+        </div>
+        <Card className="bg-slate-800/30 border-slate-700">
+          <CardContent>
+            <EmptyState
+              variant="messages"
+              title="No messages yet"
+              description="Agents will communicate here once tasks begin. Start a task to see real-time coordination."
+            />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   if (loading && messages.length === 0) {
     return (

--- a/apps/dashboard/src/pages/network.tsx
+++ b/apps/dashboard/src/pages/network.tsx
@@ -9,7 +9,9 @@ export function NetworkPage() {
   if (agents.length === 0) {
     return (
       <div className="flex items-center justify-center h-[calc(100vh-theme(spacing.16))]">
+
         <Card className="max-w-md w-full bg-slate-800/30 border-slate-700">
+        <Card className="max-w-md w-full">
           <CardContent>
             <EmptyState
               variant="network"


### PR DESCRIPTION
## Summary
Adds a reusable `EmptyState` component and integrates it across all major dashboard pages.

### New Component: `EmptyState`
- **7 variants**: agents, tasks, messages, events, credits, network, generic
- Ocean-themed inline SVG illustrations (fish, bubbles, coral, chat bubbles, etc.)
- Animated floating bubbles via framer-motion
- Optional CTA button with cyan accent
- Compact mode for inline usage within cards
- Responsive design

### Pages Updated
1. **Agents** — "No agents registered yet" + CTA
2. **Tasks** — "No tasks in the queue" + CTA (full-page empty state)
3. **Messages** — "No messages yet" with description
4. **Events** — "No events recorded" (compact, inline)
5. **Credits** — "No credit transactions" (compact, inline)
6. **Network** — "No agent network yet" + CTA
7. **Dashboard** — "No activity yet" (compact, inline)

Closes #174