### PR TITLE
fix: theme picker dropdown + base-ui render prop wrappers

### DIFF
--- a/apps/dashboard/src/components/ui/dialog.tsx
+++ b/apps/dashboard/src/components/ui/dialog.tsx
@@ -10,7 +10,11 @@ const DialogTrigger = React.forwardRef<
 >(({ asChild, children, ...props }, ref) => {
   if (asChild && React.isValidElement(children)) {
     return (
-      <BaseDialog.Trigger ref={ref} render={children} {...props} />
+      <BaseDialog.Trigger
+        ref={ref}
+        render={children}
+        {...props}
+      />
     );
   }
   return (
@@ -27,7 +31,11 @@ const DialogClose = React.forwardRef<
 >(({ asChild, children, ...props }, ref) => {
   if (asChild && React.isValidElement(children)) {
     return (
-      <BaseDialog.Close ref={ref} render={children} {...props} />
+      <BaseDialog.Close
+        ref={ref}
+        render={children}
+        {...props}
+      />
     );
   }
   return (

--- a/apps/dashboard/src/components/ui/dropdown-menu.tsx
+++ b/apps/dashboard/src/components/ui/dropdown-menu.tsx
@@ -12,7 +12,11 @@ const DropdownMenuTrigger = React.forwardRef<
 >(({ asChild, children, ...props }, ref) => {
   if (asChild && React.isValidElement(children)) {
     return (
-      <Menu.Trigger ref={ref} render={children} {...props} />
+      <Menu.Trigger
+        ref={ref}
+        render={children}
+        {...props}
+      />
     );
   }
   return (
@@ -75,10 +79,12 @@ const DropdownMenuContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentPropsWithoutRef<typeof Menu.Popup> & {
     sideOffset?: number;
+    align?: 'start' | 'center' | 'end';
+    side?: 'top' | 'bottom' | 'left' | 'right';
   }
->(({ className, sideOffset = 4, ...props }, ref) => (
+>(({ className, sideOffset = 4, align, side, ...props }, ref) => (
   <Menu.Portal>
-    <Menu.Positioner sideOffset={sideOffset}>
+    <Menu.Positioner sideOffset={sideOffset} alignment={align === 'end' ? 'end' : align === 'start' ? 'start' : 'center'} side={side}>
       <Menu.Popup
         ref={ref}
         className={cn(
@@ -157,11 +163,11 @@ DropdownMenuRadioItem.displayName = "DropdownMenuRadioItem";
 
 const DropdownMenuLabel = React.forwardRef<
   HTMLDivElement,
-  React.ComponentPropsWithoutRef<typeof Menu.GroupLabel> & {
+  React.HTMLAttributes<HTMLDivElement> & {
     inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
-  <Menu.GroupLabel
+  <div
     ref={ref}
     className={cn(
       "px-2 py-1.5 text-sm font-semibold",

--- a/apps/dashboard/src/components/ui/tooltip.tsx
+++ b/apps/dashboard/src/components/ui/tooltip.tsx
@@ -18,8 +18,8 @@ const TooltipTrigger = React.forwardRef<
     return (
       <BaseTooltip.Trigger
         ref={ref}
-        {...props}
         render={children}
+        {...props}
       />
     );
   }


### PR DESCRIPTION
Fixes base-ui production error #31 when clicking the theme picker.

**Changes:**
- DropdownMenuContent: forward align/side props to Menu.Positioner
- DropdownMenuLabel: use plain div instead of Menu.GroupLabel
- Verified render element form for all trigger wrappers (tooltip, dropdown-menu, dialog)

**Tested:** Theme picker opens correctly in demo mode, zero console errors.