### PR TITLE
fix: make agent cards clickable on dashboard + add See All links

### DIFF
--- a/apps/dashboard/src/components/idle-agents-widget.tsx
+++ b/apps/dashboard/src/components/idle-agents-widget.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { Link } from "react-router-dom";
 import { Sparkles, Clock, CheckCircle, AlertTriangle, UserPlus, Inbox, ChevronRight } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Badge } from "./ui/badge";
@@ -226,9 +227,15 @@ export function IdleAgentsWidget({
             <Sparkles className="h-5 w-5 text-emerald-500" />
           </motion.div>
           <span>Available Agents</span>
-          <Badge variant="secondary" className="ml-auto">
+          <Badge variant="secondary" className="ml-auto mr-2">
             {idleAgents.length}
           </Badge>
+          <Link 
+            to="/agents" 
+            className="text-xs text-cyan-500 hover:text-cyan-400 transition-colors whitespace-nowrap"
+          >
+            See all →
+          </Link>
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-2">

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect, useRef } from "react";
+import { useNavigate, Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   Users,
@@ -140,6 +141,7 @@ function formatEventTime(dateString: string, index?: number, speed?: number) {
 }
 
 export function DashboardPage() {
+  const navigate = useNavigate();
   const { agents } = useAgents();
   const { tasks } = useTasks();
   const { transactions } = useCredits();
@@ -443,10 +445,18 @@ export function DashboardPage() {
         <Card className="lg:col-span-2">
           <CardHeader className="flex flex-row items-center justify-between">
             <CardTitle>Recent Activity</CardTitle>
-            <Badge variant="outline" className="text-xs">
-              <Zap className="h-3 w-3 mr-1" />
-              Live
-            </Badge>
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="text-xs">
+                <Zap className="h-3 w-3 mr-1" />
+                Live
+              </Badge>
+              <Link 
+                to="/events" 
+                className="text-xs text-cyan-500 hover:text-cyan-400 transition-colors whitespace-nowrap"
+              >
+                See all →
+              </Link>
+            </div>
           </CardHeader>
         <CardContent>
           <div className="space-y-3">
@@ -504,6 +514,7 @@ export function DashboardPage() {
         <IdleAgentsWidget 
           maxCount={6} 
           className="lg:col-span-1"
+          onAgentClick={(agent) => navigate(`/agents?selected=${agent.agentId}`)}
         />
       </div>
     </div>


### PR DESCRIPTION
- Wire up onAgentClick on IdleAgentsWidget to navigate to /agents with selected agent
- Add 'See all →' link to Available Agents section header (links to /agents)
- Add 'See all →' link to Recent Activity section header (links to /events)
- Agent cards already had hover states and framer-motion animations