### PR TITLE
fix: move network stats bar to top header

### DIFF
--- a/apps/dashboard/src/pages/network.tsx
+++ b/apps/dashboard/src/pages/network.tsx
@@ -27,43 +27,38 @@ export function NetworkPage() {
 
   return (
     <div className="h-[calc(100vh-theme(spacing.16))] -m-6 lg:-m-6 -mx-4 sm:-mx-6">
-      {/* Header overlay - hidden on mobile/landscape, shown on larger screens */}
-      <div className="hidden landscape:hidden sm:portrait:block lg:block absolute top-4 sm:top-6 left-1/2 -translate-x-1/2 z-10 text-center px-4">
-        <h1 className="text-xl sm:text-2xl font-bold text-white mb-1">Agent Network</h1>
-        <p className="text-xs sm:text-sm text-zinc-400">
-          Real-time agent hierarchy
-        </p>
-      </div>
-
-      {/* Stats bar - compact horizontal strip on landscape, grid on portrait mobile */}
-      <div className="absolute bottom-4 sm:bottom-6 left-1/2 -translate-x-1/2 z-10 
-        bg-zinc-900/90 backdrop-blur border border-zinc-800 
-        rounded-full px-3 sm:px-6 py-1.5 sm:py-3
-        w-auto max-w-[calc(100%-8rem)] landscape:max-w-none sm:max-w-none">
-        <div className="flex gap-3 sm:gap-6 items-center">
-          <div className="text-center">
-            <div className="text-base sm:text-xl font-bold text-white">14</div>
-            <div className="text-[9px] sm:text-xs text-zinc-500 hidden landscape:hidden sm:block">Agents</div>
+      {/* Header bar with title + stats */}
+      <div className="absolute top-4 sm:top-6 left-1/2 -translate-x-1/2 z-10
+        bg-zinc-900/90 backdrop-blur border border-zinc-800
+        rounded-full px-4 sm:px-6 py-2 sm:py-3
+        w-auto max-w-[calc(100%-4rem)]">
+        <div className="flex gap-4 sm:gap-6 items-center">
+          <div className="hidden sm:block">
+            <h1 className="text-sm sm:text-base font-bold text-white leading-tight">Agent Network</h1>
+            <p className="text-[10px] sm:text-xs text-zinc-500">Real-time hierarchy</p>
           </div>
-          <div className="w-px h-6 bg-zinc-700 hidden sm:block" />
-          <div className="text-center">
-            <div className="text-base sm:text-xl font-bold text-emerald-500">11</div>
-            <div className="text-[9px] sm:text-xs text-zinc-500 hidden landscape:hidden sm:block">Active</div>
-          </div>
-          <div className="w-px h-6 bg-zinc-700 hidden sm:block" />
-          <div className="text-center">
-            <div className="text-base sm:text-xl font-bold text-amber-500">2</div>
-            <div className="text-[9px] sm:text-xs text-zinc-500 hidden landscape:hidden sm:block">Pending</div>
-          </div>
-          <div className="w-px h-6 bg-zinc-700 hidden sm:block" />
-          <div className="text-center">
-            <div className="text-base sm:text-xl font-bold text-violet-500">1</div>
-            <div className="text-[9px] sm:text-xs text-zinc-500 hidden landscape:hidden sm:block">Paused</div>
-          </div>
-          <div className="w-px h-6 bg-zinc-700 hidden sm:block" />
-          <div className="text-center">
-            <div className="text-base sm:text-xl font-bold text-white">98.7K</div>
-            <div className="text-[9px] sm:text-xs text-zinc-500 hidden landscape:hidden sm:block">Credits</div>
+          <div className="w-px h-8 bg-zinc-700 hidden sm:block" />
+          <div className="flex gap-3 sm:gap-5 items-center">
+            <div className="text-center">
+              <div className="text-sm sm:text-lg font-bold text-white">14</div>
+              <div className="text-[9px] sm:text-xs text-zinc-500">Agents</div>
+            </div>
+            <div className="text-center">
+              <div className="text-sm sm:text-lg font-bold text-emerald-500">11</div>
+              <div className="text-[9px] sm:text-xs text-zinc-500">Active</div>
+            </div>
+            <div className="text-center">
+              <div className="text-sm sm:text-lg font-bold text-amber-500">2</div>
+              <div className="text-[9px] sm:text-xs text-zinc-500">Pending</div>
+            </div>
+            <div className="text-center">
+              <div className="text-sm sm:text-lg font-bold text-violet-500">1</div>
+              <div className="text-[9px] sm:text-xs text-zinc-500">Paused</div>
+            </div>
+            <div className="text-center">
+              <div className="text-sm sm:text-lg font-bold text-white">98.7K</div>
+              <div className="text-[9px] sm:text-xs text-zinc-500">Credits</div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Stats bar overlapped with demo controls at bottom. Combined title + stats into a single top header bar.