### PR TITLE
fix: demo mode crash + base-ui asChild wrappers

### DIFF
--- a/apps/dashboard/src/app/app.tsx
+++ b/apps/dashboard/src/app/app.tsx
@@ -38,10 +38,10 @@ const Router = isDemoMode ? HashRouter : BrowserRouter;
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: isDemoMode ? 0 : 1000 * 60, // No cache in demo mode
-      gcTime: isDemoMode ? 0 : 1000 * 60 * 5, // No garbage collection delay in demo
+      staleTime: isDemoMode ? 1000 * 5 : 1000 * 60, // 5s in demo (refreshed by simulation ticks)
+      gcTime: isDemoMode ? 1000 * 30 : 1000 * 60 * 5, // 30s in demo
       refetchOnWindowFocus: false,
-      refetchOnMount: isDemoMode ? 'always' : true, // Always refetch in demo mode
+      refetchOnMount: true,
     },
   },
 });

--- a/apps/dashboard/src/components/ui/dialog.tsx
+++ b/apps/dashboard/src/components/ui/dialog.tsx
@@ -3,7 +3,23 @@ import { Dialog as BaseDialog } from "@base-ui/react/dialog";
 import { cn } from "../../lib/utils";
 
 const Dialog = BaseDialog.Root;
-const DialogTrigger = BaseDialog.Trigger;
+// DialogTrigger with render prop support for custom elements
+const DialogTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof BaseDialog.Trigger> & { asChild?: boolean }
+>(({ asChild, children, ...props }, ref) => {
+  if (asChild && React.isValidElement(children)) {
+    return (
+      <BaseDialog.Trigger ref={ref} render={children} {...props} />
+    );
+  }
+  return (
+    <BaseDialog.Trigger ref={ref} {...props}>
+      {children}
+    </BaseDialog.Trigger>
+  );
+});
+DialogTrigger.displayName = "DialogTrigger";
 // DialogClose with render prop support for custom elements
 const DialogClose = React.forwardRef<
   HTMLButtonElement,

--- a/apps/dashboard/src/components/ui/dropdown-menu.tsx
+++ b/apps/dashboard/src/components/ui/dropdown-menu.tsx
@@ -5,7 +5,23 @@ import { cn } from "../../lib/utils";
 
 const DropdownMenu = Menu.Root;
 
-const DropdownMenuTrigger = Menu.Trigger;
+// DropdownMenuTrigger with render prop support for custom elements
+const DropdownMenuTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof Menu.Trigger> & { asChild?: boolean }
+>(({ asChild, children, ...props }, ref) => {
+  if (asChild && React.isValidElement(children)) {
+    return (
+      <Menu.Trigger ref={ref} render={children} {...props} />
+    );
+  }
+  return (
+    <Menu.Trigger ref={ref} {...props}>
+      {children}
+    </Menu.Trigger>
+  );
+});
+DropdownMenuTrigger.displayName = "DropdownMenuTrigger";
 
 const DropdownMenuGroup = Menu.Group;
 

--- a/apps/dashboard/src/components/ui/tooltip.tsx
+++ b/apps/dashboard/src/components/ui/tooltip.tsx
@@ -9,7 +9,27 @@ TooltipProvider.displayName = "TooltipProvider";
 
 const Tooltip = BaseTooltip.Root;
 
-const TooltipTrigger = BaseTooltip.Trigger;
+// Wrap base-ui Trigger to support Radix-style `asChild` prop
+const TooltipTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof BaseTooltip.Trigger> & { asChild?: boolean }
+>(({ asChild, children, ...props }, ref) => {
+  if (asChild && React.isValidElement(children)) {
+    return (
+      <BaseTooltip.Trigger
+        ref={ref}
+        {...props}
+        render={children}
+      />
+    );
+  }
+  return (
+    <BaseTooltip.Trigger ref={ref} {...props}>
+      {children}
+    </BaseTooltip.Trigger>
+  );
+});
+TooltipTrigger.displayName = "TooltipTrigger";
 
 const TooltipContent = React.forwardRef<
   HTMLDivElement,


### PR DESCRIPTION
## What
- **Fixes demo mode blank screen crash** — recharts v3's ResponsiveContainer triggers infinite redux store dispatch loop in ChartDataContextProvider
- **Fixes base-ui component warnings** — button-in-button nesting and asChild DOM attribute errors

## How
- Replaced `ResponsiveContainer` with custom `useContainerSize` hook using ResizeObserver
- Added `ChartErrorBoundary` for graceful chart failure handling  
- Added `asChild` → `render` prop wrappers in tooltip, dialog, dropdown-menu components
- Reverted aggressive TanStack Query config changes in demo QueryClient

## Root Cause
Recharts v3.7.0's internal redux store dispatches in a loop when `ResponsiveContainer` can't measure dimensions properly. Our custom ResizeObserver hook avoids the buggy recharts measurement code entirely.