### PR TITLE
ci: auto-cleanup PR caches on close

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,39 @@
+name: Cleanup PR Caches
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup caches for closed PR branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = `refs/pull/${context.payload.pull_request.number}/merge`;
+            const headRef = `refs/heads/${context.payload.pull_request.head.ref}`;
+
+            for (const refToClean of [ref, headRef]) {
+              console.log(`Cleaning caches for ref: ${refToClean}`);
+              try {
+                const caches = await github.rest.actions.getActionsCacheList({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: refToClean,
+                });
+                for (const cache of caches.data.actions_caches) {
+                  console.log(`Deleting cache: ${cache.key} (${cache.id})`);
+                  await github.rest.actions.deleteActionsCacheById({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    cache_id: cache.id,
+                  });
+                }
+              } catch (e) {
+                console.log(`No caches found for ${refToClean}`);
+              }
+            }


### PR DESCRIPTION
Adds a workflow that automatically deletes caches for closed/merged PR branches. Also purged 17 stale caches manually.