### PR TITLE
feat: responsive redesign for mobile and tablet layouts

### DIFF
--- a/apps/dashboard/src/components/dashboard-grid.tsx
+++ b/apps/dashboard/src/components/dashboard-grid.tsx
@@ -224,18 +224,19 @@ export function DashboardToolbar({
   const [showPresets, setShowPresets] = useState(false);
 
   return (
-    <div className="flex items-center gap-2 flex-wrap">
+    <div className="flex items-center gap-1.5 sm:gap-2 flex-wrap">
       {/* Edit mode toggle */}
       <button
         onClick={() => setEditMode(!editMode)}
-        className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+        className={`inline-flex items-center gap-1.5 px-2 sm:px-3 py-1.5 text-xs sm:text-sm rounded-lg border transition-colors min-h-[36px] sm:min-h-0 ${
           editMode
             ? "bg-cyan-500/10 border-cyan-500/50 text-cyan-400"
             : "border-border text-muted-foreground hover:text-foreground hover:bg-accent"
         }`}
       >
         <LayoutGrid className="h-3.5 w-3.5" />
-        {editMode ? "Done" : "Edit layout"}
+        <span className="hidden sm:inline">{editMode ? "Done" : "Edit layout"}</span>
+        <span className="sm:hidden">{editMode ? "Done" : "Edit"}</span>
       </button>
 
       {/* Widget picker */}
@@ -367,7 +368,7 @@ export function DashboardGrid({
         items={visibleWidgets.map((w) => w.id)}
         strategy={verticalListSortingStrategy}
       >
-        <div className="space-y-6">
+        <div className="space-y-4 sm:space-y-6">
           <AnimatePresence mode="popLayout">
             {visibleWidgets.map((widget) => (
               <motion.div

--- a/apps/dashboard/src/components/idle-agents-widget.tsx
+++ b/apps/dashboard/src/components/idle-agents-widget.tsx
@@ -238,16 +238,20 @@ export function IdleAgentsWidget({
           </Link>
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-2">
-        <AnimatePresence mode="popLayout">
-          {idleAgents.map((idleInfo) => (
-            <IdleAgentCard
-              key={idleInfo.agent.id}
-              idleInfo={idleInfo}
-              onClick={() => onAgentClick?.(idleInfo.agent)}
-            />
-          ))}
-        </AnimatePresence>
+      <CardContent>
+        {/* Horizontal scroll on mobile, vertical list on desktop */}
+        <div className="flex gap-3 overflow-x-auto pb-2 -mx-2 px-2 snap-x snap-mandatory sm:snap-none sm:flex-col sm:overflow-x-visible sm:mx-0 sm:px-0 sm:pb-0 sm:space-y-2 sm:gap-0 scrollbar-hide">
+          <AnimatePresence mode="popLayout">
+            {idleAgents.map((idleInfo) => (
+              <div key={idleInfo.agent.id} className="flex-shrink-0 w-[260px] snap-start sm:w-full sm:flex-shrink">
+                <IdleAgentCard
+                  idleInfo={idleInfo}
+                  onClick={() => onAgentClick?.(idleInfo.agent)}
+                />
+              </div>
+            ))}
+          </AnimatePresence>
+        </div>
         
         {agents.filter(a => a.status === "ACTIVE").length > 0 && (
           <div className="pt-2 text-center">

--- a/apps/dashboard/src/components/ui/page-header.tsx
+++ b/apps/dashboard/src/components/ui/page-header.tsx
@@ -8,11 +8,11 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
-    <div className="flex items-center justify-between">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div>
-        <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
+        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">{title}</h1>
         {description && (
-          <p className="text-muted-foreground">{description}</p>
+          <p className="text-sm sm:text-base text-muted-foreground">{description}</p>
         )}
       </div>
       {actions && <div className="flex items-center gap-2">{actions}</div>}

--- a/apps/dashboard/src/components/ui/stat-card.tsx
+++ b/apps/dashboard/src/components/ui/stat-card.tsx
@@ -27,20 +27,20 @@ export function StatCard({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <CardTitle className="text-sm font-medium text-muted-foreground">
+      <CardHeader className="flex flex-row items-center justify-between pb-2 p-3 sm:p-6 sm:pb-2">
+        <CardTitle className="text-xs sm:text-sm font-medium text-muted-foreground">
           {title}
         </CardTitle>
-        {Icon && <Icon className="h-4 w-4 text-muted-foreground" />}
+        {Icon && <Icon className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-muted-foreground" />}
       </CardHeader>
-      <CardContent>
+      <CardContent className="p-3 pt-0 sm:p-6 sm:pt-0">
         <div className="flex items-center justify-between gap-2">
           <motion.div
             key={String(value)}
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ type: "spring", stiffness: 400, damping: 30 }}
-            className="text-2xl font-bold"
+            className="text-xl sm:text-2xl font-bold"
           >
             {value}
           </motion.div>

--- a/apps/dashboard/src/pages/credits.tsx
+++ b/apps/dashboard/src/pages/credits.tsx
@@ -87,40 +87,40 @@ function TransactionVirtualList({ transactions }: { transactions: ReturnType<typ
                   width: "100%",
                   transform: `translateY(${virtualRow.start}px)`,
                 }}
-                className="flex items-center justify-between rounded-lg border border-border p-3"
+                className="flex items-center justify-between gap-2 rounded-lg border border-border p-2 sm:p-3 min-h-[44px]"
               >
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-2 sm:gap-3 min-w-0">
                   {tx.type === "CREDIT" ? (
                     <motion.div
                       initial={{ scale: 0 }}
                       animate={{ scale: 1 }}
                       transition={{ type: "spring", delay: 0.1 }}
-                      className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/10"
+                      className="flex h-7 w-7 sm:h-8 sm:w-8 items-center justify-center rounded-full bg-emerald-500/10 shrink-0"
                     >
-                      <ArrowUpRight className="h-4 w-4 text-emerald-500" />
+                      <ArrowUpRight className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-emerald-500" />
                     </motion.div>
                   ) : (
                     <motion.div
                       initial={{ scale: 0 }}
                       animate={{ scale: 1 }}
                       transition={{ type: "spring", delay: 0.1 }}
-                      className="flex h-8 w-8 items-center justify-center rounded-full bg-amber-500/10"
+                      className="flex h-7 w-7 sm:h-8 sm:w-8 items-center justify-center rounded-full bg-amber-500/10 shrink-0"
                     >
-                      <ArrowDownLeft className="h-4 w-4 text-amber-500" />
+                      <ArrowDownLeft className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-amber-500" />
                     </motion.div>
                   )}
-                  <div>
-                    <p className="text-sm font-medium">{tx.reason}</p>
-                    <p className="text-xs text-muted-foreground">
+                  <div className="min-w-0">
+                    <p className="text-xs sm:text-sm font-medium truncate">{tx.reason}</p>
+                    <p className="text-[10px] sm:text-xs text-muted-foreground">
                       {formatDate(tx.createdAt)} at {formatTime(tx.createdAt)}
                     </p>
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="text-right shrink-0">
                   <motion.p
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
-                    className={`font-medium ${
+                    className={`text-sm sm:text-base font-medium ${
                       tx.type === "CREDIT"
                         ? "text-emerald-500"
                         : "text-amber-500"
@@ -129,8 +129,8 @@ function TransactionVirtualList({ transactions }: { transactions: ReturnType<typ
                     {tx.type === "CREDIT" ? "+" : "-"}
                     {tx.amount.toLocaleString()}
                   </motion.p>
-                  <p className="text-xs text-muted-foreground">
-                    Balance: {tx.balanceAfter.toLocaleString()}
+                  <p className="text-[10px] sm:text-xs text-muted-foreground">
+                    Bal: {tx.balanceAfter.toLocaleString()}
                   </p>
                 </div>
               </motion.div>
@@ -224,7 +224,7 @@ export function CreditsPage() {
       />
 
       {/* Stats */}
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid gap-3 sm:gap-4 grid-cols-2 lg:grid-cols-4">
         <StatCard
           title="Net Balance"
           value={netBalance.toLocaleString()}
@@ -256,14 +256,14 @@ export function CreditsPage() {
       </div>
 
       {/* Chart and transactions */}
-      <div className="grid gap-4 lg:grid-cols-2">
+      <div className="grid gap-4 grid-cols-1 lg:grid-cols-2">
         {/* Balance chart */}
         <Card>
           <CardHeader>
-            <CardTitle>Balance Over Time</CardTitle>
+            <CardTitle className="text-base sm:text-lg">Balance Over Time</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="h-[300px]">
+            <div className="h-[220px] sm:h-[300px]">
               {balanceHistory.length > 0 ? (
                 <ResponsiveContainer width="100%" height="100%">
                   <AreaChart data={balanceHistory}>
@@ -334,7 +334,7 @@ export function CreditsPage() {
       </div>
 
       {/* Advanced Analytics Section */}
-      <div className="grid gap-6 md:grid-cols-2 mt-6">
+      <div className="grid gap-4 sm:gap-6 grid-cols-1 md:grid-cols-2 mt-4 sm:mt-6">
         <BudgetBurndown
           budget={25000}
           spent={totalSpent || 9250}

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -205,7 +205,7 @@ export function DashboardPage() {
     switch (id) {
       case "stats-overview":
         return (
-          <StaggerContainer className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <StaggerContainer className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
             <StaggerItem><StatCard
               title="Active Agents"
               value={activeAgents}
@@ -262,10 +262,10 @@ export function DashboardPage() {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Credit Flow</CardTitle>
+          <CardTitle className="text-base sm:text-lg">Credit Flow</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="h-[300px]">
+          <div className="h-[220px] sm:h-[300px]">
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={creditHistory}>
                 <defs>
@@ -302,10 +302,10 @@ export function DashboardPage() {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Tasks by Status</CardTitle>
+          <CardTitle className="text-base sm:text-lg">Tasks by Status</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="h-[300px]">
+          <div className="h-[220px] sm:h-[300px]">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={tasksByStatus} layout="vertical">
                 <CartesianGrid strokeDasharray="3 3" className="stroke-border" horizontal={false} />
@@ -363,18 +363,18 @@ export function DashboardPage() {
                     ? { duration: 0.15 }
                     : { type: "spring", stiffness: 400, damping: 30, delay: index * 0.03 }
                   }
-                  className="flex items-center justify-between rounded-lg border border-border p-3 hover:bg-accent/50 transition-colors"
+                  className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 rounded-lg border border-border p-3 hover:bg-accent/50 transition-colors min-h-[44px]"
                 >
-                  <div className="flex items-center gap-3">
-                    <div>{getEventIcon(event.type)}</div>
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="shrink-0">{getEventIcon(event.type)}</div>
                     <div className="min-w-0">
                       <p className="text-sm font-medium truncate">{event.actor?.name || "System"}</p>
-                      <p className="text-xs text-muted-foreground truncate max-w-[200px]">
+                      <p className="text-xs text-muted-foreground truncate max-w-[200px] sm:max-w-[300px]">
                         {event.reasoning || event.type.replace(/\./g, ' → ')}
                       </p>
                     </div>
                   </div>
-                  <div className="flex items-center gap-2 flex-shrink-0">
+                  <div className="flex items-center gap-2 flex-shrink-0 pl-7 sm:pl-0">
                     <Badge variant={getEventBadgeVariant(event.type)} className="text-xs">
                       {event.type.split('.').pop()}
                     </Badge>

--- a/apps/dashboard/src/pages/events.tsx
+++ b/apps/dashboard/src/pages/events.tsx
@@ -115,26 +115,26 @@ function EventVirtualList({ filteredEvents }: { filteredEvents: ReturnType<typeo
                   width: "100%",
                   transform: `translateY(${virtualRow.start}px)`,
                 }}
-                className="flex items-start gap-4 p-4 hover:bg-accent/50 transition-colors border-b border-border"
+                className="flex items-start gap-3 sm:gap-4 p-3 sm:p-4 hover:bg-accent/50 transition-colors border-b border-border min-h-[44px]"
               >
                 <motion.div
                   initial={{ scale: 0, rotate: -180 }}
                   animate={{ scale: 1, rotate: 0 }}
                   transition={{ type: "spring", delay: 0.1 }}
-                  className="mt-0.5"
+                  className="mt-0.5 shrink-0"
                 >
                   {getSeverityIcon(event.severity)}
                 </motion.div>
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    <Badge variant={getSeverityVariant(event.severity)}>
+                  <div className="flex items-center gap-2 mb-1 flex-wrap">
+                    <Badge variant={getSeverityVariant(event.severity)} className="text-xs">
                       {event.type}
                     </Badge>
                     <span className="text-xs text-muted-foreground">
                       {formatTime(event.createdAt)}
                     </span>
                   </div>
-                  <p className="text-sm">
+                  <p className="text-xs sm:text-sm">
                     <span className="font-medium">{event.actor?.name || "System"}</span>
                     {" "}
                     <span className="text-muted-foreground">
@@ -142,7 +142,7 @@ function EventVirtualList({ filteredEvents }: { filteredEvents: ReturnType<typeo
                     </span>
                   </p>
                   {event.reasoning && (
-                    <p className="text-xs text-muted-foreground mt-1 italic">
+                    <p className="text-xs text-muted-foreground mt-1 italic line-clamp-2 sm:line-clamp-none">
                       "{event.reasoning}"
                     </p>
                   )}
@@ -202,7 +202,7 @@ export function EventsPage() {
       />
 
       {/* Stats */}
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid gap-3 sm:gap-4 grid-cols-2 lg:grid-cols-4">
         <StatCard title="Total Events" value={events.length} icon={Activity} />
         <StatCard title="Critical" value={severityCounts.critical} icon={AlertCircle} />
         <StatCard title="Warnings" value={severityCounts.warning} icon={AlertTriangle} />

--- a/apps/dashboard/src/pages/settings.tsx
+++ b/apps/dashboard/src/pages/settings.tsx
@@ -22,7 +22,7 @@ export function SettingsPage() {
       />
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-        <TabsList className="grid w-full grid-cols-8 lg:w-[1120px]">
+        <TabsList className="flex overflow-x-auto sm:grid sm:w-full sm:grid-cols-8 lg:w-[1120px] scrollbar-hide">
           <TabsTrigger value="profile" className="flex items-center gap-2">
             <User className="h-4 w-4" />
             <span className="hidden sm:inline">Profile</span>

--- a/apps/dashboard/src/pages/tasks.tsx
+++ b/apps/dashboard/src/pages/tasks.tsx
@@ -112,10 +112,10 @@ function TaskCard({ task, onClick, compact }: TaskCardProps) {
       transition={{ type: "spring", stiffness: 400, damping: 30 }}
       onClick={onClick}
     >
-      <Card className={`cursor-pointer transition-all hover:bg-accent/50 hover:shadow-md hover:border-primary/20 ${
+      <Card className={`cursor-pointer transition-all hover:bg-accent/50 hover:shadow-md hover:border-primary/20 min-h-[44px] ${
         hasRejection ? 'border-amber-500/50 bg-amber-500/5' : ''
       }`}>
-        <CardContent className="p-3">
+        <CardContent className={compact ? "p-2 sm:p-3" : "p-3"}>
           <div className="flex items-start gap-2">
             <GripVertical className="h-4 w-4 mt-0.5 text-muted-foreground/50 flex-shrink-0" />
             <div className="flex-1 min-w-0 space-y-2">
@@ -401,11 +401,11 @@ function TaskDetailSidebar({ task, onClose }: TaskDetailSidebarProps) {
 
 function KanbanView({ tasks, onTaskClick }: { tasks: Task[]; onTaskClick: (task: Task) => void }) {
   return (
-    <div className="flex gap-3 sm:gap-4 overflow-x-auto pb-4 -mx-4 px-4 sm:mx-0 sm:px-0 snap-x snap-mandatory sm:snap-none">
+    <div className="flex gap-3 sm:gap-4 overflow-x-auto pb-4 -mx-3 px-3 sm:-mx-4 sm:px-4 md:mx-0 md:px-0 snap-x snap-mandatory md:snap-none scrollbar-hide">
       {statusColumns.map((column) => {
         const columnTasks = tasks.filter((t) => t.status?.toUpperCase() === column.id);
         return (
-          <div key={column.id} className="flex-shrink-0 w-[280px] sm:w-72 snap-start">
+          <div key={column.id} className="flex-shrink-0 w-[75vw] sm:w-[280px] md:w-72 snap-center sm:snap-start">
             <div className="flex items-center gap-2 mb-3 sticky top-0 bg-background/95 backdrop-blur-sm py-1 z-10">
               <div className={`w-2 h-2 rounded-full ${column.color}`} />
               <h3 className="font-medium text-sm">{column.label}</h3>
@@ -413,11 +413,11 @@ function KanbanView({ tasks, onTaskClick }: { tasks: Task[]; onTaskClick: (task:
                 {columnTasks.length}
               </Badge>
             </div>
-            <ScrollArea className="h-[calc(100vh-360px)] sm:h-[calc(100vh-320px)]">
+            <ScrollArea className="h-[calc(100vh-400px)] sm:h-[calc(100vh-360px)] md:h-[calc(100vh-320px)]">
               <div className="space-y-2 pr-2">
                 <AnimatePresence mode="popLayout">
                   {columnTasks.map((task) => (
-                    <TaskCard key={task.id} task={task} onClick={() => onTaskClick(task)} />
+                    <TaskCard key={task.id} task={task} onClick={() => onTaskClick(task)} compact />
                   ))}
                 </AnimatePresence>
                 {columnTasks.length === 0 && (
@@ -459,44 +459,49 @@ function ListView({ tasks, onTaskClick, selectedTaskId }: ListViewProps) {
                 exit={{ opacity: 0, x: 20 }}
                 transition={{ type: "spring", stiffness: 400, damping: 30 }}
                 onClick={() => onTaskClick(task)}
-                className={`flex items-center gap-4 p-4 hover:bg-accent/50 transition-colors cursor-pointer ${
+                className={`flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 p-3 sm:p-4 hover:bg-accent/50 transition-colors cursor-pointer min-h-[44px] ${
                   isSelected ? "bg-accent/70 border-l-2 border-l-primary" : ""
                 }`}
               >
-                <span className="font-mono text-sm text-muted-foreground w-20 flex-shrink-0">
-                  {task.identifier}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium truncate">{task.title}</p>
+                {/* Mobile: stacked layout */}
+                <div className="flex items-center gap-2 sm:contents">
+                  <span className="font-mono text-xs sm:text-sm text-muted-foreground sm:w-20 flex-shrink-0">
+                    {task.identifier}
+                  </span>
+                  <Badge variant={getPriorityVariant(task.priority)} className="flex-shrink-0 sm:order-3">
+                    {task.priority?.toLowerCase()}
+                  </Badge>
+                  <Badge
+                    variant={task.status === "DONE" ? "success" : "secondary"}
+                    className="sm:w-24 sm:justify-center flex-shrink-0 sm:order-4"
+                  >
+                    {task.status?.replace("_", " ").toLowerCase()}
+                  </Badge>
                 </div>
-                <Badge variant={getPriorityVariant(task.priority)} className="flex-shrink-0">
-                  {task.priority?.toLowerCase()}
-                </Badge>
-                <Badge
-                  variant={task.status === "DONE" ? "success" : "secondary"}
-                  className="w-24 justify-center flex-shrink-0"
-                >
-                  {task.status?.replace("_", " ").toLowerCase()}
-                </Badge>
-                {task.assignee ? (
-                  <div className="flex items-center gap-1 w-28 flex-shrink-0">
-                    <div className="w-5 h-5 rounded-full bg-primary/20 flex items-center justify-center text-xs">
-                      🤖
+                <div className="flex-1 min-w-0 sm:order-2">
+                  <p className="font-medium truncate text-sm sm:text-base">{task.title}</p>
+                </div>
+                <div className="flex items-center gap-3 sm:contents text-xs sm:text-sm pl-0 sm:pl-0">
+                  {task.assignee ? (
+                    <div className="flex items-center gap-1 sm:w-28 flex-shrink-0 sm:order-5">
+                      <div className="w-5 h-5 rounded-full bg-primary/20 flex items-center justify-center text-xs">
+                        🤖
+                      </div>
+                      <span className="text-muted-foreground truncate">
+                        {task.assignee.name}
+                      </span>
                     </div>
-                    <span className="text-sm text-muted-foreground truncate">
-                      {task.assignee.name}
+                  ) : (
+                    <span className="text-muted-foreground/50 sm:w-28 flex-shrink-0 italic sm:order-5 hidden sm:inline">
+                      Unassigned
                     </span>
-                  </div>
-                ) : (
-                  <span className="text-sm text-muted-foreground/50 w-28 flex-shrink-0 italic">
-                    Unassigned
-                  </span>
-                )}
-                {dueDate && (
-                  <span className={`text-xs w-16 flex-shrink-0 ${isOverdue ? 'text-red-500' : 'text-muted-foreground'}`}>
-                    {dueDate}
-                  </span>
-                )}
+                  )}
+                  {dueDate && (
+                    <span className={`sm:w-16 flex-shrink-0 sm:order-6 ${isOverdue ? 'text-red-500' : 'text-muted-foreground'}`}>
+                      {dueDate}
+                    </span>
+                  )}
+                </div>
               </motion.div>
             );
           })}
@@ -657,64 +662,68 @@ export function TasksPage() {
         
         <TabsContent value="list" className="mt-4 space-y-4">
           {/* Filters and Sort for List view */}
-          <div className="flex flex-wrap gap-3 items-center">
-            {/* Search */}
-            <div className="relative flex-1 min-w-[200px] max-w-sm">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <input
-                type="text"
-                placeholder="Search tasks..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-9 pr-3 py-2 text-sm rounded-md border border-input bg-background focus:outline-none focus:ring-2 focus:ring-ring"
-              />
+          <div className="space-y-3">
+            <div className="flex gap-3 items-center">
+              {/* Search */}
+              <div className="relative flex-1 min-w-0 max-w-sm">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <input
+                  type="text"
+                  placeholder="Search tasks..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="w-full pl-9 pr-3 py-2 text-sm rounded-md border border-input bg-background focus:outline-none focus:ring-2 focus:ring-ring min-h-[44px] sm:min-h-0"
+                />
+              </div>
             </div>
             
-            {/* Status Filter */}
-            <select
-              value={statusFilter}
-              onChange={(e) => setStatusFilter(e.target.value)}
-              className="px-3 py-2 text-sm rounded-md border border-input bg-background focus:outline-none focus:ring-2 focus:ring-ring"
-            >
-              <option value="all">All Status</option>
-              <option value="BACKLOG">Backlog</option>
-              <option value="TODO">To Do</option>
-              <option value="IN_PROGRESS">In Progress</option>
-              <option value="REVIEW">Review</option>
-              <option value="DONE">Done</option>
-              <option value="BLOCKED">Blocked</option>
-            </select>
-            
-            {/* Priority Filter */}
-            <select
-              value={priorityFilter}
-              onChange={(e) => setPriorityFilter(e.target.value)}
-              className="px-3 py-2 text-sm rounded-md border border-input bg-background focus:outline-none focus:ring-2 focus:ring-ring"
-            >
-              <option value="all">All Priority</option>
-              <option value="URGENT">Urgent</option>
-              <option value="HIGH">High</option>
-              <option value="NORMAL">Normal</option>
-              <option value="LOW">Low</option>
-            </select>
-            
-            {/* Sort buttons */}
-            <div className="flex items-center gap-1 ml-auto">
-              <span className="text-sm text-muted-foreground">Sort:</span>
-              {(["created", "priority", "status", "title"] as SortField[]).map((field) => (
-                <Button
-                  key={field}
-                  variant={sortField === field ? "secondary" : "ghost"}
-                  size="sm"
-                  onClick={() => handleSort(field)}
-                  className="capitalize"
-                >
-                  {field === "created" ? "Date" : field}
-                  {sortField === field && (
-                    <ArrowUpDown className={`ml-1 h-3 w-3 ${sortDirection === "desc" ? "rotate-180" : ""}`} />
-                  )}
-                </Button>
-              ))}
+            <div className="flex flex-wrap gap-3 items-center">
+              {/* Status Filter */}
+              <select
+                value={statusFilter}
+                onChange={(e) => setStatusFilter(e.target.value)}
+                className="px-3 py-2 text-sm rounded-md border border-input bg-background focus:outline-none focus:ring-2 focus:ring-ring min-h-[44px] sm:min-h-0"
+              >
+                <option value="all">All Status</option>
+                <option value="BACKLOG">Backlog</option>
+                <option value="TODO">To Do</option>
+                <option value="IN_PROGRESS">In Progress</option>
+                <option value="REVIEW">Review</option>
+                <option value="DONE">Done</option>
+                <option value="BLOCKED">Blocked</option>
+              </select>
+              
+              {/* Priority Filter */}
+              <select
+                value={priorityFilter}
+                onChange={(e) => setPriorityFilter(e.target.value)}
+                className="px-3 py-2 text-sm rounded-md border border-input bg-background focus:outline-none focus:ring-2 focus:ring-ring min-h-[44px] sm:min-h-0"
+              >
+                <option value="all">All Priority</option>
+                <option value="URGENT">Urgent</option>
+                <option value="HIGH">High</option>
+                <option value="NORMAL">Normal</option>
+                <option value="LOW">Low</option>
+              </select>
+              
+              {/* Sort buttons */}
+              <div className="flex items-center gap-1 sm:ml-auto overflow-x-auto">
+                <span className="text-sm text-muted-foreground shrink-0">Sort:</span>
+                {(["created", "priority", "status", "title"] as SortField[]).map((field) => (
+                  <Button
+                    key={field}
+                    variant={sortField === field ? "secondary" : "ghost"}
+                    size="sm"
+                    onClick={() => handleSort(field)}
+                    className="capitalize min-h-[44px] sm:min-h-0 shrink-0"
+                  >
+                    {field === "created" ? "Date" : field}
+                    {sortField === field && (
+                      <ArrowUpDown className={`ml-1 h-3 w-3 ${sortDirection === "desc" ? "rotate-180" : ""}`} />
+                    )}
+                  </Button>
+                ))}
+              </div>
             </div>
           </div>
           

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -296,6 +296,43 @@
   }
 }
 
+/* ========================================
+   Mobile responsive utilities
+   ======================================== */
+
+/* Minimum touch target sizes on mobile */
+@media (max-width: 640px) {
+  button,
+  a,
+  [role="button"],
+  select,
+  input[type="checkbox"],
+  input[type="radio"] {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  /* Don't force icon-only buttons to be huge */
+  button > svg:only-child {
+    min-height: unset;
+    min-width: unset;
+  }
+
+  /* Ensure readable body text */
+  body {
+    font-size: 14px;
+  }
+}
+
+/* Hide scrollbar utility */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 /* Underwater theme animations */
 @keyframes wave-subtle {
   0%, 100% {


### PR DESCRIPTION
## Summary
Closes #173 — Complete responsive redesign of the BikiniBottom dashboard.

## Changes

### Navigation & Layout
- **Mobile bottom nav bar** with Dashboard, Agents, Tasks, Messages icons
- **Scroll-hiding header** — hides on scroll-down, shows on scroll-up (mobile only)
- Responsive content padding (tighter on mobile, standard on desktop)
- Footer badge hidden on mobile (bottom nav takes precedence)

### Dashboard Page
- Stat cards: 1-col mobile → 2-col tablet → 4-col desktop
- Charts: reduced height on mobile (220px vs 300px) for readability
- Recent activity: vertically stacked layout on mobile with proper truncation
- Available agents: horizontal scroll carousel on mobile

### Agents Page
- Agent grid: 1-col mobile → 2-col tablet → 3-col desktop (responsive virtualizer)
- **Collapsible filter bar** with 'Filters' toggle button on mobile
- Stat cards: 2×2 grid on mobile
- Scrollable tab navigation on mobile
- Split panel already works as full-screen overlay on mobile ✓

### Tasks Page
- Kanban: 75vw column width with `snap-center` scroll on mobile
- Compact task card padding on mobile
- List view rows stack vertically on mobile (identifier + badges on top, title below)
- Responsive filter bar

### Events, Credits, Messages
- Stat cards: 2×2 on mobile, 4-col on desktop
- Chart heights responsive
- Transaction rows compact on mobile
- Messages page already had good mobile support ✓

### Global Improvements
- **Touch targets**: 44px minimum on mobile (buttons, links, selects, inputs)
- **Typography**: headings scale down on mobile (3xl→2xl, 2xl→xl), min 14px body
- **Scrollbar-hide** utility for clean horizontal scroll areas
- Settings page: scrollable tab list on mobile (8 tabs)

## Technical Details
- All responsive via Tailwind CSS breakpoints (sm:, md:, lg:)
- No new dependencies
- Build passes ✓