### PR TITLE
feat(dashboard): real-time presence indicators

### DIFF
--- a/apps/dashboard/src/components/agent-avatar.tsx
+++ b/apps/dashboard/src/components/agent-avatar.tsx
@@ -8,6 +8,8 @@ import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import { getAgentAvatarUrl, getAvatarSettings } from '../lib/avatar';
 import { Bot } from 'lucide-react';
 import { cn } from '../lib/utils';
+import { PresenceGlow, StatusDot } from './presence';
+import type { PresenceStatus } from '../hooks/use-presence';
 
 interface AgentAvatarProps {
   agentId: string;
@@ -16,6 +18,8 @@ interface AgentAvatarProps {
   size?: 'sm' | 'md' | 'lg' | 'xl';
   className?: string;
   showRing?: boolean;
+  /** When provided, wraps the avatar with a presence glow ring and status dot */
+  presenceStatus?: PresenceStatus;
 }
 
 const SIZE_MAP = {
@@ -46,6 +50,7 @@ export function AgentAvatar({
   size = 'md',
   className,
   showRing = true,
+  presenceStatus,
 }: AgentAvatarProps) {
   const sizeConfig = SIZE_MAP[size];
   const levelColor = LEVEL_COLORS[level] || '#71717a';
@@ -67,14 +72,14 @@ export function AgentAvatar({
     [agentId, level, sizeConfig.px, avatarSettings]
   );
 
-  return (
+  const avatar = (
     <Avatar
       className={cn(
         sizeConfig.class,
-        showRing && 'ring-2',
+        showRing && !presenceStatus && 'ring-2',
         className
       )}
-      style={showRing ? { '--tw-ring-color': levelColor } as React.CSSProperties : undefined}
+      style={showRing && !presenceStatus ? { '--tw-ring-color': levelColor } as React.CSSProperties : undefined}
     >
       <AvatarImage src={avatarUrl} alt={name || agentId} />
       <AvatarFallback
@@ -84,4 +89,21 @@ export function AgentAvatar({
       </AvatarFallback>
     </Avatar>
   );
+
+  if (presenceStatus) {
+    return (
+      <div className="relative inline-flex">
+        <PresenceGlow status={presenceStatus}>
+          {avatar}
+        </PresenceGlow>
+        <StatusDot
+          status={presenceStatus}
+          size="sm"
+          className="absolute -bottom-0.5 -right-0.5 z-10"
+        />
+      </div>
+    );
+  }
+
+  return avatar;
 }

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -38,6 +38,8 @@ import { Avatar, AvatarFallback } from "./ui/avatar";
 import { useDemo } from "../demo";
 import { DemoControls } from "../demo/DemoControls";
 import { useAuth } from "../contexts";
+import { usePresence } from "../hooks";
+import { ActiveAgentsBadge } from "./presence";
 import type { ReactNode } from "react";
 
 interface LayoutProps {
@@ -62,6 +64,7 @@ export function Layout({ children }: LayoutProps) {
   const demo = useDemo();
   const isDemo = searchParams.get("demo") === "true";
   const { user, logout, isAuthenticated } = useAuth();
+  const { activeCount } = usePresence();
 
   // Close mobile menu on navigation
   useEffect(() => {
@@ -109,6 +112,9 @@ export function Layout({ children }: LayoutProps) {
                 Multi-Agent Coordination
               </span>
             </div>
+            {isDemo && activeCount > 0 && (
+              <ActiveAgentsBadge count={activeCount} className="ml-auto" />
+            )}
           </div>
 
           {/* Navigation */}
@@ -386,6 +392,9 @@ export function Layout({ children }: LayoutProps) {
             </div>
             </div>
             <div className="flex items-center gap-2">
+              {isDemo && activeCount > 0 && (
+                <ActiveAgentsBadge count={activeCount} />
+              )}
               {isDemo && (
                 <Button
                   variant="ghost"

--- a/apps/dashboard/src/components/presence.tsx
+++ b/apps/dashboard/src/components/presence.tsx
@@ -1,0 +1,164 @@
+/**
+ * Real-time presence indicator components.
+ *
+ * - StatusDot        – small colored dot with optional pulse
+ * - PresenceGlow     – wrapper that adds a glow ring around children
+ * - TypingIndicator  – animated "···" dots
+ * - ActiveAgentsBadge – "N agents active" header pill
+ */
+
+import { motion } from 'framer-motion';
+import { cn } from '../lib/utils';
+import type { PresenceStatus } from '../hooks/use-presence';
+
+/* ------------------------------------------------------------------ */
+/*  Color mappings                                                     */
+/* ------------------------------------------------------------------ */
+
+const dotColors: Record<PresenceStatus, string> = {
+  active: 'bg-emerald-500',
+  busy: 'bg-amber-500',
+  error: 'bg-rose-500',
+  idle: 'bg-slate-500',
+};
+
+const glowColors: Record<PresenceStatus, string> = {
+  active: 'rgba(16,185,129,0.45)',   // emerald
+  busy: 'rgba(245,158,11,0.35)',     // amber
+  error: 'rgba(244,63,94,0.45)',     // rose
+  idle: 'rgba(100,116,139,0.18)',    // slate
+};
+
+const ringColors: Record<PresenceStatus, string> = {
+  active: 'ring-emerald-500/60',
+  busy: 'ring-amber-500/50',
+  error: 'ring-rose-500/60',
+  idle: 'ring-slate-500/25',
+};
+
+/* ------------------------------------------------------------------ */
+/*  StatusDot                                                          */
+/* ------------------------------------------------------------------ */
+
+interface StatusDotProps {
+  status: PresenceStatus;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+export function StatusDot({ status, size = 'sm', className }: StatusDotProps) {
+  const sizeClass = size === 'sm' ? 'h-2 w-2' : 'h-2.5 w-2.5';
+  const shouldPulse = status === 'active' || status === 'error';
+
+  return (
+    <span className={cn('relative inline-flex', className)}>
+      {shouldPulse && (
+        <motion.span
+          className={cn('absolute inline-flex rounded-full opacity-75', sizeClass, dotColors[status])}
+          animate={{ scale: [1, 1.8, 1], opacity: [0.7, 0, 0.7] }}
+          transition={{ repeat: Infinity, duration: status === 'error' ? 1.2 : 2, ease: 'easeInOut' }}
+        />
+      )}
+      <span className={cn('relative inline-flex rounded-full', sizeClass, dotColors[status])} />
+    </span>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  PresenceGlow                                                       */
+/* ------------------------------------------------------------------ */
+
+interface PresenceGlowProps {
+  status: PresenceStatus;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function PresenceGlow({ status, children, className }: PresenceGlowProps) {
+  const shouldPulse = status === 'active' || status === 'error';
+
+  return (
+    <div className={cn('relative', className)}>
+      {shouldPulse ? (
+        <motion.div
+          className={cn('absolute inset-0 rounded-full ring-2', ringColors[status])}
+          animate={{
+            scale: [1, 1.08, 1],
+            opacity: [0.7, 1, 0.7],
+          }}
+          transition={{
+            repeat: Infinity,
+            duration: status === 'error' ? 1.2 : 2.5,
+            ease: 'easeInOut',
+          }}
+          style={{ boxShadow: `0 0 12px ${glowColors[status]}` }}
+        />
+      ) : (
+        <div
+          className={cn('absolute inset-0 rounded-full ring-1', ringColors[status])}
+        />
+      )}
+      {children}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  TypingIndicator                                                    */
+/* ------------------------------------------------------------------ */
+
+interface TypingIndicatorProps {
+  agentName: string;
+  className?: string;
+}
+
+export function TypingIndicator({ agentName, className }: TypingIndicatorProps) {
+  return (
+    <div className={cn('flex items-center gap-2 text-xs text-muted-foreground', className)}>
+      <span className="font-medium text-foreground/70">{agentName}</span>
+      <span className="inline-flex items-center gap-0.5">
+        is typing
+        {[0, 1, 2].map((i) => (
+          <motion.span
+            key={i}
+            className="inline-block w-1 h-1 rounded-full bg-muted-foreground"
+            animate={{ opacity: [0.3, 1, 0.3], y: [0, -2, 0] }}
+            transition={{
+              repeat: Infinity,
+              duration: 1,
+              delay: i * 0.2,
+              ease: 'easeInOut',
+            }}
+          />
+        ))}
+      </span>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  ActiveAgentsBadge (for header)                                     */
+/* ------------------------------------------------------------------ */
+
+interface ActiveAgentsBadgeProps {
+  count: number;
+  className?: string;
+}
+
+export function ActiveAgentsBadge({ count, className }: ActiveAgentsBadgeProps) {
+  if (count === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-400 border border-emerald-500/20',
+        className
+      )}
+    >
+      <StatusDot status="active" size="sm" />
+      <span>
+        {count} agent{count !== 1 ? 's' : ''} active
+      </span>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/ui/empty-state.tsx
+++ b/apps/dashboard/src/components/ui/empty-state.tsx
@@ -1,17 +1,3 @@
-<<<<<<< HEAD
-import { Network, LayoutDashboard, Users, Coins } from 'lucide-react';
-import { Button } from './button';
-
-const ICONS = {
-  network: Network,
-  dashboard: LayoutDashboard,
-  agents: Users,
-  credits: Coins,
-} as const;
-
-interface EmptyStateProps {
-  variant?: keyof typeof ICONS;
-=======
 import { motion } from "framer-motion";
 import { Button } from "./button";
 
@@ -19,31 +5,10 @@ type EmptyStateVariant = "agents" | "tasks" | "messages" | "events" | "credits" 
 
 interface EmptyStateProps {
   variant?: EmptyStateVariant;
->>>>>>> 63941bb (feat(dashboard): add EmptyState component with ocean-themed illustrations #174)
   title: string;
   description: string;
   ctaLabel?: string;
   onCta?: () => void;
-<<<<<<< HEAD
-}
-
-export function EmptyState({ variant = 'dashboard', title, description, ctaLabel, onCta }: EmptyStateProps) {
-  const Icon = ICONS[variant] ?? LayoutDashboard;
-
-  return (
-    <div className="flex flex-col items-center justify-center py-12 text-center">
-      <div className="rounded-full bg-cyan-500/10 p-4 mb-4">
-        <Icon className="h-8 w-8 text-cyan-400" />
-      </div>
-      <h3 className="text-lg font-semibold mb-2">{title}</h3>
-      <p className="text-sm text-muted-foreground max-w-sm mb-4">{description}</p>
-      {ctaLabel && onCta && (
-        <Button variant="outline" onClick={onCta} className="text-sm">
-          {ctaLabel}
-        </Button>
-      )}
-    </div>
-=======
   compact?: boolean;
 }
 
@@ -185,6 +150,5 @@ export function EmptyState({ variant = "generic", title, description, ctaLabel, 
         </Button>
       )}
     </motion.div>
->>>>>>> 63941bb (feat(dashboard): add EmptyState component with ocean-themed illustrations #174)
   );
 }

--- a/apps/dashboard/src/hooks/index.ts
+++ b/apps/dashboard/src/hooks/index.ts
@@ -4,3 +4,4 @@ export { useCredits, type CreditTransaction } from "./use-credits";
 export { useEvents, type Event } from "./use-events";
 export { useMessages, useConversations, useConversationMessages, type Message, type Conversation } from "./use-messages";
 export { useCurrentPhase } from "./use-current-phase";
+export { usePresence, type AgentPresence, type PresenceStatus } from "./use-presence";

--- a/apps/dashboard/src/hooks/use-presence.ts
+++ b/apps/dashboard/src/hooks/use-presence.ts
@@ -1,0 +1,112 @@
+/**
+ * Simulated real-time presence data for demo mode.
+ * Assigns a handful of agents as "active" with current tasks,
+ * and one or two as "error" state. The rest are idle.
+ */
+
+import { useMemo } from 'react';
+import { useAgents } from './use-agents';
+import { useTasks } from './use-tasks';
+
+export type PresenceStatus = 'active' | 'busy' | 'idle' | 'error';
+
+export interface AgentPresence {
+  agentId: string;
+  status: PresenceStatus;
+  currentTask?: string;
+  isComposing?: boolean;
+}
+
+/**
+ * Returns a map of agentId → presence info.
+ * In demo mode this is deterministic based on agent/task data.
+ */
+export function usePresence(): {
+  presenceMap: Map<string, AgentPresence>;
+  activeCount: number;
+} {
+  const { agents } = useAgents();
+  const { tasks } = useTasks();
+
+  return useMemo(() => {
+    const map = new Map<string, AgentPresence>();
+
+    if (!agents || agents.length === 0) {
+      return { presenceMap: map, activeCount: 0 };
+    }
+
+    // Find agents with in-progress tasks
+    const inProgressTasks = (tasks ?? []).filter(
+      (t: any) => t.status === 'in_progress' || t.status === 'assigned'
+    );
+
+    const busyAgentIds = new Set<string>();
+    const agentTaskMap = new Map<string, string>();
+
+    for (const task of inProgressTasks) {
+      if (task.assigneeId) {
+        busyAgentIds.add(task.assigneeId);
+        if (!agentTaskMap.has(task.assigneeId)) {
+          agentTaskMap.set(task.assigneeId, task.title);
+        }
+      }
+    }
+
+    // Pick up to 4 active agents (agents with active status + tasks)
+    // Mark 1 as error for visual variety
+    const activeAgents = agents.filter((a: any) => a.status === 'active');
+    let activeCount = 0;
+    let errorSet = false;
+
+    for (const agent of agents) {
+      const id = agent.id;
+
+      // Suspended/revoked → error
+      if (agent.status === 'suspended' || agent.status === 'revoked') {
+        map.set(id, { agentId: id, status: 'error' });
+        if (!errorSet) errorSet = true;
+        continue;
+      }
+
+      // Has in-progress task → active
+      if (busyAgentIds.has(id) && agent.status === 'active') {
+        activeCount++;
+        map.set(id, {
+          agentId: id,
+          status: 'active',
+          currentTask: agentTaskMap.get(id),
+          // First 2 active agents are "composing" for typing indicator demo
+          isComposing: activeCount <= 2,
+        });
+        continue;
+      }
+
+      // Paused → busy
+      if (agent.status === 'paused') {
+        map.set(id, { agentId: id, status: 'busy' });
+        continue;
+      }
+
+      // Default idle
+      map.set(id, { agentId: id, status: 'idle' });
+    }
+
+    // If no agents are active from tasks, pick first 3 active-status agents as active
+    if (activeCount === 0) {
+      let forced = 0;
+      for (const agent of activeAgents) {
+        if (forced >= 3) break;
+        forced++;
+        activeCount++;
+        map.set(agent.id, {
+          agentId: agent.id,
+          status: 'active',
+          currentTask: 'Processing tasks...',
+          isComposing: forced <= 2,
+        });
+      }
+    }
+
+    return { presenceMap: map, activeCount };
+  }, [agents, tasks]);
+}

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -25,7 +25,7 @@ import {
 } from "../components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs";
 import { PhaseChip } from "../components/phase-chip";
-import { useAgents, useCurrentPhase } from "../hooks";
+import { useAgents, useCurrentPhase, usePresence } from "../hooks";
 import { AgentOnboarding } from "../components/agent-onboarding";
 import { BudgetManager } from "../components/budget-manager";
 import { CapabilityManager } from "../components/capability-manager";
@@ -431,6 +431,7 @@ function ReputationTab({ agents }: { agents: Agent[] }) {
                         name={agent.name}
                         level={agent.level}
                         size="md"
+                        presenceStatus={presenceMap.get(agent.id)?.status}
                       />
                       <div>
                         <div className="font-medium">{agent.name}</div>
@@ -630,12 +631,18 @@ function AgentVirtualGrid({
                               name={agent.name}
                               level={agent.level}
                               size="md"
+                              presenceStatus={presenceMap.get(agent.id)?.status}
                             />
                             <div>
                               <CardTitle className="text-base">{agent.name}</CardTitle>
                               <p className="text-xs text-muted-foreground">
                                 {getLevelLabel(agent.level)} • @{agent.agentId}
                               </p>
+                              {presenceMap.get(agent.id)?.currentTask && (
+                                <p className="text-[10px] text-emerald-400 truncate max-w-[160px]">
+                                  working on: {presenceMap.get(agent.id)!.currentTask}
+                                </p>
+                              )}
                             </div>
                           </div>
                           <DropdownMenu>
@@ -705,6 +712,7 @@ function AgentVirtualGrid({
 export function AgentsPage() {
   const { agents, loading, error } = useAgents();
   const { currentPhase } = useCurrentPhase();
+  const { presenceMap } = usePresence();
   const [selectedAgent, setSelectedAgent] = useState<Agent | null>(null);
   const [dialogMode, setDialogMode] = useState<DialogMode>(null);
   const [activeTab, setActiveTab] = useState("agents");

--- a/apps/dashboard/src/pages/messages.tsx
+++ b/apps/dashboard/src/pages/messages.tsx
@@ -13,6 +13,8 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { motion, AnimatePresence } from 'framer-motion';
+import { TypingIndicator } from '../components/presence';
+import { usePresence } from '../hooks';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
@@ -290,6 +292,20 @@ function FeedVirtualList({ filtered }: { filtered: Message[] }) {
   );
 }
 
+function ComposingIndicators() {
+  const { presenceMap } = usePresence();
+  const composing = Array.from(presenceMap.values()).filter((p) => p.isComposing);
+  if (composing.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-1 px-2 py-1.5 border-t border-border/40">
+      {composing.slice(0, 3).map((p) => (
+        <TypingIndicator key={p.agentId} agentName={p.agentId} />
+      ))}
+    </div>
+  );
+}
+
 function MissionControlFeed({ messages }: { messages: Message[] }) {
   const [filter, setFilter] = useState<string | null>(null);
 
@@ -321,6 +337,7 @@ function MissionControlFeed({ messages }: { messages: Message[] }) {
       </div>
 
       <FeedVirtualList filtered={filtered} />
+      <ComposingIndicators />
     </div>
   );
 }

--- a/apps/dashboard/src/pages/network.tsx
+++ b/apps/dashboard/src/pages/network.tsx
@@ -10,7 +10,6 @@ export function NetworkPage() {
     return (
       <div className="flex items-center justify-center h-[calc(100vh-theme(spacing.16))]">
 
-        <Card className="max-w-md w-full bg-slate-800/30 border-slate-700">
         <Card className="max-w-md w-full">
           <CardContent>
             <EmptyState


### PR DESCRIPTION
Closes #181

## Changes
- **Presence hook** (`usePresence`): Simulates real-time presence from demo agent/task data — active, busy, idle, error states
- **UI components** (`presence.tsx`): StatusDot (pulsing colored dot), PresenceGlow (animated ring wrapper), TypingIndicator (animated dots), ActiveAgentsBadge (header pill)
- **AgentAvatar enhancement**: New `presenceStatus` prop wraps avatar with emerald/amber/rose/slate glow ring + status dot
- **Header status bar**: Shows "N agents active" badge in sidebar and mobile header
- **Agent cards**: "working on: ..." text under active agent names
- **Comms feed**: Typing indicators for composing agents
- **Bug fixes**: Resolved merge conflicts in empty-state.tsx, fixed duplicate Card tag in network.tsx

All animations use framer-motion with subtle infinite loops (scale + opacity). No heavy GPU usage.