### PR TITLE
fix: resolve all lint errors across monorepo

### DIFF
--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from "@nestjs/common";
 
-import { AgentRole, Proficiency } from "@openspawn/shared-types";
+import { AgentRole, Proficiency, generateSigningSecret, encryptSecret } from "@openspawn/shared-types";
 
 import { CurrentAgent, Roles, type AuthenticatedAgent } from "../auth";
 
@@ -125,7 +125,6 @@ export class AgentsController {
     @Body() dto: SpawnAgentDto & { hmacSecretEnc?: string },
   ) {
     // For now, generate a new secret (in production, might be passed in)
-    const { generateSigningSecret, encryptSecret } = await import("@openspawn/shared-types");
     const plaintextSecret = generateSigningSecret();
     const encryptionKey = process.env["ENCRYPTION_KEY"];
     if (!encryptionKey) {

--- a/apps/api/src/agents/trust.service.ts
+++ b/apps/api/src/agents/trust.service.ts
@@ -406,7 +406,7 @@ export class TrustService {
    * Apply inactivity decay to all agents who haven't been active
    * Run this as a scheduled task (e.g., weekly)
    */
-  async applyInactivityDecay(daysThreshold: number = 14): Promise<number> {
+  async applyInactivityDecay(daysThreshold = 14): Promise<number> {
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - daysThreshold);
 
@@ -434,7 +434,7 @@ export class TrustService {
    */
   async getLeaderboard(
     orgId: string,
-    limit: number = 10
+    limit = 10
   ): Promise<
     Array<{
       id: string;

--- a/apps/api/src/commands/sync-schema.ts
+++ b/apps/api/src/commands/sync-schema.ts
@@ -12,7 +12,7 @@
 import { DataSource } from "typeorm";
 
 // Direct import from built lib
-import { createDataSourceOptions } from "../../../../libs/database/src/data-source";
+import { createDataSourceOptions } from '@openspawn/database';
 
 async function syncSchema() {
   console.log("\n⚠️  Syncing database schema (development only)...\n");

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -89,7 +89,7 @@ function useSidebarCollapsed() {
   const toggle = useCallback(() => {
     setCollapsed((prev) => {
       const next = !prev;
-      try { localStorage.setItem(SIDEBAR_STORAGE_KEY, String(next)); } catch {}
+      try { localStorage.setItem(SIDEBAR_STORAGE_KEY, String(next)); } catch { /* noop */ }
       return next;
     });
   }, []);

--- a/apps/dashboard/src/components/ui/input.tsx
+++ b/apps/dashboard/src/components/ui/input.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => (

--- a/apps/dashboard/src/components/ui/label.tsx
+++ b/apps/dashboard/src/components/ui/label.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
 
 const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
   ({ className, ...props }, ref) => (

--- a/apps/dashboard/src/components/ui/split-panel.tsx
+++ b/apps/dashboard/src/components/ui/split-panel.tsx
@@ -39,7 +39,7 @@ export function SplitPanel({
     try {
       const stored = localStorage.getItem(`${STORAGE_KEY}-${storageKey}`);
       if (stored) return Number(stored);
-    } catch {}
+    } catch { /* noop */ }
     return defaultLeftWidth;
   });
 
@@ -47,7 +47,7 @@ export function SplitPanel({
   useEffect(() => {
     try {
       localStorage.setItem(`${STORAGE_KEY}-${storageKey}`, String(leftPercent));
-    } catch {}
+    } catch { /* noop */ }
   }, [leftPercent, storageKey]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {

--- a/apps/dashboard/src/demo/DemoProvider.tsx
+++ b/apps/dashboard/src/demo/DemoProvider.tsx
@@ -50,11 +50,11 @@ export function useDemo(): DemoContextValue {
       currentTick: 0,
       scenario: 'fresh',
       recentEvents: [],
-      play: () => {},
-      pause: () => {},
-      setSpeed: () => {},
-      setScenario: () => {},
-      reset: () => {},
+      play: () => { /* noop */ },
+      pause: () => { /* noop */ },
+      setSpeed: () => { /* noop */ },
+      setScenario: () => { /* noop */ },
+      reset: () => { /* noop */ },
     };
   }
   return ctx;

--- a/apps/dashboard/src/demo/mock-fetcher.ts
+++ b/apps/dashboard/src/demo/mock-fetcher.ts
@@ -22,7 +22,7 @@ import {
 import { debug } from '../lib/debug';
 
 // Extract operation name from a DocumentNode at runtime
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function getOperationName(doc: { definitions: Array<{ name?: { value: string } }> }): string {
   return doc.definitions[0]?.name?.value ?? 'Unknown';
 }

--- a/apps/dashboard/src/hooks/use-messages.ts
+++ b/apps/dashboard/src/hooks/use-messages.ts
@@ -101,7 +101,7 @@ export interface Conversation {
   createdAt: string;
 }
 
-export function useMessages(limit: number = 50) {
+export function useMessages(limit = 50) {
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['messages', limit],
     queryFn: fetcher<{ messages: Message[] }, { limit: number }>(

--- a/apps/dashboard/src/lib/avatar.ts
+++ b/apps/dashboard/src/lib/avatar.ts
@@ -221,14 +221,14 @@ export function generateAgentAvatar({ seed, level = 5, size = 64, styleOverride 
  * Get avatar URL as a direct data URI
  * Use this in img src or Avatar components
  */
-export function getAgentAvatarUrl(agentId: string, level: number = 5, size: number = 64): string {
+export function getAgentAvatarUrl(agentId: string, level = 5, size = 64): string {
   return generateAgentAvatar({ seed: agentId, level, size });
 }
 
 /**
  * Generate a preview avatar for a specific style (uses current background settings)
  */
-export function generateStylePreview(styleKey: AvatarStyleKey, seed: string = 'preview', size: number = 64, level: number = 9): string {
+export function generateStylePreview(styleKey: AvatarStyleKey, seed = 'preview', size = 64, level = 9): string {
   const style = getStyle(styleKey);
   const backgrounds = getBackgroundColors(level);
   const bgType = getBackgroundType();
@@ -250,9 +250,9 @@ export function generateStylePreview(styleKey: AvatarStyleKey, seed: string = 'p
 export function generateBackgroundPreview(
   bgColorKey: BackgroundColorKey, 
   bgTypeKey: BackgroundTypeKey,
-  seed: string = 'bg-preview', 
-  size: number = 64,
-  level: number = 9
+  seed = 'bg-preview', 
+  size = 64,
+  level = 9
 ): string {
   const styleKey = getAvatarStyle();
   const style = getStyle(styleKey);

--- a/apps/dashboard/src/lib/debug.ts
+++ b/apps/dashboard/src/lib/debug.ts
@@ -6,8 +6,8 @@
 export const debug = {
   demo: import.meta.env.DEV
     ? (...args: unknown[]) => console.log('[Demo]', ...args)
-    : () => {},
+    : () => { /* noop */ },
   mockFetcher: import.meta.env.DEV
     ? (...args: unknown[]) => console.log('[MockFetcher]', ...args)
-    : () => {},
+    : () => { /* noop */ },
 };

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -722,7 +722,7 @@ export function AgentsPage() {
     active: generateSparklineData(7, "up"),
     balance: generateSparklineData(7, "stable"),
     level: generateSparklineData(7, "up"),
-  }), []); // eslint-disable-line react-hooks/exhaustive-deps
+  }), []);
   
   // Filtering state
   const [searchQuery, setSearchQuery] = useState("");
@@ -1041,7 +1041,7 @@ export function AgentsPage() {
               title="No agents registered yet"
               description="Register your first agent to get started with the multi-agent system."
               ctaLabel="Register your first agent →"
-              onCta={() => {}}
+              onCta={() => { /* noop */ }}
             />
           </CardContent>
         </Card>

--- a/apps/dashboard/src/pages/credits.tsx
+++ b/apps/dashboard/src/pages/credits.tsx
@@ -161,7 +161,7 @@ export function CreditsPage() {
     earned: generateSparklineData(7, "up"),
     spent: generateSparklineData(7, "up"),
     burnRate: generateSparklineData(7, "down"),
-  }), []); // eslint-disable-line react-hooks/exhaustive-deps
+  }), []);
 
   // Compute balance history from transactions (sorted chronologically)
   const balanceHistory = useMemo(() => {

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -139,7 +139,7 @@ export function DashboardPage() {
     tasks: generateSparklineData(7, "up"),
     completed: generateSparklineData(7, "up"),
     credits: generateSparklineData(7, "stable"),
-  }), []); // eslint-disable-line react-hooks/exhaustive-deps
+  }), []);
 
   const activeAgents = agents.filter((a) => a.status?.toUpperCase() === "ACTIVE").length;
   const pendingAgents = agents.filter((a) => a.status?.toUpperCase() === "PENDING").length;

--- a/apps/dashboard/src/pages/mobile-status.tsx
+++ b/apps/dashboard/src/pages/mobile-status.tsx
@@ -89,7 +89,7 @@ function AgentRow({ agent, presence, currentTask, health, expanded, onToggle }: 
   // Deterministic sparkline data based on agent status
   const sparkData = useMemo(
     () => generateSparklineData(8, presence === "active" ? "up" : presence === "error" ? "down" : "stable"),
-    [agent.id, presence] // eslint-disable-line react-hooks/exhaustive-deps
+    [agent.id, presence]
   );
 
   const levelColor = getLevelColor(agent.level);

--- a/apps/dashboard/src/pages/network.tsx
+++ b/apps/dashboard/src/pages/network.tsx
@@ -26,7 +26,7 @@ export function NetworkPage() {
               title="No agent network yet"
               description="Register agents to see their connections and hierarchy visualized here."
               ctaLabel="Register agents to get started →"
-              onCta={() => {}}
+              onCta={() => { /* noop */ }}
             />
           </CardContent>
         </Card>

--- a/libs/demo-data/src/fixtures/events.ts
+++ b/libs/demo-data/src/fixtures/events.ts
@@ -226,7 +226,7 @@ export function getEventsByType(type: string): DemoEvent[] {
   return events.filter(e => e.type === type);
 }
 
-export function getRecentEvents(count: number = 10): DemoEvent[] {
+export function getRecentEvents(count = 10): DemoEvent[] {
   return [...events]
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
     .slice(0, count);

--- a/libs/demo-data/src/fixtures/messages.ts
+++ b/libs/demo-data/src/fixtures/messages.ts
@@ -103,7 +103,7 @@ export function generateMessage(
 export function generateConversation(
   agent1Id: string,
   agent2Id: string,
-  messageCount: number = 4,
+  messageCount = 4,
   taskRef?: string
 ): DemoMessage[] {
   const messages: DemoMessage[] = [];

--- a/libs/demo-data/src/simulation/engine.ts
+++ b/libs/demo-data/src/simulation/engine.ts
@@ -232,7 +232,7 @@ export class SimulationEngine {
   }
   
   // Main simulation tick
-  tick(emitEvents: boolean = true): SimulationEvent[] {
+  tick(emitEvents = true): SimulationEvent[] {
     const events: SimulationEvent[] = [];
     const now = new Date();
     
@@ -862,7 +862,7 @@ export class SimulationEngine {
     const eventType = randomFrom(eventTypes);
     
     // Get context based on event type
-    let context: { task?: DemoTask; agent?: DemoAgent; amount?: number } = {};
+    const context: { task?: DemoTask; agent?: DemoAgent; amount?: number } = {};
     
     if (eventType === 'task.transition') {
       const activeTasks = this.state.scenario.tasks.filter(

--- a/libs/sdk/eslint.config.mjs
+++ b/libs/sdk/eslint.config.mjs
@@ -13,7 +13,8 @@ export default [
           "ignoredFiles": [
             "{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}",
             "{projectRoot}/vite.config.{js,ts,mjs,mts}"
-          ]
+          ],
+          "ignoredDependencies": ["vitest", "@nx/vite"]
         }
       ]
     },

--- a/libs/sdk/src/lib/http-client.ts
+++ b/libs/sdk/src/lib/http-client.ts
@@ -116,12 +116,13 @@ export class HttpClient {
         throw new ForbiddenError(message);
       case 404:
         throw new NotFoundError(message);
-      case 429:
+      case 429: {
         const retryAfter = response.headers.get('Retry-After');
         throw new RateLimitError(
           message,
           retryAfter ? parseInt(retryAfter, 10) : undefined
         );
+      }
       default:
         throw new ApiError(message, response.status, errorData);
     }


### PR DESCRIPTION
## Summary
Fixes all lint errors across the monorepo so `npx nx run-many -t lint` passes clean (0 errors, warnings only).

### Changes
- **API**: Convert dynamic `import()` of `@openspawn/shared-types` to static import in `agents.controller.ts`, resolving all `@nx/enforce-module-boundaries` errors
- **Dashboard**: Add `/* noop */` comments to empty catch blocks and stub methods; remove `eslint-disable-line react-hooks/exhaustive-deps` comments (plugin not installed); convert empty interfaces to type aliases; remove redundant type annotations
- **SDK**: Wrap case block with lexical declarations in braces (`no-case-declarations`); ignore build-time deps in `@nx/dependency-checks`
- **Demo-data/Engine**: Remove redundant type annotations from default parameters; fix `let` → `const`
- **Misc**: Use package import `@openspawn/database` instead of relative path in sync-schema.ts

### Verification
- ✅ `npx nx run-many -t lint --parallel=3` — 0 errors (warnings only)
- ✅ `npx nx run-many -t build --parallel=3` — all pass
- ✅ `npx nx run-many -t test --parallel=3` — all pass
- ✅ `pnpm exec tsc --noEmit -p apps/api/tsconfig.app.json` — clean