### PR TITLE
feat(dashboard): touch-optimized network graph

### DIFF
--- a/apps/dashboard/src/hooks/index.ts
+++ b/apps/dashboard/src/hooks/index.ts
@@ -6,3 +6,4 @@ export { useMessages, useConversations, useConversationMessages, type Message, t
 export { useCurrentPhase } from "./use-current-phase";
 export { usePresence, type AgentPresence, type PresenceStatus } from "./use-presence";
 export { useAgentHealth, type AgentHealth } from "./use-agent-health";
+export { useTouchDevice } from "./use-touch-device";

--- a/apps/dashboard/src/hooks/use-touch-device.ts
+++ b/apps/dashboard/src/hooks/use-touch-device.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from "react";
+
+interface TouchDeviceInfo {
+  /** True when a touch-capable device is detected */
+  isTouchDevice: boolean;
+  /** True when viewport is narrow (< 768px) */
+  isMobile: boolean;
+  /** True when viewport is narrow or touch is detected */
+  isMobileOrTouch: boolean;
+}
+
+/**
+ * Detect touch capability and mobile viewport.
+ * Listens for resize and first touch events.
+ */
+export function useTouchDevice(): TouchDeviceInfo {
+  const [isTouchDevice, setIsTouchDevice] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  });
+
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth < 768;
+  });
+
+  useEffect(() => {
+    const checkMobile = () => setIsMobile(window.innerWidth < 768);
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+
+    // If first touch detected, mark as touch device
+    const onTouch = () => {
+      setIsTouchDevice(true);
+      window.removeEventListener("touchstart", onTouch);
+    };
+    if (!isTouchDevice) {
+      window.addEventListener("touchstart", onTouch, { passive: true });
+    }
+
+    return () => {
+      window.removeEventListener("resize", checkMobile);
+      window.removeEventListener("touchstart", onTouch);
+    };
+  }, [isTouchDevice]);
+
+  return {
+    isTouchDevice,
+    isMobile,
+    isMobileOrTouch: isMobile || isTouchDevice,
+  };
+}


### PR DESCRIPTION
## Touch-Optimized Network Graph (Phase 4 Mobile)

Makes the agent network graph fully usable on touch devices.

### Touch Gestures
- **Pinch-to-zoom** — ReactFlow native, explicitly enabled via `zoomOnPinch`
- **Two-finger pan** — `panOnDrag` enabled, scroll-zoom disabled on touch
- **Double-tap to zoom** — double-tap a node to zoom in and center on it
- **Long-press** — 500ms hold on a node opens the detail panel

### Mobile Controls
- **Zoom +/−** buttons (bottom-right, 48×48px touch targets)
- **Fit view ⊡** button to reset zoom/pan to show all nodes
- Hidden on desktop (desktop keeps the built-in ReactFlow Controls)

### Node Interaction
- Tap a node → select + show details (existing behavior preserved)
- Node size increased 1.2× on mobile for easier tapping (min 44px+)
- Font sizes bumped up on mobile for readability
- Node dragging disabled on mobile to prevent accidental moves

### Performance Optimizations
- Pulsing glow → static glow on mobile (no infinite CSS animations)
- Edge particles simplified: max 1 particle on mobile (vs 3 desktop)
- Ambient edge particles disabled on mobile
- Edge glow blur underlay disabled on mobile
- Edge `animated` dash disabled on mobile
- Spawning burst animation disabled on mobile
- `fitView` transition shortened from 800ms→400ms on mobile

### Other
- Legend hidden on small screens (`<768px`) to save space
- New `useTouchDevice` hook — detects touch capability + mobile viewport
- No minimap existed to hide

### Files Changed
- `apps/dashboard/src/hooks/use-touch-device.ts` — **new** touch detection hook
- `apps/dashboard/src/hooks/index.ts` — export new hook
- `apps/dashboard/src/components/agent-network.tsx` — all touch optimizations