### PR TITLE
feat: Notification Center (#185)

### DIFF
--- a/apps/dashboard/src/components/index.ts
+++ b/apps/dashboard/src/components/index.ts
@@ -11,6 +11,7 @@ export * from "./reputation-card";
 export * from "./reputation-history";
 export * from "./trust-leaderboard";
 export * from "./live-notifications";
+export * from "./notification-center";
 export * from "./agent-activity-heatmap";
 export * from "./budget-burndown";
 export * from "./agent-efficiency";

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -40,6 +40,7 @@ import { DemoControls } from "../demo/DemoControls";
 import { useAuth } from "../contexts";
 import { usePresence } from "../hooks";
 import { ActiveAgentsBadge } from "./presence";
+import { NotificationCenter } from "./notification-center";
 import type { ReactNode } from "react";
 
 interface LayoutProps {
@@ -412,9 +413,16 @@ export function Layout({ children }: LayoutProps) {
                   )}
                 </Button>
               )}
+              <NotificationCenter />
               <ThemeToggle />
             </div>
           </header>
+
+          {/* Desktop top bar */}
+          <div className="hidden lg:flex items-center justify-end gap-2 px-6 py-2 border-b border-border">
+            <NotificationCenter />
+            <ThemeToggle />
+          </div>
 
           {/* Main content */}
           <main className="flex-1 overflow-auto">

--- a/apps/dashboard/src/components/live-notifications.tsx
+++ b/apps/dashboard/src/components/live-notifications.tsx
@@ -1,24 +1,23 @@
 import { useState, useEffect, createContext, useContext, useCallback } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { X, CheckCircle, AlertTriangle, Info, Zap, MessageSquare, CreditCard, Users } from 'lucide-react';
-import { cn } from '../lib/utils';
-import { getAgentAvatarUrl } from '../lib/avatar';
 import type { ReactNode } from 'react';
 
-interface Notification {
+export type NotificationType = 'agent' | 'task' | 'message' | 'credit' | 'system';
+
+export interface Notification {
   id: string;
-  type: 'success' | 'warning' | 'info' | 'task' | 'message' | 'credit' | 'agent';
+  type: NotificationType;
   title: string;
-  message?: string;
-  agentId?: string;
-  agentLevel?: number;
+  description: string;
   timestamp: Date;
+  read: boolean;
 }
 
 interface NotificationContextType {
   notifications: Notification[];
-  addNotification: (notification: Omit<Notification, 'id' | 'timestamp'>) => void;
-  removeNotification: (id: string) => void;
+  unreadCount: number;
+  markAsRead: (id: string) => void;
+  markAllRead: () => void;
+  addNotification: (notification: Omit<Notification, 'id' | 'timestamp' | 'read'>) => void;
 }
 
 const NotificationContext = createContext<NotificationContextType | null>(null);
@@ -29,130 +28,57 @@ export function useNotifications() {
   return context;
 }
 
-const typeConfig = {
-  success: { icon: CheckCircle, color: 'text-emerald-400', bg: 'bg-emerald-500/10 border-emerald-500/30' },
-  warning: { icon: AlertTriangle, color: 'text-amber-400', bg: 'bg-amber-500/10 border-amber-500/30' },
-  info: { icon: Info, color: 'text-cyan-400', bg: 'bg-cyan-500/10 border-cyan-500/30' },
-  task: { icon: CheckCircle, color: 'text-cyan-400', bg: 'bg-cyan-500/10 border-cyan-500/30' },
-  message: { icon: MessageSquare, color: 'text-violet-400', bg: 'bg-violet-500/10 border-violet-500/30' },
-  credit: { icon: CreditCard, color: 'text-amber-400', bg: 'bg-amber-500/10 border-amber-500/30' },
-  agent: { icon: Users, color: 'text-emerald-400', bg: 'bg-emerald-500/10 border-emerald-500/30' },
-};
-
-// Demo notifications that simulate real activity
-const demoNotifications: Omit<Notification, 'id' | 'timestamp'>[] = [
-  { type: 'task', title: 'Task Completed', message: 'Code Wizard finished API-001', agentId: 'code-wizard', agentLevel: 8 },
-  { type: 'message', title: 'New Message', message: 'Talent Agent → Research Bot', agentId: 'talent-agent', agentLevel: 10 },
-  { type: 'credit', title: 'Credits Earned', message: '+500 credits for task completion', agentId: 'code-wizard', agentLevel: 8 },
-  { type: 'agent', title: 'Agent Active', message: 'Research Bot started working', agentId: 'research-bot', agentLevel: 6 },
-  { type: 'success', title: 'Deployment Ready', message: 'API endpoints deployed successfully' },
-  { type: 'task', title: 'Task Assigned', message: 'DOC-042 assigned to Content Crafter', agentId: 'content-crafter', agentLevel: 5 },
-  { type: 'warning', title: 'Budget Alert', message: 'Code Wizard at 80% budget' },
-  { type: 'agent', title: 'New Agent', message: 'Junior Helper joined the team', agentId: 'junior-helper', agentLevel: 2 },
+const demoNotifications: Omit<Notification, 'id' | 'timestamp' | 'read'>[] = [
+  { type: 'agent', title: 'Agent Registered', description: 'Code Wizard has joined the network and is ready for tasks.' },
+  { type: 'task', title: 'Task Completed', description: 'API-001 finished successfully by Code Wizard in 3m 42s.' },
+  { type: 'message', title: 'New Direct Message', description: 'Talent Agent sent you a message about the deployment.' },
+  { type: 'credit', title: 'Low Balance Warning', description: 'Your credit balance is below 500. Consider topping up.' },
+  { type: 'system', title: 'System Maintenance', description: 'Scheduled maintenance window tonight at 2:00 AM UTC.' },
+  { type: 'agent', title: 'Agent Status Change', description: 'Research Bot went idle after completing 12 tasks.' },
+  { type: 'task', title: 'Task Failed', description: 'DOC-042 failed with exit code 1. Check logs for details.' },
+  { type: 'message', title: 'Mention in #general', description: 'Content Crafter mentioned you in the general channel.' },
+  { type: 'credit', title: 'Credits Earned', description: '+500 credits awarded for completing the API integration sprint.' },
+  { type: 'system', title: 'Rate Limit Warning', description: 'Agent Code Wizard approaching API rate limit (85% used).' },
 ];
 
 export function NotificationProvider({ children }: { children: ReactNode }) {
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
-  const addNotification = useCallback((notification: Omit<Notification, 'id' | 'timestamp'>) => {
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  const addNotification = useCallback((notification: Omit<Notification, 'id' | 'timestamp' | 'read'>) => {
     const newNotification: Notification = {
       ...notification,
       id: `notif-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
       timestamp: new Date(),
+      read: false,
     };
-    setNotifications((prev) => [newNotification, ...prev].slice(0, 5));
+    setNotifications((prev) => [newNotification, ...prev]);
   }, []);
 
-  const removeNotification = useCallback((id: string) => {
-    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  const markAsRead = useCallback((id: string) => {
+    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
   }, []);
 
-  // Auto-remove notifications after 5 seconds
+  const markAllRead = useCallback(() => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+  }, []);
+
+  // Seed demo notifications on mount
   useEffect(() => {
-    const timer = setInterval(() => {
-      setNotifications((prev) => {
-        const now = Date.now();
-        return prev.filter((n) => now - n.timestamp.getTime() < 5000);
-      });
-    }, 1000);
-    return () => clearInterval(timer);
+    const now = Date.now();
+    const seeded = demoNotifications.map((n, i) => ({
+      ...n,
+      id: `demo-${i}`,
+      timestamp: new Date(now - (i * 4 + 1) * 60000), // staggered past times
+      read: i >= 5, // first 5 unread
+    }));
+    setNotifications(seeded);
   }, []);
-
-  // Demo mode: simulate random notifications
-  useEffect(() => {
-    const isDemo = window.location.search.includes('demo=true');
-    if (!isDemo) return;
-
-    const interval = setInterval(() => {
-      const randomNotif = demoNotifications[Math.floor(Math.random() * demoNotifications.length)];
-      addNotification(randomNotif);
-    }, 8000);
-
-    // Initial notification
-    setTimeout(() => addNotification(demoNotifications[0]), 2000);
-
-    return () => clearInterval(interval);
-  }, [addNotification]);
 
   return (
-    <NotificationContext.Provider value={{ notifications, addNotification, removeNotification }}>
+    <NotificationContext.Provider value={{ notifications, unreadCount, markAsRead, markAllRead, addNotification }}>
       {children}
-      <NotificationToasts />
     </NotificationContext.Provider>
-  );
-}
-
-function NotificationToasts() {
-  const { notifications, removeNotification } = useNotifications();
-
-  return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
-      <AnimatePresence mode="popLayout">
-        {notifications.map((notification) => {
-          const config = typeConfig[notification.type];
-          const Icon = config.icon;
-
-          return (
-            <motion.div
-              key={notification.id}
-              initial={{ opacity: 0, y: 50, scale: 0.8 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, x: 100, scale: 0.8 }}
-              transition={{ type: 'spring', damping: 25, stiffness: 300 }}
-              className={cn(
-                'pointer-events-auto flex items-start gap-3 p-4 rounded-lg border backdrop-blur-sm shadow-lg min-w-[320px] max-w-[400px]',
-                config.bg
-              )}
-            >
-              {notification.agentId ? (
-                <img
-                  src={getAgentAvatarUrl(notification.agentId, notification.agentLevel || 5)}
-                  alt=""
-                  className="w-10 h-10 rounded-full ring-2 ring-white/20"
-                />
-              ) : (
-                <div className={cn('p-2 rounded-full', config.bg)}>
-                  <Icon className={cn('w-5 h-5', config.color)} />
-                </div>
-              )}
-              
-              <div className="flex-1 min-w-0">
-                <p className="font-medium text-white">{notification.title}</p>
-                {notification.message && (
-                  <p className="text-sm text-slate-300 truncate">{notification.message}</p>
-                )}
-              </div>
-
-              <button
-                onClick={() => removeNotification(notification.id)}
-                className="p-1 rounded hover:bg-white/10 transition-colors"
-              >
-                <X className="w-4 h-4 text-slate-400" />
-              </button>
-            </motion.div>
-          );
-        })}
-      </AnimatePresence>
-    </div>
   );
 }

--- a/apps/dashboard/src/components/notification-center.tsx
+++ b/apps/dashboard/src/components/notification-center.tsx
@@ -1,0 +1,165 @@
+import { useState, useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Bell, Bot, CheckSquare, MessageSquare, Coins, AlertTriangle, Check } from 'lucide-react';
+import { cn } from '../lib/utils';
+import { useNotifications } from './live-notifications';
+import type { NotificationType } from './live-notifications';
+
+const typeConfig: Record<NotificationType, { icon: typeof Bell; label: string; accent: string; border: string; bg: string }> = {
+  agent:   { icon: Bot,            label: 'Agent',   accent: 'text-emerald-400', border: 'border-l-emerald-500', bg: 'bg-emerald-500/5' },
+  task:    { icon: CheckSquare,    label: 'Task',    accent: 'text-cyan-400',    border: 'border-l-cyan-500',    bg: 'bg-cyan-500/5' },
+  message: { icon: MessageSquare,  label: 'Message', accent: 'text-violet-400',  border: 'border-l-violet-500',  bg: 'bg-violet-500/5' },
+  credit:  { icon: Coins,          label: 'Credit',  accent: 'text-amber-400',   border: 'border-l-amber-500',   bg: 'bg-amber-500/5' },
+  system:  { icon: AlertTriangle,  label: 'System',  accent: 'text-rose-400',    border: 'border-l-rose-500',    bg: 'bg-rose-500/5' },
+};
+
+function relativeTime(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function NotificationCenter() {
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const { notifications, unreadCount, markAsRead, markAllRead } = useNotifications();
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    // Delay to avoid the bell click triggering close
+    const id = setTimeout(() => document.addEventListener('mousedown', handler), 0);
+    return () => {
+      clearTimeout(id);
+      document.removeEventListener('mousedown', handler);
+    };
+  }, [open]);
+
+  return (
+    <>
+      {/* Bell Button */}
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        className="relative p-2 rounded-md hover:bg-muted transition-colors"
+        aria-label="Notifications"
+      >
+        <Bell className="h-5 w-5 text-muted-foreground" />
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Panel Overlay */}
+      <AnimatePresence>
+        {open && (
+          <>
+            {/* Backdrop */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="fixed inset-0 z-40 bg-black/30 backdrop-blur-sm"
+            />
+
+            {/* Panel */}
+            <motion.div
+              ref={panelRef}
+              initial={{ x: '100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '100%' }}
+              transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+              className="fixed top-0 right-0 z-50 h-full w-full sm:w-[400px] flex flex-col bg-slate-950/95 backdrop-blur-md border-l border-slate-800/60"
+            >
+              {/* Header */}
+              <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800/60">
+                <h2 className="text-lg font-semibold text-white">Notifications</h2>
+                {unreadCount > 0 && (
+                  <button
+                    onClick={markAllRead}
+                    className="flex items-center gap-1.5 text-xs text-cyan-400 hover:text-cyan-300 transition-colors"
+                  >
+                    <Check className="h-3.5 w-3.5" />
+                    Mark all read
+                  </button>
+                )}
+              </div>
+
+              {/* List */}
+              <div className="flex-1 overflow-y-auto">
+                {notifications.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center h-full text-slate-400">
+                    <span className="text-4xl mb-2">🌊</span>
+                    <p className="text-sm">All caught up!</p>
+                  </div>
+                ) : (
+                  <div className="flex flex-col">
+                    {notifications.map((notification, i) => {
+                      const config = typeConfig[notification.type];
+                      const Icon = config.icon;
+
+                      return (
+                        <motion.button
+                          key={notification.id}
+                          initial={{ opacity: 0, y: 10 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          transition={{ delay: i * 0.03 }}
+                          onClick={() => markAsRead(notification.id)}
+                          className={cn(
+                            'w-full text-left px-5 py-3.5 border-l-2 transition-colors hover:bg-slate-800/40',
+                            notification.read
+                              ? 'border-l-transparent bg-transparent'
+                              : cn(config.border, config.bg)
+                          )}
+                        >
+                          <div className="flex items-start gap-3">
+                            <div className={cn('mt-0.5 p-1.5 rounded-md', notification.read ? 'bg-slate-800/50' : config.bg)}>
+                              <Icon className={cn('h-4 w-4', notification.read ? 'text-slate-500' : config.accent)} />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <div className="flex items-center justify-between gap-2">
+                                <p className={cn('text-sm font-medium truncate', notification.read ? 'text-slate-400' : 'text-white')}>
+                                  {notification.title}
+                                </p>
+                                <span className="text-[11px] text-slate-500 whitespace-nowrap">
+                                  {relativeTime(notification.timestamp)}
+                                </span>
+                              </div>
+                              <p className={cn('text-xs mt-0.5 line-clamp-2', notification.read ? 'text-slate-500' : 'text-slate-300')}>
+                                {notification.description}
+                              </p>
+                            </div>
+                          </div>
+                        </motion.button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}


### PR DESCRIPTION
Replace random toasts with a proper notification center system.

## Changes
- **Notification Bell**: Bell icon with unread count badge in header (desktop top bar + mobile header)
- **Slide-in Panel**: framer-motion animated panel from right, click outside/Esc to close
- **Grouped by type**: Agent (emerald), Task (cyan), Message (violet), Credit (amber), System (rose)
- **Read/unread state**: Left border accent + brighter bg for unread, click to mark read
- **Mark all read**: Button in panel header
- **Enhanced Provider**: Replaced toast-based system with persistent notification state
- **Demo seeds**: 10 realistic notifications seeded on mount
- **Responsive**: Full-width on mobile, 400px panel on desktop
- **Empty state**: "All caught up! 🌊"

Closes #185