### PR TITLE
feat(dashboard): collapsible sidebar + header alignment + fix split-panel card constraint

### DIFF
--- a/apps/dashboard/src/components/ui/split-panel.tsx
+++ b/apps/dashboard/src/components/ui/split-panel.tsx
@@ -106,7 +106,7 @@ export function SplitPanel({
       {/* Desktop: side-by-side */}
       <div
         ref={containerRef}
-        className="hidden md:flex h-[calc(100vh-12rem)] w-full overflow-hidden rounded-lg border border-border"
+        className="hidden md:flex h-[calc(100vh-12rem)] w-full overflow-hidden"
       >
         {/* Left panel */}
         <motion.div


### PR DESCRIPTION
## Changes

### Collapsible Sidebar
- Desktop sidebar collapses to 64px icon-only mode via toggle button at the bottom (rotating chevron)
- Smooth framer-motion animation (250ms ease-out) for width transitions
- In collapsed mode: icons centered, text hidden, tooltips on hover for all nav items and action buttons
- State persisted in localStorage (`bb-sidebar-collapsed`)
- Mobile drawer behavior unchanged

### Header / Footer Alignment
- Desktop footer badge tracks sidebar width dynamically with matching animation
- Separate mobile/tablet footer without sidebar offset  
- Desktop top bar content starts after sidebar naturally (flexbox)

### Split Panel Card Constraint Fix
- Removed `rounded-lg border border-border` from the split panel's desktop container
- Agent list and task split panels now use full available page height without Card wrapper constraints
- Drag handle still provides visual separation between panels

### Technical Notes
- Uses `motion.aside` with `animate={{ width: sidebarWidth }}` for smooth sidebar transitions
- Custom `useSidebarCollapsed` hook with localStorage persistence
- Radix UI tooltips (`delayDuration={0}`) for instant feedback in collapsed mode
- All sidebar sections (logo, nav, demo toggle, help links, user/footer) adapt to collapsed state