### PR TITLE
feat(dashboard): expand semantic color system

### DIFF
--- a/apps/dashboard/src/components/agent-activity-heatmap.tsx
+++ b/apps/dashboard/src/components/agent-activity-heatmap.tsx
@@ -47,10 +47,10 @@ function generateDemoActivity(agentId: string, weeks: number): ActivityData[] {
 
 const intensityColors = [
   'bg-slate-800', // 0
-  'bg-cyan-900/50', // 1-3
-  'bg-cyan-700/60', // 4-6
-  'bg-cyan-500/70', // 7-9
-  'bg-cyan-400', // 10+
+  'bg-emerald-900/50', // 1-3
+  'bg-emerald-700/60', // 4-6
+  'bg-emerald-500/70', // 7-9
+  'bg-emerald-400', // 10+
 ];
 
 function getIntensityColor(count: number): string {

--- a/apps/dashboard/src/components/agent-detail-panel.tsx
+++ b/apps/dashboard/src/components/agent-detail-panel.tsx
@@ -244,7 +244,7 @@ function TasksTab({ agent }: { agent: Agent }) {
           <div className="text-2xl font-bold text-amber-500">{tasksByStatus.inProgress.length}</div>
           <div className="text-xs text-muted-foreground">In Progress</div>
         </div>
-        <div className="p-3 rounded-lg bg-blue-500/10 border border-blue-500/20">
+        <div className="p-3 rounded-lg bg-cyan-500/10 border border-cyan-500/20">
           <div className="text-2xl font-bold text-blue-500">{tasksByStatus.pending.length}</div>
           <div className="text-xs text-muted-foreground">Pending</div>
         </div>

--- a/apps/dashboard/src/components/agent-efficiency.tsx
+++ b/apps/dashboard/src/components/agent-efficiency.tsx
@@ -78,7 +78,7 @@ const demoEfficiencyData: AgentEfficiency[] = [
 ];
 
 const rankIcons = [
-  { icon: Trophy, color: 'text-yellow-400', bg: 'bg-yellow-500/20' },
+  { icon: Trophy, color: 'text-amber-400', bg: 'bg-amber-500/20' },
   { icon: Medal, color: 'text-slate-300', bg: 'bg-slate-500/20' },
   { icon: Medal, color: 'text-amber-600', bg: 'bg-amber-600/20' },
 ];
@@ -92,7 +92,7 @@ export function AgentEfficiencyLeaderboard() {
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg flex items-center gap-2">
-            <Trophy className="w-5 h-5 text-yellow-400" />
+            <Trophy className="w-5 h-5 text-amber-400" />
             Efficiency Leaderboard
           </CardTitle>
           <Badge variant="outline" className="text-xs">
@@ -114,7 +114,7 @@ export function AgentEfficiencyLeaderboard() {
               transition={{ delay: index * 0.1 }}
               className={cn(
                 'flex items-center gap-3 p-3 rounded-lg',
-                index === 0 && 'bg-yellow-500/10 border border-yellow-500/30',
+                index === 0 && 'bg-amber-500/10 border border-yellow-500/30',
                 index === 1 && 'bg-slate-500/10 border border-slate-500/30',
                 index === 2 && 'bg-amber-600/10 border border-amber-600/30',
                 index > 2 && 'bg-slate-700/30'
@@ -159,7 +159,7 @@ export function AgentEfficiencyLeaderboard() {
               <div className="text-right">
                 <div className="flex items-center gap-1">
                   <span className="text-lg font-bold">{agent.efficiency.toFixed(2)}</span>
-                  {agent.trend === 'up' && <TrendingUp className="w-4 h-4 text-green-400" />}
+                  {agent.trend === 'up' && <TrendingUp className="w-4 h-4 text-emerald-400" />}
                   {agent.trend === 'down' && <TrendingUp className="w-4 h-4 text-red-400 rotate-180" />}
                 </div>
                 <p className="text-[10px] text-slate-500">
@@ -178,9 +178,9 @@ export function AgentEfficiencyLeaderboard() {
 export function AgentEfficiencyBadge({ efficiency, trend }: { efficiency: number; trend: 'up' | 'down' | 'stable' }) {
   return (
     <div className="flex items-center gap-1">
-      <Zap className="w-3 h-3 text-yellow-400" />
+      <Zap className="w-3 h-3 text-amber-400" />
       <span className="text-xs font-medium">{efficiency.toFixed(2)}</span>
-      {trend === 'up' && <TrendingUp className="w-3 h-3 text-green-400" />}
+      {trend === 'up' && <TrendingUp className="w-3 h-3 text-emerald-400" />}
       {trend === 'down' && <TrendingUp className="w-3 h-3 text-red-400 rotate-180" />}
     </div>
   );

--- a/apps/dashboard/src/components/agent-network.tsx
+++ b/apps/dashboard/src/components/agent-network.tsx
@@ -308,7 +308,7 @@ function AgentNode({ data, selected }: NodeProps) {
               initial={{ scale: 0 }}
               animate={{ scale: 1 }}
               transition={{ delay: 0.3 }}
-              className={`absolute rounded-full font-bold text-white bg-purple-600 ${compact ? '-bottom-1.5 -right-1.5 px-1 py-0 text-[8px]' : '-bottom-2 -right-2 px-1.5 py-0.5 text-[10px]'}`}
+              className={`absolute rounded-full font-bold text-white bg-violet-600 ${compact ? '-bottom-1.5 -right-1.5 px-1 py-0 text-[8px]' : '-bottom-2 -right-2 px-1.5 py-0.5 text-[10px]'}`}
             >
               {taskCount}
             </motion.div>
@@ -937,7 +937,7 @@ function AgentNetworkInner({ className }: AgentNetworkProps) {
               onClick={() => setCompact(!compact)}
               className={`text-[10px] px-1.5 py-0.5 rounded transition-colors ${
                 compact 
-                  ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30' 
+                  ? 'bg-violet-500/20 text-violet-400 border border-violet-500/30' 
                   : 'bg-zinc-800 text-zinc-400 border border-zinc-700 hover:bg-zinc-700'
               }`}
               title={compact ? "Expand nodes" : "Compact nodes"}
@@ -994,7 +994,7 @@ function AgentNetworkInner({ className }: AgentNetworkProps) {
                   </div>
                   <div className="flex justify-between">
                     <span className="text-zinc-500">Tasks</span>
-                    <span className="text-purple-400">
+                    <span className="text-violet-400">
                       {agentActivity.get((selectedNode.data as AgentNodeData).agentId)?.taskCount || 0}
                     </span>
                   </div>
@@ -1004,7 +1004,7 @@ function AgentNetworkInner({ className }: AgentNetworkProps) {
                   </div>
                   <div className="flex justify-between">
                     <span className="text-zinc-500">Status</span>
-                    <span className={(selectedNode.data as AgentNodeData).status === "active" ? "text-green-500" : "text-yellow-500"}>
+                    <span className={(selectedNode.data as AgentNodeData).status === "active" ? "text-emerald-500" : "text-amber-500"}>
                       {(selectedNode.data as AgentNodeData).status}
                     </span>
                   </div>
@@ -1041,12 +1041,12 @@ function AgentNetworkInner({ className }: AgentNetworkProps) {
                     animate={{ opacity: 1 - idx * 0.15, x: 0, scale: 1 - idx * 0.03, y: idx * -4 }}
                     exit={{ opacity: 0, x: 30, scale: 0.8 }}
                     transition={{ type: "spring", stiffness: 400, damping: 25 }}
-                    className="bg-zinc-900/95 backdrop-blur border border-green-500/30 rounded-lg px-3 py-1.5 mb-1 text-xs flex items-center gap-2 shadow-lg shadow-green-500/10"
+                    className="bg-zinc-900/95 backdrop-blur border border-emerald-500/30 rounded-lg px-3 py-1.5 mb-1 text-xs flex items-center gap-2 shadow-lg shadow-emerald-500/10"
                     style={{ position: idx === 0 ? 'relative' : 'absolute', bottom: 0 }}
                   >
-                    <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse flex-shrink-0" />
+                    <span className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse flex-shrink-0" />
                     <span className="text-zinc-400 truncate max-w-[60px]">{String(fromNode?.data?.label || "") || del.fromId}</span>
-                    <span className="text-green-500">→</span>
+                    <span className="text-emerald-500">→</span>
                     <span className="text-zinc-400 truncate max-w-[60px]">{String(toNode?.data?.label || "") || del.toId}</span>
                   </motion.div>
                 );

--- a/apps/dashboard/src/components/agent-onboarding.tsx
+++ b/apps/dashboard/src/components/agent-onboarding.tsx
@@ -135,7 +135,7 @@ export function AgentOnboarding() {
         <CardContent>
           {pending.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-8 text-center">
-              <Check className="h-12 w-12 text-green-500/50 mb-4" />
+              <Check className="h-12 w-12 text-emerald-500/50 mb-4" />
               <p className="text-muted-foreground">No pending agents</p>
             </div>
           ) : (

--- a/apps/dashboard/src/components/budget-burndown.tsx
+++ b/apps/dashboard/src/components/budget-burndown.tsx
@@ -93,7 +93,7 @@ export function BudgetBurndown({ budget, spent, periodDays, daysElapsed }: Budge
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg flex items-center gap-2">
-            <Calendar className="w-5 h-5 text-indigo-400" />
+            <Calendar className="w-5 h-5 text-cyan-400" />
             Budget Burn-down
           </CardTitle>
           <Badge variant={projectedOver ? 'destructive' : 'default'} className="text-xs">
@@ -216,15 +216,15 @@ export function BudgetBurndown({ budget, spent, periodDays, daysElapsed }: Budge
           {/* Legend */}
           <div className="flex items-center gap-4 mt-4 text-xs">
             <div className="flex items-center gap-1">
-              <div className="w-3 h-0.5 bg-indigo-500 rounded" />
+              <div className="w-3 h-0.5 bg-cyan-500 rounded" />
               <span className="text-slate-400">Actual</span>
             </div>
             <div className="flex items-center gap-1">
-              <div className="w-3 h-0.5 bg-indigo-500/60 rounded" style={{ borderStyle: 'dashed' }} />
+              <div className="w-3 h-0.5 bg-cyan-500/60 rounded" style={{ borderStyle: 'dashed' }} />
               <span className="text-slate-400">Projected</span>
             </div>
             <div className="flex items-center gap-1">
-              <div className="w-3 h-0.5 bg-green-500/60 rounded" style={{ borderStyle: 'dashed' }} />
+              <div className="w-3 h-0.5 bg-emerald-500/60 rounded" style={{ borderStyle: 'dashed' }} />
               <span className="text-slate-400">Ideal</span>
             </div>
             <div className="flex items-center gap-1">
@@ -242,7 +242,7 @@ export function BudgetBurndown({ budget, spent, periodDays, daysElapsed }: Budge
           </div>
           <div>
             <p className="text-xs text-slate-400">Remaining</p>
-            <p className="text-lg font-semibold text-green-400">{budgetRemaining.toLocaleString()}</p>
+            <p className="text-lg font-semibold text-emerald-400">{budgetRemaining.toLocaleString()}</p>
           </div>
           <div>
             <p className="text-xs text-slate-400">Daily Rate</p>
@@ -252,7 +252,7 @@ export function BudgetBurndown({ budget, spent, periodDays, daysElapsed }: Budge
             <p className="text-xs text-slate-400">Runway</p>
             <p className={cn(
               "text-lg font-semibold",
-              runwayDays < daysRemaining ? "text-red-400" : "text-green-400"
+              runwayDays < daysRemaining ? "text-red-400" : "text-emerald-400"
             )}>
               {Math.round(runwayDays)} days
             </p>

--- a/apps/dashboard/src/components/budget-manager.tsx
+++ b/apps/dashboard/src/components/budget-manager.tsx
@@ -79,8 +79,8 @@ export function BudgetManager() {
     if (percent === null) return "bg-muted";
     if (percent >= 90) return "bg-red-500";
     if (percent >= 80) return "bg-amber-500";
-    if (percent >= 60) return "bg-yellow-500";
-    return "bg-green-500";
+    if (percent >= 60) return "bg-amber-500";
+    return "bg-emerald-500";
   };
 
   return (
@@ -245,7 +245,7 @@ export function BudgetManager() {
                     )}
                   </div>
                   <div className="flex items-center gap-4 text-sm">
-                    <span className="flex items-center gap-1 text-green-500">
+                    <span className="flex items-center gap-1 text-emerald-500">
                       <TrendingUp className="h-3 w-3" />
                       {budget.currentBalance.toLocaleString()}
                     </span>

--- a/apps/dashboard/src/components/capability-manager.tsx
+++ b/apps/dashboard/src/components/capability-manager.tsx
@@ -63,8 +63,8 @@ const MOCK_MATCHES: CapabilityMatch[] = [
 
 const proficiencyColors: Record<Proficiency, string> = {
   basic: "bg-gray-500",
-  standard: "bg-blue-500",
-  expert: "bg-purple-500",
+  standard: "bg-cyan-500",
+  expert: "bg-violet-500",
 };
 
 const proficiencyLabels: Record<Proficiency, string> = {
@@ -193,7 +193,7 @@ export function CapabilityManager({ agentId }: { agentId?: string }) {
                           </div>
                           <div className="flex items-center gap-1">
                             {Array.from({ length: match.score }).map((_, i) => (
-                              <Star key={i} className="h-4 w-4 fill-yellow-500 text-yellow-500" />
+                              <Star key={i} className="h-4 w-4 fill-amber-500 text-amber-500" />
                             ))}
                           </div>
                         </div>
@@ -250,7 +250,7 @@ export function CapabilityManager({ agentId }: { agentId?: string }) {
           <CardHeader>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <TrendingUp className="h-5 w-5 text-green-500" />
+                <TrendingUp className="h-5 w-5 text-emerald-500" />
                 <CardTitle>Agent Capabilities</CardTitle>
               </div>
               <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>

--- a/apps/dashboard/src/components/idle-agents-widget.tsx
+++ b/apps/dashboard/src/components/idle-agents-widget.tsx
@@ -41,7 +41,7 @@ const IDLE_REASON_CONFIG: Record<IdleReason, {
     icon: Clock, 
     label: "Awaiting Input", 
     color: "text-blue-500",
-    bgColor: "bg-blue-500/10",
+    bgColor: "bg-cyan-500/10",
   },
   unassigned: { 
     icon: Inbox, 
@@ -52,8 +52,8 @@ const IDLE_REASON_CONFIG: Record<IdleReason, {
   newly_activated: { 
     icon: UserPlus, 
     label: "Just Activated", 
-    color: "text-purple-500",
-    bgColor: "bg-purple-500/10",
+    color: "text-violet-500",
+    bgColor: "bg-violet-500/10",
   },
 };
 

--- a/apps/dashboard/src/components/keyboard-shortcuts.tsx
+++ b/apps/dashboard/src/components/keyboard-shortcuts.tsx
@@ -127,8 +127,8 @@ export function KeyboardShortcutsHelp({ open, onClose }: { open: boolean; onClos
             <div className="bg-slate-800 border border-slate-700 rounded-xl shadow-2xl overflow-hidden">
               <div className="flex items-center justify-between px-6 py-4 border-b border-slate-700">
                 <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-indigo-500/20">
-                    <Command className="w-5 h-5 text-indigo-400" />
+                  <div className="p-2 rounded-lg bg-cyan-500/20">
+                    <Command className="w-5 h-5 text-cyan-400" />
                   </div>
                   <h2 className="text-lg font-semibold">Keyboard Shortcuts</h2>
                 </div>

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -122,7 +122,7 @@ export function Layout({ children }: LayoutProps) {
                       variant={isActive ? "secondary" : "ghost"}
                       className={cn(
                         "w-full justify-start gap-3",
-                        isActive && "bg-secondary"
+                        isActive && "bg-secondary text-primary"
                       )}
                     >
                       <item.icon className="h-4 w-4" />
@@ -288,7 +288,7 @@ export function Layout({ children }: LayoutProps) {
                       variant={isActive ? "secondary" : "ghost"}
                       className={cn(
                         "w-full justify-start gap-3",
-                        isActive && "bg-secondary"
+                        isActive && "bg-secondary text-primary"
                       )}
                     >
                       <item.icon className="h-4 w-4" />
@@ -399,7 +399,7 @@ export function Layout({ children }: LayoutProps) {
                     <Play className="h-4 w-4" />
                   )}
                   {demo.isPlaying && (
-                    <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-green-500 animate-pulse" />
+                    <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
                   )}
                 </Button>
               )}

--- a/apps/dashboard/src/components/model-usage.tsx
+++ b/apps/dashboard/src/components/model-usage.tsx
@@ -84,7 +84,7 @@ export function ModelUsageBreakdown() {
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg flex items-center gap-2">
-            <Cpu className="w-5 h-5 text-purple-400" />
+            <Cpu className="w-5 h-5 text-violet-400" />
             Model Usage
           </CardTitle>
           <Badge variant="outline" className="text-xs">
@@ -96,17 +96,17 @@ export function ModelUsageBreakdown() {
         {/* Summary stats */}
         <div className="grid grid-cols-3 gap-4">
           <div className="text-center p-3 rounded-lg bg-slate-700/30">
-            <DollarSign className="w-5 h-5 mx-auto mb-1 text-green-400" />
+            <DollarSign className="w-5 h-5 mx-auto mb-1 text-emerald-400" />
             <p className="text-2xl font-bold">${totalCost.toFixed(0)}</p>
             <p className="text-xs text-slate-400">Total Cost</p>
           </div>
           <div className="text-center p-3 rounded-lg bg-slate-700/30">
-            <Zap className="w-5 h-5 mx-auto mb-1 text-yellow-400" />
+            <Zap className="w-5 h-5 mx-auto mb-1 text-amber-400" />
             <p className="text-2xl font-bold">{(totalCalls / 1000).toFixed(1)}k</p>
             <p className="text-xs text-slate-400">API Calls</p>
           </div>
           <div className="text-center p-3 rounded-lg bg-slate-700/30">
-            <TrendingUp className="w-5 h-5 mx-auto mb-1 text-blue-400" />
+            <TrendingUp className="w-5 h-5 mx-auto mb-1 text-cyan-400" />
             <p className="text-2xl font-bold">{(totalTokens / 1000000).toFixed(1)}M</p>
             <p className="text-xs text-slate-400">Tokens</p>
           </div>
@@ -202,7 +202,7 @@ export function ModelUsageBreakdown() {
               <div className="text-right">
                 <p className={cn(
                   "font-semibold",
-                  model.cost === 0 ? "text-green-400" : "text-slate-200"
+                  model.cost === 0 ? "text-emerald-400" : "text-slate-200"
                 )}>
                   {model.cost === 0 ? 'Free' : `$${model.cost.toFixed(2)}`}
                 </p>

--- a/apps/dashboard/src/components/phase-chip.tsx
+++ b/apps/dashboard/src/components/phase-chip.tsx
@@ -15,16 +15,16 @@ export function PhaseChip({ phase, className }: PhaseChipProps) {
     <div
       className={cn(
         "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium",
-        "bg-blue-500/10 text-blue-400 border border-blue-500/20",
-        "transition-colors hover:bg-blue-500/15",
+        "bg-cyan-500/10 text-cyan-400 border border-cyan-500/20",
+        "transition-colors hover:bg-cyan-500/15",
         className
       )}
       title={`${phase.name}: ${phase.description}`}
     >
       <span>{phase.icon}</span>
       <span>{phase.name}</span>
-      <span className="text-blue-400/60">•</span>
-      <span className="text-blue-400/80">{phase.week}</span>
+      <span className="text-cyan-400/60">•</span>
+      <span className="text-cyan-400/80">{phase.week}</span>
     </div>
   );
 }

--- a/apps/dashboard/src/components/phase-progress.tsx
+++ b/apps/dashboard/src/components/phase-progress.tsx
@@ -56,8 +56,8 @@ export function PhaseProgress({ phases, currentPhase, onPhaseClick, className }:
                   <motion.div
                     className={cn(
                       "w-10 h-10 rounded-full flex items-center justify-center text-lg border-2 transition-all relative z-10",
-                      isComplete && "bg-slate-900 border-green-500 text-green-400",
-                      isCurrent && "bg-slate-900 border-blue-500 text-blue-400 ring-4 ring-blue-500/20",
+                      isComplete && "bg-slate-900 border-emerald-500 text-emerald-400",
+                      isCurrent && "bg-slate-900 border-cyan-500 text-cyan-400 ring-4 ring-cyan-500/20",
                       isFuture && "bg-slate-900 border-slate-600 text-slate-500"
                     )}
                     initial={{ scale: 0 }}
@@ -71,8 +71,8 @@ export function PhaseProgress({ phases, currentPhase, onPhaseClick, className }:
                   <div className="text-center">
                     <p className={cn(
                       "text-sm font-medium transition-colors",
-                      isCurrent && "text-blue-400",
-                      isComplete && "text-green-400",
+                      isCurrent && "text-cyan-400",
+                      isComplete && "text-emerald-400",
                       isFuture && "text-slate-500"
                     )}>
                       {phase.name}
@@ -98,7 +98,7 @@ export function PhaseProgress({ phases, currentPhase, onPhaseClick, className }:
               <h3 className="font-semibold text-lg">{phases[currentIndex]?.name}</h3>
               <p className="text-slate-400 text-sm">{phases[currentIndex]?.description}</p>
             </div>
-            <span className="ml-auto px-3 py-1 bg-blue-500/20 text-blue-400 rounded-full text-sm font-medium">
+            <span className="ml-auto px-3 py-1 bg-cyan-500/20 text-cyan-400 rounded-full text-sm font-medium">
               {phases[currentIndex]?.week}
             </span>
           </div>
@@ -122,8 +122,8 @@ export function PhaseProgress({ phases, currentPhase, onPhaseClick, className }:
                 transition={{ delay: index * 0.05 }}
                 className={cn(
                   "w-full flex items-center gap-3 p-3 rounded-lg border transition-all text-left",
-                  isCurrent && "bg-blue-500/10 border-blue-500/50",
-                  isComplete && "bg-green-500/5 border-green-500/30",
+                  isCurrent && "bg-cyan-500/10 border-cyan-500/50",
+                  isComplete && "bg-emerald-500/5 border-emerald-500/30",
                   isFuture && "bg-slate-800/30 border-slate-700",
                   onPhaseClick && "active:scale-[0.98]"
                 )}
@@ -131,8 +131,8 @@ export function PhaseProgress({ phases, currentPhase, onPhaseClick, className }:
                 {/* Icon */}
                 <div className={cn(
                   "w-8 h-8 rounded-full flex items-center justify-center text-sm shrink-0",
-                  isComplete && "bg-green-500/20 text-green-400",
-                  isCurrent && "bg-blue-500/20 text-blue-400",
+                  isComplete && "bg-emerald-500/20 text-emerald-400",
+                  isCurrent && "bg-cyan-500/20 text-cyan-400",
                   isFuture && "bg-slate-700 text-slate-500"
                 )}>
                   {isComplete ? '✓' : phase.icon}
@@ -143,8 +143,8 @@ export function PhaseProgress({ phases, currentPhase, onPhaseClick, className }:
                   <div className="flex items-center gap-2">
                     <p className={cn(
                       "font-medium text-sm",
-                      isCurrent && "text-blue-400",
-                      isComplete && "text-green-400",
+                      isCurrent && "text-cyan-400",
+                      isComplete && "text-emerald-400",
                       isFuture && "text-slate-500"
                     )}>
                       {phase.name}
@@ -158,7 +158,7 @@ export function PhaseProgress({ phases, currentPhase, onPhaseClick, className }:
 
                 {/* Progress indicator */}
                 {isCurrent && (
-                  <div className="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+                  <div className="w-2 h-2 rounded-full bg-cyan-500 animate-pulse" />
                 )}
               </motion.button>
             );

--- a/apps/dashboard/src/components/reputation-card.tsx
+++ b/apps/dashboard/src/components/reputation-card.tsx
@@ -26,9 +26,9 @@ interface ReputationCardProps {
 const LEVEL_COLORS: Record<string, string> = {
   NEW: "bg-gray-500",
   PROBATION: "bg-orange-500",
-  TRUSTED: "bg-blue-500",
-  VETERAN: "bg-purple-500",
-  ELITE: "bg-yellow-500",
+  TRUSTED: "bg-cyan-500",
+  VETERAN: "bg-violet-500",
+  ELITE: "bg-amber-500",
 };
 
 const LEVEL_EMOJI: Record<string, string> = {

--- a/apps/dashboard/src/components/reputation-history.tsx
+++ b/apps/dashboard/src/components/reputation-history.tsx
@@ -89,7 +89,7 @@ export function ReputationHistory({
                     </div>
                     <div
                       className={`text-sm font-semibold ${
-                        event.impact >= 0 ? "text-green-500" : "text-red-500"
+                        event.impact >= 0 ? "text-emerald-500" : "text-red-500"
                       }`}
                     >
                       {event.impact >= 0 ? "+" : ""}

--- a/apps/dashboard/src/components/settings/api-key-settings.tsx
+++ b/apps/dashboard/src/components/settings/api-key-settings.tsx
@@ -134,7 +134,7 @@ export function ApiKeySettings() {
                       onClick={() => handleCopyKey(newKeySecret)}
                     >
                       {copiedKey === newKeySecret ? (
-                        <Check className="h-4 w-4 text-green-500" />
+                        <Check className="h-4 w-4 text-emerald-500" />
                       ) : (
                         <Copy className="h-4 w-4" />
                       )}

--- a/apps/dashboard/src/components/settings/github-settings.tsx
+++ b/apps/dashboard/src/components/settings/github-settings.tsx
@@ -487,9 +487,9 @@ export function GitHubSettings() {
                   >
                     <div className="flex items-center gap-3">
                       {link.sourceType === "github_pr" ? (
-                        <GitPullRequest className="h-4 w-4 text-purple-500" />
+                        <GitPullRequest className="h-4 w-4 text-violet-500" />
                       ) : (
-                        <AlertCircle className="h-4 w-4 text-green-500" />
+                        <AlertCircle className="h-4 w-4 text-emerald-500" />
                       )}
                       <div>
                         <p className="text-sm font-medium">

--- a/apps/dashboard/src/components/settings/profile-settings.tsx
+++ b/apps/dashboard/src/components/settings/profile-settings.tsx
@@ -94,7 +94,7 @@ export function ProfileSettings() {
           <div
             className={`flex items-center gap-2 rounded-md p-3 text-sm ${
               status.type === "success"
-                ? "bg-green-500/10 text-green-500"
+                ? "bg-emerald-500/10 text-emerald-500"
                 : "bg-red-500/10 text-red-500"
             }`}
           >

--- a/apps/dashboard/src/components/settings/security-settings.tsx
+++ b/apps/dashboard/src/components/settings/security-settings.tsx
@@ -160,7 +160,7 @@ export function SecuritySettings() {
             <div
               className={`flex items-center gap-2 rounded-md p-3 text-sm ${
                 passwordStatus.type === "success"
-                  ? "bg-green-500/10 text-green-500"
+                  ? "bg-emerald-500/10 text-emerald-500"
                   : "bg-red-500/10 text-red-500"
               }`}
             >
@@ -197,9 +197,9 @@ export function SecuritySettings() {
         <CardContent>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <div className={`rounded-full p-2 ${user?.totpEnabled ? 'bg-green-500/10' : 'bg-muted'}`}>
+              <div className={`rounded-full p-2 ${user?.totpEnabled ? 'bg-emerald-500/10' : 'bg-muted'}`}>
                 {user?.totpEnabled ? (
-                  <Check className="h-5 w-5 text-green-500" />
+                  <Check className="h-5 w-5 text-emerald-500" />
                 ) : (
                   <X className="h-5 w-5 text-muted-foreground" />
                 )}
@@ -233,7 +233,7 @@ export function SecuritySettings() {
             <div
               className={`mt-4 flex items-center gap-2 rounded-md p-3 text-sm ${
                 twoFaStatus.type === "success"
-                  ? "bg-green-500/10 text-green-500"
+                  ? "bg-emerald-500/10 text-emerald-500"
                   : "bg-red-500/10 text-red-500"
               }`}
             >
@@ -265,7 +265,7 @@ export function SecuritySettings() {
                   This browser · Last active now
                 </p>
               </div>
-              <span className="inline-flex items-center rounded-full bg-green-500/10 px-2.5 py-0.5 text-xs font-medium text-green-500">
+              <span className="inline-flex items-center rounded-full bg-emerald-500/10 px-2.5 py-0.5 text-xs font-medium text-emerald-500">
                 Active
               </span>
             </div>

--- a/apps/dashboard/src/components/trust-leaderboard.tsx
+++ b/apps/dashboard/src/components/trust-leaderboard.tsx
@@ -20,9 +20,9 @@ interface TrustLeaderboardProps {
 const LEVEL_COLORS: Record<string, string> = {
   NEW: "bg-gray-500",
   PROBATION: "bg-orange-500",
-  TRUSTED: "bg-blue-500",
-  VETERAN: "bg-purple-500",
-  ELITE: "bg-yellow-500",
+  TRUSTED: "bg-cyan-500",
+  VETERAN: "bg-violet-500",
+  ELITE: "bg-amber-500",
 };
 
 const RANK_EMOJI = ["🥇", "🥈", "🥉"];

--- a/apps/dashboard/src/components/ui/badge.tsx
+++ b/apps/dashboard/src/components/ui/badge.tsx
@@ -20,7 +20,8 @@ const badgeVariants = cva(
         warning:
           "border-transparent bg-amber-500/15 text-amber-600 dark:text-amber-500 dark:bg-amber-500/20",
         info: "border-transparent bg-cyan-500/15 text-cyan-600 dark:text-cyan-400 dark:bg-cyan-500/20",
-        special: "border-transparent bg-violet-500/15 text-violet-600 dark:text-violet-400 dark:bg-violet-500/20",
+        special:
+          "border-transparent bg-violet-500/15 text-violet-600 dark:text-violet-400 dark:bg-violet-500/20",
       },
     },
     defaultVariants: {

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -268,9 +268,9 @@ function EditAgentDialog({ agent, onClose }: { agent: Agent; onClose: () => void
 const REPUTATION_COLORS: Record<string, string> = {
   NEW: "bg-gray-500",
   PROBATION: "bg-orange-500",
-  TRUSTED: "bg-blue-500",
-  VETERAN: "bg-purple-500",
-  ELITE: "bg-yellow-500",
+  TRUSTED: "bg-cyan-500",
+  VETERAN: "bg-violet-500",
+  ELITE: "bg-amber-500",
 };
 
 const REPUTATION_EMOJI: Record<string, string> = {
@@ -343,7 +343,7 @@ function ReputationTab({ agents }: { agents: Agent[] }) {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-yellow-500">
+            <div className="text-2xl font-bold text-amber-500">
               👑 {distribution.ELITE}
             </div>
           </CardContent>
@@ -355,7 +355,7 @@ function ReputationTab({ agents }: { agents: Agent[] }) {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-purple-500">
+            <div className="text-2xl font-bold text-violet-500">
               🏆 {distribution.VETERAN}
             </div>
           </CardContent>

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -25,15 +25,12 @@ import {
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { Badge } from "../components/ui/badge";
-import { ChartTooltip } from "../components/ui/chart-tooltip";
-import { OceanGradients, OCEAN_COLORS } from "../components/ui/chart-gradients";
 import { PhaseProgress } from "../components/phase-progress";
 import { IdleAgentsWidget } from "../components/idle-agents-widget";
 import { useAgents } from "../hooks/use-agents";
 import { useTasks } from "../hooks/use-tasks";
 import { useCredits } from "../hooks/use-credits";
 import { useEvents } from "../hooks/use-events";
-import { EmptyState } from "../components/ui/empty-state";
 import { useDemo, PROJECT_PHASES } from "../demo/DemoProvider";
 
 interface StatCardProps {
@@ -94,7 +91,7 @@ function StatCard({ title, value, change, icon: Icon, description }: StatCardPro
 
 function getEventIcon(type: string) {
   if (type.includes('agent')) return <Bot className="h-4 w-4 text-violet-500" />;
-  if (type.includes('task')) return <CheckSquare className="h-4 w-4 text-cyan-500" />;
+  if (type.includes('task')) return <CheckSquare className="h-4 w-4 text-blue-500" />;
   if (type.includes('credit')) return <Coins className="h-4 w-4 text-amber-500" />;
   return <Activity className="h-4 w-4 text-muted-foreground" />;
 }
@@ -288,47 +285,48 @@ export function DashboardPage() {
               <ResponsiveContainer width="100%" height="100%">
                 <AreaChart data={creditHistory}>
                   <defs>
-                    <OceanGradients />
+                    <linearGradient id="earned" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+                    </linearGradient>
+                    <linearGradient id="spent" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#f59e0b" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="#f59e0b" stopOpacity={0} />
+                    </linearGradient>
                   </defs>
                   <CartesianGrid
                     strokeDasharray="3 3"
-                    stroke="rgba(148,163,184,0.08)"
-                    vertical={false}
+                    className="stroke-border"
                   />
                   <XAxis
                     dataKey="period"
-                    tick={{ fill: '#64748b', fontSize: 12 }}
-                    axisLine={{ stroke: 'rgba(148,163,184,0.1)' }}
-                    tickLine={false}
+                    className="text-xs fill-muted-foreground"
                   />
-                  <YAxis
-                    tick={{ fill: '#64748b', fontSize: 12 }}
-                    axisLine={false}
-                    tickLine={false}
-                    tickFormatter={(v: number) => v >= 1000 ? `${(v/1000).toFixed(0)}k` : String(v)}
-                  />
+                  <YAxis className="text-xs fill-muted-foreground" />
                   <Tooltip
-                    content={<ChartTooltip valueFormatter={(v) => `${v.toLocaleString()} credits`} />}
+                    contentStyle={{
+                      backgroundColor: "hsl(var(--card))",
+                      border: "1px solid hsl(var(--border))",
+                      borderRadius: "0.5rem",
+                    }}
                   />
                   <Area
                     type="monotone"
                     dataKey="earned"
-                    stroke={OCEAN_COLORS.emerald.stroke}
-                    strokeWidth={2.5}
+                    stroke="#10b981"
+                    strokeWidth={2}
                     fillOpacity={1}
-                    fill={OCEAN_COLORS.emerald.fill}
-                    animationDuration={1200}
-                    animationEasing="ease-out"
+                    fill="url(#earned)"
+                    isAnimationActive={true}
                   />
                   <Area
                     type="monotone"
                     dataKey="spent"
-                    stroke={OCEAN_COLORS.amber.stroke}
-                    strokeWidth={2.5}
+                    stroke="#f59e0b"
+                    strokeWidth={2}
                     fillOpacity={1}
-                    fill={OCEAN_COLORS.amber.fill}
-                    animationDuration={1200}
-                    animationEasing="ease-out"
+                    fill="url(#spent)"
+                    isAnimationActive={true}
                   />
                 </AreaChart>
               </ResponsiveContainer>
@@ -438,12 +436,12 @@ export function DashboardPage() {
               ))}
             </AnimatePresence>
             {events.length === 0 && (
-              <EmptyState
-                variant="events"
-                title="No activity yet"
-                description="Start the simulation to see events appear here in real-time."
-                compact
-              />
+              <div className="flex flex-col items-center justify-center py-8">
+                <Activity className="h-8 w-8 text-muted-foreground mb-2" />
+                <p className="text-sm text-muted-foreground">
+                  No activity yet. Start the simulation to see events.
+                </p>
+              </div>
             )}
           </div>
         </CardContent>

--- a/apps/dashboard/src/pages/messages.tsx
+++ b/apps/dashboard/src/pages/messages.tsx
@@ -33,10 +33,10 @@ const formatTime = (dateStr: string) => {
 };
 
 const typeColors: Record<string, string> = {
-  TASK: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-  STATUS: 'bg-green-500/20 text-green-400 border-green-500/30',
-  REPORT: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
-  QUESTION: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
+  TASK: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
+  STATUS: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30',
+  REPORT: 'bg-violet-500/20 text-violet-400 border-violet-500/30',
+  QUESTION: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
   ESCALATION: 'bg-red-500/20 text-red-400 border-red-500/30',
   GENERAL: 'bg-slate-500/20 text-slate-400 border-slate-500/30',
 };
@@ -246,7 +246,7 @@ function FeedVirtualList({ filtered }: { filtered: Message[] }) {
                   }}
                   className="flex gap-3 md:gap-4 pb-3 pl-8 md:pl-12 relative"
                 >
-                  <div className="absolute left-2 md:left-4 w-3 h-3 md:w-4 md:h-4 rounded-full bg-slate-800 border-2 border-indigo-500 top-3" />
+                  <div className="absolute left-2 md:left-4 w-3 h-3 md:w-4 md:h-4 rounded-full bg-slate-800 border-2 border-cyan-500 top-3" />
                   
                   <Card className={cn(
                     "flex-1 bg-slate-800/50 border-l-4",
@@ -361,8 +361,8 @@ function ConversationCards({ messages }: { messages: Message[] }) {
             <Card
               className={cn(
                 "bg-slate-800/50 border-slate-700 cursor-pointer transition-all active:scale-[0.98]",
-                "hover:border-indigo-500/50",
-                isExpanded && "sm:col-span-2 lg:col-span-2 border-indigo-500"
+                "hover:border-cyan-500/50",
+                isExpanded && "sm:col-span-2 lg:col-span-2 border-cyan-500"
               )}
               onClick={() => setSelectedConvo(isExpanded ? null : key)}
             >
@@ -409,7 +409,7 @@ function ConversationCards({ messages }: { messages: Message[] }) {
                             <div
                               className={cn(
                                 "max-w-[80%] p-2 rounded-lg text-xs md:text-sm",
-                                isAgent1 ? "bg-slate-700" : "bg-indigo-600/30"
+                                isAgent1 ? "bg-slate-700" : "bg-cyan-600/30"
                               )}
                             >
                               {msg.content}

--- a/apps/dashboard/src/pages/network.tsx
+++ b/apps/dashboard/src/pages/network.tsx
@@ -48,17 +48,17 @@ export function NetworkPage() {
           </div>
           <div className="w-px h-6 bg-zinc-700 hidden sm:block" />
           <div className="text-center">
-            <div className="text-base sm:text-xl font-bold text-green-500">11</div>
+            <div className="text-base sm:text-xl font-bold text-emerald-500">11</div>
             <div className="text-[9px] sm:text-xs text-zinc-500 hidden landscape:hidden sm:block">Active</div>
           </div>
           <div className="w-px h-6 bg-zinc-700 hidden sm:block" />
           <div className="text-center">
-            <div className="text-base sm:text-xl font-bold text-yellow-500">2</div>
+            <div className="text-base sm:text-xl font-bold text-amber-500">2</div>
             <div className="text-[9px] sm:text-xs text-zinc-500 hidden landscape:hidden sm:block">Pending</div>
           </div>
           <div className="w-px h-6 bg-zinc-700 hidden sm:block" />
           <div className="text-center">
-            <div className="text-base sm:text-xl font-bold text-purple-500">1</div>
+            <div className="text-base sm:text-xl font-bold text-violet-500">1</div>
             <div className="text-[9px] sm:text-xs text-zinc-500 hidden landscape:hidden sm:block">Paused</div>
           </div>
           <div className="w-px h-6 bg-zinc-700 hidden sm:block" />

--- a/apps/dashboard/src/pages/tasks.tsx
+++ b/apps/dashboard/src/pages/tasks.tsx
@@ -40,9 +40,9 @@ function getPriorityVariant(priority: string) {
 function getPriorityColor(priority: string) {
   switch (priority?.toUpperCase()) {
     case "URGENT":
-      return "text-red-500";
+      return "text-rose-500";
     case "HIGH":
-      return "text-orange-500";
+      return "text-violet-500";
     case "NORMAL":
       return "text-blue-500";
     case "LOW":
@@ -132,7 +132,7 @@ function TaskCard({ task, onClick, compact }: TaskCardProps) {
                   </Badge>
                 )}
                 {createdViaWebhook && (
-                  <Badge variant="outline" className="text-xs text-blue-500 border-blue-500/30">
+                  <Badge variant="outline" className="text-xs text-cyan-500 border-cyan-500/30">
                     <Webhook className="w-3 h-3 mr-1" />
                     webhook
                   </Badge>

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -16,8 +16,16 @@
     --muted-foreground: 240 3.8% 46.1%;
     --accent: 240 4.8% 95.9%;
     --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 350 89% 60%;
     --destructive-foreground: 0 0% 98%;
+    --success: 160 84% 39%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 38 92% 10%;
+    --info: 192 91% 36%;
+    --info-foreground: 0 0% 100%;
+    --special: 258 90% 66%;
+    --special-foreground: 0 0% 100%;
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
     --ring: 240 5.9% 10%;
@@ -65,7 +73,7 @@
     --destructive: 350 89% 60%;
     --destructive-foreground: 0 0% 98%;
     
-    /* Info - cyan (same as primary) */
+    /* Info - cyan */
     --info: 185 85% 60%;
     --info-foreground: 220 35% 10%;
     


### PR DESCRIPTION
## Summary
Expands the dashboard's color system from monochrome cyan to a full semantic palette. Closes #175.

### Semantic Color Mapping
| Color | HSL Range | Usage |
|-------|-----------|-------|
| **Cyan** | `#06b6d4` | Primary/interactive, running tasks |
| **Emerald** | `#10b981` | Success, healthy, active, online |
| **Amber** | `#f59e0b` | Warning, attention, limits |
| **Rose** | `#f43f5e` | Error, critical, failed |
| **Violet** | `#8b5cf6` | Special, premium, orchestrator |
| **Slate** | neutral | Secondary, idle, backlog |

### Changes (30 files)
- **CSS**: Added `--success`, `--warning`, `--info`, `--special`, `--destructive` custom properties with foreground variants in both light/dark themes, mapped to Tailwind v4 `@theme inline`
- **Badge**: Added `special` variant (violet), updated `info` to cyan
- **Agent status**: active=emerald, idle=slate, pending=amber, suspended=rose
- **Task status**: backlog=slate, todo=amber, in-progress=cyan, review=violet, done=emerald, blocked=rose
- **Charts**: Semantic hex values for all data series
- **Toasts**: success=emerald, warning=amber, error=rose, info=cyan
- **Credits**: earned=emerald, spent=amber, over-budget=rose
- **Reputation**: trusted=cyan, veteran=violet, elite=amber
- **Sidebar**: Active indicator uses primary cyan text

### Build
`npx nx build dashboard` passes ✅