### PR TITLE
perf: memoization audit

### DIFF
--- a/apps/dashboard/src/components/org-chart.tsx
+++ b/apps/dashboard/src/components/org-chart.tsx
@@ -511,19 +511,21 @@ function OrgChartInner({ className, onAgentClick, onTeamClick }: { className?: s
         animatedIds.add(base[Math.floor(Math.random() * base.length)].id);
       }
 
-      setEdges(
-        base.map((e) => ({
-          ...e,
-          data: { ...((e.data as object) || {}), animated: animatedIds.has(e.id) },
-        })),
+      setEdges((prev) =>
+        prev.map((e) => {
+          const shouldAnimate = animatedIds.has(e.id);
+          const wasAnimated = (e.data as any)?.animated;
+          if (shouldAnimate === wasAnimated) return e;
+          return { ...e, data: { ...((e.data as object) || {}), animated: shouldAnimate } };
+        }),
       );
 
       setTimeout(() => {
-        setEdges(
-          base.map((e) => ({
-            ...e,
-            data: { ...((e.data as object) || {}), animated: false },
-          })),
+        setEdges((prev) =>
+          prev.map((e) => {
+            if (!(e.data as any)?.animated) return e;
+            return { ...e, data: { ...((e.data as object) || {}), animated: false } };
+          }),
         );
       }, displayMs);
     }, intervalMs);

--- a/apps/dashboard/src/demo/DemoProvider.tsx
+++ b/apps/dashboard/src/demo/DemoProvider.tsx
@@ -123,9 +123,12 @@ export function DemoProvider({
 
   // Trigger confetti based on event type (toned down - only major events)
   // Disabled entirely at high speeds (>1x) to avoid visual clutter
+  const speedRef = useRef(speed);
+  speedRef.current = speed;
+
   const triggerCelebration = useCallback((event: SimulationEvent) => {
     // Skip all confetti at high demo speeds
-    if (speed > 1) return;
+    if (speedRef.current > 1) return;
 
     // Check cooldown before firing confetti
     const now = Date.now();
@@ -145,7 +148,7 @@ export function DemoProvider({
       lastConfettiRef.current = now;
       celebrateElite();
     }
-  }, [speed]);
+  }, []);
 
   // Subscribe to simulation events
   // Re-subscribe when scenario changes (new engine is created)

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -1,4 +1,5 @@
 import { Component, useMemo, useState, useEffect, useRef, useCallback, type ReactNode, type ErrorInfo } from "react";
+import { useContainerSize } from "../hooks/use-container-size";
 
 class ChartErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
   state = { hasError: false };
@@ -8,29 +9,6 @@ class ChartErrorBoundary extends Component<{ children: ReactNode }, { hasError: 
     if (this.state.hasError) return <div className="flex items-center justify-center h-full text-muted-foreground text-sm">Chart unavailable</div>;
     return this.props.children;
   }
-}
-
-/** Measures container dimensions without recharts' buggy ResponsiveContainer */
-function useContainerSize(ref: React.RefObject<HTMLDivElement | null>) {
-  const [size, setSize] = useState({ width: 0, height: 0 });
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const ro = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (entry) {
-        const { width, height } = entry.contentRect;
-        setSize((prev) =>
-          prev.width === Math.round(width) && prev.height === Math.round(height)
-            ? prev
-            : { width: Math.round(width), height: Math.round(height) }
-        );
-      }
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [ref]);
-  return size;
 }
 import { useNavigate, Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";


### PR DESCRIPTION
## Memoization Audit Fixes

### Org Chart Edge Animations
- Previously: every `setEdges` call spread ALL edges into new objects, even unchanged ones
- Now: only edges whose `animated` state actually changes get new object references
- Result: fewer React re-renders during message flow animations

### DemoProvider Event Subscription
- Previously: `triggerCelebration` depended on `speed`, causing the callback to change on every speed adjustment, which re-subscribed the event listener effect
- Now: uses `speedRef` to read speed without creating a dependency
- Result: event subscription is stable across speed changes

### Dashboard useContainerSize Deduplication
- Removed local copy of `useContainerSize` from dashboard.tsx
- Now imports from shared `hooks/use-container-size.ts` (created in PR #247)

### Already Fixed (PR #247)
- `use-messages.ts` refetchInterval respects demo mode (`false` instead of hardcoded 10s)