### PR TITLE
fix: activity feed at high demo speeds

### DIFF
--- a/apps/dashboard/src/demo/DemoProvider.tsx
+++ b/apps/dashboard/src/demo/DemoProvider.tsx
@@ -122,7 +122,11 @@ export function DemoProvider({
   const CONFETTI_COOLDOWN_MS = 8000; // 8 seconds between confetti
 
   // Trigger confetti based on event type (toned down - only major events)
+  // Disabled entirely at high speeds (>1x) to avoid visual clutter
   const triggerCelebration = useCallback((event: SimulationEvent) => {
+    // Skip all confetti at high demo speeds
+    if (speed > 1) return;
+
     // Check cooldown before firing confetti
     const now = Date.now();
     if (now - lastConfettiRef.current < CONFETTI_COOLDOWN_MS) {
@@ -141,7 +145,7 @@ export function DemoProvider({
       lastConfettiRef.current = now;
       celebrateElite();
     }
-  }, []);
+  }, [speed]);
 
   // Subscribe to simulation events
   // Re-subscribe when scenario changes (new engine is created)


### PR DESCRIPTION
Fixes the Recent Activity feed looking terrible at 2x+ demo speeds.

## Changes
- **Debounce rendering**: Events arriving within 200ms are batched into a single render cycle at >1x speed
- **Speed-aware animations**: Switches from spring physics to fast 150ms transitions; disables layout animations that caused overlap
- **Confetti disabled at high speeds**: No particle effects when speed >1x to keep data readable  
- **Sequence timestamps**: Shows "Latest", "#2", "#3" instead of all saying "Just now"
- **Simplified icon rendering**: Removed per-icon spring animation that contributed to visual stacking

Items are already capped at 8 visible.