### PR TITLE
feat: split-panel layout for agents and tasks pages

### DIFF
--- a/apps/dashboard/src/components/agent-detail-panel.tsx
+++ b/apps/dashboard/src/components/agent-detail-panel.tsx
@@ -22,6 +22,8 @@ type Agent = AgentFieldsFragment;
 interface AgentDetailPanelProps {
   agentId: string | null;
   onClose: () => void;
+  /** Render inline (for split-panel) instead of as a fixed overlay */
+  inline?: boolean;
 }
 
 // Level colors matching network page
@@ -631,7 +633,7 @@ function SettingsTab({ agent }: { agent: Agent }) {
   );
 }
 
-export function AgentDetailPanel({ agentId, onClose }: AgentDetailPanelProps) {
+export function AgentDetailPanel({ agentId, onClose, inline }: AgentDetailPanelProps) {
   const { agents } = useAgents();
   const [activeTab, setActiveTab] = useState("overview");
   
@@ -653,26 +655,8 @@ export function AgentDetailPanel({ agentId, onClose }: AgentDetailPanelProps) {
 
   const levelColor = getLevelColor(agent.level);
 
-  return (
-    <AnimatePresence>
-      <div className="fixed inset-0 z-50 flex items-center justify-end">
-        {/* Backdrop */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          onClick={onClose}
-          className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        />
-
-        {/* Panel */}
-        <motion.div
-          initial={{ x: "100%" }}
-          animate={{ x: 0 }}
-          exit={{ x: "100%" }}
-          transition={{ type: "spring", damping: 30, stiffness: 300 }}
-          className="relative h-full w-full max-w-2xl bg-background border-l border-border shadow-2xl flex flex-col"
-        >
+  const panelContent = (
+    <>
           {/* Header */}
           <div 
             className="flex-shrink-0 p-6 border-b border-border"
@@ -779,6 +763,31 @@ export function AgentDetailPanel({ agentId, onClose }: AgentDetailPanelProps) {
               </div>
             </ScrollArea>
           </Tabs>
+    </>
+  );
+
+  if (inline) {
+    return <div className="h-full flex flex-col bg-background">{panelContent}</div>;
+  }
+
+  return (
+    <AnimatePresence>
+      <div className="fixed inset-0 z-50 flex items-center justify-end">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+          className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        />
+        <motion.div
+          initial={{ x: "100%" }}
+          animate={{ x: 0 }}
+          exit={{ x: "100%" }}
+          transition={{ type: "spring", damping: 30, stiffness: 300 }}
+          className="relative h-full w-full max-w-2xl bg-background border-l border-border shadow-2xl flex flex-col"
+        >
+          {panelContent}
         </motion.div>
       </div>
     </AnimatePresence>

--- a/apps/dashboard/src/components/ui/index.ts
+++ b/apps/dashboard/src/components/ui/index.ts
@@ -10,3 +10,4 @@ export * from "./tabs";
 export * from "./tooltip";
 export * from "./empty-state";
 export * from "./sparkline";
+export * from "./split-panel";

--- a/apps/dashboard/src/components/ui/split-panel.tsx
+++ b/apps/dashboard/src/components/ui/split-panel.tsx
@@ -1,0 +1,169 @@
+import { useState, useRef, useCallback, useEffect, type ReactNode } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+const STORAGE_KEY = "split-panel-width";
+
+interface SplitPanelProps {
+  left: ReactNode;
+  right: ReactNode;
+  /** Default left panel width as percentage (0-100). Default 40 */
+  defaultLeftWidth?: number;
+  /** Minimum left panel width in px. Default 250 */
+  minLeft?: number;
+  /** Minimum right panel width in px. Default 300 */
+  minRight?: number;
+  /** localStorage key suffix for persisting width */
+  storageKey?: string;
+  /** Whether the right panel has content to show */
+  rightOpen?: boolean;
+  /** Placeholder for empty right panel */
+  rightPlaceholder?: ReactNode;
+}
+
+export function SplitPanel({
+  left,
+  right,
+  defaultLeftWidth = 40,
+  minLeft = 250,
+  minRight = 300,
+  storageKey = "default",
+  rightOpen = true,
+  rightPlaceholder,
+}: SplitPanelProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+  const [collapsed, setCollapsed] = useState(false);
+
+  // Load persisted width or use default
+  const [leftPercent, setLeftPercent] = useState(() => {
+    try {
+      const stored = localStorage.getItem(`${STORAGE_KEY}-${storageKey}`);
+      if (stored) return Number(stored);
+    } catch {}
+    return defaultLeftWidth;
+  });
+
+  // Persist width changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(`${STORAGE_KEY}-${storageKey}`, String(leftPercent));
+    } catch {}
+  }, [leftPercent, storageKey]);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDragging.current = true;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const totalWidth = rect.width;
+      const x = e.clientX - rect.left;
+      const percent = (x / totalWidth) * 100;
+
+      // Enforce min widths
+      const minLeftPercent = (minLeft / totalWidth) * 100;
+      const maxLeftPercent = 100 - (minRight / totalWidth) * 100;
+      const clamped = Math.max(minLeftPercent, Math.min(maxLeftPercent, percent));
+      setLeftPercent(clamped);
+      if (collapsed) setCollapsed(false);
+    };
+
+    const handleMouseUp = () => {
+      isDragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+  }, [minLeft, minRight, collapsed]);
+
+  const handleDoubleClick = useCallback(() => {
+    setCollapsed((c) => !c);
+  }, []);
+
+  // Keyboard shortcut: [ to toggle collapse
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "[" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setCollapsed((c) => !c);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const effectiveLeft = collapsed ? 0 : leftPercent;
+
+  return (
+    <>
+      {/* Desktop: side-by-side */}
+      <div
+        ref={containerRef}
+        className="hidden md:flex h-[calc(100vh-12rem)] w-full overflow-hidden rounded-lg border border-border"
+      >
+        {/* Left panel */}
+        <motion.div
+          animate={{ width: `${effectiveLeft}%` }}
+          transition={{ type: "spring", stiffness: 400, damping: 35 }}
+          className="h-full overflow-hidden flex-shrink-0"
+          style={{ minWidth: collapsed ? 0 : minLeft }}
+        >
+          <div className="h-full overflow-auto">{left}</div>
+        </motion.div>
+
+        {/* Drag handle */}
+        <div
+          onMouseDown={handleMouseDown}
+          onDoubleClick={handleDoubleClick}
+          className="group relative flex-shrink-0 w-1 cursor-col-resize bg-slate-700 hover:bg-slate-500 transition-colors"
+          title="Drag to resize • Double-click to collapse • Cmd+[ to toggle"
+        >
+          {/* Grip dots */}
+          <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 flex flex-col items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="w-1 h-1 rounded-full bg-slate-400" />
+            ))}
+          </div>
+        </div>
+
+        {/* Right panel */}
+        <div className="flex-1 h-full overflow-auto min-w-0">
+          {rightOpen ? (
+            right
+          ) : (
+            rightPlaceholder || (
+              <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+                Select an item to view details
+              </div>
+            )
+          )}
+        </div>
+      </div>
+
+      {/* Mobile: stacked with slide-over */}
+      <div className="md:hidden">
+        <div className="min-h-[50vh]">{left}</div>
+        <AnimatePresence>
+          {rightOpen && (
+            <motion.div
+              initial={{ x: "100%" }}
+              animate={{ x: 0 }}
+              exit={{ x: "100%" }}
+              transition={{ type: "spring", stiffness: 300, damping: 30 }}
+              className="fixed inset-0 z-50 bg-background overflow-auto"
+            >
+              {right}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </>
+  );
+}

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -36,6 +36,7 @@ import { Progress } from "../components/ui/progress";
 import { EmptyState } from "../components/ui/empty-state";
 import { AgentModeBadge, AgentModeSelector, AgentModeCard } from "../components/agent-mode-selector";
 import { AgentDetailPanel } from "../components/agent-detail-panel";
+import { SplitPanel } from "../components/ui/split-panel";
 
 // Use generated types from GraphQL
 import { AgentMode, AgentStatus } from "../graphql/generated/graphql";
@@ -877,7 +878,11 @@ export function AgentsPage() {
         </TabsList>
 
         {/* All Agents Tab */}
-        <TabsContent value="agents" className="space-y-6">
+        <TabsContent value="agents">
+      <SplitPanel
+        storageKey="agents"
+        rightOpen={!!detailPanelAgentId}
+        left={<div className="p-4 space-y-6">
       {/* Filters and Search */}
       <div className="flex flex-wrap gap-3 items-center">
         {/* Search */}
@@ -1058,6 +1063,15 @@ export function AgentsPage() {
       {selectedAgent && dialogMode === "credits" && (
         <AdjustCreditsDialog agent={selectedAgent} onClose={handleCloseDialog} />
       )}
+      </div>}
+        right={
+          <AgentDetailPanel
+            agentId={detailPanelAgentId}
+            onClose={() => setDetailPanelAgentId(null)}
+            inline
+          />
+        }
+      />
         </TabsContent>
 
         {/* Reputation Tab */}
@@ -1081,11 +1095,7 @@ export function AgentsPage() {
         </TabsContent>
       </Tabs>
 
-      {/* Agent Detail Panel */}
-      <AgentDetailPanel 
-        agentId={detailPanelAgentId} 
-        onClose={() => setDetailPanelAgentId(null)} 
-      />
+      {/* Agent Detail Panel now integrated in SplitPanel above */}
     </div>
   );
 }

--- a/apps/dashboard/src/pages/tasks.tsx
+++ b/apps/dashboard/src/pages/tasks.tsx
@@ -9,6 +9,7 @@ import { ScrollArea } from "../components/ui/scroll-area";
 import { PhaseChip } from "../components/phase-chip";
 import { EmptyState } from "../components/ui/empty-state";
 import { useTasks, type Task, useCurrentPhase } from "../hooks";
+import { SplitPanel } from "../components/ui/split-panel";
 
 type SortField = "created" | "priority" | "status" | "title";
 type SortDirection = "asc" | "desc";
@@ -203,13 +204,8 @@ function TaskDetailSidebar({ task, onClose }: TaskDetailSidebarProps) {
   const hasRejection = task.rejection && task.status === "REVIEW";
   
   return (
-    <motion.div
-      initial={{ x: "100%", opacity: 0 }}
-      animate={{ x: 0, opacity: 1 }}
-      exit={{ x: "100%", opacity: 0 }}
-      transition={{ type: "spring", stiffness: 300, damping: 30 }}
-      className="fixed right-0 top-0 h-full w-full sm:w-[400px] bg-background border-l border-border shadow-xl z-30 flex flex-col"
-    >
+    <div className="h-full bg-background flex flex-col">
+
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-border">
         <div className="flex items-center gap-2">
@@ -399,7 +395,7 @@ function TaskDetailSidebar({ task, onClose }: TaskDetailSidebarProps) {
           )}
         </div>
       </div>
-    </motion.div>
+    </div>
   );
 }
 
@@ -628,7 +624,11 @@ export function TasksPage() {
   }
 
   return (
-    <div className={`space-y-6 transition-all ${selectedTask ? "mr-0 sm:mr-[400px]" : ""}`}>
+    <SplitPanel
+      storageKey="tasks"
+      defaultLeftWidth={55}
+      rightOpen={!!selectedTask}
+      left={<div className="p-4 space-y-6">
       {/* Page header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -733,15 +733,15 @@ export function TasksPage() {
         </TabsContent>
       </Tabs>
       
-      {/* Task Detail Sidebar - no backdrop, stays open */}
-      <AnimatePresence>
-        {selectedTask && (
+    </div>}
+      right={
+        selectedTask ? (
           <TaskDetailSidebar 
             task={selectedTask} 
             onClose={() => setSelectedTask(null)} 
           />
-        )}
-      </AnimatePresence>
-    </div>
+        ) : null
+      }
+    />
   );
 }


### PR DESCRIPTION
Closes #180

## Changes
- **New SplitPanel component** (`apps/dashboard/src/components/ui/split-panel.tsx`)
  - Resizable two-panel layout with drag handle
  - Props: `left`, `right`, `defaultLeftWidth`, `minLeft`, `minRight`, `storageKey`, `rightOpen`, `rightPlaceholder`
  - Drag handle: 4px slate-700 bar, slate-500 on hover, grip dots pattern
  - Smooth mouse-event-based resize (no jank)
  - Double-click handle or Cmd+[ to collapse/expand left panel
  - framer-motion spring animations for collapse/expand
  - Panel width persisted in localStorage
  - Mobile: vertical stack with slide-over overlay from right

- **Agents page** — left panel: agent list with filters/stats/grid; right panel: inline AgentDetailPanel
- **Tasks page** — left panel: task list/kanban; right panel: task detail sidebar
- **AgentDetailPanel** — added `inline` prop for embedded rendering (no backdrop/fixed overlay)

## Design
- Dark theme compatible, matches existing slate color palette
- Placeholder shown when no item selected