### PR TITLE
ci: fix Nx cache key to prevent unbounded growth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,21 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      # Nx cache
-      - name: Cache Nx
-        uses: actions/cache@v4
+      # Nx cache — use restore/save to avoid per-commit key growth
+      - name: Restore Nx cache
+        uses: actions/cache/restore@v4
         with:
           path: .nx/cache
-          key: nx-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          key: nx-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            nx-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
             nx-${{ runner.os }}-
+
+      - name: Save Nx cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: .nx/cache
+          key: nx-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
The Nx cache key included `github.sha`, creating a new ~60MB cache entry for every single commit to main. With 13 PRs merged today, that's 30 caches hitting the repo limit.

**Fix:** Use `actions/cache/restore` + `actions/cache/save` with a stable key based only on `pnpm-lock.yaml` hash. One cache per lockfile version instead of one per commit.

Also purged all stale caches manually.