### PR TITLE
feat(dashboard): AgentNetwork side panel + hardcoded color cleanup

### DIFF
--- a/apps/dashboard/src/components/agent-network.tsx
+++ b/apps/dashboard/src/components/agent-network.tsx
@@ -26,7 +26,6 @@ import { useAgents, type Agent } from "../hooks/use-agents";
 import { useTasks } from "../hooks/use-tasks";
 import { useMessages, useConversations } from "../hooks/use-messages";
 import { getAgentAvatarUrl, getAvatarSettings } from "../lib/avatar";
-import { AgentDetailPanel } from "./agent-detail-panel";
 import { useAgentHealth } from "../hooks/use-agent-health";
 import { useTouchDevice } from "../hooks/use-touch-device";
 import { levelColors } from "../lib/status-colors";
@@ -608,6 +607,7 @@ const edgeTypes = { taskFlow: TaskFlowEdge };
 
 interface AgentNetworkProps {
   className?: string;
+  onAgentClick?: (agentId: string) => void;
 }
 
 // Edge tooltip component
@@ -886,7 +886,7 @@ function MobileZoomControls({ onFitView }: { onFitView: () => void }) {
 }
 
 // Inner component
-function AgentNetworkInner({ className }: AgentNetworkProps) {
+function AgentNetworkInner({ className, onAgentClick }: AgentNetworkProps) {
   const demo = useDemo();
   const { agents, loading: agentsLoading } = useAgents();
   const { tasks, loading: tasksLoading } = useTasks();
@@ -901,7 +901,6 @@ function AgentNetworkInner({ className }: AgentNetworkProps) {
     sourceLabel: string; 
     targetLabel: string;
   } | null>(null);
-  const [detailPanelAgentId, setDetailPanelAgentId] = useState<string | null>(null);
   const [activeDelegations, setActiveDelegations] = useState<TaskDelegation[]>([]);
   const [compact, setCompact] = useState(false);
   const [isLayouted, setIsLayouted] = useState(false);
@@ -1025,7 +1024,7 @@ function AgentNetworkInner({ className }: AgentNetworkProps) {
     setSelectedNode(node as Node<AgentNodeData>);
     setSelectedEdge(null);
     if (node.id !== "human") {
-      setDetailPanelAgentId(node.id);
+      onAgentClick?.(node.id);
     }
   }
   
@@ -1035,7 +1034,7 @@ function AgentNetworkInner({ className }: AgentNetworkProps) {
     longPressNodeRef.current = node.id;
     longPressTimerRef.current = setTimeout(() => {
       if (longPressNodeRef.current === node.id && node.id !== "human") {
-        setDetailPanelAgentId(node.id);
+        onAgentClick?.(node.id);
         setSelectedNode(node as Node<AgentNodeData>);
       }
     }, 500); // 500ms long-press
@@ -1257,21 +1256,16 @@ function AgentNetworkInner({ className }: AgentNetworkProps) {
           </div>
         )}
 
-        {/* Agent Detail Panel */}
-        <AgentDetailPanel 
-          agentId={detailPanelAgentId} 
-          onClose={() => setDetailPanelAgentId(null)} 
-        />
       </div>
     </NetworkContext.Provider>
   );
 }
 
 // Wrapper with ReactFlowProvider
-export function AgentNetwork({ className }: AgentNetworkProps) {
+export function AgentNetwork({ className, onAgentClick }: AgentNetworkProps) {
   return (
     <ReactFlowProvider>
-      <AgentNetworkInner className={className} />
+      <AgentNetworkInner className={className} onAgentClick={onAgentClick} />
     </ReactFlowProvider>
   );
 }

--- a/apps/dashboard/src/pages/network.tsx
+++ b/apps/dashboard/src/pages/network.tsx
@@ -56,7 +56,7 @@ export function NetworkPage() {
     <div className="h-[calc(100vh-theme(spacing.16))] -m-6 lg:-m-6 -mx-4 sm:-mx-6">
       {/* Header bar with title + stats + view toggle */}
       <div className="absolute top-4 sm:top-6 left-1/2 -translate-x-1/2 z-10
-        bg-zinc-900/90 backdrop-blur border border-zinc-800
+        bg-zinc-900/90 backdrop-blur border border-border
         rounded-full px-4 sm:px-6 py-2 sm:py-3
         w-auto max-w-[calc(100%-4rem)]">
         <div className="flex gap-4 sm:gap-6 items-center">
@@ -64,11 +64,11 @@ export function NetworkPage() {
             <h1 className="text-sm sm:text-base font-bold text-foreground leading-tight">
               {view === "network" ? "Agent Network" : "Org Chart"}
             </h1>
-            <p className="text-[10px] sm:text-xs text-zinc-500">
+            <p className="text-[10px] sm:text-xs text-muted-foreground">
               {view === "network" ? "Real-time hierarchy" : "Team structure"}
             </p>
           </div>
-          <div className="w-px h-8 bg-zinc-700 hidden sm:block" />
+          <div className="w-px h-8 bg-border hidden sm:block" />
 
           {/* View toggle */}
           <div className="flex items-center gap-1 bg-zinc-800 rounded-full p-0.5">
@@ -94,31 +94,31 @@ export function NetworkPage() {
 
           {view === "network" && (
             <>
-              <div className="w-px h-8 bg-zinc-700 hidden sm:block" />
+              <div className="w-px h-8 bg-border hidden sm:block" />
               <div className="flex gap-3 sm:gap-5 items-center">
                 <div className="text-center">
                   <div className="text-sm sm:text-lg font-bold text-foreground">
                     {agents.length}
                   </div>
-                  <div className="text-[9px] sm:text-xs text-zinc-500">Agents</div>
+                  <div className="text-[9px] sm:text-xs text-muted-foreground">Agents</div>
                 </div>
                 <div className="text-center">
                   <div className="text-sm sm:text-lg font-bold text-emerald-500">
                     {agents.filter((a) => a.status?.toString().toUpperCase() === "ACTIVE").length}
                   </div>
-                  <div className="text-[9px] sm:text-xs text-zinc-500">Active</div>
+                  <div className="text-[9px] sm:text-xs text-muted-foreground">Active</div>
                 </div>
                 <div className="text-center">
                   <div className="text-sm sm:text-lg font-bold text-amber-500">
                     {agents.filter((a) => a.status?.toString().toUpperCase() === "PENDING").length}
                   </div>
-                  <div className="text-[9px] sm:text-xs text-zinc-500">Pending</div>
+                  <div className="text-[9px] sm:text-xs text-muted-foreground">Pending</div>
                 </div>
                 <div className="text-center">
                   <div className="text-sm sm:text-lg font-bold text-foreground">
                     {(agents.reduce((s, a) => s + a.currentBalance, 0) / 1000).toFixed(1)}K
                   </div>
-                  <div className="text-[9px] sm:text-xs text-zinc-500">Credits</div>
+                  <div className="text-[9px] sm:text-xs text-muted-foreground">Credits</div>
                 </div>
               </div>
             </>
@@ -127,7 +127,7 @@ export function NetworkPage() {
       </div>
 
       {view === "network" ? (
-        <AgentNetwork className="w-full h-full" />
+        <AgentNetwork className="w-full h-full" onAgentClick={openAgentDetail} />
       ) : (
         <OrgChart className="w-full h-full" onAgentClick={openAgentDetail} onTeamClick={openTeamDetail} />
       )}


### PR DESCRIPTION
Wires AgentNetwork graph to the global side panel. Replaces hardcoded zinc/slate colors with semantic tokens in 6 files (graph HUD overlays left intentionally dark).