### PR TITLE
feat(dashboard): org chart team nodes open side panel

### DIFF
--- a/apps/dashboard/src/components/org-chart.tsx
+++ b/apps/dashboard/src/components/org-chart.tsx
@@ -339,7 +339,7 @@ function buildOrgGraph(
   // Count agents per team
   const agentCountMap = new Map<string, number>();
   agents.forEach((a) => {
-    const tid = (a as Agent & { teamId?: string }).teamId;
+    const tid = a.teamId;
     if (tid) agentCountMap.set(tid, (agentCountMap.get(tid) ?? 0) + 1);
   });
 
@@ -384,7 +384,7 @@ function buildOrgGraph(
     if (subs.length > 0) return; // skip parent teams; agents are shown under sub-teams
 
     const teamAgents = agents.filter(
-      (a) => (a as Agent & { teamId?: string }).teamId === team.id,
+      (a) => a.teamId === team.id,
     );
     const color = getTeamColor(team.color);
 
@@ -424,7 +424,7 @@ function buildOrgGraph(
     if (subs.length === 0) return; // already handled above
 
     const teamAgents = agents.filter(
-      (a) => (a as Agent & { teamId?: string }).teamId === team.id,
+      (a) => a.teamId === team.id,
     );
     const color = getTeamColor(team.color);
 
@@ -462,7 +462,7 @@ function buildOrgGraph(
 }
 
 // ── Inner component ─────────────────────────────────────────────────────────
-function OrgChartInner({ className, onAgentClick }: { className?: string; onAgentClick?: (agentId: string) => void }) {
+function OrgChartInner({ className, onAgentClick, onTeamClick }: { className?: string; onAgentClick?: (agentId: string) => void; onTeamClick?: (teamId: string) => void }) {
   const { agents, loading } = useAgents();
   const [nodes, setNodes, onNodesChange] = useNodesState([] as Node[]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([] as Edge[]);
@@ -521,11 +521,13 @@ function OrgChartInner({ className, onAgentClick }: { className?: string; onAgen
   const handleNodeClick = useCallback(
     (_: unknown, node: Node) => {
       const d = node.data as Record<string, unknown>;
-      if (!d.isTeam && d.agentDbId && onAgentClick) {
+      if (d.isTeam && d.teamId && onTeamClick) {
+        onTeamClick(d.teamId as string);
+      } else if (!d.isTeam && d.agentDbId && onAgentClick) {
         onAgentClick(d.agentDbId as string);
       }
     },
-    [onAgentClick],
+    [onAgentClick, onTeamClick],
   );
 
   if (loading) {
@@ -568,10 +570,10 @@ function OrgChartInner({ className, onAgentClick }: { className?: string; onAgen
 }
 
 // ── Public component (wrapped in provider) ──────────────────────────────────
-export function OrgChart({ className, onAgentClick }: { className?: string; onAgentClick?: (agentId: string) => void }) {
+export function OrgChart({ className, onAgentClick, onTeamClick }: { className?: string; onAgentClick?: (agentId: string) => void; onTeamClick?: (teamId: string) => void }) {
   return (
     <ReactFlowProvider>
-      <OrgChartInner className={className} onAgentClick={onAgentClick} />
+      <OrgChartInner className={className} onAgentClick={onAgentClick} onTeamClick={onTeamClick} />
     </ReactFlowProvider>
   );
 }

--- a/apps/dashboard/src/pages/network.tsx
+++ b/apps/dashboard/src/pages/network.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { AgentNetwork } from "../components/agent-network";
 import { OrgChart } from "../components/org-chart";
 import { AgentDetailPanel } from "../components/agent-detail-panel";
+import { TeamDetailPanel } from "../components/team-detail-panel";
 import { useAgents } from "../hooks";
 import { useSidePanel } from "../contexts";
 import { EmptyState } from "../components/ui/empty-state";
@@ -19,6 +20,17 @@ export function NetworkPage() {
     openSidePanel(
       <AgentDetailPanel agentId={agentId} onClose={closeSidePanel} />,
       { width: 520 }
+    );
+  };
+
+  const openTeamDetail = (teamId: string) => {
+    openSidePanel(
+      <TeamDetailPanel
+        teamId={teamId}
+        onAgentClick={openAgentDetail}
+        onTeamClick={openTeamDetail}
+      />,
+      { width: 480, title: 'Team Details' }
     );
   };
 
@@ -117,7 +129,7 @@ export function NetworkPage() {
       {view === "network" ? (
         <AgentNetwork className="w-full h-full" />
       ) : (
-        <OrgChart className="w-full h-full" onAgentClick={openAgentDetail} />
+        <OrgChart className="w-full h-full" onAgentClick={openAgentDetail} onTeamClick={openTeamDetail} />
       )}
 
       {/* Agent Detail Panel now uses global side panel */}


### PR DESCRIPTION
Clicking team nodes in the org chart now opens the TeamDetailPanel in the global side panel. Also removed unsafe type casts.