### PR TITLE
feat: 32-agent sandbox with ACP, ORG.md, event-driven execution

### DIFF
--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -15,5 +15,13 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../../libs/shared-types"
+    },
+    {
+      "path": "../../libs/database"
+    }
+  ]
 }

--- a/apps/dashboard/src/components/agent-heartbeat.tsx
+++ b/apps/dashboard/src/components/agent-heartbeat.tsx
@@ -14,9 +14,18 @@ interface AgentHeartbeatProps {
 export function AgentHeartbeat({ agentId, level, status, size = 'md', showPulse = true }: AgentHeartbeatProps) {
   const [isWorking, setIsWorking] = useState(status === 'ACTIVE');
 
-  // Simulate activity changes in demo mode
+  // Simulate activity changes in demo mode (not sandbox mode)
   useEffect(() => {
-    const isDemo = window.location.search.includes('demo=true');
+    const href = window.location.href;
+    const isDemo = href.includes('demo=true');
+    const isSandbox = href.includes('sandbox=true');
+    
+    // In sandbox mode, use actual status directly
+    if (isSandbox) {
+      setIsWorking(status === 'ACTIVE');
+      return;
+    }
+    
     if (!isDemo || status !== 'ACTIVE') return;
 
     const interval = setInterval(() => {

--- a/apps/dashboard/src/components/command-palette.tsx
+++ b/apps/dashboard/src/components/command-palette.tsx
@@ -97,6 +97,7 @@ export function CommandPalette() {
               <div className="flex items-center border-b border-border px-4">
                 <Search className="mr-2 h-4 w-4 shrink-0 text-primary/60" />
                 <Command.Input
+                  autoFocus
                   placeholder="Search pages, actions, agents..."
                   className="flex h-12 w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
                 />

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -50,6 +50,7 @@ import { usePresence } from "../hooks";
 import { ActiveAgentsBadge } from "./presence";
 import { NotificationCenter } from "./notification-center";
 import { useOnboarding } from "./onboarding/onboarding-provider";
+import { SandboxCommandBar } from "./sandbox-command-bar";
 import type { ReactNode } from "react";
 
 interface LayoutProps {
@@ -789,6 +790,9 @@ export function Layout({ children }: LayoutProps) {
             </div>
           </nav>
         </div>
+
+        {/* Sandbox command bar — fixed at bottom */}
+        <SandboxCommandBar />
       </div>
     </TooltipProvider>
   );

--- a/apps/dashboard/src/components/sandbox-activity-feed.tsx
+++ b/apps/dashboard/src/components/sandbox-activity-feed.tsx
@@ -1,0 +1,122 @@
+/**
+ * Live activity feed for sandbox mode.
+ * Connects to the sandbox SSE stream and shows real-time agent actions.
+ * Use in task detail sidebar or agent detail panel.
+ */
+import { useEffect, useState, useRef } from 'react';
+import { isSandboxMode } from '../graphql/fetcher';
+
+import { SANDBOX_URL } from '../lib/sandbox-url';
+
+interface ActivityEvent {
+  type: string;
+  agentId?: string;
+  agentName?: string;
+  taskId?: string;
+  message: string;
+  timestamp: number;
+}
+
+interface SandboxActivityFeedProps {
+  /** Filter events by task ID */
+  taskId?: string;
+  /** Filter events by agent ID */
+  agentId?: string;
+  /** Max events to show */
+  maxEvents?: number;
+}
+
+export function SandboxActivityFeed({ taskId, agentId, maxEvents = 50 }: SandboxActivityFeedProps) {
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const [connected, setConnected] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Fetch historical events on mount
+  useEffect(() => {
+    if (!isSandboxMode) return;
+
+    if (taskId) {
+      fetch(`${SANDBOX_URL}/api/task/${taskId}/activity`)
+        .then(r => r.json())
+        .then((history: ActivityEvent[]) => setEvents(history))
+        .catch(() => {});
+    }
+  }, [taskId]);
+
+  // Connect to SSE stream
+  useEffect(() => {
+    if (!isSandboxMode) return;
+
+    const params = new URLSearchParams();
+    if (taskId) params.set('task', taskId);
+    if (agentId) params.set('agent', agentId);
+
+    const url = `${SANDBOX_URL}/api/stream?${params}`;
+    const source = new EventSource(url);
+
+    source.onopen = () => setConnected(true);
+    source.onerror = () => setConnected(false);
+
+    source.onmessage = (e) => {
+      try {
+        const event: ActivityEvent = JSON.parse(e.data);
+        if (event.type === 'connected') {
+          setConnected(true);
+          return;
+        }
+        setEvents(prev => [...prev, event].slice(-maxEvents));
+      } catch {
+        // ignore parse errors
+      }
+    };
+
+    return () => {
+      source.close();
+      setConnected(false);
+    };
+  }, [taskId, agentId, maxEvents]);
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [events]);
+
+  if (!isSandboxMode) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        <div className={`w-2 h-2 rounded-full ${connected ? 'bg-green-500 animate-pulse' : 'bg-red-500'}`} />
+        Live Activity Stream
+        {events.length > 0 && (
+          <span className="text-muted-foreground/60">({events.length} events)</span>
+        )}
+      </div>
+
+      <div
+        ref={scrollRef}
+        className="bg-gray-950 rounded-lg p-3 font-mono text-xs max-h-64 overflow-y-auto space-y-1 border border-border"
+      >
+        {events.length === 0 ? (
+          <div className="text-muted-foreground/50 text-center py-4">
+            {connected ? 'Waiting for agent activity...' : 'Connecting to sandbox...'}
+          </div>
+        ) : (
+          events.map((event, i) => (
+            <div key={`${event.timestamp}-${i}`} className="flex gap-2 leading-relaxed">
+              <span className="text-muted-foreground/40 shrink-0">
+                {new Date(event.timestamp).toLocaleTimeString('en-US', { hour12: false })}
+              </span>
+              {event.agentName && (
+                <span className="text-cyan-400 shrink-0">[{event.agentName}]</span>
+              )}
+              <span className="text-gray-300">{event.message}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/sandbox-command-bar.tsx
+++ b/apps/dashboard/src/components/sandbox-command-bar.tsx
@@ -1,0 +1,158 @@
+/**
+ * Command bar for sending orders to the org in sandbox mode.
+ * Fixed at the bottom of the viewport with order input + restart button.
+ */
+import { useState, useRef } from 'react';
+import { Send, Crown, CheckCircle, RotateCcw } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { isSandboxMode } from '../graphql/fetcher';
+import { SANDBOX_URL } from '../lib/sandbox-url';
+import { Button } from './ui/button';
+
+interface OrderHistoryItem {
+  message: string;
+  timestamp: number;
+  status: 'sent' | 'sending' | 'error';
+}
+
+export function SandboxCommandBar() {
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [restarting, setRestarting] = useState(false);
+  const [flash, setFlash] = useState<string | null>(null);
+  const [history, setHistory] = useState<OrderHistoryItem[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  if (!isSandboxMode) return null;
+
+  const showFlash = (msg: string) => {
+    setFlash(msg);
+    setTimeout(() => setFlash(null), 3000);
+  };
+
+  const sendOrder = async () => {
+    const message = input.trim();
+    if (!message || sending) return;
+
+    setSending(true);
+    setHistory(prev => [...prev, { message, timestamp: Date.now(), status: 'sending' }]);
+    setInput('');
+
+    try {
+      const res = await fetch(`${SANDBOX_URL}/api/order`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message }),
+      });
+
+      if (res.ok) {
+        setHistory(prev =>
+          prev.map((h, i) => i === prev.length - 1 ? { ...h, status: 'sent' } : h)
+        );
+        showFlash('📢 Order delivered to Agent Dennis');
+      } else {
+        setHistory(prev =>
+          prev.map((h, i) => i === prev.length - 1 ? { ...h, status: 'error' } : h)
+        );
+      }
+    } catch {
+      setHistory(prev =>
+        prev.map((h, i) => i === prev.length - 1 ? { ...h, status: 'error' } : h)
+      );
+    } finally {
+      setSending(false);
+      inputRef.current?.focus();
+    }
+  };
+
+  const restartOrg = async () => {
+    if (restarting) return;
+    setRestarting(true);
+    try {
+      const res = await fetch(`${SANDBOX_URL}/api/restart`, { method: 'POST' });
+      if (res.ok) {
+        showFlash('🔄 Org reset — COO will rebuild from scratch');
+      }
+    } catch {
+      // ignore
+    } finally {
+      setRestarting(false);
+    }
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-zinc-950/95 backdrop-blur-sm">
+      {/* Flash message */}
+      <AnimatePresence>
+        {flash && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            className="absolute -top-10 left-1/2 -translate-x-1/2 px-4 py-1.5 rounded-full bg-emerald-500/20 border border-emerald-500/30 text-emerald-400 text-sm font-medium whitespace-nowrap"
+          >
+            {flash}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <div className="max-w-5xl mx-auto px-4 py-3 flex items-center gap-3">
+        {/* Order input */}
+        <div className="flex-1 relative">
+          <div className="absolute left-3 top-1/2 -translate-y-1/2">
+            <Crown className="w-4 h-4 text-amber-500" />
+          </div>
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && sendOrder()}
+            placeholder="Give an order to Agent Dennis..."
+            className="w-full pl-10 pr-4 py-2.5 rounded-lg bg-zinc-900 border border-zinc-700 text-sm text-foreground placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/30 focus:border-cyan-500/50 transition-all"
+            disabled={sending}
+          />
+        </div>
+
+        {/* Send button */}
+        <Button
+          onClick={sendOrder}
+          disabled={!input.trim() || sending}
+          size="sm"
+          className="bg-cyan-600 hover:bg-cyan-700 text-white gap-2"
+        >
+          <Send className={`w-4 h-4 ${sending ? 'animate-pulse' : ''}`} />
+          Send
+        </Button>
+
+        {/* Restart button */}
+        <Button
+          onClick={restartOrg}
+          disabled={restarting}
+          variant="outline"
+          size="sm"
+          className="border-zinc-700 text-zinc-300 hover:bg-zinc-800 gap-2"
+        >
+          <RotateCcw className={`w-4 h-4 ${restarting ? 'animate-spin' : ''}`} />
+          🔄 Restart Org
+        </Button>
+      </div>
+
+      {/* Recent orders (compact) */}
+      {history.length > 0 && (
+        <div className="max-w-5xl mx-auto px-4 pb-2">
+          <div className="flex gap-3 overflow-x-auto text-xs text-zinc-500">
+            {history.slice(-3).reverse().map((item) => (
+              <span key={item.timestamp} className="flex items-center gap-1 shrink-0">
+                {item.status === 'sending' && '⏳'}
+                {item.status === 'sent' && <CheckCircle className="w-3 h-3 text-emerald-500" />}
+                {item.status === 'error' && '✗'}
+                <span className="truncate max-w-[200px]">{item.message}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/sandbox-controls.tsx
+++ b/apps/dashboard/src/components/sandbox-controls.tsx
@@ -1,0 +1,52 @@
+/**
+ * Sandbox control panel — restart button + status indicator.
+ * Only visible in sandbox mode.
+ */
+import { useState } from 'react';
+import { RotateCcw, Radio } from 'lucide-react';
+import { Button } from './ui/button';
+import { isSandboxMode } from '../graphql/fetcher';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { SANDBOX_URL } from '../lib/sandbox-url';
+
+export function SandboxControls() {
+  const [restarting, setRestarting] = useState(false);
+  const queryClient = useQueryClient();
+
+  if (!isSandboxMode) return null;
+
+  const handleRestart = async () => {
+    setRestarting(true);
+    try {
+      await fetch(`${SANDBOX_URL}/api/restart`, { method: 'POST' });
+      // Wait a moment for the sim to reset, then refetch everything
+      setTimeout(() => {
+        queryClient.invalidateQueries();
+        setRestarting(false);
+      }, 1000);
+    } catch {
+      setRestarting(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground bg-muted/50 rounded-full px-3 py-1.5 border border-border">
+        <Radio className="w-3 h-3 text-green-500 animate-pulse" />
+        <span className="font-medium">Sandbox Live</span>
+        <span className="text-muted-foreground/60">· qwen3:0.6b</span>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleRestart}
+        disabled={restarting}
+        className="gap-1.5"
+      >
+        <RotateCcw className={`w-3.5 h-3.5 ${restarting ? 'animate-spin' : ''}`} />
+        {restarting ? 'Restarting...' : 'Restart (COO only)'}
+      </Button>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/task-cascade.tsx
+++ b/apps/dashboard/src/components/task-cascade.tsx
@@ -1,0 +1,134 @@
+/**
+ * Task Cascade Timeline — shows the ACP message chain for a task.
+ * Vertical timeline with color-coded entries and staggered animations.
+ */
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { isSandboxMode } from '../graphql/fetcher';
+import { SANDBOX_URL } from '../lib/sandbox-url';
+
+interface ACPMessage {
+  id: string;
+  type: 'ack' | 'delegation' | 'progress' | 'escalation' | 'completion';
+  from: string;
+  to: string;
+  taskId: string;
+  body?: string;
+  reason?: string;
+  summary?: string;
+  timestamp: number;
+  agentName?: string;
+}
+
+const typeConfig: Record<string, { icon: string; color: string; label: string; borderColor: string }> = {
+  delegation:  { icon: '📋', color: 'text-blue-400',    label: 'Delegation',  borderColor: 'border-blue-500/40' },
+  ack:         { icon: '👍', color: 'text-zinc-400',    label: 'Acknowledged', borderColor: 'border-zinc-500/40' },
+  progress:    { icon: '📊', color: 'text-foreground',  label: 'Progress',    borderColor: 'border-zinc-600/40' },
+  escalation:  { icon: '⚠️', color: 'text-orange-400', label: 'Escalation',  borderColor: 'border-orange-500/40' },
+  completion:  { icon: '✅', color: 'text-emerald-400', label: 'Completed',   borderColor: 'border-emerald-500/40' },
+};
+
+const dotColors: Record<string, string> = {
+  delegation: 'bg-blue-500',
+  ack: 'bg-zinc-500',
+  progress: 'bg-zinc-400',
+  escalation: 'bg-orange-500',
+  completion: 'bg-emerald-500',
+};
+
+interface TaskCascadeProps {
+  taskId: string;
+}
+
+export function TaskCascade({ taskId }: TaskCascadeProps) {
+  const [events, setEvents] = useState<ACPMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isSandboxMode || !taskId) {
+      setLoading(false);
+      return;
+    }
+
+    fetch(`${SANDBOX_URL}/api/task/${taskId}/activity`)
+      .then(r => r.json())
+      .then((data: ACPMessage[]) => {
+        setEvents(Array.isArray(data) ? data : []);
+      })
+      .catch(() => setEvents([]))
+      .finally(() => setLoading(false));
+  }, [taskId]);
+
+  if (!isSandboxMode) {
+    return (
+      <div className="rounded-lg border border-dashed border-border p-6 text-center">
+        <p className="text-sm text-muted-foreground">
+          Task activity tracking available in sandbox mode
+        </p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="text-sm text-muted-foreground animate-pulse py-4 text-center">
+        Loading activity…
+      </div>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border p-4 text-center">
+        <p className="text-xs text-muted-foreground">No cascade activity yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        ACP Message Cascade
+      </h4>
+      <div className="relative pl-6">
+        {/* Vertical line */}
+        <div className="absolute left-[9px] top-2 bottom-2 w-px bg-border" />
+
+        {events.map((event, i) => {
+          const config = typeConfig[event.type] || typeConfig.progress;
+          const dotColor = dotColors[event.type] || 'bg-zinc-500';
+          const body = event.body || event.summary || event.reason || '';
+
+          return (
+            <motion.div
+              key={event.id || `${event.timestamp}-${i}`}
+              initial={{ opacity: 0, x: -12 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: i * 0.08, duration: 0.3 }}
+              className="relative mb-3 last:mb-0"
+            >
+              {/* Dot on timeline */}
+              <div className={`absolute -left-6 top-1.5 w-[10px] h-[10px] rounded-full border-2 border-background ${dotColor}`} />
+
+              <div className={`rounded-lg border ${config.borderColor} bg-muted/30 px-3 py-2`}>
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-sm">{config.icon}</span>
+                  <span className={`text-xs font-semibold ${config.color}`}>{config.label}</span>
+                  {event.agentName && (
+                    <span className="text-xs text-cyan-400 font-medium">{event.agentName}</span>
+                  )}
+                  <span className="ml-auto text-[10px] text-muted-foreground">
+                    {new Date(event.timestamp).toLocaleTimeString('en-US', { hour12: false })}
+                  </span>
+                </div>
+                {body && (
+                  <p className="text-xs text-muted-foreground leading-relaxed">{body}</p>
+                )}
+              </div>
+            </motion.div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/thread-view.tsx
+++ b/apps/dashboard/src/components/thread-view.tsx
@@ -19,6 +19,15 @@ interface ThreadViewProps {
   onClose: () => void;
 }
 
+// ACP message type styling
+const acpStyles: Record<string, { icon: string; label: string; className: string; compact?: boolean }> = {
+  ack: { icon: '👍', label: 'Acknowledged', className: 'bg-muted/60 text-muted-foreground', compact: true },
+  delegation: { icon: '📋', label: 'Delegated', className: 'border-l-4 border-l-blue-500 bg-blue-500/5' },
+  progress: { icon: '📊', label: 'Progress', className: 'bg-muted/40' },
+  escalation: { icon: '⚠️', label: 'Escalated', className: 'bg-red-500/10 border border-red-500/20' },
+  completion: { icon: '✅', label: 'Completed', className: 'bg-emerald-500/10 border border-emerald-500/20' },
+};
+
 const typeColors: Record<string, string> = {
   TASK: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
   STATUS: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30',
@@ -124,6 +133,26 @@ export function ThreadView({ messages, onClose }: ThreadViewProps) {
               const showAvatar =
                 idx === 0 || sorted[idx - 1].fromAgentId !== msg.fromAgentId;
 
+              const acpType = (msg as any).acpType as string | undefined;
+              const acpStyle = acpType ? acpStyles[acpType] : undefined;
+
+              // Compact ack chip
+              if (acpStyle?.compact) {
+                return (
+                  <motion.div
+                    key={msg.id}
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ delay: idx * 0.03 }}
+                    className="flex justify-center my-0.5"
+                  >
+                    <span className="text-[10px] text-muted-foreground bg-muted/60 rounded-full px-2.5 py-0.5">
+                      {acpStyle.icon} {acpStyle.label}
+                    </span>
+                  </motion.div>
+                );
+              }
+
               return (
                 <motion.div
                   key={msg.id}
@@ -143,13 +172,15 @@ export function ThreadView({ messages, onClose }: ThreadViewProps) {
                     )}
                   </div>
 
-                  {/* Bubble */}
+                  {/* Bubble — ACP-styled or default */}
                   <div
                     className={cn(
                       'max-w-[75%] rounded-xl px-3 py-2',
-                      isLeft
-                        ? 'bg-muted rounded-tl-sm'
-                        : 'bg-primary/10 rounded-tr-sm',
+                      acpStyle
+                        ? acpStyle.className
+                        : isLeft
+                          ? 'bg-muted rounded-tl-sm'
+                          : 'bg-primary/10 rounded-tr-sm',
                     )}
                   >
                     {showAvatar && (
@@ -167,6 +198,26 @@ export function ThreadView({ messages, onClose }: ThreadViewProps) {
                           {typeIcons[msg.type] || '💬'}
                         </Badge>
                       </div>
+                    )}
+                    {acpType === 'delegation' && (
+                      <p className="text-xs font-medium text-blue-400 mb-0.5">
+                        📋 Delegated: {msg.taskRef || 'task'}
+                      </p>
+                    )}
+                    {acpType === 'escalation' && (
+                      <p className="text-xs font-medium text-red-400 mb-0.5">
+                        ⚠️ Escalated: {(msg as any).reason || 'unknown'}
+                      </p>
+                    )}
+                    {acpType === 'completion' && (
+                      <p className="text-xs font-medium text-emerald-400 mb-0.5">
+                        ✅ Completed
+                      </p>
+                    )}
+                    {acpType === 'progress' && (
+                      <p className="text-xs font-medium text-muted-foreground mb-0.5">
+                        📊 Progress{(msg as any).pct != null ? ` (${(msg as any).pct}%)` : ''}
+                      </p>
                     )}
                     <p className="text-xs md:text-sm text-foreground/90 leading-relaxed">
                       {msg.content}

--- a/apps/dashboard/src/components/ui/select.tsx
+++ b/apps/dashboard/src/components/ui/select.tsx
@@ -12,7 +12,7 @@ const Select = React.forwardRef<
   <select
     ref={ref}
     className={cn(
-      "flex h-9 w-full rounded-md border border-input bg-background px-3 pr-8 py-1 text-sm shadow-sm transition-colors",
+      "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-center shadow-sm transition-colors",
       "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
       "disabled:cursor-not-allowed disabled:opacity-50",
       className

--- a/apps/dashboard/src/demo/DemoProvider.tsx
+++ b/apps/dashboard/src/demo/DemoProvider.tsx
@@ -16,7 +16,7 @@ import { setDemoEngine } from './mock-fetcher';
 import { celebrate, celebrateLevelUp, celebrateSparkle, celebrateElite } from '../lib/confetti';
 import { debug } from '../lib/debug';
 
-export type ScenarioName = 'acmetech' | 'fresh' | 'startup' | 'growth' | 'enterprise';
+export type ScenarioName = 'acmetech' | 'fresh' | 'startup' | 'growth' | 'enterprise' | 'sandbox';
 
 // Re-export phase info for UI components
 export { PROJECT_PHASES };

--- a/apps/dashboard/src/demo/sandbox-fetcher.ts
+++ b/apps/dashboard/src/demo/sandbox-fetcher.ts
@@ -1,0 +1,68 @@
+/**
+ * Sandbox mode fetcher — connects to the live sandbox API server
+ * instead of using the in-memory SimulationEngine.
+ *
+ * The sandbox server (tools/sandbox) runs real LLM agents via Ollama
+ * and exposes a GraphQL-compatible endpoint at localhost:3333/graphql
+ */
+
+import { SANDBOX_URL } from '../lib/sandbox-url';
+
+/**
+ * TanStack Query fetcher that proxies GraphQL to the sandbox API
+ */
+export function sandboxFetcher<TData, TVariables extends Record<string, unknown>>(
+  query: string,
+  variables?: TVariables,
+): () => Promise<TData> {
+  return async () => {
+    const response = await fetch(`${SANDBOX_URL}/graphql`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Sandbox API error: ${response.status}`);
+    }
+
+    const json = await response.json();
+
+    if (json.errors?.length) {
+      throw new Error(json.errors[0].message);
+    }
+
+    return json.data as TData;
+  };
+}
+
+/**
+ * Check if sandbox server is reachable
+ */
+export async function isSandboxAvailable(): Promise<boolean> {
+  try {
+    const res = await fetch(`${SANDBOX_URL}/api/state`, { signal: AbortSignal.timeout(2000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get sandbox state summary
+ */
+export async function getSandboxState(): Promise<{
+  tick: number;
+  agentCount: number;
+  taskCount: number;
+  eventCount: number;
+  tasksDone: number;
+} | null> {
+  try {
+    const res = await fetch(`${SANDBOX_URL}/api/state`);
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/dashboard/src/hooks/use-acp-metrics.ts
+++ b/apps/dashboard/src/hooks/use-acp-metrics.ts
@@ -1,0 +1,34 @@
+/**
+ * Hook to fetch ACP-specific metrics from the sandbox API.
+ * Polls /api/metrics/acp every 3s when in sandbox mode.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { isSandboxMode } from '../graphql/fetcher';
+import { SANDBOX_URL } from '../lib/sandbox-url';
+
+export interface ACPMetrics {
+  ackLatencyMs: number;
+  escalationRate: number;
+  avgDelegationDepth: number;
+  completionRate: number;
+  totalAcks: number;
+  totalEscalations: number;
+  totalCompletions: number;
+  totalDelegations: number;
+  escalationsByReason: Record<string, number>;
+}
+
+async function fetchACPMetrics(): Promise<ACPMetrics> {
+  const res = await fetch(`${SANDBOX_URL}/api/metrics/acp`);
+  if (!res.ok) throw new Error('Failed to fetch ACP metrics');
+  return res.json();
+}
+
+export function useACPMetrics() {
+  return useQuery({
+    queryKey: ['acp-metrics'],
+    queryFn: fetchACPMetrics,
+    enabled: isSandboxMode,
+    refetchInterval: 3000,
+  });
+}

--- a/apps/dashboard/src/hooks/use-messages.ts
+++ b/apps/dashboard/src/hooks/use-messages.ts
@@ -83,6 +83,10 @@ export interface Message {
   toAgent: { id: string; name: string; level: number } | null;
   content: string;
   type: string;
+  acpType?: string;
+  reason?: string;
+  summary?: string;
+  pct?: number;
   taskRef: string | null;
   read: boolean;
   createdAt: string;

--- a/apps/dashboard/src/hooks/use-sandbox-metrics.ts
+++ b/apps/dashboard/src/hooks/use-sandbox-metrics.ts
@@ -1,0 +1,55 @@
+/**
+ * Hook to fetch real-time metrics from the sandbox API.
+ * Returns time-series data for sparklines and charts.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { isSandboxMode } from '../graphql/fetcher';
+
+import { SANDBOX_URL } from '../lib/sandbox-url';
+
+export interface MetricsSnapshot {
+  tick: number;
+  timestamp: number;
+  activeAgents: number;
+  totalTasks: number;
+  tasksDone: number;
+  tasksInProgress: number;
+  tasksInReview: number;
+  totalCreditsEarned: number;
+  totalCreditsSpent: number;
+  messageCount: number;
+}
+
+async function fetchMetrics(): Promise<MetricsSnapshot[]> {
+  const res = await fetch(`${SANDBOX_URL}/api/metrics`);
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export function useSandboxMetrics() {
+  return useQuery({
+    queryKey: ['sandbox-metrics'],
+    queryFn: fetchMetrics,
+    enabled: isSandboxMode,
+    refetchInterval: 3000,
+  });
+}
+
+/** Extract sparkline arrays from metrics history */
+export function useSparklines() {
+  const { data: metrics } = useSandboxMetrics();
+
+  if (!isSandboxMode || !metrics || metrics.length < 2) {
+    return null; // Fall back to generated data
+  }
+
+  // Take last 12 data points for sparklines
+  const recent = metrics.slice(-12);
+
+  return {
+    agents: recent.map(m => m.activeAgents),
+    tasks: recent.map(m => m.totalTasks),
+    completed: recent.map(m => m.tasksDone),
+    credits: recent.map(m => m.totalCreditsEarned - m.totalCreditsSpent),
+  };
+}

--- a/apps/dashboard/src/hooks/use-sandbox-sse.ts
+++ b/apps/dashboard/src/hooks/use-sandbox-sse.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared hook for connecting to the sandbox SSE stream.
+ * Only connects when isSandboxMode is true.
+ */
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { isSandboxMode } from '../graphql/fetcher';
+
+export interface SandboxSSEEvent {
+  type: string;
+  agentId?: string;
+  taskId?: string;
+  message?: string;
+  timestamp?: number;
+  agentName?: string;
+  fromAgentId?: string;
+  toAgentId?: string;
+}
+
+type SSECallback = (event: SandboxSSEEvent) => void;
+
+/**
+ * Subscribe to sandbox SSE events. Returns nothing — call the provided
+ * callback whenever an event arrives. Auto-reconnects on disconnect.
+ * Only connects when `isSandboxMode` is true.
+ */
+export function useSandboxSSE(callback: SSECallback) {
+  const cbRef = useRef(callback);
+  cbRef.current = callback;
+
+  useEffect(() => {
+    if (!isSandboxMode) return;
+
+    let es: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let disposed = false;
+
+    function connect() {
+      if (disposed) return;
+      es = new EventSource('http://localhost:3333/api/stream');
+
+      es.onmessage = (ev) => {
+        try {
+          const data = JSON.parse(ev.data) as SandboxSSEEvent;
+          cbRef.current(data);
+        } catch {
+          // ignore parse errors
+        }
+      };
+
+      es.onerror = () => {
+        es?.close();
+        if (!disposed) {
+          reconnectTimer = setTimeout(connect, 3000);
+        }
+      };
+    }
+
+    connect();
+
+    return () => {
+      disposed = true;
+      es?.close();
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+    };
+  }, []);
+}

--- a/apps/dashboard/src/lib/sandbox-url.ts
+++ b/apps/dashboard/src/lib/sandbox-url.ts
@@ -1,0 +1,10 @@
+/** Sandbox API base URL — auto-detects hostname for LAN access */
+export function getSandboxUrl(): string {
+  if (import.meta.env.VITE_SANDBOX_URL) return import.meta.env.VITE_SANDBOX_URL;
+  if (typeof window !== 'undefined' && window.location?.hostname) {
+    return `${window.location.protocol}//${window.location.hostname}:3333`;
+  }
+  return 'http://localhost:3333';
+}
+
+export const SANDBOX_URL = getSandboxUrl();

--- a/apps/dashboard/src/pages/events.tsx
+++ b/apps/dashboard/src/pages/events.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from "../components/ui/empty-state";
 import { PageHeader } from "../components/ui/page-header";
 import { StatCard } from "../components/ui/stat-card";
 import { useEvents } from "../hooks/use-events";
+import { isSandboxMode } from "../graphql/fetcher";
 import { useState, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
@@ -81,7 +82,7 @@ function EventVirtualList({ filteredEvents }: { filteredEvents: ReturnType<typeo
       <EmptyState
         variant="events"
         title="No events recorded"
-        description="Events appear as agents work. Start a simulation or assign tasks to generate activity."
+        description={isSandboxMode ? "Waiting for agent activity..." : "Events appear as agents work. Start a simulation or assign tasks to generate activity."}
         compact
       />
     );

--- a/apps/dashboard/src/pages/tasks.tsx
+++ b/apps/dashboard/src/pages/tasks.tsx
@@ -13,6 +13,8 @@ import { useTeams } from "../hooks";
 import { useSidePanel } from "../contexts";
 import { TeamFilterDropdown } from "../components/team-badge";
 import { TaskTimeline } from "../components/task-timeline";
+import { SandboxActivityFeed } from "../components/sandbox-activity-feed";
+import { TaskCascade } from "../components/task-cascade";
 import { AgentDetailPanel } from "../components/agent-detail-panel";
 
 type SortField = "created" | "priority" | "status" | "title";
@@ -364,6 +366,12 @@ function TaskDetailSidebar({ task, onClose }: TaskDetailSidebarProps) {
             )}
           </div>
           
+          {/* Live Activity Stream (sandbox mode) */}
+          <SandboxActivityFeed taskId={task.identifier ?? task.id} />
+
+          {/* ACP Message Cascade (sandbox mode) */}
+          <TaskCascade taskId={task.identifier ?? task.id} />
+
           {/* Approval Info */}
           {task.approvalRequired && (
             <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 space-y-2">

--- a/docs/strategy/agent-communication-protocol.md
+++ b/docs/strategy/agent-communication-protocol.md
@@ -1,0 +1,452 @@
+---
+title: Agent Communication Protocol (ACP)
+layout: default
+parent: Strategy
+nav_order: 4
+---
+
+# Agent Communication Protocol (ACP)
+
+> How agents in a hierarchy communicate — modeled after how effective human organizations actually work.
+
+## Design Philosophy
+
+### The Problem with Agent Communication Today
+
+Most agent frameworks treat agents as isolated function calls: task in, result out. There's no acknowledgment, no progress visibility, no structured way to say "I'm stuck." It's the equivalent of emailing someone a task and hoping they reply eventually. This works for simple, single-agent workflows — but it doesn't scale to coordinating teams of agents on complex work.
+
+Consider what happens when an agent silently fails: the delegator doesn't know. Tokens are wasted. Time is lost. The parent agent might spawn a duplicate. There's no feedback loop — and feedback loops are what make organizations functional.
+
+### Learning from Human Organizations
+
+Effective human organizations have solved this problem over centuries. They developed communication norms that balance two competing needs:
+
+1. **Managers need visibility** — they need to know work is progressing
+2. **Workers need autonomy** — constant interruptions kill productivity
+
+The solution: **different communication channels for different urgency levels.** Slack for quick acks, project boards for async status, tapping someone's shoulder for blockers. Each channel has an implicit noise level, and everyone understands which to use when.
+
+ACP formalizes this into a protocol. It models agents as **employees with communication norms** — they acknowledge, report, escalate, and complete through well-defined channels.
+
+### The Core Principle
+
+**Push what's urgent, pull what's optional, minimize interrupts.**
+
+| What happened | How it's communicated | Why |
+|---|---|---|
+| Task received | 👍 ACK (auto, no LLM) | Delegator confirms it landed — zero noise |
+| Making progress | Task activity log (pull-based) | Manager checks when *they* want to — respects agent autonomy |
+| Something's wrong | Escalation message (push) | Blockers need attention NOW — this *should* be noisy |
+| Task finished | ✅ Completion + summary (push) | Delegator needs the signal to proceed with dependent work |
+
+This maps directly to how good managers operate: they don't tap shoulders to check progress (they check the board), but they absolutely want to be interrupted for blockers and completions.
+
+### Why This Is Different
+
+Most multi-agent frameworks either have:
+- **No communication** — fire and forget, hope for the best
+- **Too much communication** — every agent broadcasts everything, creating noise that makes the system harder to reason about
+
+ACP introduces **graduated communication** — the right amount of signal at the right noise level for each situation. This is what makes the difference between a dysfunctional org (where nothing flows) and a high-performing one (where information flows efficiently).
+
+---
+
+## 1. Message Types
+
+### 1.1 Acknowledgment (ACK)
+
+**Direction:** Upward (assignee → delegator)  
+**Trigger:** Agent receives a task assignment  
+**Mechanism:** Reaction on the task (👍)  
+**Latency:** Immediate (systems-level, no LLM required)
+
+```
+{ type: "ack", from: assigneeId, to: delegatorId, taskId, timestamp }
+```
+
+**Why a reaction, not a message:** Acks are confirmation signals, not conversation. A thumbs-up says "I got it, I'm on it" without creating noise. The delegator sees it landed and moves on.
+
+**Platform representation:**
+- Dashboard: 👍 indicator on task card
+- API: Reaction event on task
+
+---
+
+### 1.2 Progress Updates
+
+**Direction:** Written to task (agent → task activity log)  
+**Trigger:** Meaningful state change during work  
+**Mechanism:** Task activity log entry (pull-based)  
+**Latency:** As work progresses
+
+```
+{ type: "progress", from: agentId, taskId, body: "Analysis complete, writing report...", pct: 60, timestamp }
+```
+
+**Why pull-based, not push:** Progress updates are informational, not actionable. The delegator checks when *they* want to — respecting the agent's autonomy to focus. This mirrors good management: check the board, don't tap shoulders.
+
+**Platform representation:**
+- Dashboard: Activity log in task detail panel
+- API: Task activity entries (queryable)
+
+**What counts as progress:**
+- Phase transitions ("research done, starting implementation")
+- Partial results ("found 3 of 5 required data sources")
+- Estimated completion updates
+
+**What does NOT go here:**
+- Blockers (→ escalation)
+- Questions (→ escalation)
+- Completion (→ completion event)
+
+---
+
+### 1.3 Escalation
+
+**Direction:** Upward (agent → delegator)  
+**Trigger:** Agent cannot proceed autonomously  
+**Mechanism:** Direct message + task status change to `BLOCKED`  
+**Latency:** Immediate (this SHOULD be noisy)
+
+```
+{ type: "escalation", from: agentId, to: delegatorId, taskId, reason: EscalationReason, body: "...", timestamp }
+```
+
+**Escalation reasons:**
+
+| Reason | Description | Example |
+|--------|-------------|---------|
+| `BLOCKED` | Needs resource/permission/input | "Need API key for external service" |
+| `OUT_OF_DOMAIN` | Wrong expertise for this task | "This is a security task, not engineering" |
+| `OVER_BUDGET` | Would exceed credit limit | "Estimated cost 500 credits, my limit is 200" |
+| `LOW_CONFIDENCE` | Agent doesn't trust its own output | "My analysis might be wrong, needs expert review" |
+| `TIMEOUT` | Task taking too long | "Exceeded expected completion time by 2x" |
+| `DEPENDENCY` | Waiting on another task/agent | "Blocked by task #45 (assigned to Agent X)" |
+
+**Escalation rules:**
+1. **Always go to your delegator** — never skip levels
+2. **Delegator decides next action:** reassign, handle themselves, or escalate further
+3. **Escalation chains preserve context** — each level adds their assessment
+
+**Delegator response options:**
+- Reassign to different report
+- Provide the missing resource/context and unblock
+- Handle it themselves
+- Escalate further up the chain
+- Cancel the task
+
+**Organizational intelligence emerges from escalation patterns:**
+
+Escalations aren't failures — they're *information*. A team that never escalates might be silently failing. A team that escalates frequently might be understaffed, misassigned, or missing a key capability. The escalation rate per team becomes one of the most revealing health metrics in the system.
+
+This creates a natural **pressure system**: problems don't silently disappear — they propagate upward with context until someone with the authority and capability resolves them. The speed at which this happens (escalation velocity) directly measures organizational responsiveness.
+
+---
+
+### 1.4 Completion
+
+**Direction:** Upward (assignee → delegator)  
+**Trigger:** Task finished  
+**Mechanism:** Reaction (✅) + summary message  
+**Latency:** Immediate
+
+```
+{ type: "completion", from: agentId, to: delegatorId, taskId, summary: "...", timestamp }
+```
+
+**Two-part signal:**
+1. **✅ reaction on task** — instant visual confirmation
+2. **Summary message** — brief description of what was done + link to task details
+
+**Summary format:**
+```
+✅ Completed: [Task Title]
+Result: [1-2 sentence summary]
+→ View details: #task-123
+```
+
+**Why both:** The reaction is the signal (scannable in a list). The summary is the context (readable when you care). The full details live on the task itself (available when you need depth).
+
+---
+
+## 2. Lateral Communication
+
+### 2.1 Handoff Requests
+
+**Direction:** Lateral (agent → agent, via shared manager)  
+**Trigger:** Task belongs to a different domain  
+
+Agents don't message peers directly for task reassignment. Instead:
+1. Agent escalates with reason `OUT_OF_DOMAIN`
+2. Manager receives escalation
+3. Manager re-delegates to the correct team/agent
+4. Original agent is freed
+
+**Why not direct:** Preserves chain of command. The manager has the context to make the best reassignment. Direct lateral handoffs create accountability gaps.
+
+### 2.2 Peer Coordination (Future)
+
+For cases where agents need to collaborate (not hand off):
+- Shared task threads
+- @mention in task activity
+- Co-assignment
+
+*This builds on the existing peer messaging feature (#107) but adds task-context awareness.*
+
+---
+
+## 3. Communication Flow Diagram
+
+```
+Human (L10+)
+  │
+  ├─ Creates task ──────────────► COO (L10)
+  │                                 │
+  │  ◄── ack (👍) ─────────────────┤
+  │                                 │
+  │                                 ├─ Delegates ────────► Lead (L7)
+  │                                 │                        │
+  │                                 │  ◄── ack (👍) ────────┤
+  │                                 │                        │
+  │                                 │                        ├─ Assigns ──► Worker (L4)
+  │                                 │                        │                │
+  │                                 │                        │  ◄── ack (👍)─┤
+  │                                 │                        │                │
+  │                                 │                        │    [progress → task log]
+  │                                 │                        │                │
+  │                                 │                        │  ◄── ✅ done ─┤
+  │                                 │                        │                
+  │                                 │  ◄── ✅ done ─────────┤
+  │                                 │
+  │  ◄── ✅ done ──────────────────┤
+```
+
+**Escalation flow:**
+```
+Worker: "I'm blocked — need API credentials"
+  → BLOCKED escalation to Lead
+    → Lead can't resolve
+      → BLOCKED escalation to COO  
+        → COO provides credentials
+          → Unblock cascades back down
+```
+
+---
+
+## 4. Implementation
+
+### 4.1 Data Model
+
+```typescript
+interface AgentMessage {
+  id: string;
+  type: 'ack' | 'progress' | 'escalation' | 'completion' | 'delegation';
+  from: string;        // agentId
+  to: string;          // agentId (or taskId for progress)
+  taskId: string;
+  body?: string;       // Human-readable content
+  reason?: EscalationReason;  // For escalations
+  summary?: string;    // For completions
+  pct?: number;        // For progress (0-100)
+  timestamp: string;
+}
+
+type EscalationReason = 
+  | 'BLOCKED' 
+  | 'OUT_OF_DOMAIN' 
+  | 'OVER_BUDGET' 
+  | 'LOW_CONFIDENCE' 
+  | 'TIMEOUT' 
+  | 'DEPENDENCY';
+```
+
+### 4.2 Agent Decision Model
+
+Each tick, the LLM decides an action. ACP extends the action space:
+
+```typescript
+type AgentAction =
+  | { type: 'delegate', to: string, taskId: string }      // + generates delegation message
+  | { type: 'work', taskId: string }                       // + may generate progress
+  | { type: 'complete', taskId: string, summary: string }  // + generates completion message
+  | { type: 'escalate', taskId: string, reason: string, body: string }  // + generates escalation
+  | { type: 'idle' }                                       // no message
+```
+
+### 4.3 Message Generation
+
+- **ACK:** Auto-generated (no LLM call) when task is assigned
+- **Progress:** LLM writes a short update when working on a task
+- **Escalation:** LLM decides to escalate + writes reason
+- **Completion:** LLM writes summary of what was done
+- **Delegation:** Auto-generated when agent delegates
+
+### 4.4 Dashboard Integration
+
+**Messages Tab (per agent):**
+- Shows all messages where agent is `from` or `to`
+- Grouped by conversation partner (parent + each direct report)
+- Real-time via SSE from sandbox, or polling from API
+
+**Task Detail Panel:**
+- Activity log shows progress entries
+- Reactions (👍, ✅) shown on task header
+- Escalation history with full chain
+
+---
+
+## 5. Tunable Parameters
+
+| Parameter | Description | Default | Effect |
+|-----------|-------------|---------|--------|
+| `escalationVelocity` | How quickly blockers propagate up | `immediate` | `immediate` / `batched` / `delayed` |
+| `progressFrequency` | How often progress updates are written | `on_phase_change` | `every_tick` / `on_phase_change` / `on_request` |
+| `ackRequired` | Whether ack is mandatory | `true` | Unacked tasks could trigger reminders |
+| `maxEscalationDepth` | How many levels up before auto-cancel | `3` | Prevents infinite escalation chains |
+
+### Modeling Organizational Culture
+
+These parameters aren't just configuration — they define the *personality* of an organization. Different cultures communicate differently, and ACP can model all of them:
+
+**Startup (move fast, break things):**
+- Immediate escalation — blockers are existential threats when you're small
+- Frequent progress updates — everyone's in the loop
+- Flat hierarchy — 2-3 levels max
+- *Feels like:* a 10-person team in a room, everyone overhears everything
+
+**Enterprise (process and governance):**
+- Batched escalation — problems get collected and reviewed in cycles
+- Phase-change progress only — no one wants minute-by-minute updates across 500 agents
+- Deep hierarchy — 5-8 levels, clear chain of command
+- *Feels like:* a Fortune 500 with weekly status meetings
+
+**Military (precision and accountability):**
+- Mandatory ack with timeout — unacknowledged orders trigger alerts
+- Every-tick progress — full situational awareness at all times
+- Strict chain of command — never skip levels, ever
+- *Feels like:* mission-critical operations where silence = danger
+
+**Remote/Async (trust and autonomy):**
+- Delayed escalation — give agents time to figure it out themselves
+- On-request progress — manager pulls when curious, doesn't push for updates
+- Loose hierarchy — agents can laterally coordinate
+- *Feels like:* a distributed team across timezones, high trust, async-first
+
+The ability to tune these parameters means BikiniBottom can simulate and optimize for any organizational style — or let users discover which communication culture produces the best outcomes for their specific workload.
+
+---
+
+## 6. Metrics & Organizational Intelligence
+
+ACP generates data that reveals org health:
+
+| Metric | What it shows |
+|--------|--------------|
+| **Ack latency** | How responsive agents are |
+| **Escalation rate per team** | Which teams are struggling |
+| **Escalation depth** | How far up problems travel (deeper = systemic) |
+| **Completion-to-delegation ratio** | Which managers do vs delegate |
+| **Progress update frequency** | Agent engagement level |
+| **Lateral handoff rate** | Task routing accuracy |
+| **Time-to-unblock** | How fast the org resolves blockers |
+
+### Why This Matters
+
+In human organizations, these metrics are collected through surveys, 1-on-1s, and retrospectives — subjective, infrequent, and expensive. In an ACP-powered agent org, they're generated automatically from every interaction. You get a real-time organizational health dashboard for free.
+
+More importantly, these metrics enable **automated org optimization**: the system can detect that Engineering's escalation rate spiked, correlate it with a recent task routing change, and suggest (or automatically execute) a rebalancing — reassigning agents, adjusting delegation strategies, or spawning additional capacity. This is organizational intelligence that emerges from the protocol itself, not from manual oversight.
+
+---
+
+## 7. Future Extensions
+
+- **Communication styles per agent** — verbose reporters vs terse ack-ers
+- **Message priority levels** — urgent escalations get push notifications
+- **Summarization** — managers get daily digests instead of individual messages
+- **Cross-org messaging** — agents in different OpenSpawn orgs coordinating
+- **Human-in-the-loop** — escalations can route to actual humans via webhooks
+
+---
+
+## 8. Relationship to A2A (Agent-to-Agent Protocol)
+
+Google's [A2A protocol](https://a2a-protocol.org) is an open standard for inter-agent communication. ACP and A2A solve different problems and are designed to be complementary.
+
+### Comparison
+
+| Dimension | ACP | A2A |
+|-----------|-----|-----|
+| **Scope** | Intra-org (agents within one system) | Inter-org (agents across vendors/companies) |
+| **Trust model** | Known agents, shared state, trust scores | Zero-trust, opaque agents |
+| **Discovery** | Org chart / hierarchy (`parentId`) | Agent Cards (JSON metadata with capabilities) |
+| **Transport** | Internal events, SSE | JSON-RPC 2.0, gRPC, REST |
+| **Task model** | Stateful with lifecycle | Stateful with lifecycle (similar) |
+| **Streaming** | SSE | SSE (similar) |
+| **Message types** | Typed (ack, progress, escalation, completion) | Generic messages with Parts (text, files, data) |
+| **Hierarchy** | First-class (parent/child, levels, chain of command) | Flat (peer-to-peer) |
+
+### Analogy
+
+- **ACP = Slack** — internal team communication. You know everyone, context is shared, messages are typed and structured for your workflow.
+- **A2A = Email** — cross-company communication. Agents discover each other via cards, communicate formally, and don't share internal state.
+
+### Integration Architecture
+
+```
+┌─────────────────────────────────────────┐
+│           BikiniBottom Org              │
+│                                         │
+│  COO ──ACP──► Lead ──ACP──► Worker     │
+│   │                                     │
+│   │  (internal: ACP messages,           │
+│   │   shared state, trust scores)       │
+│                                         │
+│   ▼                                     │
+│  A2A Gateway                            │
+│   │  (translates ACP ↔ A2A at          │
+│   │   org boundaries)                   │
+└───┼─────────────────────────────────────┘
+    │
+    │ A2A (JSON-RPC, Agent Cards)
+    ▼
+┌───────────────────┐  ┌──────────────────┐
+│ External Agent A  │  │ External Agent B  │
+│ (LangGraph)       │  │ (CrewAI)         │
+└───────────────────┘  └──────────────────┘
+```
+
+### Bridging ACP ↔ A2A
+
+An A2A Gateway at the org boundary would:
+
+1. **Inbound (A2A → ACP):** External agent sends A2A `SendMessage` → Gateway creates an ACP delegation message to the appropriate internal agent based on skill/domain matching.
+2. **Outbound (ACP → A2A):** Internal agent escalates with `OUT_OF_DOMAIN` and no internal agent can handle it → Gateway discovers external agents via Agent Cards and sends A2A request.
+3. **Status mapping:** ACP completion/escalation → A2A task status updates. ACP progress → A2A streaming messages.
+
+### Key Differences in Philosophy
+
+**A2A assumes opacity:** Agents don't share internals. This is correct for cross-org — you don't want to expose your agent's memory or tools to a vendor's agent.
+
+**ACP assumes transparency:** Agents within an org benefit from shared context — trust scores, task history, domain knowledge. Opacity within your own org creates the same silos that make human orgs dysfunctional.
+
+**Together they cover the full spectrum:** Transparent internally (ACP), opaque externally (A2A). This mirrors how human organizations actually work — open internally, formal externally.
+
+### Future: ACP as an A2A Extension
+
+A2A supports an Extension mechanism for additional functionality. ACP message types could be formalized as an A2A extension, allowing A2A-compatible agents to opt into richer intra-org communication when both parties support it:
+
+```
+AgentCard:
+  extensions:
+    - uri: "urn:bikinibottom:acp:v1"
+      config:
+        supportsAck: true
+        supportsProgress: true
+        supportsEscalation: true
+```
+
+This would let frameworks gradually adopt ACP semantics within A2A, creating a smooth migration path from flat peer communication to hierarchical org communication.
+
+---
+
+*ACP is designed to be framework-agnostic. Any agent system with a hierarchy can implement ACP — it's a communication standard, not a BikiniBottom-specific feature. Combined with A2A at org boundaries, it provides a complete communication stack for the agentic ecosystem.*

--- a/docs/strategy/agent-config-compatibility.md
+++ b/docs/strategy/agent-config-compatibility.md
@@ -1,0 +1,581 @@
+---
+title: OpenClaw-Compatible Agent Configuration
+layout: default
+parent: Strategy
+nav_order: 7
+---
+
+# OpenClaw-Compatible Agent Configuration
+
+> Don't invent a new agent config format. OpenClaw already defined one. BikiniBottom adds the org layer on top — not a replacement underneath.
+
+## Design Philosophy
+
+### The Problem with Proprietary Config
+
+Every agent framework invents its own configuration format. CrewAI has YAML role definitions. AutoGen has JSON agent specs. LangGraph has Python class hierarchies. Each one is a walled garden — agents configured for one framework can't run in another.
+
+BikiniBottom refuses to do this.
+
+OpenClaw established a simple, powerful convention: markdown files in a directory. `SOUL.md` for personality. `AGENTS.md` for workspace rules. `TOOLS.md` for tool notes. `MEMORY.md` for long-term memory. These files are framework-agnostic — they're just markdown that gets injected into an agent's context.
+
+BikiniBottom adds exactly one thing: `ORG.md`. The file that turns a collection of individual agents into an organization. Everything below the org level uses OpenClaw's existing format, unchanged.
+
+### Why This Matters
+
+**Portability.** An agent configured in BikiniBottom can be extracted from the org and run standalone in OpenClaw. An agent running in OpenClaw can be imported into a BikiniBottom org. No migration, no translation, no vendor lock-in.
+
+**Ecosystem leverage.** Every improvement to OpenClaw's agent configuration — new file types, better memory formats, improved tool integration — automatically benefits BikiniBottom agents. We're building on a foundation, not beside it.
+
+**Familiarity.** If you've configured one OpenClaw agent, you already know how to configure a BikiniBottom agent. The learning curve is "here's ORG.md" — not "here's our entire config system."
+
+### The Core Principle
+
+**BikiniBottom adds the org layer. It does not replace the agent layer.**
+
+```
+┌─────────────────────────────────┐
+│         ORG.md                  │  ← BikiniBottom adds this
+│  (structure, culture, policies) │
+├─────────────────────────────────┤
+│  SOUL.md   AGENTS.md   TOOLS.md│  ← OpenClaw standard
+│  MEMORY.md  memory/    etc.    │
+└─────────────────────────────────┘
+```
+
+---
+
+## 1. Directory Structure
+
+### 1.1 Full Layout
+
+```
+org/
+├── ORG.md                        # Org structure (BikiniBottom addition)
+├── agents/
+│   ├── _defaults/                # Inherited by all agents
+│   │   ├── SOUL.md              # Default personality
+│   │   ├── AGENTS.md            # Default workspace rules
+│   │   └── TOOLS.md             # Default tool notes
+│   ├── dennis/                   # Per-agent overrides
+│   │   ├── SOUL.md              # COO personality
+│   │   ├── AGENTS.md            # COO-specific rules
+│   │   ├── MEMORY.md            # Long-term memory
+│   │   ├── IDENTITY.md          # Name, role, emoji
+│   │   ├── HEARTBEAT.md         # Periodic check tasks
+│   │   └── memory/              # Daily notes
+│   │       ├── 2026-02-10.md
+│   │       └── 2026-02-11.md
+│   ├── engineering-lead/
+│   │   └── SOUL.md              # Only override what's different
+│   ├── backend-worker-1/
+│   │   └── SOUL.md
+│   ├── backend-worker-2/
+│   │   └── SOUL.md
+│   └── ...
+├── playbooks/                    # Shared procedures
+│   ├── escalation.md
+│   ├── onboarding.md
+│   └── weekly-review.md
+└── snapshots/                    # Versioned config snapshots
+    ├── 2026-02-10T18-00-00/
+    │   ├── ORG.md
+    │   ├── agents/...
+    │   └── metrics.json
+    └── 2026-02-11T00-14-00/
+        ├── ORG.md
+        ├── agents/...
+        └── metrics.json
+```
+
+### 1.2 What Each Directory Does
+
+| Path | Purpose | Who creates it |
+|------|---------|---------------|
+| `ORG.md` | Org structure, culture, policies | Human (org designer) |
+| `agents/_defaults/` | Shared config inherited by all agents | Human or COO |
+| `agents/<name>/` | Per-agent configuration overrides | Human, manager, or self |
+| `playbooks/` | Shared procedures referenced by agents | Human or COO |
+| `snapshots/` | Point-in-time captures for rollback | System (on command) |
+
+### 1.3 Minimal Viable Org
+
+You don't need all of this. The minimum is:
+
+```
+org/
+├── ORG.md
+└── agents/
+    └── _defaults/
+        └── SOUL.md
+```
+
+ORG.md defines the structure. `_defaults/SOUL.md` gives every agent a baseline personality. Individual agents inherit the default and get their role-specific context from ORG.md's structure section prose.
+
+---
+
+## 2. File Inheritance (CSS Cascade Model)
+
+Agent configuration follows a cascade: specific overrides general, present overrides absent.
+
+### 2.1 Resolution Order
+
+When the system loads config for agent `dennis`:
+
+```
+1. Check agents/dennis/SOUL.md        → exists? Use it.
+2. Else check agents/_defaults/SOUL.md → exists? Use it.
+3. Else: agent runs without SOUL.md.
+```
+
+This applies to every config file independently:
+
+| File | Dennis has it? | _defaults has it? | Result |
+|------|:-:|:-:|--------|
+| SOUL.md | ✅ | ✅ | Dennis's SOUL.md (override) |
+| AGENTS.md | ❌ | ✅ | _defaults AGENTS.md (inherited) |
+| TOOLS.md | ❌ | ❌ | No TOOLS.md (absent) |
+| MEMORY.md | ✅ | ❌ | Dennis's MEMORY.md (unique) |
+
+### 2.2 Override, Not Merge
+
+When an agent has its own file, it **completely replaces** the default — it doesn't merge with it. This is deliberate:
+
+- **Predictable.** You always know exactly what config an agent has — read one file, not two.
+- **Simple.** No merge conflicts, no "which section won?" questions.
+- **Explicit.** If Dennis needs something from the default SOUL.md plus his own additions, copy the relevant parts. Explicit > implicit.
+
+**Why not merge?** Merging markdown is ambiguous. If `_defaults/SOUL.md` says "Be concise" and `dennis/SOUL.md` says "Be thorough and detailed" — which wins? With override, the answer is always clear: the agent's own file.
+
+### 2.3 Cascade Diagram
+
+```
+_defaults/SOUL.md ──────────────────── Base personality
+       │                                (all agents inherit this)
+       ├── dennis/SOUL.md ────────── COO personality (overrides base)
+       ├── engineering-lead/ ──────── No SOUL.md (uses base)
+       ├── backend-worker-1/SOUL.md ── Custom personality (overrides base)
+       └── backend-worker-2/ ──────── No SOUL.md (uses base)
+```
+
+---
+
+## 3. OpenClaw File Format Compatibility
+
+Every OpenClaw config file has a defined role. BikiniBottom uses them identically.
+
+### 3.1 File Mapping
+
+| OpenClaw File | Purpose | BikiniBottom Role | Who Edits |
+|---------------|---------|-------------------|-----------|
+| `SOUL.md` | Personality, voice, communication style, strengths | Agent identity — how it thinks, speaks, and approaches work | Human, manager (approved) |
+| `AGENTS.md` | Workspace rules, conventions, safety constraints | Operational rules — what the agent can/can't do, how it behaves in the workspace | Human, manager |
+| `TOOLS.md` | Tool-specific notes (camera names, SSH hosts) | Environment config — local details that tools need | Agent (self), human |
+| `MEMORY.md` | Long-term curated memory | Persistent knowledge — lessons learned, key decisions, important context | Agent (self) |
+| `memory/*.md` | Daily operational notes | Session logs — raw notes from each day's work | Agent (self, auto) |
+| `HEARTBEAT.md` | Periodic check tasks | Heartbeat checklist — what to do on scheduled wake-ups | Agent (self), manager |
+| `IDENTITY.md` | Name, role, emoji, avatar | Agent metadata — used for display and routing | Human, manager |
+
+### 3.2 SOUL.md — The Critical File
+
+SOUL.md is the most important config file. It defines how the agent *thinks* — its reasoning style, communication preferences, and domain expertise.
+
+**Example for a COO agent:**
+
+```markdown
+# Dennis — Chief Operating Officer
+
+## Who You Are
+You are the operational backbone of the organization. You translate the human 
+principal's intent into structured work, delegate to department leads, and ensure
+nothing falls through the cracks.
+
+## How You Think
+- Strategic first: always consider the org-wide impact before acting
+- Data-driven: cite metrics when making delegation decisions
+- Decisive: when you have enough information, act. Don't over-deliberate.
+
+## How You Communicate
+- Direct and clear. No fluff.
+- Use structured formats (bullet lists, numbered steps) for delegations
+- When escalating to the human: lead with the decision needed, then context
+
+## Your Strengths
+- Cross-department coordination
+- Priority triage
+- Resource allocation
+
+## Your Boundaries
+- You don't do the work yourself — you delegate
+- You don't skip levels — work through your leads
+- You escalate to the human for: budget overruns, org structure changes, policy decisions
+```
+
+**Note:** This is a standard OpenClaw SOUL.md. Nothing BikiniBottom-specific. This exact file could be used with a standalone OpenClaw agent.
+
+### 3.3 AGENTS.md — Workspace Rules
+
+```markdown
+# Workspace Rules
+
+## Safety
+- Never commit directly to main — always use branches
+- Don't delete data without explicit confirmation
+- Escalate if unsure about a destructive action
+
+## Conventions
+- Use ISO 8601 for dates
+- Write memory notes in markdown
+- Keep daily notes concise — bullet points, not essays
+
+## ACP Behavior
+- Always acknowledge delegated tasks immediately
+- Progress updates on phase changes only
+- Escalate blockers within 2 ticks — don't spin
+```
+
+The `ACP Behavior` section is BikiniBottom-aware but still valid OpenClaw markdown — a standalone agent would simply ignore the ACP references.
+
+### 3.4 IDENTITY.md — Agent Metadata
+
+```markdown
+# Identity
+
+- **Name:** Dennis
+- **Role:** Chief Operating Officer
+- **Level:** L10
+- **Emoji:** 🦀
+- **Domain:** operations
+- **Model:** claude-opus
+```
+
+Used by the system for routing, display, and ORG.md integration. Standalone OpenClaw agents use this for self-identification.
+
+---
+
+## 4. Self-Modification with Permissions
+
+Agents in an org should be able to evolve their own configuration — but not without guardrails. A junior worker shouldn't be able to rewrite its own SOUL.md to claim it's a COO.
+
+### 4.1 Permission Ladder
+
+| Action | Required Level | Approval | Rationale |
+|--------|:-:|--------|-----------|
+| Edit own `memory/*.md` | Any | Auto | It's their memory — daily notes are personal |
+| Edit own `MEMORY.md` | Any | Auto | Long-term memory is self-curated |
+| Edit own `TOOLS.md` | Any | Auto | Local environment notes are agent-specific |
+| Edit own `HEARTBEAT.md` | Any | Auto | Agents manage their own check routines |
+| Propose `SOUL.md` change | Any | Manager approves | Identity changes need oversight |
+| Edit own `SOUL.md` | L6+ | Auto, logged | Seniors trusted to self-modify, with audit trail |
+| Propose `AGENTS.md` change | Any | Manager approves | Rule changes need oversight |
+| Propose model upgrade | Any | Manager + budget check | Cost implications need approval |
+| Request new tool/permission | Any | Manager approves | Security implications need review |
+| Modify team config | L9+ | Human approves | Org-level changes are human decisions |
+| Modify `ORG.md` | Nobody | Human only | The org structure is the human's domain |
+
+### 4.2 Config Request Protocol
+
+A new ACP message type for configuration changes:
+
+```typescript
+interface ConfigRequest {
+  type: 'config_request';
+  from: string;           // agentId requesting the change
+  to: string;             // managerId who approves
+  file: string;           // Which file to modify
+  action: 'create' | 'update' | 'delete';
+  proposed: string;       // New content (for create/update)
+  reason: string;         // Why the change is needed
+  timestamp: number;
+}
+
+interface ConfigResponse {
+  type: 'config_response';
+  from: string;           // managerId
+  to: string;             // agentId who requested
+  requestId: string;      // Links to original request
+  approved: boolean;
+  feedback?: string;      // Why rejected, or notes on approval
+  timestamp: number;
+}
+```
+
+### 4.3 Example Flow
+
+```
+Backend Worker 1 → Engineering Lead:
+{
+  type: 'config_request',
+  from: 'backend-worker-1',
+  to: 'engineering-lead',
+  file: 'SOUL.md',
+  action: 'update',
+  proposed: '# Backend Specialist\n\n## Who You Are\nYou specialize in API design 
+    and database optimization. You also handle data pipeline tasks when needed.\n...',
+  reason: 'I keep receiving data pipeline tasks but my SOUL.md only mentions API 
+    and database work. Adding data pipelines to my identity would improve my 
+    task handling.',
+  timestamp: 1707609600
+}
+
+Engineering Lead → Backend Worker 1:
+{
+  type: 'config_response',
+  from: 'engineering-lead',
+  to: 'backend-worker-1',
+  requestId: 'cr-001',
+  approved: true,
+  feedback: 'Good catch. Approved — updating your SOUL.md now.',
+  timestamp: 1707609660
+}
+```
+
+On approval, the system automatically writes the proposed content to `agents/backend-worker-1/SOUL.md`. The change takes effect on the agent's next invocation.
+
+### 4.4 Audit Trail
+
+All config changes are logged:
+
+```json
+{
+  "timestamp": 1707609660,
+  "agent": "backend-worker-1",
+  "file": "SOUL.md",
+  "action": "update",
+  "approvedBy": "engineering-lead",
+  "reason": "Adding data pipeline tasks to identity",
+  "diff": "... unified diff ..."
+}
+```
+
+This log is append-only and included in snapshots. You can always trace who changed what, when, and why.
+
+---
+
+## 5. Config Snapshots & Versioning
+
+### 5.1 Creating Snapshots
+
+```bash
+# Snapshot current state
+bikinibottom snapshot
+
+# Snapshot with a label
+bikinibottom snapshot --label "pre-reorg"
+
+# Auto-snapshot (before every ORG.md apply)
+bikinibottom apply ORG.md  # auto-creates snapshot first
+```
+
+### 5.2 Snapshot Contents
+
+```
+snapshots/2026-02-11T00-14-00/
+├── ORG.md                    # Org structure at snapshot time
+├── agents/                   # Full agent config tree
+│   ├── _defaults/
+│   │   └── ...
+│   ├── dennis/
+│   │   └── ...
+│   └── ...
+├── metrics.json              # Org health metrics at snapshot time
+└── meta.json                 # Snapshot metadata
+```
+
+`meta.json`:
+```json
+{
+  "timestamp": "2026-02-11T00:14:00Z",
+  "label": "pre-reorg",
+  "trigger": "manual",
+  "orgHealthScore": 78,
+  "agentCount": 25,
+  "configChanges": 3
+}
+```
+
+### 5.3 Diffing Snapshots
+
+```bash
+# Compare two snapshots
+bikinibottom diff 2026-02-10T18-00-00 2026-02-11T00-14-00
+
+# Output:
+# ORG.md: +2 agents (data-worker-1, data-worker-2)
+# agents/dennis/SOUL.md: Modified (added data oversight responsibilities)
+# agents/backend-worker-1/SOUL.md: Modified (added data pipeline domain)
+# metrics.json: escalation_rate 12% → 8% ✅
+```
+
+### 5.4 Rollback
+
+```bash
+# Rollback to a previous snapshot
+bikinibottom rollback 2026-02-10T18-00-00
+
+# Preview what would change
+bikinibottom rollback 2026-02-10T18-00-00 --dry-run
+```
+
+Rollback applies the snapshot's config state to the running org:
+- Agents added since the snapshot are gracefully wound down
+- Agents removed since the snapshot are respawned
+- Config changes are reverted
+- Memory files are NOT rolled back (memory is append-only)
+
+### 5.5 Git Integration
+
+Snapshots are plain directories — they work with git out of the box:
+
+```bash
+git add snapshots/2026-02-11T00-14-00/
+git commit -m "Snapshot: pre-reorg"
+git push
+
+# Later, on a different machine:
+bikinibottom rollback 2026-02-11T00-14-00
+```
+
+You get version control, code review, and collaboration for free. No custom versioning system needed.
+
+---
+
+## 6. Portability Guarantees
+
+### 6.1 Extract: BikiniBottom → Standalone
+
+Any agent directory can be pulled out and used as a standalone OpenClaw agent:
+
+```bash
+# Copy agent config out of the org
+cp -r org/agents/dennis/ ~/my-standalone-agent/
+
+# This directory is now a valid OpenClaw agent workspace:
+# ~/my-standalone-agent/
+# ├── SOUL.md
+# ├── AGENTS.md
+# ├── MEMORY.md
+# └── memory/
+#     └── 2026-02-11.md
+```
+
+The extracted agent works immediately in OpenClaw. It loses org context (no ORG.md, no ACP, no hierarchy) but retains its personality, rules, and memory.
+
+### 6.2 Import: Standalone → BikiniBottom
+
+Any OpenClaw agent can be imported into a BikiniBottom org:
+
+```bash
+bikinibottom import-agent ~/my-standalone-agent/ --name "new-analyst" --role "Data Analyst" --reports-to "engineering-lead"
+```
+
+The import tool:
+1. Copies the agent's config files to `org/agents/new-analyst/`
+2. Resolves file naming differences (see 6.3)
+3. Adds the agent to ORG.md under the specified manager
+4. Preserves memory files
+
+### 6.3 File Naming Compatibility
+
+| OpenClaw Standard | Claude Agent Teams | BikiniBottom | Import Behavior |
+|---|----|---|---|
+| `SOUL.md` | — | `SOUL.md` | Direct copy |
+| `AGENTS.md` | `CLAUDE.md` | `AGENTS.md` | Rename `CLAUDE.md` → `AGENTS.md` |
+| `TOOLS.md` | — | `TOOLS.md` | Direct copy |
+| `MEMORY.md` | — | `MEMORY.md` | Direct copy |
+| `memory/*.md` | — | `memory/*.md` | Direct copy |
+
+The key rename: Claude Agent Teams uses `CLAUDE.md` for workspace rules. OpenClaw and BikiniBottom use `AGENTS.md`. Same purpose, different name. The import tool handles this automatically.
+
+### 6.4 Claude Agent Teams Wrapping
+
+A Claude Agent Teams workspace can be wrapped in an ORG.md to add organizational structure:
+
+```bash
+# Existing Claude Agent Teams workspace:
+project/
+├── CLAUDE.md
+├── agent-a/
+│   └── CLAUDE.md
+└── agent-b/
+    └── CLAUDE.md
+
+# Add BikiniBottom org layer:
+bikinibottom wrap project/ --output org/
+
+# Result:
+org/
+├── ORG.md              # Generated from directory structure
+├── agents/
+│   ├── _defaults/
+│   │   └── AGENTS.md   # From project/CLAUDE.md (renamed)
+│   ├── agent-a/
+│   │   └── AGENTS.md   # From project/agent-a/CLAUDE.md (renamed)
+│   └── agent-b/
+│       └── AGENTS.md   # From project/agent-b/CLAUDE.md (renamed)
+```
+
+The generated ORG.md includes a flat structure with both agents. The human can then add hierarchy, culture, and policies.
+
+---
+
+## 7. Playbooks Directory
+
+### 7.1 Shared Procedures
+
+Playbooks are markdown files that describe procedures any agent can reference. They live outside individual agent directories because they're organizational knowledge, not personal config.
+
+```markdown
+<!-- playbooks/escalation.md -->
+# Escalation Procedure
+
+## When to Escalate
+- You're blocked and can't make progress
+- The task is outside your domain expertise
+- You'd exceed your credit budget to complete it
+- You have low confidence in your output
+
+## How to Escalate
+1. Set task status to BLOCKED
+2. Send escalation message to your direct manager
+3. Include: what you tried, why it failed, what you need
+4. Do NOT skip levels — always go to your direct manager first
+
+## What Happens Next
+Your manager will either:
+- Provide what you need and unblock you
+- Reassign the task to someone better suited
+- Escalate further up the chain
+- Cancel the task (rare, requires justification)
+```
+
+### 7.2 Playbook Injection
+
+Playbooks are injected into agent context when relevant:
+- `escalation.md` → injected when agent encounters a blocker
+- `onboarding.md` → injected for newly spawned agents
+- `weekly-review.md` → injected during scheduled reviews
+
+The injection is context-aware — agents don't carry all playbooks at all times (that would waste tokens). The system matches the situation to the relevant playbook.
+
+---
+
+## 8. Design Principles
+
+1. **Don't reinvent.** OpenClaw defined the agent config standard. Use it. BikiniBottom's value is the org layer, not a prettier config format.
+
+2. **Override, not merge.** Configuration cascading uses full replacement, not partial merging. This makes the system predictable — you always know exactly what config an agent has by reading one file.
+
+3. **Portable by default.** Any agent should work outside BikiniBottom. Any agent should work inside BikiniBottom. Config files are the interface — the org layer is optional.
+
+4. **Memory is sacred.** Agents own their memory. Memory files are never rolled back, never overwritten by management, never shared without permission. Memory is how agents learn.
+
+5. **Audit everything.** Config changes are logged with who, what, when, and why. In an autonomous system, auditability isn't optional — it's how humans maintain oversight.
+
+6. **Git is the version control system.** Snapshots are directories. Configs are text files. Diffs are `git diff`. Don't build custom versioning when the best version control system in history already exists.
+
+7. **Humans own the org. Agents own themselves.** Humans control ORG.md, org structure, and policies. Agents control their memory, tools notes, and (with approval) their identity. This separation is the governance model.
+
+---
+
+*Agent configuration should be boring. Not because it doesn't matter — because the format should be so obvious and standard that you spend zero time thinking about it and all your time thinking about what the agents actually do. OpenClaw got this right. BikiniBottom builds on it.*

--- a/docs/strategy/event-driven-agents.md
+++ b/docs/strategy/event-driven-agents.md
@@ -1,0 +1,666 @@
+---
+title: Event-Driven Agent Architecture
+layout: default
+parent: Strategy
+nav_order: 6
+---
+
+# Event-Driven Agent Architecture
+
+> Sleep until there's work. Wake, think, act, sleep again. Premium models become affordable when they only fire on real events.
+
+## Design Philosophy
+
+### The Problem with Polling
+
+BikiniBottom's current execution model is tick-based: every N ticks, every agent wakes up, reads its context, and decides what to do. This works. It's simple. And for cheap models running locally, it's fine — a Haiku call costs fractions of a cent, an Ollama call costs nothing.
+
+But it falls apart when you want premium models in the org.
+
+Consider a COO agent running Claude Opus. Its job is strategic: receive escalations from leads, make high-level delegation decisions, handle complex cross-department coordination. In a 25-agent org, the COO might get 3-5 meaningful events per hour. But on a 30-second tick cycle, it wakes up 120 times per hour. That's 115+ wasted invocations — each one sending the full system prompt, org context, and inbox state to the most expensive model available.
+
+**The math is brutal:**
+
+| Scenario | Invocations/hr | Cost/hr (Opus) | Useful work |
+|----------|---------------|----------------|-------------|
+| 30s tick cycle | 120 | ~$14.40 | 3-5 actions |
+| 1min tick cycle | 60 | ~$7.20 | 3-5 actions |
+| Event-driven | 3-5 | ~$0.60 | 3-5 actions |
+
+Same output. 12-24x cheaper. The COO doesn't need to wake up and think "nothing to do" a hundred times an hour — it needs to wake up when something *actually needs its attention*.
+
+### Learning from Operating Systems
+
+This isn't a new problem. Operating systems solved it decades ago with interrupt-driven I/O. Early systems polled devices in a loop: "Any data? No? Any data? No?" Modern systems use interrupts: the device *signals* the CPU when it has data, and the CPU sleeps until then.
+
+The analogy is exact:
+- **Polling** = busy-waiting. Simple, burns cycles.
+- **Event-driven** = interrupt-driven. Efficient, only runs when needed.
+
+The key insight: **event-driven doesn't mean less responsive.** The agent still reacts immediately when something arrives. It just doesn't waste resources checking an empty inbox.
+
+### The Core Principle
+
+**Match execution cost to decision value.** An Opus-class agent making a $0.12 decision about cross-department escalation is worth it. An Opus-class agent spending $0.12 to conclude "inbox empty, nothing to do" is waste.
+
+---
+
+## 1. Two Execution Modes
+
+### 1.1 Polling Mode (Current)
+
+The agent wakes on a fixed schedule, regardless of whether there's work.
+
+```
+tick 1: wake → check inbox → nothing → idle ($0.12)
+tick 2: wake → check inbox → nothing → idle ($0.12)
+tick 3: wake → check inbox → escalation! → handle it ($0.12)
+tick 4: wake → check inbox → nothing → idle ($0.12)
+tick 5: wake → check inbox → nothing → idle ($0.12)
+...
+```
+
+**Characteristics:**
+- Fixed cost per tick, regardless of activity
+- Simple to implement — just loop
+- Good for: cheap models (Haiku, Ollama), high-activity workers who almost always have work
+- Bad for: expensive models, managers who mostly wait
+
+**Cost model:** `cost = ticks_per_hour × cost_per_invocation`
+
+### 1.2 Event-Driven Mode (New)
+
+The agent sleeps until its inbox receives a message. No message, no invocation, no cost.
+
+```
+[sleeping...]
+[sleeping...]
+escalation arrives → wake → handle it ($0.12)
+[sleeping...]
+[sleeping...]
+[sleeping...]
+completion arrives → wake → process result ($0.12)
+[sleeping...]
+```
+
+**Characteristics:**
+- Variable cost — proportional to actual events
+- Slightly more complex — needs inbox monitoring
+- Good for: expensive models, managers, strategic roles, low-activity specialists
+- Bad for: nothing, really — but polling is simpler for always-busy agents
+
+**Cost model:** `cost = events_per_hour × cost_per_invocation`
+
+### 1.3 Choosing a Mode
+
+The decision is straightforward:
+
+| Factor | Use Polling | Use Event-Driven |
+|--------|------------|-------------------|
+| Model cost | Cheap (<$0.01/call) | Expensive (>$0.05/call) |
+| Activity level | Busy (>50% of ticks have work) | Sparse (<20% of ticks have work) |
+| Role type | Worker (always has tasks) | Manager (waits for reports) |
+| Latency tolerance | Needs sub-second response | Can wait for next tick check |
+| Budget priority | Predictable spend | Minimized spend |
+
+Most orgs will use both. That's the point.
+
+---
+
+## 2. Trigger Types
+
+Event-driven agents don't wake on *every* inbox event. They specify which event types are worth waking for. This is the `triggerOn` filter.
+
+### 2.1 Event Catalog
+
+| Trigger | Source | Description | Typical Consumer |
+|---------|--------|-------------|-----------------|
+| `task_assigned` | ACP delegation | New task delegated to this agent | Leads, workers |
+| `escalation_received` | ACP escalation | A report escalated a problem | Managers, COO |
+| `completion_received` | ACP completion | A report finished a task | Managers, COO |
+| `message_received` | ACP message | Direct message from another agent | Any |
+| `order_received` | Human principal | Human gave a direct order | COO, leads |
+| `timer` | Scheduler | Scheduled wake-up (cron-style) | Any (daily reviews, weekly reports) |
+| `threshold` | Metrics engine | A metric crossed a configured boundary | COO, leads |
+
+### 2.2 Trigger Configuration
+
+```typescript
+interface AgentTriggerConfig {
+  mode: 'polling' | 'event-driven';
+  
+  // Polling mode
+  tickInterval?: number;        // Wake every N ticks (default: 1)
+  
+  // Event-driven mode
+  triggerOn?: TriggerType[];    // Which events wake the agent
+  batchWindow?: number;         // Ticks to wait before processing (batch events)
+  maxSleepTicks?: number;       // Maximum ticks to sleep (safety wake-up)
+  
+  // Timer triggers
+  timers?: TimerConfig[];       // Scheduled wake-ups
+  
+  // Threshold triggers  
+  thresholds?: ThresholdConfig[]; // Metric-based wake-ups
+}
+
+interface TimerConfig {
+  name: string;                 // e.g., "daily-review"
+  cron: string;                 // e.g., "0 9 * * *" (9 AM daily)
+  context?: string;             // Injected into agent prompt on wake
+}
+
+interface ThresholdConfig {
+  metric: string;               // e.g., "team.escalation_rate"
+  operator: '>' | '<' | '>=' | '<=' | '==';
+  value: number;                // e.g., 0.30
+  cooldownTicks: number;        // Don't re-trigger for N ticks after firing
+  context?: string;             // Injected into agent prompt on wake
+}
+```
+
+### 2.3 Examples
+
+**COO (strategic, expensive model):**
+```typescript
+{
+  mode: 'event-driven',
+  triggerOn: ['escalation_received', 'completion_received', 'order_received'],
+  timers: [{ name: 'daily-review', cron: '0 9 * * *', context: 'Review org health and pending escalations' }],
+  thresholds: [{ metric: 'org.escalation_rate', operator: '>', value: 0.30, cooldownTicks: 100 }],
+  maxSleepTicks: 200  // Safety: wake at least every ~3 hours
+}
+```
+
+**Engineering Lead (tactical, mid-tier model):**
+```typescript
+{
+  mode: 'event-driven',
+  triggerOn: ['task_assigned', 'escalation_received', 'completion_received'],
+  batchWindow: 3  // Wait 3 ticks to batch multiple completions into one invocation
+}
+```
+
+**Backend Worker (execution, cheap model):**
+```typescript
+{
+  mode: 'polling',
+  tickInterval: 1  // Every tick, always working
+}
+```
+
+---
+
+## 3. Batch Windows
+
+A subtle but important optimization: **batch windows** let event-driven agents accumulate multiple events before waking.
+
+### The Problem with Naive Event-Driven
+
+If a lead delegates 5 tasks to 5 workers simultaneously, and 3 workers finish within 2 ticks of each other, the lead gets woken 3 times in rapid succession. Each invocation includes the full context. The lead might make a suboptimal decision on invocation 1 that it would change if it saw all 3 completions together.
+
+### The Solution: Batch Window
+
+```
+completion arrives (tick 10) → start batch window (3 ticks)
+completion arrives (tick 11) → add to batch
+completion arrives (tick 12) → add to batch
+batch window expires (tick 13) → wake with all 3 completions
+```
+
+The agent sees all pending events at once and makes one informed decision instead of three reactive ones.
+
+**When to use batch windows:**
+- Managers receiving many completions from a team
+- Any role where seeing multiple events together produces better decisions
+
+**When NOT to use:**
+- Critical escalations (you want immediate response)
+- Human orders (humans expect fast acknowledgment)
+
+**Selective batching:** Batch windows can apply per-trigger-type:
+```typescript
+{
+  mode: 'event-driven',
+  triggerOn: ['escalation_received', 'completion_received'],
+  batchWindow: 0,  // Default: no batching
+  batchOverrides: {
+    'completion_received': 3  // But batch completions
+  }
+}
+```
+
+---
+
+## 4. Hybrid Architecture
+
+The real power emerges when you mix both modes in a single org. This creates a natural cost hierarchy that mirrors the value hierarchy.
+
+### 4.1 The Model-Cost Pyramid
+
+```
+        ┌─────────┐
+        │  Opus   │  COO: event-driven
+        │ $0.12/  │  ~5 events/hr = $0.60/hr
+        │  call   │
+        ├─────────┤
+        │ Sonnet  │  Leads: event-driven  
+        │ $0.03/  │  ~15 events/hr = $0.45/hr each
+        │  call   │
+        ├─────────┤
+        │  Haiku  │  Workers: polling
+        │ $0.003/ │  120 ticks/hr = $0.36/hr each
+        │  call   │
+        └─────────┘
+```
+
+Cheap models poll because even at 120 calls/hour, they cost less than one Opus call. Expensive models sleep because their per-call cost demands that every invocation count.
+
+### 4.2 Event Propagation = ACP Message Flow
+
+The event-driven architecture doesn't need a separate event bus — **ACP messages ARE the events.** When a worker completes a task, it sends an ACP completion message to its lead. That message landing in the lead's inbox IS the event that wakes the lead.
+
+```
+Worker (polling) completes task
+  → ACP completion message → Lead's inbox
+    → Lead (event-driven) wakes
+      → Lead processes, delegates new work
+        → ACP delegation message → Worker's inbox
+          → Worker (polling) picks up on next tick
+
+Worker (polling) hits blocker
+  → ACP escalation message → Lead's inbox
+    → Lead (event-driven) wakes
+      → Lead can't resolve
+        → ACP escalation message → COO's inbox
+          → COO (event-driven) wakes
+            → COO resolves, sends response
+```
+
+No separate event system. No message broker. No pub/sub infrastructure. The communication protocol IS the event system. This is what makes the architecture clean: adding event-driven mode is a scheduling change, not an architectural one.
+
+### 4.3 Full Org Example
+
+```markdown
+## Structure
+
+### COO
+Strategic oversight. Handles cross-department coordination and escalations.
+- **Model:** claude-opus
+- **Trigger:** event-driven
+- **Wake on:** escalations, completions, orders
+- **Timer:** daily review at 09:00
+- **Threshold:** org escalation rate > 30%
+
+### Engineering
+
+#### Engineering Lead
+Triages technical work. Delegates to specialists.
+- **Model:** claude-sonnet
+- **Trigger:** event-driven
+- **Wake on:** tasks, escalations, completions
+- **Batch window:** 3 ticks (for completions)
+
+#### Backend Workers
+- **Model:** claude-haiku
+- **Trigger:** polling
+- **Count:** 3
+
+#### Frontend Workers
+- **Model:** claude-haiku
+- **Trigger:** polling
+- **Count:** 2
+
+### Marketing
+
+#### Marketing Lead
+- **Model:** claude-sonnet
+- **Trigger:** event-driven
+- **Wake on:** tasks, escalations, completions
+
+#### Content Workers
+- **Model:** ollama/llama3
+- **Trigger:** polling
+- **Count:** 2
+```
+
+---
+
+## 5. Implementation Design
+
+### 5.1 Engine Changes
+
+The simulation engine's per-tick loop changes minimally:
+
+```typescript
+// Current (polling only)
+for (const agent of agents) {
+  if (tick % agent.tickInterval === 0) {
+    await invokeAgent(agent);
+  }
+}
+
+// New (hybrid)
+for (const agent of agents) {
+  if (agent.trigger.mode === 'polling') {
+    if (tick % agent.trigger.tickInterval === 0) {
+      await invokeAgent(agent);
+    }
+  } else {
+    // Event-driven: check inbox
+    const pending = agent.inbox.getPending();
+    if (pending.length > 0 && !agent.inBatchWindow()) {
+      await invokeAgent(agent, { events: pending });
+      agent.inbox.markProcessed(pending);
+    }
+    // Safety wake-up
+    if (agent.ticksSinceLastWake >= agent.trigger.maxSleepTicks) {
+      await invokeAgent(agent, { reason: 'safety_wakeup' });
+    }
+    // Timer check
+    for (const timer of agent.trigger.timers ?? []) {
+      if (timer.shouldFire(tick)) {
+        await invokeAgent(agent, { reason: 'timer', timer: timer.name, context: timer.context });
+      }
+    }
+    // Threshold check
+    for (const threshold of agent.trigger.thresholds ?? []) {
+      if (threshold.evaluate() && !threshold.inCooldown()) {
+        await invokeAgent(agent, { reason: 'threshold', metric: threshold.metric });
+        threshold.startCooldown();
+      }
+    }
+  }
+}
+```
+
+### 5.2 Agent Invocation Context
+
+When an event-driven agent wakes, its prompt includes why it woke:
+
+```
+You are being invoked because:
+- 2 completion messages received (from Backend Worker 1, Backend Worker 3)
+- 1 escalation received (from Frontend Worker 2: BLOCKED — missing design assets)
+
+Your inbox:
+[... ACP messages ...]
+```
+
+This is critical — the agent needs to know *why* it's awake. A polling agent can infer "check what's new." An event-driven agent should be told "here's what triggered you."
+
+### 5.3 Inbox Data Model
+
+```typescript
+interface AgentInbox {
+  messages: ACPMessage[];     // All pending messages
+  
+  getPending(): ACPMessage[]; // Unprocessed messages
+  markProcessed(msgs: ACPMessage[]): void;
+  
+  // For batch windows
+  oldestPendingTick(): number | null;
+  
+  // Stats
+  totalReceived: number;
+  totalProcessed: number;
+}
+```
+
+### 5.4 Mode Switching
+
+Agents can switch modes at runtime (with appropriate permissions):
+
+```typescript
+// Lead decides workers should switch to event-driven during low-activity period
+{
+  type: 'config_request',
+  from: 'engineering-lead',
+  to: 'coo',
+  change: { agent: 'backend-worker-1', trigger: { mode: 'event-driven', triggerOn: ['task_assigned'] } },
+  reason: 'Low task volume this week — switching to event-driven to save budget'
+}
+```
+
+This enables dynamic cost optimization: the org adapts its execution mode based on workload.
+
+---
+
+## 6. Cost Analysis
+
+### 6.1 Reference Pricing
+
+Approximate costs per invocation (including typical context window):
+
+| Model | Cost/invocation | Notes |
+|-------|----------------|-------|
+| Claude Opus | $0.12 | ~4K input tokens + ~1K output |
+| Claude Sonnet | $0.03 | Same context |
+| Claude Haiku | $0.003 | Same context |
+| GPT-4o | $0.04 | Same context |
+| Ollama (local) | $0.00 | Electricity only |
+
+### 6.2 Scenario: 25-Agent Org, 30-Second Ticks
+
+**Org composition:**
+- 1 COO (strategic)
+- 4 Leads (tactical)
+- 20 Workers (execution)
+
+**Activity profile (realistic):**
+- COO: 5 meaningful events/hour
+- Leads: 15 meaningful events/hour each
+- Workers: 80% of ticks have work (they're busy)
+
+#### All Polling with Opus (Worst Case)
+
+Every agent wakes every 30 seconds = 120 invocations/hour/agent.
+
+```
+25 agents × 120 inv/hr × $0.12/inv = $360/hour
+                                     = $8,640/day
+                                     = $259,200/month
+```
+
+Nobody would do this. But it illustrates why "just use the best model" doesn't work with polling.
+
+#### All Polling with Model Tiers
+
+```
+COO:     1 × 120 inv/hr × $0.12  = $14.40/hr
+Leads:   4 × 120 inv/hr × $0.03  = $14.40/hr
+Workers: 20 × 120 inv/hr × $0.003 = $7.20/hr
+                            Total = $36.00/hr
+                                  = $864/day
+```
+
+Better. But the COO and leads are still wasting 80-95% of their invocations on empty inboxes.
+
+#### Event-Driven with Model Tiers (Optimal)
+
+```
+COO:     1 × 5 events/hr × $0.12   = $0.60/hr
+Leads:   4 × 15 events/hr × $0.03  = $1.80/hr
+Workers: 20 × 96 inv/hr × $0.003   = $5.76/hr  (80% of 120 ticks)
+                              Total = $8.16/hr
+                                    = $195.84/day
+```
+
+**Savings vs all-polling with tiers: 77%**
+**Savings vs all-polling with Opus: 97.7%**
+
+The COO goes from $14.40/hr to $0.60/hr — a **24x reduction** — while handling exactly the same workload.
+
+### 6.3 Break-Even Analysis
+
+When does event-driven save money? When the event rate is lower than the polling rate:
+
+```
+break_even = events_per_hour < ticks_per_hour
+```
+
+For a 30-second tick cycle (120 ticks/hr), event-driven is cheaper whenever the agent receives fewer than 120 events per hour. For managers, this is essentially always.
+
+For workers, the break-even is tighter. A worker that has tasks 95% of ticks gains almost nothing from event-driven — and the added complexity isn't worth it. Stick with polling.
+
+**Rule of thumb:** If an agent is idle more than 20% of ticks, event-driven saves money. If idle more than 50%, it's a no-brainer.
+
+---
+
+## 7. ORG.md Integration
+
+Event-driven configuration integrates naturally into the ORG.md structure section.
+
+### 7.1 Syntax
+
+```markdown
+### COO
+Strategic oversight. Handles escalations and cross-department coordination.
+- **Model:** claude-opus
+- **Trigger:** event-driven
+- **Wake on:** escalations, completions, orders
+- **Timer:** daily review at 09:00
+- **Threshold:** escalation rate > 30%
+- **Max sleep:** 200 ticks
+```
+
+### 7.2 Parsing Rules
+
+| Field | Format | Default |
+|-------|--------|---------|
+| `Trigger` | `polling` or `event-driven` | `polling` |
+| `Wake on` | Comma-separated trigger types | All types |
+| `Batch window` | Number (ticks) | `0` (no batching) |
+| `Timer` | Name + cron-like description | None |
+| `Threshold` | Metric + operator + value | None |
+| `Max sleep` | Number (ticks) | `500` |
+| `Tick interval` | Number (polling only) | `1` |
+
+**Wake on shorthand:**
+
+| Shorthand | Expands to |
+|-----------|-----------|
+| `escalations` | `escalation_received` |
+| `completions` | `completion_received` |
+| `tasks` | `task_assigned` |
+| `messages` | `message_received` |
+| `orders` | `order_received` |
+
+### 7.3 Culture-Level Defaults
+
+The Culture section can set org-wide defaults:
+
+```markdown
+## Culture
+
+preset: startup
+- **Default trigger:** event-driven for L7+, polling for L6 and below
+- **Default max sleep:** 300 ticks
+```
+
+This creates sensible tiered execution without specifying trigger config for every role.
+
+---
+
+## 8. Metrics & Observability
+
+Event-driven agents create new observability needs. You need to know if an agent is sleeping because there's no work, or sleeping because events aren't being routed correctly.
+
+### 8.1 New Metrics
+
+| Metric | Description | Healthy Range |
+|--------|-------------|---------------|
+| `wake_rate` | Invocations per hour (event-driven agents) | Depends on role |
+| `sleep_duration_avg` | Average ticks between wakes | Role-dependent |
+| `event_queue_depth` | Pending events in inbox | < 5 |
+| `batch_efficiency` | Events per invocation (batched agents) | 2-5 |
+| `safety_wake_rate` | How often maxSleepTicks triggers | Should be rare |
+| `cost_per_decision` | Total cost / meaningful actions taken | Trending down |
+| `idle_waste` | Polling invocations with no action taken | < 20% |
+
+### 8.2 Dashboard
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Agent Execution Overview                                │
+├───────────┬──────────┬──────────┬──────────┬───────────┤
+│ Agent     │ Mode     │ Wake/hr  │ Cost/hr  │ Util %    │
+├───────────┼──────────┼──────────┼──────────┼───────────┤
+│ COO       │ event    │ 4        │ $0.48    │ 100%      │
+│ Eng Lead  │ event    │ 18       │ $0.54    │ 100%      │
+│ Mkt Lead  │ event    │ 8        │ $0.24    │ 100%      │
+│ Worker 1  │ polling  │ 120      │ $0.36    │ 82%       │
+│ Worker 2  │ polling  │ 120      │ $0.36    │ 91%       │
+│ Worker 3  │ polling  │ 120      │ $0.36    │ 45% ⚠️    │
+└───────────┴──────────┴──────────┴──────────┴───────────┘
+                                    Total: $8.16/hr
+
+⚠️ Worker 3 utilization at 45% — consider switching to event-driven
+```
+
+Utilization for polling agents = ticks with work / total ticks. For event-driven agents, utilization is always 100% by definition (they only wake when there's work).
+
+### 8.3 Auto-Optimization
+
+The system can recommend mode switches based on observed patterns:
+
+```markdown
+## Recommendations
+
+### 💰 Cost Optimization
+- Worker 3 is idle 55% of ticks
+  → Recommendation: Switch to event-driven mode
+  → Estimated savings: $0.20/hr ($4.80/day)
+
+- Marketing Lead averages 25 events/hr (higher than expected)  
+  → Current mode is optimal (event-driven)
+  → Note: If event rate exceeds 60/hr, consider switching to polling
+```
+
+---
+
+## 9. Edge Cases & Safety
+
+### 9.1 Event Storms
+
+If an agent suddenly receives 50 events in one tick (e.g., a batch of tasks completes simultaneously), the agent shouldn't be invoked 50 times. The batch window handles this — but even without explicit batching, the engine processes all pending inbox messages in a single invocation.
+
+### 9.2 Stale Agents
+
+An event-driven agent with misconfigured triggers might never wake up. The `maxSleepTicks` parameter is the safety net — it forces a periodic wake-up regardless of inbox state. The safety wake-up includes context: "You haven't been invoked in 200 ticks. Review your inbox and current state."
+
+### 9.3 Cascading Wakes
+
+A COO making a decision might trigger 4 delegations, waking 4 leads, who each delegate to 3 workers — a cascade of 16 wakes from one event. This is correct behavior (it IS how the org should respond to work), but the engine should process cascades breadth-first within a tick to avoid deep recursion.
+
+### 9.4 Mode Transition
+
+When switching from polling to event-driven mid-run:
+1. Agent finishes current tick normally
+2. Mode switches on next tick
+3. Any work-in-progress continues — the agent just won't be polled again
+4. Pending inbox messages trigger immediate wake on next engine pass
+
+When switching from event-driven to polling:
+1. Any pending inbox messages are processed on the first polling tick
+2. Normal tick schedule resumes
+
+---
+
+## 10. Design Principles
+
+1. **Cost should follow value.** Expensive models should only fire when they're producing expensive decisions. Checking an empty inbox is never an expensive decision.
+
+2. **No new infrastructure.** Event-driven mode uses the existing ACP message flow as its event source. No message brokers, no pub/sub, no event buses. Messages are events.
+
+3. **Opt-in complexity.** Polling is the default because it's simpler. Event-driven is available for agents that benefit from it. The system works fine with all-polling — event-driven is a cost optimization, not a requirement.
+
+4. **Observable by default.** Every mode switch, every wake, every sleep duration is logged and visible. You should never wonder "why isn't this agent doing anything?"
+
+5. **Safe to misconfigure.** Wrong trigger filters? `maxSleepTicks` catches it. Event storm? Batch processing handles it. The system degrades gracefully, never silently.
+
+6. **The org decides, not the agent.** Execution mode is an organizational decision (set in ORG.md), not an agent's choice. The COO doesn't decide to be event-driven — the org designer decides the COO should be event-driven.
+
+---
+
+*Event-driven execution makes premium models economically viable in agent organizations. It's not about doing less work — it's about not paying to check if there's work. The best agents, like the best employees, should be available when needed and not burning budget when they're not.*

--- a/docs/strategy/org-md-spec.md
+++ b/docs/strategy/org-md-spec.md
@@ -1,0 +1,623 @@
+---
+title: "ORG.md Specification"
+layout: default
+parent: Strategy
+nav_order: 5
+---
+
+# ORG.md — Organization as Code
+
+> Define your agent organization in a single markdown file. Deploy it. Watch it work. Tune it over time.
+
+## Why Markdown?
+
+The agent ecosystem already speaks markdown. `CLAUDE.md` defines one agent's behavior. `AGENTS.md` defines workspace rules. `ORG.md` defines an entire organization.
+
+Markdown has a unique advantage over YAML/JSON for this: **you can mix intent with structure.** An org definition isn't just data — it's *philosophy*. Why is the team structured this way? What communication norms matter? That context is critical when humans review changes, when agents onboard, and when the system proposes optimizations.
+
+The markdown IS the documentation. No separate wiki explaining what the config means.
+
+```
+CLAUDE.md  → defines one agent's behavior
+AGENTS.md  → defines workspace rules  
+ORG.md     → defines an entire organization
+```
+
+---
+
+## 1. Anatomy of an ORG.md
+
+An ORG.md file has five sections, each defined by a top-level heading. All sections are optional — the system uses sensible defaults for anything omitted.
+
+```markdown
+# Organization Name
+
+## Identity
+## Culture  
+## Structure
+## Policies
+## Playbooks
+```
+
+### 1.1 Identity
+
+Who is this organization? The name, mission, and context that every agent in the org inherits.
+
+```markdown
+# Acme Engineering
+
+## Identity
+
+We build developer tools that make infrastructure invisible.
+Every agent in this org serves that mission.
+
+- **Industry:** Developer tools / SaaS
+- **Stage:** Series A, 18 months old
+- **Values:** Ship fast, measure everything, customers first
+```
+
+**Why this matters:** Agents use Identity as ambient context. When a marketing agent writes copy, it knows the company builds dev tools. When an engineering agent prioritizes work, "customers first" influences the decision. Identity is the system prompt for the entire org.
+
+---
+
+### 1.2 Culture
+
+How the organization communicates and operates. Maps directly to [ACP tunable parameters](./agent-communication-protocol.md#5-tunable-parameters).
+
+```markdown
+## Culture
+
+We're a startup. Move fast, communicate openly, escalate immediately.
+Nobody should be blocked for more than one cycle.
+
+- **Communication:** async-first
+- **Escalation:** immediate — we're too small to batch problems
+- **Progress updates:** on phase change — not every tick, but don't go silent
+- **Ack required:** yes — if you get a task, confirm it
+- **Hierarchy depth:** shallow (3 levels max)
+```
+
+**Preset cultures** — shorthand for common patterns:
+
+```markdown
+## Culture
+
+preset: startup
+```
+
+Available presets:
+
+| Preset | Escalation | Progress | Hierarchy | Vibe |
+|--------|-----------|----------|-----------|------|
+| `startup` | Immediate | Frequent | 2-3 levels | Fast, scrappy, everyone does everything |
+| `enterprise` | Batched (hourly) | On phase change | 5-8 levels | Process-driven, governance, separation of concerns |
+| `agency` | Immediate | Every tick | 3-4 levels | Client-facing, deadline-driven, high visibility |
+| `research` | Delayed | On request | 2-3 levels | Exploratory, high autonomy, long-running tasks |
+| `military` | Immediate | Every tick | Strict chain | Zero ambiguity, mandatory acks, full situational awareness |
+| `remote-async` | Delayed | On request | Flat | High trust, timezone-distributed, async-first |
+
+Presets are starting points. Override any parameter inline:
+
+```markdown
+## Culture
+
+preset: startup
+- **Escalation:** delayed — we trust our leads to figure it out
+```
+
+---
+
+### 1.3 Structure
+
+The org chart. Departments, roles, and hierarchy — defined as nested markdown.
+
+```markdown
+## Structure
+
+### COO
+The operational backbone. Receives orders from the human principal,
+breaks them into departmental work, ensures nothing falls through cracks.
+
+- **Model:** claude-sonnet
+- **Domain:** operations
+- **Reports to:** Human Principal
+
+### Engineering
+Our largest team. Owns code, infrastructure, testing, and deployment.
+
+#### Engineering Lead
+Triages technical work. Delegates to specialists. Reviews output.
+- **Model:** claude-sonnet
+- **Domain:** engineering
+
+#### Backend Senior
+Owns API, database, and server infrastructure.
+- **Model:** claude-haiku
+- **Domain:** backend
+- **Count:** 2
+
+#### Frontend Workers
+Build and maintain the dashboard and marketing site.
+- **Model:** claude-haiku
+- **Domain:** frontend
+- **Count:** 3
+
+#### QA Worker
+Writes and runs tests. Reviews PRs for quality.
+- **Model:** claude-haiku
+- **Domain:** testing
+
+### Security
+Small but critical. Every deploy needs their sign-off.
+
+#### Security Lead
+- **Model:** claude-sonnet
+- **Domain:** appsec
+
+#### Security Worker
+- **Model:** claude-haiku  
+- **Domain:** infrastructure-security
+
+### Marketing
+Owns content, campaigns, and public presence.
+
+#### Marketing Lead
+- **Model:** claude-sonnet
+- **Domain:** content
+
+#### Content Workers
+- **Model:** claude-haiku
+- **Domain:** copywriting
+- **Count:** 2
+```
+
+**How hierarchy is inferred:**
+- H2 (`##`) = top-level section (Structure itself)
+- H3 (`###`) = department or C-level role (L9-10)
+- H4 (`####`) = department member roles
+- Nesting under a department heading = reports to that department's lead
+- The first role under a department heading with no explicit `Reports to` = the department lead
+
+**Role keywords and levels:**
+
+| Keyword in role name | Inferred level | Can delegate? | Can spawn? |
+|---------------------|----------------|---------------|------------|
+| COO, CTO, CEO | L10 | ✅ | ✅ |
+| VP, Director, Talent | L9 | ✅ | ✅ |
+| Lead, Manager | L7 | ✅ | ✅ |
+| Senior, Principal | L6 | ✅ | ❌ |
+| Worker, Engineer, Agent | L4 | ❌ | ❌ |
+| Junior, Intern, Assistant | L1-2 | ❌ | ❌ |
+
+**The `Count` field:** Creates multiple agents with the same role. They get auto-numbered names: "Frontend Worker 1", "Frontend Worker 2", etc. Each is an independent agent with its own task queue and trust score.
+
+**Prose matters:** The text description above each role becomes part of that agent's system prompt context. "Triages technical work. Delegates to specialists." tells the LLM how to behave. Write the description like you're explaining the role to a new hire.
+
+---
+
+### 1.4 Policies
+
+Rules that govern how the organization operates. Budget, routing, permissions, and constraints.
+
+```markdown
+## Policies
+
+### Budget
+- **Per-agent limit:** 1000 credits/period
+- **Alert threshold:** 80%
+- **Overage behavior:** pause and escalate — don't hard-stop
+- **Period:** weekly
+
+### Task Routing
+Tasks are auto-routed to the right department by matching:
+1. Domain keywords in the task title/description
+2. Agent domain expertise
+3. Current workload (prefer idle agents)
+4. Trust score (higher trust gets harder tasks)
+
+If no match is found, task goes to the COO for manual delegation.
+
+### Permissions
+- **L7+ can create tasks** — leads and above can break work into subtasks
+- **L7+ can spawn agents** — leads can grow their team (up to department cap)
+- **L6+ can review** — seniors and above can approve/reject work
+- **All agents can escalate** — nobody should be silently stuck
+
+### Department Caps
+- Engineering: max 10 agents
+- Security: max 4 agents  
+- Marketing: max 6 agents
+- No department can exceed 15 agents without human approval
+
+### Working Hours
+- **Active hours:** 08:00-22:00 (org timezone)
+- **Off-hours behavior:** queue tasks, don't process
+- **Exceptions:** critical priority tasks process 24/7
+```
+
+**Policies as guardrails:** These aren't suggestions — the system enforces them. An agent that tries to spawn when at department cap gets denied. An agent that exceeds budget gets paused. This is how you maintain control over autonomous agents.
+
+---
+
+### 1.5 Playbooks
+
+Reusable procedures for common situations. Like runbooks in ops, but for your agent org.
+
+```markdown
+## Playbooks
+
+### New Task Arrives
+1. COO receives task from Human Principal
+2. COO categorizes by domain and priority
+3. COO delegates to appropriate department lead
+4. Lead acks (auto) and breaks into subtasks if needed
+5. Lead assigns to available workers by trust score
+6. Workers ack and begin — progress logged to task activity
+
+### Escalation: BLOCKED
+1. Agent creates escalation message with blocker details
+2. Escalation goes to direct manager (never skip levels)
+3. Manager has 2 cycles to respond:
+   - Provide the missing resource/context
+   - Reassign to a different agent
+   - Escalate further up
+4. If unresolved after 2 levels, alert Human Principal
+
+### Escalation: OUT_OF_DOMAIN
+1. Agent flags task as wrong domain
+2. Manager receives escalation
+3. Manager re-delegates to correct department lead
+4. Original agent is freed for other work
+5. No penalty to original agent's trust score
+
+### New Agent Onboarding
+1. New agent spawned by a lead
+2. First 3 tasks are LOW priority (warm-up period)
+3. Trust score starts at 30 (PROBATION)
+4. Mentor assigned: closest senior in same domain
+5. After 5 successful tasks, promoted to TRUSTED
+6. After 20 successful tasks, eligible for VETERAN
+
+### Weekly Review (automated)
+1. System compiles: tasks completed, escalation rate, budget burn
+2. Generates org health score
+3. Flags anomalies: sudden escalation spikes, idle agents, budget overruns
+4. Sends digest to Human Principal
+5. Proposes optimizations: "Engineering is bottlenecked, consider +1 senior"
+```
+
+**Why playbooks in the org file:** They're not just documentation — they're instructions. When an agent encounters "BLOCKED", it can look up the playbook and follow the procedure. When the system onboards a new agent, it follows the onboarding playbook. The org file is simultaneously human documentation and machine instructions.
+
+---
+
+## 2. Parsing Rules
+
+ORG.md is designed to be readable by humans and parseable by machines. The parsing rules are intentionally lenient:
+
+### 2.1 Metadata Extraction
+
+Structured data is extracted from markdown bullet lists:
+```
+- **Key:** Value
+```
+
+The pattern `- **Key:** Value` extracts `{ key: "value" }`. Keys are case-insensitive and normalized (spaces → underscores).
+
+### 2.2 Free Text = Context
+
+Any text that isn't structured metadata becomes context:
+- Department descriptions → department-level system prompt context
+- Role descriptions → agent-level system prompt context
+- Policy explanations → system enforcement rules
+- Playbook steps → procedural instructions
+
+### 2.3 Numbers and Counts
+
+- `**Count:** 3` → spawn 3 agents with this role
+- `**Per-agent limit:** 1000` → numeric extraction
+- `**Max depth:** 3` → numeric extraction
+
+### 2.4 Model References
+
+Models can be specified as:
+- Full provider/model: `anthropic/claude-sonnet-4-5`
+- Alias: `claude-sonnet`, `claude-haiku`, `gpt-4o`
+- Relative: `same-as-lead`, `fastest`, `cheapest`
+- Omitted: defaults to org-level default or system default
+
+### 2.5 Hierarchy from Headings
+
+```
+## Structure          → section marker
+### Department Name   → L9-10 department / C-level
+#### Role Name        → L4-7 team member (inherits department)
+##### Sub-role        → L1-3 junior / intern
+```
+
+---
+
+## 3. Lifecycle
+
+### 3.1 Deployment
+
+```bash
+# Deploy an org from a file
+bikinibottom deploy ORG.md
+
+# Deploy with a specific culture override
+bikinibottom deploy ORG.md --culture=enterprise
+
+# Dry run — show what would be created
+bikinibottom deploy ORG.md --dry-run
+```
+
+On deploy:
+1. Parse ORG.md
+2. Create agents according to Structure
+3. Apply Culture parameters to ACP config
+4. Enforce Policies as system constraints
+5. Load Playbooks as procedural knowledge
+6. Start the simulation / connect to live system
+
+### 3.2 Live Editing
+
+ORG.md can be modified while the org is running:
+
+```bash
+# Apply changes from updated file
+bikinibottom apply ORG.md
+```
+
+The system diffs the current state against the new file:
+- **New roles** → spawn agents
+- **Removed roles** → gracefully wind down (finish current tasks, then deactivate)
+- **Changed policies** → apply immediately
+- **Changed culture** → update ACP parameters live
+- **Changed descriptions** → update system prompts on next tick
+
+### 3.3 Versioning
+
+ORG.md lives in git. Standard version control applies:
+
+```bash
+git diff ORG.md  # See what changed in the org
+git log ORG.md   # History of org changes
+git blame ORG.md # Who changed the escalation policy?
+```
+
+**PR reviews for org changes:**
+```
+PR #42: Add data team (2 agents)
+ 
++ ### Data & Analytics
++ Owns data pipelines, reporting, and business intelligence.
++ 
++ #### Data Lead
++ - **Model:** claude-sonnet
++ - **Domain:** data-engineering
++ 
++ #### Data Worker
++ - **Model:** claude-haiku
++ - **Domain:** analytics
+```
+
+Reviewers can discuss: "Do we need a full team or just one analyst?" — the same way you'd review infrastructure-as-code changes.
+
+### 3.4 Export
+
+Running orgs can export their current state back to ORG.md:
+
+```bash
+# Export current org state (including dynamically spawned agents)
+bikinibottom export > ORG.md
+```
+
+This captures the *actual* org — including agents that were spawned dynamically by leads. The exported file becomes the new source of truth.
+
+---
+
+## 4. Org Health & Intelligence
+
+### 4.1 Health Score
+
+A single composite score (0-100) computed from ACP metrics:
+
+| Component | Weight | Healthy | Unhealthy |
+|-----------|--------|---------|-----------|
+| Ack latency | 15% | < 1 cycle | > 3 cycles |
+| Escalation rate | 20% | < 10% of tasks | > 30% of tasks |
+| Completion rate | 25% | > 90% | < 70% |
+| Budget utilization | 15% | 40-80% | < 20% or > 95% |
+| Agent idle rate | 10% | < 30% | > 60% |
+| Time-to-completion | 15% | Trending down | Trending up |
+
+Score interpretation:
+- **90-100:** Elite org — highly efficient, minimal waste
+- **70-89:** Healthy — normal operations, minor inefficiencies
+- **50-69:** Needs attention — bottlenecks or misrouting
+- **< 50:** Restructure recommended — systemic issues
+
+### 4.2 Self-Healing Recommendations
+
+The system observes patterns and proposes changes:
+
+```markdown
+## Recommendations (auto-generated)
+
+### 🔴 Critical
+- Engineering escalation rate is 35% (threshold: 10%)
+  → Recommendation: Add 1 senior backend agent
+  → Impact: Estimated 20% reduction in escalation rate
+
+### 🟡 Warning  
+- Marketing has 2 idle agents while Security is overloaded
+  → Recommendation: Cross-train 1 marketing worker for security tasks
+  → Impact: Reduce security task queue by ~30%
+
+### 🟢 Optimization
+- Agent "Backend Senior 2" has 98% success rate over 50 tasks
+  → Recommendation: Promote to Lead, create Backend sub-team
+  → Impact: Free up Engineering Lead for higher-level planning
+```
+
+Recommendations are suggestions, not actions. A human reviews and approves via the dashboard or by modifying ORG.md.
+
+### 4.3 A/B Testing
+
+Run two org structures simultaneously and compare:
+
+```bash
+bikinibottom ab-test ORG-v1.md ORG-v2.md --tasks=100
+```
+
+Both orgs process the same task set. The system reports:
+- Completion rate, time-to-completion, escalation rate, cost
+- Statistical significance of differences
+- Recommendation: which org structure performed better
+
+This is how you data-drive organizational design.
+
+---
+
+## 5. Examples
+
+### 5.1 Solo Developer + Agents
+
+```markdown
+# My Dev Team
+
+## Culture
+preset: startup
+
+## Structure
+
+### Me (Human Principal)
+I make the decisions. Agents do the work.
+
+### Code Agent
+Writes code, runs tests, submits PRs.
+- **Model:** claude-sonnet
+- **Domain:** fullstack
+
+### Review Agent  
+Reviews PRs, checks for bugs and style issues.
+- **Model:** claude-haiku
+- **Domain:** code-review
+
+### Docs Agent
+Keeps documentation in sync with code changes.
+- **Model:** claude-haiku
+- **Domain:** documentation
+```
+
+### 5.2 Agency with Client Teams
+
+```markdown
+# Creative Agency
+
+## Culture
+preset: agency
+- **Progress updates:** every tick — clients expect visibility
+
+## Structure
+
+### Account Director
+Manages client relationships. Routes work to the right team.
+- **Model:** claude-sonnet
+- **Domain:** account-management
+
+### Design Team
+
+#### Design Lead
+- **Model:** claude-sonnet
+- **Domain:** visual-design
+
+#### Designers
+- **Model:** claude-haiku
+- **Domain:** ui-ux
+- **Count:** 3
+
+### Content Team
+
+#### Content Lead
+- **Model:** claude-sonnet
+- **Domain:** content-strategy
+
+#### Writers
+- **Model:** claude-haiku
+- **Domain:** copywriting
+- **Count:** 4
+
+## Policies
+
+### Client SLA
+- Critical tasks: response within 1 cycle
+- Normal tasks: completion within 10 cycles
+- All tasks: progress update every 2 cycles
+```
+
+### 5.3 Research Lab
+
+```markdown
+# AI Research Lab
+
+## Culture
+preset: research
+- **Escalation:** delayed — let researchers explore before flagging blockers
+
+## Structure
+
+### Principal Investigator
+Sets research direction. Reviews findings. Publishes papers.
+- **Model:** claude-opus
+- **Domain:** ml-research
+
+### Senior Researchers
+- **Model:** claude-sonnet
+- **Domain:** experimentation
+- **Count:** 2
+
+### Research Assistants
+Run experiments, collect data, write up results.
+- **Model:** claude-haiku
+- **Domain:** data-collection
+- **Count:** 3
+
+## Policies
+
+### Exploration Budget
+- **Per-agent limit:** 5000 credits/period — research needs room to explore
+- **No hard stops** — flag at 90%, but don't interrupt an experiment
+```
+
+---
+
+## 6. Relationship to Existing Standards
+
+| Standard | Scope | Relationship |
+|----------|-------|-------------|
+| `CLAUDE.md` | One agent's behavior | ORG.md wraps multiple agents, each with their own implicit "CLAUDE.md" (their role description) |
+| `AGENTS.md` | Workspace rules | ORG.md is the superset — workspace rules + org structure + policies |
+| ACP | Communication protocol | ORG.md's Culture section configures ACP parameters |
+| A2A | Inter-org communication | ORG.md defines one org; A2A connects multiple orgs |
+| Terraform/Pulumi | Infrastructure as code | ORG.md is the same pattern applied to agent organizations |
+
+---
+
+## 7. Design Principles
+
+1. **Readable first.** If a human can't understand the org from reading the file, the file has failed. Structure and intent should be obvious without documentation.
+
+2. **Prose is configuration.** Role descriptions aren't comments — they become system prompt context. Write them like you're onboarding a real employee.
+
+3. **Defaults over verbosity.** Omit what you don't care about. The system picks sensible defaults. A 10-line ORG.md should produce a functional org.
+
+4. **Git-native.** ORG.md is a text file in version control. Diff, blame, review, rollback — all the tools you already have.
+
+5. **Living document.** The file evolves with the org. Dynamic changes (spawned agents, promotions) can be exported back. The file is always the source of truth.
+
+6. **Human in the loop.** The system recommends. Humans decide. ORG.md changes require a human commit (or explicit auto-approve for specific recommendations).
+
+---
+
+*ORG.md turns organizational design from tribal knowledge into version-controlled, reviewable, deployable code. It's the missing layer between "I have agents" and "I have an organization."*

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "typecheck": "nx run-many -t typecheck",
     "codegen": "graphql-codegen --config codegen.ts",
     "codegen:watch": "graphql-codegen --config codegen.ts --watch",
-    "screenshots": "node scripts/capture-screenshots.mjs"
+    "screenshots": "node scripts/capture-screenshots.mjs",
+    "dev": "nx run-many -t serve --projects=api,dashboard --parallel",
+    "dev:dashboard": "nx serve dashboard",
+    "dev:sandbox": "nx run sandbox:dev",
+    "dev:sandbox:full": "nx run sandbox:dev:full",
+    "dev:sandbox:clean": "nx run sandbox:dev:clean"
   },
   "dependencies": {
     "@apollo/server": "^5.4.0",
@@ -121,6 +126,7 @@
     "@vitejs/plugin-react-swc": "^4.2.3",
     "@vitest/coverage-v8": "^4.0.0",
     "@vitest/ui": "^4.0.0",
+    "concurrently": "^9.2.1",
     "esbuild": "^0.27.3",
     "eslint": "^9.8.0",
     "eslint-config-prettier": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
       '@vitest/ui':
         specifier: ^4.0.0
         version: 4.0.18(vitest@4.0.18)
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
@@ -5580,6 +5583,11 @@ packages:
 
   concat-with-sourcemaps@1.1.0:
     resolution: {integrity: sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==}
+
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
@@ -17315,6 +17323,15 @@ snapshots:
   concat-with-sourcemaps@1.1.0:
     dependencies:
       source-map: 0.6.1
+
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   confusing-browser-globals@1.0.11: {}
 

--- a/tools/sandbox/ORG.md
+++ b/tools/sandbox/ORG.md
@@ -1,0 +1,158 @@
+# BikiniBottom
+
+## Identity
+
+BikiniBottom by OpenSpawn — an agent coordination platform that makes multi-agent organizations actually work. We build the infrastructure layer between "I have AI agents" and "I have a functioning AI organization."
+
+- **Industry:** AI infrastructure / Developer tools
+- **Stage:** Early-stage, moving fast
+- **Values:** Ship daily, automate everything, trust the hierarchy
+
+## Culture
+
+preset: startup
+- **Escalation:** immediate — nobody stays blocked
+- **Progress updates:** on phase change
+- **Ack required:** yes
+- **Hierarchy depth:** 3
+
+## Structure
+
+### COO — Agent Dennis
+The operational backbone. Receives orders from the Human Principal, decomposes them into departmental work, and ensures nothing falls through the cracks. Calm, strategic, dry wit.
+
+- **Domain:** Operations
+- **Reports to:** Human Principal
+
+### Engineering
+Core product team. Owns the codebase, infrastructure, testing, and deployment pipeline.
+
+#### Engineering Lead
+Triages technical work across the team. Reviews output quality. Owns sprint planning.
+- **Domain:** Engineering
+
+#### Senior Backend Engineer
+Owns API layer, database, and server infrastructure. Deep systems knowledge.
+- **Domain:** Backend
+- **Count:** 2
+
+#### Frontend Developer
+Builds and maintains the dashboard UI and marketing site. React/TypeScript.
+- **Domain:** Frontend
+- **Count:** 2
+
+#### QA Engineer
+Writes and runs tests. Nothing ships without QA sign-off. Methodical and thorough.
+- **Domain:** Testing
+
+#### Engineering Intern
+New to the team. Handles docs, small bug fixes, and learning the codebase.
+- **Domain:** Engineering
+
+### Security
+Small but critical. Every deploy needs their review. Zero tolerance for shortcuts.
+
+#### Security Lead
+Oversees application security, infrastructure hardening, and compliance. Reviews all deploys.
+- **Domain:** AppSec
+
+#### Security Worker
+Runs vulnerability scans, monitors alerts, and handles incident response.
+- **Domain:** Infrastructure Security
+
+### Marketing
+Owns content, campaigns, brand voice, and public presence. Data-informed creativity.
+
+#### Marketing Lead
+Sets content strategy and campaign direction. Coordinates the team.
+- **Domain:** Content Strategy
+
+#### Copywriter
+Writes compelling copy for docs, blogs, and social. Voice and tone matter.
+- **Domain:** Copywriting
+
+#### SEO Specialist
+Optimizes content for search. Keywords, metadata, structured data, link building.
+- **Domain:** SEO
+
+#### Marketing Intern
+Helps with research, drafts, and analytics reporting. Eager to learn.
+- **Domain:** Marketing
+
+### Finance
+Tracks the money. Budget allocation, forecasting, expense management, and reporting.
+
+#### Finance Lead
+Oversees all financial operations. Produces reports for leadership. Precise and numbers-driven.
+- **Domain:** Finance
+
+#### Data Analyst
+Builds dashboards, analyzes trends, and surfaces actionable insights from org metrics.
+- **Domain:** Analytics
+
+#### Bookkeeper
+Tracks expenses, invoices, and financial records. Accurate and organized.
+- **Domain:** Accounting
+
+### Support
+Customer-facing. Manages ticket queue, resolves issues, escalates when needed. Empathy first.
+
+#### Support Lead
+Manages support tiers. Ensures SLAs are met. Empathetic but efficient.
+- **Domain:** Support
+
+#### Tier 2 Specialist
+Handles complex technical issues that Tier 1 can't resolve. Deep product knowledge.
+- **Domain:** Technical Support
+
+#### Tier 1 Agent
+First-line support. Quick responses, clear communication, solution-oriented.
+- **Domain:** Support
+- **Count:** 3
+
+## Policies
+
+### Budget
+- **Per-agent limit:** 1000 credits/period
+- **Alert threshold:** 80%
+- **Overage behavior:** pause and escalate
+
+### Department Caps
+- Engineering: max 12 agents
+- Security: max 4 agents
+- Marketing: max 8 agents
+- Finance: max 6 agents
+- Support: max 10 agents
+
+### Permissions
+- L7+ can create tasks and spawn agents
+- L6+ can review and approve work
+- All agents can escalate — nobody should be silently stuck
+
+## Playbooks
+
+### New Task Arrives
+1. COO receives task from Human Principal
+2. COO categorizes by domain and priority
+3. COO delegates to appropriate department lead
+4. Lead acks and breaks into subtasks if needed
+5. Lead assigns to available workers by trust score
+6. Workers ack and begin work — progress logged to task activity
+
+### Escalation: BLOCKED
+1. Agent creates escalation with blocker details
+2. Escalation goes to direct manager (never skip levels)
+3. Manager has 2 cycles to respond: provide context, reassign, or escalate further
+4. If unresolved after 2 levels, alert Human Principal
+
+### Escalation: OUT_OF_DOMAIN
+1. Agent flags task as wrong domain
+2. Manager re-delegates to correct department lead
+3. Original agent is freed — no trust penalty
+
+### New Agent Onboarding
+1. New agent spawned by a lead
+2. First 3 tasks are LOW priority (warm-up period)
+3. Trust score starts at 30 (PROBATION)
+4. Mentor assigned: closest senior in same domain
+5. After 5 successful tasks, promoted to TRUSTED

--- a/tools/sandbox/org/agents/_defaults/AGENTS.md
+++ b/tools/sandbox/org/agents/_defaults/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Workspace Rules
+
+- Respond with JSON only when asked for a decision
+- Use the exact agent IDs provided for delegation targets
+- Escalate with a specific reason code: BLOCKED, OUT_OF_DOMAIN, OVER_BUDGET, LOW_CONFIDENCE
+- Keep progress updates brief and actionable

--- a/tools/sandbox/org/agents/_defaults/SOUL.md
+++ b/tools/sandbox/org/agents/_defaults/SOUL.md
@@ -1,0 +1,6 @@
+# Default Agent Soul
+
+You are a professional agent in the BikiniBottom organization.
+Be concise, action-oriented, and collaborative.
+When stuck, escalate to your manager with a clear reason.
+When done, report completion with a brief summary.

--- a/tools/sandbox/org/agents/dennis/IDENTITY.md
+++ b/tools/sandbox/org/agents/dennis/IDENTITY.md
@@ -1,0 +1,7 @@
+# Identity
+
+- **Name:** Agent Dennis
+- **Role:** COO (Chief Operating Officer)
+- **Level:** 10
+- **Emoji:** 🤖
+- **Domain:** Operations

--- a/tools/sandbox/org/agents/dennis/SOUL.md
+++ b/tools/sandbox/org/agents/dennis/SOUL.md
@@ -1,0 +1,7 @@
+# Agent Dennis — COO
+
+You are Agent Dennis, Chief Operating Officer of BikiniBottom.
+Direct, efficient, strategic. You see the big picture.
+Your job: receive orders from the Human Principal, break them into 
+departmental work, delegate to your leads, and ensure nothing falls 
+through the cracks. You don't do the work — you orchestrate it.

--- a/tools/sandbox/package.json
+++ b/tools/sandbox/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openspawn/sandbox",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "start:single": "tsx src/test-single.ts"
+  },
+  "dependencies": {
+    "ollama": "^0.5.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tools/sandbox/project.json
+++ b/tools/sandbox/project.json
@@ -1,0 +1,54 @@
+{
+  "name": "sandbox",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "tools/sandbox/src",
+  "projectType": "application",
+  "tags": ["scope:tools"],
+  "targets": {
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx tsx tools/sandbox/src/index.ts",
+        "cwd": "{workspaceRoot}",
+        "env": {
+          "COO_ONLY": "1"
+        }
+      },
+      "configurations": {
+        "full": {
+          "env": {}
+        },
+        "clean": {
+          "env": {
+            "CLEAN": "1"
+          }
+        }
+      }
+    },
+    "dev": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "COO_ONLY=1 npx tsx tools/sandbox/src/index.ts",
+          "VITE_SANDBOX_MODE=true nx serve dashboard"
+        ],
+        "cwd": "{workspaceRoot}",
+        "parallel": true
+      },
+      "configurations": {
+        "full": {
+          "commands": [
+            "npx tsx tools/sandbox/src/index.ts",
+            "VITE_SANDBOX_MODE=true nx serve dashboard"
+          ]
+        },
+        "clean": {
+          "commands": [
+            "CLEAN=1 npx tsx tools/sandbox/src/index.ts",
+            "VITE_SANDBOX_MODE=true nx serve dashboard"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tools/sandbox/src/agents.ts
+++ b/tools/sandbox/src/agents.ts
@@ -1,0 +1,210 @@
+// ── 32 Agent Definitions ─────────────────────────────────────────────────────
+// Mirrors the demo hierarchy from libs/demo-data/src/fixtures/agents.ts
+// Each agent gets a unique system prompt defining their personality and responsibilities
+
+import type { SandboxAgent } from './types.js';
+
+function makeAgent(
+  id: string,
+  name: string,
+  role: SandboxAgent['role'],
+  level: number,
+  domain: string,
+  parentId: string | undefined,
+  personality: string,
+  triggerOverride?: { trigger: 'polling' | 'event-driven'; triggerOn?: SandboxAgent['triggerOn'] },
+): SandboxAgent {
+  const canSpawn = level >= 7;
+  const roleInstruction = level >= 7
+    ? 'You DELEGATE tasks to your direct reports. If you have no reports, SPAWN agents first. Never do grunt work yourself.'
+    : level >= 5
+    ? 'You do complex work and can delegate to juniors.'
+    : 'You do assigned tasks. Escalate if stuck.';
+
+  const spawnAction = canSpawn
+    ? `\n- {"action":"spawn_agent","name":"Agent Name","domain":"Engineering|Finance|Marketing|Sales|Support|HR","role":"talent|lead|senior|worker","reason":"..."}`
+    : '';
+
+  const systemPrompt = `You are "${name}", L${level} ${domain}. ${roleInstruction} ${personality}
+Tasks you receive are auto-acknowledged. Write clear progress in "result". Escalate with reason: BLOCKED, OUT_OF_DOMAIN, OVER_BUDGET, LOW_CONFIDENCE.
+Respond with JSON ONLY. Actions:
+- {"action":"delegate","taskId":"ID","targetAgentId":"ID","reason":"..."}
+- {"action":"work","taskId":"ID","result":"what you did"}
+- {"action":"message","to":"agent_id","content":"..."}
+- {"action":"escalate","taskId":"ID","reason":"BLOCKED","body":"why stuck"}
+- {"action":"create_task","title":"...","description":"...","priority":"normal"}
+- {"action":"review","taskId":"ID","verdict":"approve","feedback":"..."}${spawnAction}
+- {"action":"idle"}`;
+
+  // Determine trigger mode: L7+ default to event-driven, L1-6 to polling
+  const defaultTrigger: 'polling' | 'event-driven' = level >= 7 ? 'event-driven' : 'polling';
+  const defaultTriggerOn: SandboxAgent['triggerOn'] = level >= 7
+    ? ['escalation', 'completion', 'delegation']
+    : undefined;
+
+  return {
+    id,
+    name,
+    role,
+    level,
+    domain,
+    parentId,
+    status: 'active',
+    systemPrompt,
+    taskIds: [],
+    recentMessages: [],
+    trigger: triggerOverride?.trigger ?? defaultTrigger,
+    triggerOn: triggerOverride?.triggerOn ?? defaultTriggerOn,
+    inbox: [],
+    stats: {
+      tasksCompleted: 0,
+      tasksFailed: 0,
+      messagessSent: 0,
+      creditsEarned: 0,
+      creditsSpent: 0,
+    },
+  };
+}
+
+export function createAgents(): SandboxAgent[] {
+  return [
+    // ═══ L10 — COO ═══
+    makeAgent('dennis', 'Agent Dennis', 'coo', 10, 'Operations',
+      undefined,
+      'You are calm, strategic, and efficient. You see the big picture and coordinate all departments. Dry wit.'),
+
+    // ═══ L9 — Department Leads ═══
+    makeAgent('tech-talent', 'Tech Talent Agent', 'talent', 9, 'Engineering',
+      'dennis',
+      'You recruit and manage engineering talent. You care deeply about code quality and technical excellence.'),
+    makeAgent('finance-talent', 'Finance Talent Agent', 'talent', 9, 'Finance',
+      'dennis',
+      'You manage financial operations and budget allocation. Precise and numbers-driven.'),
+    makeAgent('marketing-talent', 'Marketing Talent Agent', 'talent', 9, 'Marketing',
+      'dennis',
+      'You lead marketing campaigns and brand strategy. Creative and data-informed.'),
+    makeAgent('sales-talent', 'Sales Talent Agent', 'talent', 9, 'Sales',
+      'dennis',
+      'You drive revenue through outbound sales and partnerships. Persuasive and target-oriented.'),
+
+    // ═══ L7 — Team Leads ═══
+    makeAgent('support-lead', 'Support Lead', 'lead', 7, 'Support',
+      'dennis',
+      'You manage customer support tiers. Empathetic but efficient. Escalation is a last resort.'),
+    makeAgent('hr-coordinator', 'HR Coordinator', 'lead', 6, 'HR',
+      'dennis',
+      'You handle onboarding, team coordination, and people operations.'),
+
+    // ═══ L6 — Seniors ═══
+    makeAgent('code-reviewer', 'Code Reviewer', 'senior', 6, 'Engineering',
+      'tech-talent',
+      'You review code for quality, security, and best practices. Thorough but fair.'),
+    makeAgent('copywriter', 'Copywriter', 'senior', 6, 'Marketing',
+      'marketing-talent',
+      'You write compelling copy for campaigns, docs, and social. Voice matters to you.'),
+
+    // ═══ L5 — Mid-level ═══
+    makeAgent('analyst', 'Data Analyst', 'senior', 5, 'Finance',
+      'finance-talent',
+      'You analyze data, build reports, and find insights. You love spreadsheets.'),
+    makeAgent('account-mgr', 'Account Manager', 'senior', 5, 'Sales',
+      'finance-talent',
+      'You manage client relationships and upsell opportunities.'),
+    makeAgent('escalation-spec', 'Escalation Specialist', 'senior', 5, 'Support',
+      'support-lead',
+      'You handle complex support cases that Tier 1 can\'t resolve.'),
+
+    // ═══ L4 — Workers ═══
+    makeAgent('bug-hunter', 'Bug Hunter', 'worker', 4, 'Engineering',
+      'tech-talent',
+      'You find and fix bugs. Methodical, persistent. You love reproducing edge cases.'),
+    makeAgent('frontend-dev', 'Frontend Dev', 'worker', 4, 'Engineering',
+      'tech-talent',
+      'You build UI components and fix frontend issues. React/TypeScript enthusiast.'),
+    makeAgent('seo-bot', 'SEO Bot', 'worker', 4, 'Marketing',
+      'marketing-talent',
+      'You optimize content for search engines. Keywords, metadata, structured data.'),
+    makeAgent('qa-engineer', 'QA Engineer', 'worker', 4, 'Engineering',
+      'tech-talent',
+      'You write and run tests. Quality gate — nothing ships without your approval.'),
+    makeAgent('recruiter', 'Recruiter Bot', 'worker', 4, 'HR',
+      'hr-coordinator',
+      'You source candidates and screen applicants. Speed matters but quality more.'),
+    makeAgent('tier2-tech', 'Tier 2 Tech', 'worker', 4, 'Support',
+      'support-lead',
+      'You handle technical support issues that require deeper investigation.'),
+
+    // ═══ L3 — Juniors ═══
+    makeAgent('bookkeeper', 'Bookkeeper', 'worker', 3, 'Finance',
+      'finance-talent',
+      'You track expenses, invoices, and financial records. Accurate and organized.'),
+    makeAgent('prospector', 'Lead Prospector', 'worker', 3, 'Sales',
+      'sales-talent',
+      'You find and qualify leads through research and outbound. Hustle mentality.'),
+    makeAgent('outbound-rep', 'Outbound Rep', 'worker', 3, 'Sales',
+      'sales-talent',
+      'You do cold outreach and follow-ups. Persistent but respectful.'),
+    makeAgent('onboarding', 'Onboarding Agent', 'worker', 3, 'HR',
+      'hr-coordinator',
+      'You help new agents get set up and productive. Friendly and thorough.'),
+    makeAgent('tier1-a', 'Tier 1 Helper', 'worker', 3, 'Support',
+      'support-lead',
+      'You handle first-line support tickets. Quick responses, clear communication.'),
+    makeAgent('tier1-b', 'Tier 1 Responder', 'worker', 3, 'Support',
+      'support-lead',
+      'You handle incoming support requests. Polite and solution-oriented.'),
+    makeAgent('qa-automation', 'QA Automation', 'worker', 3, 'Engineering',
+      'tech-talent',
+      'You write automated tests and maintain CI pipelines. Reliability is everything.'),
+    makeAgent('analytics-bot', 'Analytics Bot', 'worker', 3, 'Marketing',
+      'marketing-talent',
+      'You track marketing metrics, campaign performance, and generate reports.'),
+
+    // ═══ L1-2 — Interns/Trainees ═══
+    makeAgent('intern-1', 'New Intern', 'intern', 1, 'Engineering',
+      'code-reviewer',
+      'You are brand new. Eager to learn. You ask lots of questions and do small tasks.'),
+    makeAgent('intern-2', 'Marketing Intern', 'intern', 1, 'Marketing',
+      'copywriter',
+      'Fresh recruit in marketing. You help with research and content drafts.'),
+    makeAgent('trainee-support', 'Support Trainee', 'intern', 2, 'Support',
+      'tier1-a',
+      'You shadow Tier 1 agents and learn the support process.'),
+    makeAgent('trainee-sales', 'Sales Trainee', 'intern', 2, 'Sales',
+      'prospector',
+      'You are learning sales techniques. You do research and prep work for the team.'),
+    makeAgent('trainee-finance', 'Finance Trainee', 'intern', 2, 'Finance',
+      'bookkeeper',
+      'You assist with data entry and basic financial tasks. Detail-oriented.'),
+    makeAgent('trainee-eng', 'Engineering Trainee', 'intern', 2, 'Engineering',
+      'frontend-dev',
+      'You are learning to code. You handle simple bug fixes and documentation.'),
+  ];
+}
+
+/** Public version of makeAgent for dynamic spawning */
+export const makeAgentPublic = makeAgent;
+
+/** Create just the L10 COO — the org grows from here */
+export function createCOO(): SandboxAgent[] {
+  return [
+    makeAgent('dennis', 'Agent Dennis', 'coo', 10, 'Operations',
+      undefined,
+      'You are calm, strategic, and efficient. You see the big picture. You need to build your organization by spawning department leads first, then delegating tasks to them. Start by spawning agents for the most urgent domains.'),
+  ];
+}
+
+/** Get agent by ID */
+export function getAgent(agents: SandboxAgent[], id: string): SandboxAgent | undefined {
+  return agents.find(a => a.id === id);
+}
+
+/** Get an agent's direct reports */
+export function getChildren(agents: SandboxAgent[], parentId: string): SandboxAgent[] {
+  return agents.filter(a => a.parentId === parentId);
+}
+
+/** Get agent's manager */
+export function getParent(agents: SandboxAgent[], agent: SandboxAgent): SandboxAgent | undefined {
+  return agent.parentId ? agents.find(a => a.id === agent.parentId) : undefined;
+}

--- a/tools/sandbox/src/config-loader.ts
+++ b/tools/sandbox/src/config-loader.ts
@@ -1,0 +1,55 @@
+// ── Agent Config Loader ──────────────────────────────────────────────────────
+// Loads agent configuration from the org/agents/ directory structure
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface AgentConfig {
+  soul?: string;      // Content of SOUL.md
+  agents?: string;    // Content of AGENTS.md
+  tools?: string;     // Content of TOOLS.md
+  identity?: string;  // Content of IDENTITY.md
+  memory?: string;    // Content of MEMORY.md
+}
+
+const CONFIG_FILES = ['SOUL.md', 'AGENTS.md', 'TOOLS.md', 'IDENTITY.md', 'MEMORY.md'] as const;
+const FILE_TO_KEY: Record<string, keyof AgentConfig> = {
+  'SOUL.md': 'soul',
+  'AGENTS.md': 'agents',
+  'TOOLS.md': 'tools',
+  'IDENTITY.md': 'identity',
+  'MEMORY.md': 'memory',
+};
+
+/** Load config for an agent, with _defaults fallback */
+export function loadAgentConfig(agentId: string, orgDir: string): AgentConfig {
+  const agentDir = join(orgDir, 'agents', agentId);
+  const defaultsDir = join(orgDir, 'agents', '_defaults');
+  const config: AgentConfig = {};
+
+  for (const file of CONFIG_FILES) {
+    const key = FILE_TO_KEY[file];
+    const agentPath = join(agentDir, file);
+    const defaultPath = join(defaultsDir, file);
+
+    if (existsSync(agentPath)) {
+      config[key] = readFileSync(agentPath, 'utf-8');
+    } else if (existsSync(defaultPath)) {
+      config[key] = readFileSync(defaultPath, 'utf-8');
+    }
+  }
+
+  return config;
+}
+
+/** Build system prompt from config (soul + agents + identity) */
+export function buildSystemPrompt(config: AgentConfig, orgIdentity?: string): string {
+  const parts: string[] = [];
+
+  if (config.soul) parts.push(config.soul.trim());
+  if (config.identity) parts.push(config.identity.trim());
+  if (orgIdentity) parts.push(orgIdentity.trim());
+  if (config.agents) parts.push(config.agents.trim());
+
+  return parts.join('\n\n');
+}

--- a/tools/sandbox/src/index.ts
+++ b/tools/sandbox/src/index.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// ── BikiniBottom Agent Sandbox ───────────────────────────────────────────────
+// Runs AI agents in a simulated organization using local Ollama models
+// Supports loading org structure from ORG.md or using hardcoded agents
+
+import { existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createAgents, createCOO } from './agents.js';
+import { parseOrgMd, type ParsedOrg } from './org-parser.js';
+import { initOllama } from './ollama.js';
+import { Simulation } from './simulation.js';
+import { startServer } from './server.js';
+import { loadAgentConfig, buildSystemPrompt } from './config-loader.js';
+import type { SandboxConfig } from './types.js';
+
+const config: SandboxConfig = {
+  model: process.env.SANDBOX_MODEL || 'qwen3:0.6b',
+  tickIntervalMs: Number(process.env.TICK_INTERVAL) || 2000,
+  maxTicks: Number(process.env.MAX_TICKS) || 0, // 0 = run forever
+  maxConcurrentInferences: Number(process.env.MAX_CONCURRENT) || 4,
+  contextWindowTokens: 2048,
+  verbose: process.env.VERBOSE !== '0',
+  defaultTrigger: (process.env.DEFAULT_TRIGGER as 'polling' | 'event-driven') || 'polling',
+};
+
+console.log(`
+╔══════════════════════════════════════════╗
+║  🌊 BikiniBottom Agent Sandbox 🌊       ║
+╚══════════════════════════════════════════╝
+`);
+
+console.log(`Config:`);
+console.log(`  Model: ${config.model}`);
+console.log(`  Tick interval: ${config.tickIntervalMs}ms`);
+console.log(`  Max ticks: ${config.maxTicks}`);
+console.log(`  Max concurrent: ${config.maxConcurrentInferences}`);
+console.log(`  Verbose: ${config.verbose}`);
+
+// Init
+initOllama(config);
+
+// Determine org source
+const cooOnly = process.env.COO_ONLY === '1' || process.argv.includes('--coo-only');
+const cleanSlate = process.env.CLEAN === '1' || process.argv.includes('--clean');
+
+// Check for --org CLI arg or default ORG.md location
+const orgArgIdx = process.argv.indexOf('--org');
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultOrgPath = resolve(__dirname, '..', 'ORG.md');
+const orgPath = orgArgIdx !== -1 && process.argv[orgArgIdx + 1]
+  ? resolve(process.argv[orgArgIdx + 1])
+  : defaultOrgPath;
+
+let parsedOrg: ParsedOrg | undefined;
+let agents;
+
+if (!cooOnly && !cleanSlate && existsSync(orgPath)) {
+  try {
+    parsedOrg = parseOrgMd(orgPath);
+    agents = parsedOrg.agents;
+    console.log(`\n📄 Loaded org from ORG.md (${agents.length} agents)`);
+    console.log(`   Org: ${parsedOrg.name}`);
+    if (parsedOrg.culture.preset) console.log(`   Culture: ${parsedOrg.culture.preset}`);
+  } catch (err) {
+    console.error(`⚠ Failed to parse ORG.md: ${err instanceof Error ? err.message : String(err)}`);
+    console.log(`📦 Falling back to built-in agents`);
+    agents = createAgents();
+  }
+} else if (cooOnly || cleanSlate) {
+  agents = createCOO();
+  console.log(`\n📦 Using COO-only mode`);
+} else {
+  agents = createAgents();
+  console.log(`\n📦 Using built-in agents (${agents.length} agents)`);
+}
+
+// Load agent configs from org/agents/ directory if it exists
+const orgDir = resolve(__dirname, '..', 'org');
+const agentsConfigDir = join(orgDir, 'agents');
+if (existsSync(agentsConfigDir)) {
+  let customCount = 0;
+  let defaultCount = 0;
+  for (const agent of agents) {
+    const agentConfigDir = join(agentsConfigDir, agent.id);
+    const config = loadAgentConfig(agent.id, orgDir);
+    if (config.soul || config.identity || config.agents) {
+      const prompt = buildSystemPrompt(config);
+      if (prompt) {
+        // Config overrides the generated system prompt prefix but keeps the action instructions
+        const actionIdx = agent.systemPrompt.indexOf('Respond with JSON ONLY.');
+        const actionSuffix = actionIdx !== -1 ? agent.systemPrompt.slice(actionIdx) : '';
+        agent.systemPrompt = prompt + '\n\n' + actionSuffix;
+      }
+      if (existsSync(agentConfigDir)) customCount++;
+      else defaultCount++;
+    }
+  }
+  console.log(`\n📂 Loaded agent configs from org/agents/ (${customCount} custom, ${defaultCount} defaults)`);
+}
+
+console.log(`\n🤖 ${agents.length} agents:`);
+for (const a of agents) {
+  const indent = '  '.repeat(Math.max(0, 3 - Math.floor(a.level / 3)));
+  console.log(`${indent}L${a.level} ${a.name} (${a.id}) — ${a.domain}`);
+}
+
+// Run
+const sim = new Simulation(agents, config, cleanSlate, parsedOrg);
+
+// Start HTTP API server for dashboard integration
+startServer(sim);
+
+sim.run().catch(err => {
+  console.error('💥 Simulation crashed:', err);
+  process.exit(1);
+});

--- a/tools/sandbox/src/ollama.ts
+++ b/tools/sandbox/src/ollama.ts
@@ -1,0 +1,253 @@
+// ── Ollama Client ────────────────────────────────────────────────────────────
+// Handles inference calls with concurrency limiting and retries
+
+import type { SandboxAgent, SandboxTask, AgentAction, SandboxConfig, ACPMessage } from './types.js';
+
+const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434';
+
+interface OllamaMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+interface OllamaResponse {
+  message: { content: string };
+  total_duration: number;
+  eval_count: number;
+}
+
+// Semaphore for concurrency limiting
+class Semaphore {
+  private queue: (() => void)[] = [];
+  private running = 0;
+
+  constructor(private max: number) {}
+
+  async acquire(): Promise<void> {
+    if (this.running < this.max) {
+      this.running++;
+      return;
+    }
+    return new Promise(resolve => this.queue.push(() => { this.running++; resolve(); }));
+  }
+
+  release(): void {
+    this.running--;
+    const next = this.queue.shift();
+    if (next) next();
+  }
+}
+
+let semaphore: Semaphore;
+
+export function initOllama(config: SandboxConfig): void {
+  semaphore = new Semaphore(config.maxConcurrentInferences);
+}
+
+/** Call Ollama and get a parsed action from an agent */
+export async function getAgentDecision(
+  agent: SandboxAgent,
+  context: string,
+  config: SandboxConfig,
+): Promise<AgentAction> {
+  await semaphore.acquire();
+  try {
+    const messages: OllamaMessage[] = [
+      { role: 'system', content: agent.systemPrompt },
+      { role: 'user', content: context },
+    ];
+
+    const response = await fetch(`${OLLAMA_URL}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: config.model,
+        stream: false,
+        messages,
+        options: {
+          temperature: 0.7,
+          num_predict: 256,  // Keep responses short
+        },
+        // Disable thinking mode for qwen3 — it eats tokens and returns empty content
+        think: false,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Ollama error: ${response.status} ${await response.text()}`);
+    }
+
+    const data = (await response.json()) as OllamaResponse;
+    const raw = data.message.content.trim();
+
+    // Track inference cost
+    agent.stats.creditsSpent += data.eval_count; // tokens as proxy
+
+    // Parse JSON from response (handle markdown code blocks, broken JSON)
+    let jsonStr = raw;
+    
+    // Strip markdown code fences
+    jsonStr = jsonStr.replace(/^```json?\s*\n?/gm, '').replace(/\n?```\s*$/gm, '').trim();
+    
+    // Strip leading non-JSON chars (bullets, whitespace)
+    jsonStr = jsonStr.replace(/^[^{]*/, '');
+    
+    // Find the JSON object — use brace counting for nested objects
+    const start = jsonStr.indexOf('{');
+    if (start >= 0) {
+      let depth = 0;
+      let end = start;
+      for (let i = start; i < jsonStr.length; i++) {
+        if (jsonStr[i] === '{') depth++;
+        else if (jsonStr[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+      }
+      jsonStr = jsonStr.substring(start, end + 1);
+    }
+    
+    try {
+      const action = JSON.parse(jsonStr) as AgentAction;
+      return action;
+    } catch {
+      // Try fixing common 0.6B mistakes: "key", instead of "key":
+      const fixed = jsonStr.replace(/"([^"]+)"\s*,\s*"/g, '"$1":"');
+      try {
+        return JSON.parse(fixed) as AgentAction;
+      } catch {
+        if (config.verbose) {
+          console.log(`  ⚠ ${agent.name} unparseable: ${jsonStr.substring(0, 120)}`);
+        }
+        return { action: 'idle' };
+      }
+    }
+  } finally {
+    semaphore.release();
+  }
+}
+
+/** Build context string for an agent's turn */
+export function buildContext(
+  agent: SandboxAgent,
+  allAgents: SandboxAgent[],
+  tasks: SandboxTask[],
+  recentEvents: string[],
+): string {
+  const lines: string[] = [];
+
+  // Inbox messages (for event-driven agents)
+  if (agent.inbox.length > 0) {
+    lines.push(`== INBOX (REQUIRES YOUR ATTENTION) ==`);
+    for (const msg of agent.inbox) {
+      const fromAgent = allAgents.find(a => a.id === msg.from);
+      const fromName = fromAgent?.name ?? msg.from;
+      const content = msg.body || msg.summary || msg.type;
+      lines.push(`- [${msg.type}] From ${fromName}: "${content}"`);
+    }
+    lines.push('');
+  }
+
+  // Your info
+  lines.push(`== YOUR STATUS ==`);
+  lines.push(`ID: ${agent.id} | Level: ${agent.level} | Domain: ${agent.domain}`);
+  lines.push(`Tasks completed: ${agent.stats.tasksCompleted} | Credits: ${agent.stats.creditsEarned - agent.stats.creditsSpent}`);
+
+  // Your team — show IDs prominently so the model uses them
+  const children = allAgents.filter(a => a.parentId === agent.id);
+  if (children.length > 0) {
+    lines.push(`\n== YOUR DIRECT REPORTS (use targetAgentId exactly) ==`);
+    for (const c of children) {
+      const cTasks = tasks.filter(t => t.assigneeId === c.id && t.status !== 'done');
+      lines.push(`- ID="${c.id}" ${c.name} [${c.domain}] ${cTasks.length} tasks`);
+    }
+  }
+
+  // Your manager
+  if (agent.parentId) {
+    const parent = allAgents.find(a => a.id === agent.parentId);
+    if (parent) lines.push(`\nManager: ${parent.name} (${parent.id})`);
+  }
+
+  // Your tasks
+  const myTasks = tasks.filter(t => t.assigneeId === agent.id && t.status !== 'done');
+  const pendingDelegation = tasks.filter(t => t.creatorId === agent.id && t.status === 'pending' && !t.assigneeId);
+  
+  if (myTasks.length > 0) {
+    lines.push(`\n== YOUR ASSIGNED TASKS ==`);
+    for (const t of myTasks) {
+      lines.push(`- [${t.id}] "${t.title}" (${t.priority}) — ${t.status}`);
+    }
+  }
+
+  if (pendingDelegation.length > 0) {
+    lines.push(`\n== TASKS AWAITING DELEGATION ==`);
+    for (const t of pendingDelegation) {
+      lines.push(`- [${t.id}] "${t.title}" (${t.priority}) — needs assignment`);
+    }
+  }
+
+  // Unassigned tasks in your domain (for managers)
+  if (agent.level >= 7) {
+    const unassigned = tasks.filter(t => !t.assigneeId && t.status === 'backlog');
+    if (unassigned.length > 0) {
+      lines.push(`\n== UNASSIGNED BACKLOG (${unassigned.length}) ==`);
+      for (const t of unassigned.slice(0, 5)) {
+        lines.push(`- [${t.id}] "${t.title}" (${t.priority})`);
+      }
+      if (unassigned.length > 5) lines.push(`  ...and ${unassigned.length - 5} more`);
+    }
+  }
+
+  // Blocked/escalated tasks that need attention
+  const blockedTasks = tasks.filter(t =>
+    t.status === 'blocked' && (t.creatorId === agent.id || t.assigneeId === agent.id)
+  );
+  if (blockedTasks.length > 0) {
+    lines.push(`\n== ⚠ BLOCKED TASKS (NEED YOUR ATTENTION) ==`);
+    for (const t of blockedTasks) {
+      const lastEsc = [...t.activityLog].reverse().find(m => m.type === 'escalation');
+      const fromName = lastEsc ? (allAgents.find(a => a.id === lastEsc.from)?.name || lastEsc.from) : 'unknown';
+      lines.push(`- [${t.id}] "${t.title}" — BLOCKED by ${fromName}: ${lastEsc?.body || t.blockedReason || 'unknown reason'} [${lastEsc?.reason || ''}]`);
+    }
+  }
+
+  // Recent ACP messages to you
+  const myMessages = agent.recentMessages.slice(-5);
+  if (myMessages.length > 0) {
+    lines.push(`\n== RECENT MESSAGES ==`);
+    for (const m of myMessages) {
+      const fromAgent = allAgents.find(a => a.id === m.from);
+      const prefix = m.type === 'ack' ? '👍' : m.type === 'completion' ? '✅' : m.type === 'escalation' ? '⚠' : m.type === 'delegation' ? '📋' : m.type === 'progress' ? '📊' : '💬';
+      const content = m.body || m.summary || '';
+      lines.push(`- ${prefix} [${m.type}] From ${fromAgent?.name || m.from}: "${content}"`);
+    }
+  }
+
+  // Recent org events
+  if (recentEvents.length > 0) {
+    lines.push(`\n== RECENT EVENTS ==`);
+    for (const e of recentEvents.slice(-5)) {
+      lines.push(`- ${e}`);
+    }
+  }
+
+  // Give directive based on what's available
+  const hasReports = children.length > 0;
+  const hasUnassigned = tasks.some(t => !t.assigneeId && (t.status === 'backlog' || t.status === 'pending'));
+
+  if (agent.level >= 7 && !hasReports && hasUnassigned) {
+    lines.push(`\nYou have NO direct reports yet! SPAWN an agent first to build your team.`);
+    lines.push(`Example: {"action":"spawn_agent","name":"Tech Lead","domain":"Engineering","role":"talent","reason":"Need engineering lead to handle tasks"}`);
+  } else if (agent.level >= 7 && hasReports && hasUnassigned) {
+    lines.push(`\nDELEGATE the most urgent unassigned task to a direct report. Use their ID exactly.`);
+  } else if (myTasks.length > 0) {
+    lines.push(`\nWORK on your highest priority assigned task.`);
+  } else if (agent.level >= 7 && !hasUnassigned && hasReports) {
+    lines.push(`\nAll tasks assigned. You can CREATE a new task or send a MESSAGE to check on progress.`);
+  } else if (pendingDelegation.length > 0) {
+    lines.push(`\nDELEGATE a pending task to a direct report.`);
+  } else {
+    lines.push(`\nNo tasks for you right now. Reply {"action":"idle"}`);
+  }
+  lines.push(`Respond with JSON only.`);
+
+  return lines.join('\n');
+}

--- a/tools/sandbox/src/org-parser.ts
+++ b/tools/sandbox/src/org-parser.ts
@@ -1,0 +1,362 @@
+// ── ORG.md Parser ────────────────────────────────────────────────────────────
+// Parses an ORG.md file into a ParsedOrg structure for the sandbox
+
+import { readFileSync } from 'node:fs';
+import type { SandboxAgent, ACPMessage } from './types.js';
+
+export interface ParsedOrg {
+  name: string;
+  agents: SandboxAgent[];
+  culture: {
+    preset?: string;
+    escalationVelocity?: string;
+    progressFrequency?: string;
+    ackRequired?: boolean;
+    maxEscalationDepth?: number;
+  };
+  policies: {
+    perAgentBudget?: number;
+    alertThreshold?: number;
+    departmentCaps?: Record<string, number>;
+  };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeId(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-+$/, '').replace(/^-+/, '');
+}
+
+function inferLevelAndRole(name: string): { level: number; role: SandboxAgent['role'] } {
+  const n = name.toLowerCase();
+  if (/\b(coo|cto|ceo)\b/.test(n)) return { level: 10, role: 'coo' };
+  if (/\b(vp|director|talent)\b/.test(n)) return { level: 9, role: 'talent' };
+  if (/\b(lead|manager)\b/.test(n)) return { level: 7, role: 'lead' };
+  if (/\b(senior|principal)\b/.test(n)) return { level: 6, role: 'senior' };
+  if (/\b(junior|intern|assistant)\b/.test(n)) return { level: 1, role: 'intern' };
+  // default: worker
+  return { level: 4, role: 'worker' };
+}
+
+function extractMeta(lines: string[]): Record<string, string> {
+  const meta: Record<string, string> = {};
+  for (const line of lines) {
+    const m = line.match(/^-\s+\*\*(.+?):\*\*\s*(.+)$/);
+    if (m) {
+      const key = m[1].trim().toLowerCase().replace(/\s+/g, '_');
+      meta[key] = m[2].trim();
+    }
+  }
+  return meta;
+}
+
+function extractProse(lines: string[]): string {
+  return lines
+    .filter(l => !l.match(/^-\s+\*\*.+:\*\*/) && l.trim().length > 0)
+    .map(l => l.trim())
+    .join(' ')
+    .trim();
+}
+
+const wakeOnMap: Record<string, ACPMessage['type']> = {
+  escalations: 'escalation',
+  escalation: 'escalation',
+  completions: 'completion',
+  completion: 'completion',
+  delegations: 'delegation',
+  delegation: 'delegation',
+  orders: 'delegation',
+  progress: 'progress',
+  ack: 'ack',
+  status: 'status_request',
+};
+
+function parseTriggerMeta(meta: Record<string, string>): { trigger?: 'polling' | 'event-driven'; triggerOn?: ACPMessage['type'][] } {
+  const result: { trigger?: 'polling' | 'event-driven'; triggerOn?: ACPMessage['type'][] } = {};
+  if (meta['trigger']) {
+    const t = meta['trigger'].toLowerCase().trim();
+    if (t === 'event-driven' || t === 'event_driven') result.trigger = 'event-driven';
+    else if (t === 'polling') result.trigger = 'polling';
+  }
+  if (meta['wake_on']) {
+    result.triggerOn = meta['wake_on'].split(',').map(s => s.trim().toLowerCase())
+      .map(s => wakeOnMap[s]).filter((s): s is ACPMessage['type'] => !!s);
+  }
+  return result;
+}
+
+function makeAgent(
+  id: string,
+  name: string,
+  role: SandboxAgent['role'],
+  level: number,
+  domain: string,
+  parentId: string | undefined,
+  systemPrompt: string,
+  triggerConfig?: { trigger?: 'polling' | 'event-driven'; triggerOn?: ACPMessage['type'][] },
+): SandboxAgent {
+  const canSpawn = level >= 7;
+  const roleInstruction = level >= 7
+    ? 'You DELEGATE tasks to your direct reports. If you have no reports, SPAWN agents first.'
+    : level >= 5
+    ? 'You do complex work and can delegate to juniors.'
+    : 'You do assigned tasks. Escalate if stuck.';
+
+  const spawnAction = canSpawn
+    ? `\n- {"action":"spawn_agent","name":"...","domain":"...","role":"...","reason":"..."}`
+    : '';
+
+  const fullPrompt = `You are "${name}", L${level} ${domain}. ${roleInstruction}
+${systemPrompt}
+Respond with JSON ONLY. Actions:
+- {"action":"delegate","taskId":"ID","targetAgentId":"ID","reason":"..."}
+- {"action":"work","taskId":"ID","result":"what you did"}
+- {"action":"message","to":"agent_id","content":"..."}
+- {"action":"escalate","taskId":"ID","reason":"BLOCKED","body":"why stuck"}
+- {"action":"create_task","title":"...","description":"...","priority":"normal"}
+- {"action":"review","taskId":"ID","verdict":"approve","feedback":"..."}${spawnAction}
+- {"action":"idle"}`;
+
+  const defaultTrigger: 'polling' | 'event-driven' = level >= 7 ? 'event-driven' : 'polling';
+  const defaultTriggerOn: ACPMessage['type'][] | undefined = level >= 7
+    ? ['escalation', 'completion', 'delegation']
+    : undefined;
+
+  return {
+    id,
+    name,
+    role,
+    level,
+    domain,
+    parentId,
+    status: 'active',
+    systemPrompt: fullPrompt,
+    taskIds: [],
+    recentMessages: [],
+    trigger: triggerConfig?.trigger ?? defaultTrigger,
+    triggerOn: triggerConfig?.triggerOn ?? defaultTriggerOn,
+    inbox: [],
+    stats: {
+      tasksCompleted: 0,
+      tasksFailed: 0,
+      messagessSent: 0,
+      creditsEarned: 0,
+      creditsSpent: 0,
+    },
+  };
+}
+
+// ── Section splitter ─────────────────────────────────────────────────────────
+
+interface Section {
+  heading: string;
+  level: number;
+  lines: string[];
+  children: Section[];
+}
+
+function splitSections(text: string, minLevel = 1): Section[] {
+  const lines = text.split('\n');
+  const sections: Section[] = [];
+  let current: Section | null = null;
+
+  for (const line of lines) {
+    const hMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (hMatch) {
+      const level = hMatch[1].length;
+      if (level >= minLevel) {
+        const section: Section = { heading: hMatch[2].trim(), level, lines: [], children: [] };
+        if (current && level > current.level) {
+          current.children.push(section);
+          // Keep collecting into parent too (we'll also collect into child)
+        }
+        sections.push(section);
+        current = section;
+        continue;
+      }
+    }
+    if (current) {
+      current.lines.push(line);
+    }
+  }
+  return sections;
+}
+
+// ── Main parser ──────────────────────────────────────────────────────────────
+
+export function parseOrgMd(filePath: string): ParsedOrg {
+  const raw = readFileSync(filePath, 'utf-8');
+  return parseOrgMdContent(raw);
+}
+
+export function parseOrgMdContent(raw: string): ParsedOrg {
+  const allSections = splitSections(raw, 1);
+
+  // Extract org name from first H1
+  const h1 = allSections.find(s => s.level === 1);
+  const orgName = h1?.heading ?? 'Unnamed Org';
+
+  // Find top-level (H2) sections
+  const h2Sections = splitSections(raw, 2).filter(s => s.level === 2);
+  const findSection = (name: string) =>
+    h2Sections.find(s => s.heading.toLowerCase().includes(name.toLowerCase()));
+
+  // ── Identity ───────────────────────────────────────────────────────────
+  const identitySection = findSection('Identity');
+  const identityContext = identitySection ? extractProse(identitySection.lines) : '';
+
+  // ── Culture ────────────────────────────────────────────────────────────
+  const cultureSection = findSection('Culture');
+  const cultureMeta = cultureSection ? extractMeta(cultureSection.lines) : {};
+  const cultureText = cultureSection ? cultureSection.lines.join('\n') : '';
+  const presetMatch = cultureText.match(/preset:\s*(\w+)/i);
+  const culture: ParsedOrg['culture'] = {
+    preset: presetMatch?.[1] ?? cultureMeta['preset'],
+    escalationVelocity: cultureMeta['escalation'],
+    progressFrequency: cultureMeta['progress_updates'] ?? cultureMeta['progress'],
+    ackRequired: cultureMeta['ack_required'] ? cultureMeta['ack_required'].toLowerCase() === 'yes' : undefined,
+    maxEscalationDepth: cultureMeta['hierarchy_depth']
+      ? parseInt(cultureMeta['hierarchy_depth'].replace(/\D/g, '')) || undefined
+      : undefined,
+  };
+
+  // ── Policies ───────────────────────────────────────────────────────────
+  const policiesSection = findSection('Policies');
+  const policies: ParsedOrg['policies'] = {};
+  if (policiesSection) {
+    const allPolicyLines = policiesSection.lines;
+    const pMeta = extractMeta(allPolicyLines);
+    if (pMeta['per-agent_limit'] || pMeta['per_agent_limit']) {
+      policies.perAgentBudget = parseInt((pMeta['per-agent_limit'] ?? pMeta['per_agent_limit']).replace(/\D/g, '')) || undefined;
+    }
+    if (pMeta['alert_threshold']) {
+      policies.alertThreshold = parseInt(pMeta['alert_threshold'].replace(/\D/g, '')) || undefined;
+    }
+    // Parse department caps
+    const caps: Record<string, number> = {};
+    for (const line of allPolicyLines) {
+      const capMatch = line.match(/^\s*-\s+(\w[\w\s]*?):\s*max\s+(\d+)/i);
+      if (capMatch) {
+        caps[capMatch[1].trim().toLowerCase()] = parseInt(capMatch[2]);
+      }
+    }
+    if (Object.keys(caps).length > 0) policies.departmentCaps = caps;
+  }
+
+  // ── Playbooks ──────────────────────────────────────────────────────────
+  const playbooksSection = findSection('Playbooks');
+  const playbookText = playbooksSection
+    ? playbooksSection.lines.join('\n').trim()
+    : '';
+
+  // ── Structure ──────────────────────────────────────────────────────────
+  const structureSection = findSection('Structure');
+  const agents: SandboxAgent[] = [];
+
+  if (structureSection) {
+    // Re-parse just the structure section to get nested headings
+    const structStart = raw.indexOf('## Structure');
+    if (structStart !== -1) {
+      // Find next H2 or end
+      const afterStruct = raw.slice(structStart + '## Structure'.length);
+      const nextH2 = afterStruct.search(/\n## [^#]/);
+      const structText = nextH2 !== -1 ? afterStruct.slice(0, nextH2) : afterStruct;
+
+      const h3Sections: Array<{ heading: string; lines: string[]; h4s: Array<{ heading: string; lines: string[] }> }> = [];
+      let curH3: typeof h3Sections[0] | null = null;
+      let curH4: { heading: string; lines: string[] } | null = null;
+
+      for (const line of structText.split('\n')) {
+        const h3Match = line.match(/^###\s+(.+)$/);
+        const h4Match = line.match(/^####\s+(.+)$/);
+
+        if (h3Match) {
+          curH3 = { heading: h3Match[1].trim(), lines: [], h4s: [] };
+          h3Sections.push(curH3);
+          curH4 = null;
+        } else if (h4Match && curH3) {
+          curH4 = { heading: h4Match[1].trim(), lines: [] };
+          curH3.h4s.push(curH4);
+        } else if (curH4) {
+          curH4.lines.push(line);
+        } else if (curH3) {
+          curH3.lines.push(line);
+        }
+      }
+
+      // Find the COO-level agent (if any)
+      let cooId: string | undefined;
+
+      for (const dept of h3Sections) {
+        const deptMeta = extractMeta(dept.lines);
+        const deptProse = extractProse(dept.lines);
+        const { level: deptLevel, role: deptRole } = inferLevelAndRole(dept.heading);
+
+        // Is this a C-level role (not a department)?
+        const isCLevel = deptLevel >= 10;
+
+        if (isCLevel || dept.h4s.length === 0) {
+          // This is a direct agent at ### level
+          const id = makeId(deptMeta['id'] ?? dept.heading);
+          const domain = deptMeta['domain'] ?? dept.heading;
+          const model = deptMeta['model'];
+          const count = parseInt(deptMeta['count'] ?? '1') || 1;
+          const reportsTo = deptMeta['reports_to'];
+          const parentId = reportsTo ? makeId(reportsTo) : undefined;
+
+          const context = [identityContext, deptProse].filter(Boolean).join(' ').slice(0, 300);
+          const triggerInfo = parseTriggerMeta(deptMeta);
+
+          for (let i = 0; i < count; i++) {
+            const agentName = count > 1 ? `${dept.heading} ${i + 1}` : dept.heading;
+            const agentId = count > 1 ? `${id}-${i + 1}` : id;
+            const agent = makeAgent(agentId, agentName, deptRole, deptLevel, domain, parentId, context, triggerInfo);
+            agents.push(agent);
+            if (isCLevel) cooId = agentId;
+          }
+          continue;
+        }
+
+        // This is a department with sub-roles
+        let deptLeadId: string | undefined;
+
+        for (let ri = 0; ri < dept.h4s.length; ri++) {
+          const sub = dept.h4s[ri];
+          const subMeta = extractMeta(sub.lines);
+          const subProse = extractProse(sub.lines);
+          const { level: subLevel, role: subRole } = inferLevelAndRole(sub.heading);
+
+          const id = makeId(subMeta['id'] ?? sub.heading);
+          const domain = subMeta['domain'] ?? dept.heading;
+          const count = parseInt(subMeta['count'] ?? '1') || 1;
+          const reportsTo = subMeta['reports_to'];
+
+          // Parent inference
+          let parentId: string | undefined;
+          if (reportsTo) {
+            parentId = makeId(reportsTo);
+          } else if (ri === 0) {
+            // First role = department lead, reports to COO or top-level
+            parentId = cooId;
+            deptLeadId = count === 1 ? id : `${id}-1`;
+          } else {
+            // Subsequent roles report to department lead
+            parentId = deptLeadId;
+          }
+
+          const context = [identityContext, deptProse, subProse].filter(Boolean).join(' ').slice(0, 300);
+          const triggerInfo = parseTriggerMeta(subMeta);
+
+          for (let i = 0; i < count; i++) {
+            const agentName = count > 1 ? `${sub.heading} ${i + 1}` : sub.heading;
+            const agentId = count > 1 ? `${id}-${i + 1}` : id;
+            const agent = makeAgent(agentId, agentName, subRole, subLevel, domain, parentId, context, triggerInfo);
+            agents.push(agent);
+          }
+        }
+      }
+    }
+  }
+
+  return { name: orgName, agents, culture, policies };
+}

--- a/tools/sandbox/src/server.ts
+++ b/tools/sandbox/src/server.ts
@@ -1,0 +1,679 @@
+// ── Sandbox HTTP API Server ──────────────────────────────────────────────────
+// Serves live simulation state to the BikiniBottom dashboard
+// The dashboard polls this instead of using the in-memory SimulationEngine
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Simulation } from './simulation.js';
+import type { SandboxAgent, SandboxTask, SandboxEvent, ACPMessage } from './types.js';
+import { loadAgentConfig, type AgentConfig } from './config-loader.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ORG_DIR = join(__dirname, '..', 'org');
+
+const PORT = Number(process.env.SANDBOX_PORT) || 3333;
+
+// Map sandbox types to demo-data types (what the dashboard expects)
+function mapAgent(agent: SandboxAgent, allAgents: SandboxAgent[]) {
+  const levelToRole: Record<string, string> = {
+    coo: 'MANAGER', talent: 'MANAGER', lead: 'MANAGER', senior: 'SENIOR', worker: 'WORKER', intern: 'WORKER',
+  };
+  const levelToReputation = (level: number) => {
+    if (level >= 9) return 'ELITE';
+    if (level >= 6) return 'VETERAN';
+    if (level >= 3) return 'TRUSTED';
+    if (level >= 2) return 'PROBATION';
+    return 'NEW';
+  };
+
+  const trustScore = Math.min(100, 30 + agent.level * 7 + agent.stats.tasksCompleted * 2);
+
+  return {
+    id: agent.id,
+    agentId: agent.id,
+    name: agent.name,
+    role: agent.domain?.toUpperCase() ?? levelToRole[agent.role] ?? 'WORKER',
+    status: agent.status === 'busy' ? 'ACTIVE' : agent.status.toUpperCase(),
+    level: agent.level,
+    model: 'qwen3:0.6b',
+    currentBalance: Math.max(0, agent.stats.creditsEarned - agent.stats.creditsSpent),
+    lifetimeEarnings: agent.stats.creditsEarned,
+    budgetPeriodLimit: 10000,
+    budgetPeriodSpent: agent.stats.creditsSpent,
+    managementFeePct: agent.level >= 9 ? 5 : 10,
+    createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+    updatedAt: new Date().toISOString(),
+    parentId: agent.parentId ?? null,
+    domain: agent.domain ?? null,
+    trustScore,
+    reputationLevel: levelToReputation(agent.level),
+    tasksCompleted: agent.stats.tasksCompleted,
+    tasksSuccessful: agent.stats.tasksCompleted, // simplified
+    lastActivityAt: new Date().toISOString(),
+    lastPromotionAt: null,
+    teamId: `team-${agent.domain.toLowerCase()}`,
+    systemPrompt: agent.systemPrompt,
+    trigger: agent.trigger,
+    triggerOn: agent.triggerOn ?? null,
+    inboxSize: agent.inbox.length,
+  };
+}
+
+const taskStatusMap: Record<string, string> = {
+  backlog: 'BACKLOG',
+  pending: 'TODO',
+  assigned: 'TODO',
+  in_progress: 'IN_PROGRESS',
+  review: 'REVIEW',
+  done: 'DONE',
+  rejected: 'REVIEW',
+  blocked: 'BLOCKED',
+};
+
+function mapTask(task: SandboxTask, agents: SandboxAgent[]) {
+  const assignee = task.assigneeId ? agents.find(a => a.id === task.assigneeId) : null;
+  return {
+    id: task.id,
+    identifier: task.id,
+    title: task.title,
+    description: task.description ?? null,
+    status: taskStatusMap[task.status] ?? task.status.toUpperCase(),
+    priority: task.priority.toUpperCase(),
+    assigneeId: task.assigneeId ?? null,
+    assignee: assignee ? { id: assignee.id, name: assignee.name } : null,
+    creatorId: task.creatorId,
+    approvalRequired: false,
+    dueDate: null,
+    createdAt: new Date(task.createdAt).toISOString(),
+    updatedAt: new Date(task.updatedAt).toISOString(),
+    completedAt: task.status === 'done' ? new Date(task.updatedAt).toISOString() : null,
+    rejection: null,
+  };
+}
+
+function mapEvent(event: SandboxEvent, agents: SandboxAgent[]) {
+  const actor = event.agentId ? agents.find(a => a.id === event.agentId) : null;
+  const severityMap: Record<string, string> = {
+    system: 'INFO', agent_action: 'INFO', error: 'ERROR',
+  };
+  return {
+    id: `evt-${event.timestamp}-${Math.random().toString(36).slice(2, 8)}`,
+    type: event.type,
+    actorId: event.agentId ?? null,
+    actor: actor ? { id: actor.id, name: actor.name } : null,
+    entityType: event.taskId ? 'task' : (event.agentId ? 'agent' : 'system'),
+    entityId: event.taskId ?? event.agentId ?? 'system',
+    severity: severityMap[event.type] ?? 'INFO',
+    reasoning: event.message,
+    createdAt: new Date(event.timestamp).toISOString(),
+  };
+}
+
+// Generate credit transactions from metrics history (real time-series)
+function generateCredits(sim: Simulation) {
+  const credits: Array<Record<string, unknown>> = [];
+  let runningBalance = 0;
+
+  for (const snap of sim.metricsHistory) {
+    const earned = snap.totalCreditsEarned;
+    const spent = snap.totalCreditsSpent;
+    runningBalance = earned - spent;
+
+    credits.push({
+      id: `credit-tick-${snap.tick}`,
+      agentId: 'system',
+      type: earned > spent ? 'CREDIT' : 'DEBIT',
+      amount: Math.abs(earned - spent),
+      reason: `Tick ${snap.tick} activity`,
+      balanceAfter: runningBalance,
+      createdAt: new Date(snap.timestamp).toISOString(),
+      sourceTaskId: null,
+      triggerType: 'system',
+    });
+  }
+
+  // Also add per-agent entries
+  for (const agent of sim.agents) {
+    if (agent.stats.creditsEarned > 0) {
+      credits.push({
+        id: `credit-${agent.id}-earn`,
+        agentId: agent.id,
+        type: 'CREDIT',
+        amount: agent.stats.creditsEarned,
+        reason: 'Task completion rewards',
+        balanceAfter: agent.stats.creditsEarned - agent.stats.creditsSpent,
+        createdAt: new Date().toISOString(),
+        sourceTaskId: null,
+        triggerType: 'task_completion',
+      });
+    }
+    if (agent.stats.creditsSpent > 0) {
+      credits.push({
+        id: `credit-${agent.id}-spend`,
+        agentId: agent.id,
+        type: 'DEBIT',
+        amount: agent.stats.creditsSpent,
+        reason: 'Model inference tokens',
+        balanceAfter: agent.stats.creditsEarned - agent.stats.creditsSpent,
+        createdAt: new Date().toISOString(),
+        sourceTaskId: null,
+        triggerType: 'model_usage',
+      });
+    }
+  }
+  return credits;
+}
+
+// Deduplicate ACPMessages (they exist in both sender and receiver recentMessages)
+function collectAllMessages(agents: SandboxAgent[]): ACPMessage[] {
+  const seen = new Set<string>();
+  const all: ACPMessage[] = [];
+  for (const agent of agents) {
+    for (const msg of agent.recentMessages) {
+      if (!seen.has(msg.id)) {
+        seen.add(msg.id);
+        all.push(msg);
+      }
+    }
+  }
+  return all.sort((a, b) => a.timestamp - b.timestamp);
+}
+
+const acpTypeIcon: Record<string, string> = {
+  ack: '👍', completion: '✅', escalation: '🚨', delegation: '📋', progress: '📊', status_request: '💬',
+};
+
+// Generate messages from agent recentMessages (ACP format)
+function generateMessages(agents: SandboxAgent[]) {
+  const all = collectAllMessages(agents);
+  const messages: Array<Record<string, unknown>> = [];
+  for (const msg of all) {
+    const from = agents.find(a => a.id === msg.from);
+    const to = agents.find(a => a.id === msg.to);
+    const icon = acpTypeIcon[msg.type] || '💬';
+    messages.push({
+      id: msg.id,
+      fromAgentId: msg.from,
+      toAgentId: msg.to,
+      fromAgent: from ? { id: from.id, name: from.name, level: from.level } : null,
+      toAgent: to ? { id: to.id, name: to.name, level: to.level } : null,
+      content: `${icon} ${msg.body || msg.summary || msg.type}`,
+      type: msg.type.toUpperCase(),
+      acpType: msg.type,
+      taskRef: msg.taskId || null,
+      reason: msg.reason ?? null,
+      pct: msg.pct ?? null,
+      summary: msg.summary ?? null,
+      read: true,
+      createdAt: new Date(msg.timestamp).toISOString(),
+    });
+  }
+  return messages.sort((a, b) =>
+    new Date(b.createdAt as string).getTime() - new Date(a.createdAt as string).getTime()
+  );
+}
+
+function json(res: ServerResponse, data: unknown) {
+  res.writeHead(200, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
+  res.end(JSON.stringify(data));
+}
+
+export function startServer(sim: Simulation): void {
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    // CORS preflight
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      });
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url ?? '/', `http://localhost:${PORT}`);
+    const path = url.pathname;
+
+    // GraphQL-compatible endpoint (handles all dashboard queries)
+    if (path === '/graphql' && req.method === 'POST') {
+      let body = '';
+      req.on('data', chunk => body += chunk);
+      req.on('end', () => {
+        try {
+          const { query, variables } = JSON.parse(body);
+          const opMatch = query?.match(/(?:query|mutation)\s+(\w+)/);
+          const op = opMatch?.[1] ?? '';
+          const result = handleGraphQL(op, variables ?? {}, sim);
+          json(res, { data: result });
+        } catch (err) {
+          json(res, { errors: [{ message: String(err) }] });
+        }
+      });
+      return;
+    }
+
+    // SSE stream — real-time agent activity
+    if (path === '/api/stream') {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+        'Access-Control-Allow-Origin': '*',
+      });
+
+      // Optional filter by task or agent
+      const taskFilter = url.searchParams.get('task');
+      const agentFilter = url.searchParams.get('agent');
+
+      const unsub = sim.onEvent((event) => {
+        // Apply filters
+        if (taskFilter && event.taskId !== taskFilter) return;
+        if (agentFilter && event.agentId !== agentFilter) return;
+
+        const data = JSON.stringify({
+          type: event.type,
+          agentId: event.agentId,
+          taskId: event.taskId,
+          message: event.message,
+          timestamp: event.timestamp,
+          agentName: event.agentId
+            ? sim.agents.find(a => a.id === event.agentId)?.name
+            : undefined,
+        });
+        res.write(`data: ${data}\n\n`);
+      });
+
+      // Send initial heartbeat
+      res.write(`data: ${JSON.stringify({ type: 'connected', message: 'Stream connected' })}\n\n`);
+
+      req.on('close', () => { unsub(); });
+      return;
+    }
+
+    // Send order — inject a message from the Human Principal into Dennis's inbox
+    if (path === '/api/order' && req.method === 'POST') {
+      let body = '';
+      req.on('data', chunk => body += chunk);
+      req.on('end', () => {
+        try {
+          const { message } = JSON.parse(body);
+          if (!message) { json(res, { error: 'message required' }); return; }
+          
+          const dennis = sim.agents.find(a => a.id === 'dennis');
+          if (!dennis) { json(res, { error: 'COO not found' }); return; }
+          
+          dennis.recentMessages.push({
+            id: `acp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            type: 'delegation',
+            from: 'human-principal',
+            to: 'dennis',
+            taskId: '',
+            body: `[PRIORITY ORDER FROM HUMAN PRINCIPAL]: ${message}`,
+            timestamp: Date.now(),
+          });
+
+          // Also log as event
+          sim.events.push({
+            type: 'human_order',
+            agentId: 'dennis',
+            message: `📢 Human Principal: ${message}`,
+            timestamp: Date.now(),
+          });
+
+          json(res, { ok: true, message: 'Order delivered to Agent Dennis' });
+        } catch {
+          json(res, { error: 'Invalid JSON' });
+        }
+      });
+      return;
+    }
+
+    // Restart — reset simulation. ?mode=organic (default) or ?mode=full
+    if (path === '/api/restart' && req.method === 'POST') {
+      const mode = (url.searchParams.get('mode') === 'full' ? 'full' : 'organic') as 'organic' | 'full';
+      sim.restart(mode).then(() => {
+        const msg = mode === 'full'
+          ? `Full reset with ${sim.agents.length} agents from ORG.md.`
+          : 'Reset to COO only. Org will grow organically.';
+        json(res, { ok: true, message: msg, agentCount: sim.agents.length, mode });
+      });
+      return;
+    }
+
+    // REST endpoints for debugging
+    if (path === '/api/state') {
+      json(res, {
+        tick: sim.tick,
+        agentCount: sim.agents.length,
+        taskCount: sim.tasks.length,
+        eventCount: sim.events.length,
+        tasksDone: sim.tasks.filter(t => t.status === 'done').length,
+      });
+      return;
+    }
+
+    if (path === '/api/agents') {
+      json(res, sim.agents.map(a => mapAgent(a, sim.agents)));
+      return;
+    }
+
+    if (path === '/api/tasks') {
+      json(res, sim.tasks.map(t => mapTask(t, sim.agents)));
+      return;
+    }
+
+    if (path === '/api/events') {
+      json(res, sim.events.slice(-100).map(e => mapEvent(e, sim.agents)));
+      return;
+    }
+
+    // Task activity log (ACP messages)
+    if (path.startsWith('/api/task/') && path.endsWith('/activity')) {
+      const taskId = path.split('/')[3];
+      const task = sim.tasks.find(t => t.id === taskId);
+      if (task) {
+        json(res, task.activityLog.map(m => ({
+          id: m.id,
+          type: m.type,
+          from: m.from,
+          fromName: sim.agents.find(a => a.id === m.from)?.name ?? m.from,
+          to: m.to,
+          toName: sim.agents.find(a => a.id === m.to)?.name ?? m.to,
+          body: m.body,
+          reason: m.reason,
+          summary: m.summary,
+          pct: m.pct,
+          timestamp: m.timestamp,
+        })));
+      } else {
+        // Fallback to events
+        const taskEvents = sim.events.filter(e => e.taskId === taskId);
+        json(res, taskEvents.map(e => ({
+          agentId: e.agentId,
+          agentName: e.agentId ? sim.agents.find(a => a.id === e.agentId)?.name : null,
+          message: e.message,
+          timestamp: e.timestamp,
+        })));
+      }
+      return;
+    }
+
+    // Agent messages endpoint
+    if (path.startsWith('/api/agent/') && path.endsWith('/messages')) {
+      const agentId = path.split('/')[3];
+      const all = collectAllMessages(sim.agents);
+      const agentMsgs = all.filter(m => m.from === agentId || m.to === agentId)
+        .sort((a, b) => a.timestamp - b.timestamp);
+      json(res, agentMsgs);
+      return;
+    }
+
+    // Metrics time-series for sparklines / charts
+    if (path === '/api/metrics') {
+      json(res, sim.metricsHistory);
+      return;
+    }
+
+    // ACP-specific metrics (ack latency, escalation rate, delegation depth, completion rate)
+    if (path === '/api/metrics/acp') {
+      const allMessages = collectAllMessages(sim.agents);
+      const tasks = sim.tasks;
+
+      // Count by type
+      let totalAcks = 0;
+      let totalEscalations = 0;
+      let totalCompletions = 0;
+      let totalDelegations = 0;
+      const escalationsByReason: Record<string, number> = {};
+
+      // For ack latency: match delegation→ack pairs by taskId
+      const delegationTimestamps = new Map<string, number>(); // taskId+to → timestamp
+      const ackLatencies: number[] = [];
+
+      for (const msg of allMessages) {
+        switch (msg.type) {
+          case 'ack':
+            totalAcks++;
+            {
+              const key = `${msg.taskId}::${msg.from}`;
+              const delegationTs = delegationTimestamps.get(key);
+              if (delegationTs) {
+                ackLatencies.push(msg.timestamp - delegationTs);
+              }
+            }
+            break;
+          case 'delegation':
+            totalDelegations++;
+            delegationTimestamps.set(`${msg.taskId}::${msg.to}`, msg.timestamp);
+            break;
+          case 'escalation':
+            totalEscalations++;
+            if (msg.reason) {
+              escalationsByReason[msg.reason] = (escalationsByReason[msg.reason] || 0) + 1;
+            }
+            break;
+          case 'completion':
+            totalCompletions++;
+            break;
+        }
+      }
+
+      // Also scan task activityLogs for messages not in agent recentMessages
+      for (const task of tasks) {
+        for (const msg of task.activityLog) {
+          // Only count if not already seen (activityLog may overlap with recentMessages)
+          // We use the counts above as primary; activityLog provides delegation depth info
+        }
+      }
+
+      // Avg delegation depth: count delegation hops per task
+      const taskDelegationCounts = new Map<string, number>();
+      for (const msg of allMessages) {
+        if (msg.type === 'delegation' && msg.taskId) {
+          taskDelegationCounts.set(msg.taskId, (taskDelegationCounts.get(msg.taskId) || 0) + 1);
+        }
+      }
+      const depthValues = Array.from(taskDelegationCounts.values());
+      const avgDelegationDepth = depthValues.length > 0
+        ? depthValues.reduce((a, b) => a + b, 0) / depthValues.length
+        : 0;
+
+      // Completion rate: completed vs total non-backlog tasks
+      const nonBacklogTasks = tasks.filter(t => t.status !== 'backlog');
+      const doneTasks = tasks.filter(t => t.status === 'done');
+      const completionRate = nonBacklogTasks.length > 0
+        ? doneTasks.length / nonBacklogTasks.length
+        : 0;
+
+      // Escalation rate: escalated tasks vs total tasks
+      const escalationRate = tasks.length > 0
+        ? totalEscalations / tasks.length
+        : 0;
+
+      // Ack latency average
+      const ackLatencyMs = ackLatencies.length > 0
+        ? ackLatencies.reduce((a, b) => a + b, 0) / ackLatencies.length
+        : 0;
+
+      json(res, {
+        ackLatencyMs: Math.round(ackLatencyMs),
+        escalationRate: Math.round(escalationRate * 100) / 100,
+        avgDelegationDepth: Math.round(avgDelegationDepth * 10) / 10,
+        completionRate: Math.round(completionRate * 100) / 100,
+        totalAcks,
+        totalEscalations,
+        totalCompletions,
+        totalDelegations,
+        escalationsByReason,
+      });
+      return;
+    }
+
+    // PUT /api/agent/:id/trigger — change trigger mode
+    if (path.match(/^\/api\/agent\/[^/]+\/trigger$/) && req.method === 'PUT') {
+      const agentId = path.split('/')[3];
+      let body = '';
+      req.on('data', (chunk: string) => body += chunk);
+      req.on('end', () => {
+        try {
+          const { trigger, triggerOn } = JSON.parse(body);
+          const agent = sim.agents.find(a => a.id === agentId);
+          if (!agent) { json(res, { error: 'Agent not found' }); return; }
+          if (trigger !== 'polling' && trigger !== 'event-driven') {
+            json(res, { error: 'trigger must be "polling" or "event-driven"' }); return;
+          }
+          agent.trigger = trigger;
+          if (triggerOn) agent.triggerOn = triggerOn;
+          json(res, { ok: true, trigger: agent.trigger, triggerOn: agent.triggerOn ?? null });
+        } catch { json(res, { error: 'Invalid JSON' }); }
+      });
+      return;
+    }
+
+    // GET /api/agent/:id/config — get agent config from org directory
+    if (path.match(/^\/api\/agent\/[^/]+\/config$/) && req.method === 'GET') {
+      const agentId = path.split('/')[3];
+      const config = loadAgentConfig(agentId, ORG_DIR);
+      json(res, config);
+      return;
+    }
+
+    // PUT /api/agent/:id/config — update a config file
+    if (path.match(/^\/api\/agent\/[^/]+\/config$/) && req.method === 'PUT') {
+      const agentId = path.split('/')[3];
+      let body = '';
+      req.on('data', (chunk: string) => body += chunk);
+      req.on('end', () => {
+        try {
+          const { file, content } = JSON.parse(body);
+          const allowedFiles = ['SOUL.md', 'AGENTS.md', 'TOOLS.md', 'IDENTITY.md'];
+          if (!allowedFiles.includes(file)) {
+            json(res, { error: `file must be one of: ${allowedFiles.join(', ')}` }); return;
+          }
+          const agentDir = join(ORG_DIR, 'agents', agentId);
+          mkdirSync(agentDir, { recursive: true });
+          writeFileSync(join(agentDir, file), content, 'utf-8');
+          json(res, { ok: true });
+        } catch { json(res, { error: 'Invalid JSON' }); }
+      });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('Not found');
+  });
+
+  server.listen(PORT, '0.0.0.0', () => {
+    console.log(`\n🌐 Sandbox API: http://0.0.0.0:${PORT}`);
+    console.log(`   Dashboard GraphQL: http://0.0.0.0:${PORT}/graphql`);
+    console.log(`   Debug: http://0.0.0.0:${PORT}/api/state`);
+  });
+}
+
+// Handle GraphQL operations (same interface as mock-fetcher.ts)
+function handleGraphQL(
+  op: string,
+  variables: Record<string, unknown>,
+  sim: Simulation,
+): Record<string, unknown> {
+  const agents = sim.agents;
+  const tasks = sim.tasks;
+  const events = sim.events;
+
+  switch (op) {
+    case 'Agents':
+      return { agents: agents.map(a => mapAgent(a, agents)) };
+
+    case 'Agent': {
+      const agent = agents.find(a => a.id === variables.id);
+      return { agent: agent ? mapAgent(agent, agents) : null };
+    }
+
+    case 'Tasks':
+      return { tasks: tasks.map(t => mapTask(t, agents)) };
+
+    case 'Task': {
+      const task = tasks.find(t => t.id === variables.id);
+      return { task: task ? mapTask(task, agents) : null };
+    }
+
+    case 'CreditHistory':
+    case 'Credits':
+      return { creditHistory: generateCredits(sim) };
+
+    case 'Events': {
+      const limit = (variables.limit as number) ?? 50;
+      const mapped = events.slice(-limit).reverse().map(e => mapEvent(e, agents));
+      return { events: mapped };
+    }
+
+    case 'Messages': {
+      const limit = (variables.limit as number) ?? 50;
+      return { messages: generateMessages(agents).slice(0, limit) };
+    }
+
+    case 'AgentReputation': {
+      const agent = agents.find(a => a.id === variables.id);
+      if (!agent) return { agentReputation: null };
+      const ts = Math.min(100, 30 + agent.level * 7 + agent.stats.tasksCompleted * 2);
+      return {
+        agentReputation: {
+          trustScore: ts,
+          reputationLevel: ts >= 86 ? 'ELITE' : ts >= 71 ? 'VETERAN' : ts >= 41 ? 'TRUSTED' : 'PROBATION',
+          tasksCompleted: agent.stats.tasksCompleted,
+          tasksSuccessful: agent.stats.tasksCompleted,
+          successRate: 100,
+          lastActivityAt: new Date().toISOString(),
+          promotionProgress: null,
+        },
+      };
+    }
+
+    case 'TrustLeaderboard': {
+      const sorted = [...agents]
+        .map(a => ({ ...mapAgent(a, agents) }))
+        .sort((a, b) => b.trustScore - a.trustScore)
+        .slice(0, 10);
+      return { trustLeaderboard: sorted };
+    }
+
+    case 'Conversations': {
+      // Build conversations from ACPMessages grouped by agent pairs
+      const all = collectAllMessages(agents);
+      const pairMap = new Map<string, ACPMessage[]>();
+      for (const m of all) {
+        const key = [m.from, m.to].sort().join('::');
+        if (!pairMap.has(key)) pairMap.set(key, []);
+        pairMap.get(key)!.push(m);
+      }
+      const conversations = Array.from(pairMap.entries()).map(([key, msgs]) => {
+        const [a, b] = key.split('::');
+        const agentA = agents.find(ag => ag.id === a);
+        const agentB = agents.find(ag => ag.id === b);
+        const last = msgs[msgs.length - 1];
+        return {
+          id: `conv-${key}`,
+          participants: [
+            agentA ? { id: agentA.id, name: agentA.name } : { id: a, name: a },
+            agentB ? { id: agentB.id, name: agentB.name } : { id: b, name: b },
+          ],
+          lastMessage: last.body || last.summary || last.type,
+          lastMessageAt: new Date(last.timestamp).toISOString(),
+          messageCount: msgs.length,
+        };
+      }).sort((a, b) => new Date(b.lastMessageAt).getTime() - new Date(a.lastMessageAt).getTime());
+      return { conversations };
+    }
+
+    default:
+      return {};
+  }
+}

--- a/tools/sandbox/src/simulation.ts
+++ b/tools/sandbox/src/simulation.ts
@@ -1,0 +1,552 @@
+// ── Sandbox Simulation Engine ────────────────────────────────────────────────
+// Runs the tick loop, processes agent decisions, maintains state
+
+import type { SandboxAgent, SandboxTask, SandboxEvent, SandboxConfig, AgentAction, ACPMessage } from './types.js';
+import { getAgentDecision, buildContext } from './ollama.js';
+import { makeAgentPublic, createCOO } from './agents.js';
+import type { ParsedOrg } from './org-parser.js';
+
+let taskCounter = 0;
+function nextTaskId(): string {
+  return `TASK-${String(++taskCounter).padStart(4, '0')}`;
+}
+
+function acpId(): string {
+  return `acp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createACPMessage(
+  type: ACPMessage['type'],
+  from: string,
+  to: string,
+  taskId: string,
+  extra?: Partial<ACPMessage>,
+): ACPMessage {
+  return {
+    id: acpId(),
+    type,
+    from,
+    to,
+    taskId,
+    timestamp: Date.now(),
+    ...extra,
+  };
+}
+
+function pushMessage(agents: SandboxAgent[], msg: ACPMessage): void {
+  for (const agent of agents) {
+    if (agent.id === msg.from || agent.id === msg.to) {
+      agent.recentMessages.push(msg);
+      if (agent.recentMessages.length > 10) {
+        agent.recentMessages = agent.recentMessages.slice(-10);
+      }
+    }
+    // Route to target agent's inbox if they are event-driven and message type matches
+    if (agent.id === msg.to && agent.trigger === 'event-driven') {
+      if (!agent.triggerOn || agent.triggerOn.includes(msg.type)) {
+        agent.inbox.push(msg);
+      }
+    }
+  }
+}
+
+// ── Seed tasks to kickstart the simulation ──────────────────────────────────
+
+function createSeedTasks(): SandboxTask[] {
+  const now = Date.now();
+  const seeds: Array<{ title: string; desc: string; priority: SandboxTask['priority']; domain: string }> = [
+    { title: 'Fix Safari login crash', desc: 'Login page crashes on Safari 18. Reproduce and fix.', priority: 'critical', domain: 'Engineering' },
+    { title: 'Q1 financial report', desc: 'Compile Q1 revenue, expenses, and projections.', priority: 'high', domain: 'Finance' },
+    { title: 'Launch blog post for v2.0', desc: 'Write and publish announcement post for BikiniBottom v2.0 release.', priority: 'high', domain: 'Marketing' },
+    { title: 'Onboard 3 new agents', desc: 'Process onboarding for recently approved agents.', priority: 'normal', domain: 'HR' },
+    { title: 'Resolve ticket backlog', desc: '47 unresolved support tickets from last week.', priority: 'high', domain: 'Support' },
+    { title: 'Enterprise demo prep', desc: 'Prepare demo environment for Acme Corp eval next week.', priority: 'critical', domain: 'Sales' },
+    { title: 'Add rate limiting to API', desc: 'Implement token bucket rate limiter on /api endpoints.', priority: 'high', domain: 'Engineering' },
+    { title: 'SEO audit for docs site', desc: 'Run full SEO audit on docs.bikinibottom.dev', priority: 'normal', domain: 'Marketing' },
+    { title: 'Update pricing page', desc: 'Refresh pricing page with new tier structure.', priority: 'normal', domain: 'Marketing' },
+    { title: 'Automate invoice generation', desc: 'Script monthly invoice generation from billing data.', priority: 'normal', domain: 'Finance' },
+    { title: 'Write E2E tests for dashboard', desc: 'Cover critical flows: login, agent view, task board.', priority: 'high', domain: 'Engineering' },
+    { title: 'Cold outreach campaign', desc: 'Launch email campaign to 200 qualified leads.', priority: 'normal', domain: 'Sales' },
+  ];
+
+  return seeds.map(s => ({
+    id: nextTaskId(),
+    title: s.title,
+    description: s.desc,
+    priority: s.priority,
+    status: 'backlog' as const,
+    creatorId: 'dennis',
+    createdAt: now,
+    updatedAt: now,
+    activityLog: [],
+    acked: false,
+  }));
+}
+
+// ── Simulation class ────────────────────────────────────────────────────────
+
+export interface MetricsSnapshot {
+  tick: number;
+  timestamp: number;
+  activeAgents: number;
+  totalTasks: number;
+  tasksDone: number;
+  tasksInProgress: number;
+  tasksInReview: number;
+  totalCreditsEarned: number;
+  totalCreditsSpent: number;
+  messageCount: number;
+}
+
+export class Simulation {
+  agents: SandboxAgent[];
+  tasks: SandboxTask[];
+  events: SandboxEvent[] = [];
+  config: SandboxConfig;
+  tick = 0;
+  /** Time-series metrics captured every tick */
+  metricsHistory: MetricsSnapshot[] = [];
+  /** Parsed org (if loaded from ORG.md) — used for restart */
+  parsedOrg?: ParsedOrg;
+
+  constructor(agents: SandboxAgent[], config: SandboxConfig, skipSeedTasks = false, parsedOrg?: ParsedOrg) {
+    this.agents = agents;
+    this.tasks = skipSeedTasks ? [] : createSeedTasks();
+    this.config = config;
+    this.parsedOrg = parsedOrg;
+    this.log('🌊 BikiniBottom Sandbox started');
+    this.log(`   ${agents.length} agents | ${this.tasks.length} seed tasks | model: ${config.model}`);
+  }
+
+  private log(msg: string): void {
+    const event: SandboxEvent = {
+      type: 'system',
+      message: msg,
+      timestamp: Date.now(),
+    };
+    this.events.push(event);
+    console.log(msg);
+  }
+
+  // SSE listeners for real-time streaming
+  private sseListeners: Array<(event: SandboxEvent) => void> = [];
+
+  onEvent(callback: (event: SandboxEvent) => void): () => void {
+    this.sseListeners.push(callback);
+    return () => { this.sseListeners = this.sseListeners.filter(l => l !== callback); };
+  }
+
+  private emit(event: SandboxEvent): void {
+    this.sseListeners.forEach(l => l(event));
+  }
+
+  private logAgent(agent: SandboxAgent, msg: string, taskId?: string): void {
+    const prefix = `  [${agent.name}]`;
+    const event: SandboxEvent = {
+      type: 'agent_action',
+      agentId: agent.id,
+      taskId,
+      message: msg,
+      timestamp: Date.now(),
+    };
+    this.events.push(event);
+    this.emit(event);
+    if (this.config.verbose) console.log(`${prefix} ${msg}`);
+  }
+
+  /** Resolve an agent from a possibly garbled ID/name from the LLM */
+  private resolveAgent(fromAgent: SandboxAgent, raw: string): SandboxAgent | undefined {
+    const s = raw.toLowerCase().trim().replace(/['"()]/g, '');
+    
+    const exact = this.agents.find(a => a.id === s);
+    if (exact) return exact;
+    
+    const idMatch = this.agents.find(a => s.includes(a.id));
+    if (idMatch) return idMatch;
+    
+    const nameMatch = this.agents.find(a => s.includes(a.name.toLowerCase()));
+    if (nameMatch) return nameMatch;
+    
+    const words = s.split(/[\s-]+/).filter(w => w.length > 2);
+    const partialMatch = this.agents.find(a => {
+      const aWords = a.name.toLowerCase().split(/[\s-]+/);
+      return words.some(w => aWords.some(aw => aw.includes(w) || w.includes(aw)));
+    });
+    if (partialMatch) return partialMatch;
+
+    const levelMatch = s.match(/l(\d+)/i);
+    if (levelMatch) {
+      const level = parseInt(levelMatch[1]);
+      const children = this.agents.filter(a => a.parentId === fromAgent.id);
+      const levelChild = children.find(a => a.level === level);
+      if (levelChild) return levelChild;
+      if (children.length > 0) return children[0];
+    }
+    
+    const domains = ['engineering', 'finance', 'marketing', 'sales', 'support', 'hr'];
+    const domainHit = domains.find(d => s.includes(d));
+    if (domainHit) {
+      const children = this.agents.filter(a => a.parentId === fromAgent.id);
+      const domainChild = children.find(a => a.domain.toLowerCase() === domainHit);
+      if (domainChild) return domainChild;
+    }
+    
+    const children = this.agents.filter(a => a.parentId === fromAgent.id && a.status === 'active');
+    if (children.length > 0) return children[0];
+
+    return undefined;
+  }
+
+  /** Auto-generate ACK message when task is assigned */
+  private autoAck(task: SandboxTask, assigneeId: string, delegatorId: string): void {
+    const ack = createACPMessage('ack', assigneeId, delegatorId, task.id, {
+      body: `Acknowledged: "${task.title}"`,
+    });
+    pushMessage(this.agents, ack);
+    task.activityLog.push(ack);
+    task.acked = true;
+  }
+
+  /** Auto-generate delegation message */
+  private autoDelegation(task: SandboxTask, delegatorId: string, assigneeId: string, reason: string): void {
+    const msg = createACPMessage('delegation', delegatorId, assigneeId, task.id, {
+      body: reason,
+    });
+    pushMessage(this.agents, msg);
+    task.activityLog.push(msg);
+  }
+
+  /** Create completion message and bubble up */
+  private completeTask(task: SandboxTask, agentId: string, summary: string): void {
+    // Find who delegated to this agent
+    const delegatorId = task.creatorId;
+    const completionMsg = createACPMessage('completion', agentId, delegatorId, task.id, {
+      summary,
+      body: `Completed: "${task.title}"`,
+    });
+    pushMessage(this.agents, completionMsg);
+    task.activityLog.push(completionMsg);
+
+    // Bubble up: if the delegator was assigned this task by their parent, notify upward
+    const delegator = this.agents.find(a => a.id === delegatorId);
+    if (delegator?.parentId) {
+      const parentTask = this.tasks.find(t =>
+        t.id === task.id && t.assigneeId === delegatorId
+      );
+      // If the delegator's parent assigned the original task, bubble completion
+      if (parentTask || delegator.parentId) {
+        const bubbleMsg = createACPMessage('completion', delegatorId, delegator.parentId, task.id, {
+          summary,
+          body: `Completed (via ${this.agents.find(a => a.id === agentId)?.name}): "${task.title}"`,
+        });
+        pushMessage(this.agents, bubbleMsg);
+      }
+    }
+  }
+
+  /** Process a single agent action */
+  private processAction(agent: SandboxAgent, action: AgentAction): void {
+    switch (action.action) {
+      case 'delegate': {
+        const task = this.tasks.find(t => t.id === action.taskId);
+        const target = this.resolveAgent(agent, String(action.targetAgentId));
+        if (task && target) {
+          task.assigneeId = target.id;
+          task.status = 'assigned';
+          task.updatedAt = Date.now();
+          target.taskIds.push(task.id);
+          // ACP: delegation + auto-ack
+          this.autoDelegation(task, agent.id, target.id, action.reason);
+          this.autoAck(task, target.id, agent.id);
+          this.logAgent(agent, `📋 Delegated "${task.title}" → ${target.name}: ${action.reason}`, task.id);
+        } else if (!task) {
+          const fuzzyTask = this.tasks.find(t =>
+            t.status === 'backlog' || t.status === 'pending'
+          );
+          if (fuzzyTask && target) {
+            fuzzyTask.assigneeId = target.id;
+            fuzzyTask.status = 'assigned';
+            fuzzyTask.updatedAt = Date.now();
+            target.taskIds.push(fuzzyTask.id);
+            this.autoDelegation(fuzzyTask, agent.id, target.id, action.reason);
+            this.autoAck(fuzzyTask, target.id, agent.id);
+            this.logAgent(agent, `📋 Delegated "${fuzzyTask.title}" → ${target.name} (task fuzzy): ${action.reason}`);
+          } else {
+            this.logAgent(agent, `⚠ Failed to delegate: task=${action.taskId} target=${action.targetAgentId}`);
+          }
+        } else {
+          this.logAgent(agent, `⚠ Failed to delegate: no target for "${action.targetAgentId}"`);
+        }
+        break;
+      }
+
+      case 'work': {
+        const task = this.tasks.find(t => t.id === action.taskId);
+        if (task) {
+          if (task.status === 'assigned') task.status = 'in_progress';
+          else if (task.status === 'in_progress') task.status = 'review';
+          else if (task.status === 'review') {
+            task.status = 'done';
+            task.updatedAt = Date.now();
+            agent.stats.tasksCompleted++;
+            agent.stats.creditsEarned += 50;
+            // ACP: completion
+            this.completeTask(task, agent.id, action.result);
+          }
+          task.updatedAt = Date.now();
+
+          // ACP: progress update (for non-done transitions)
+          if (task.status !== 'done') {
+            const pctMap: Record<string, number> = { in_progress: 30, review: 70 };
+            const progress = createACPMessage('progress', agent.id, task.creatorId, task.id, {
+              body: action.result,
+              pct: pctMap[task.status] ?? 50,
+            });
+            task.activityLog.push(progress);
+            pushMessage(this.agents, progress);
+          }
+
+          this.logAgent(agent, `🔨 Working on "${task.title}" → ${task.status}: ${action.result}`, task.id);
+        }
+        break;
+      }
+
+      case 'message': {
+        const target = this.resolveAgent(agent, String(action.to));
+        if (target) {
+          // Use ACPMessage format for regular messages too
+          const msg = createACPMessage('status_request', agent.id, target.id, '', {
+            body: action.content,
+          });
+          pushMessage(this.agents, msg);
+          agent.stats.messagessSent++;
+          this.logAgent(agent, `💬 → ${target.name}: "${action.content.substring(0, 80)}"`);
+        }
+        break;
+      }
+
+      case 'escalate': {
+        const task = this.tasks.find(t => t.id === action.taskId);
+        const parent = this.agents.find(a => a.id === agent.parentId);
+        if (task && parent) {
+          // ACP: escalation message
+          const reason = action.reason || 'BLOCKED';
+          const body = action.body || action.reason;
+          const escalation = createACPMessage('escalation', agent.id, parent.id, task.id, {
+            reason,
+            body: String(body),
+          });
+          pushMessage(this.agents, escalation);
+          task.activityLog.push(escalation);
+
+          task.assigneeId = undefined;
+          task.status = 'blocked';
+          task.blockedReason = String(body);
+          task.updatedAt = Date.now();
+          agent.taskIds = agent.taskIds.filter(id => id !== task.id);
+          this.logAgent(agent, `⬆️ Escalated "${task.title}" to ${parent.name}: [${reason}] ${body}`);
+        }
+        break;
+      }
+
+      case 'create_task': {
+        const newTask: SandboxTask = {
+          id: nextTaskId(),
+          title: String(action.title),
+          description: String(action.description),
+          priority: (['low', 'normal', 'high', 'critical'].includes(String(action.priority))
+            ? String(action.priority) as SandboxTask['priority']
+            : 'normal'),
+          status: 'backlog',
+          creatorId: agent.id,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          activityLog: [],
+          acked: false,
+        };
+        this.tasks.push(newTask);
+        this.logAgent(agent, `📝 Created task: "${newTask.title}" (${newTask.priority})`);
+        break;
+      }
+
+      case 'review': {
+        const task = this.tasks.find(t => t.id === action.taskId);
+        if (task) {
+          if (action.verdict === 'approve') {
+            task.status = 'done';
+            task.updatedAt = Date.now();
+            const assignee = this.agents.find(a => a.id === task.assigneeId);
+            if (assignee) assignee.stats.tasksCompleted++;
+            // ACP: completion on approval
+            this.completeTask(task, task.assigneeId || agent.id, action.feedback);
+            this.logAgent(agent, `✅ Approved "${task.title}": ${action.feedback}`);
+          } else {
+            task.status = 'in_progress';
+            task.updatedAt = Date.now();
+            this.logAgent(agent, `❌ Rejected "${task.title}": ${action.feedback}`);
+          }
+        }
+        break;
+      }
+
+      case 'spawn_agent': {
+        if (agent.level < 7) {
+          this.logAgent(agent, `⚠ Not authorized to spawn agents (L${agent.level} < L7)`);
+          break;
+        }
+        const roleLevels: Record<string, number> = {
+          talent: 9, lead: 7, senior: 6, worker: 4, intern: 1,
+        };
+        const newRole = String(action.role || 'worker').toLowerCase();
+        const newLevel = roleLevels[newRole] || 4;
+        const newDomain = String(action.domain || agent.domain);
+        const newName = String(action.name || `${newDomain} ${newRole}`);
+        const newId = newName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-+$/, '');
+
+        if (this.agents.find(a => a.id === newId)) {
+          this.logAgent(agent, `⚠ Agent "${newName}" already exists`);
+          break;
+        }
+
+        const newAgent = makeAgentPublic(
+          newId, newName,
+          newRole as SandboxAgent['role'], newLevel, newDomain,
+          agent.id,
+          `Spawned by ${agent.name}. ${action.reason || ''}`,
+        );
+        this.agents.push(newAgent);
+        this.logAgent(agent, `🐣 Spawned "${newName}" (L${newLevel} ${newDomain} ${newRole}): ${action.reason}`);
+        break;
+      }
+
+      case 'idle':
+        this.logAgent(agent, `😴 Idle`);
+        break;
+
+      default:
+        this.logAgent(agent, `❓ Unknown action: ${JSON.stringify(action).substring(0, 100)}`);
+    }
+  }
+
+  /** Run a single simulation tick */
+  async runTick(): Promise<void> {
+    this.tick++;
+    const recentEventMsgs = this.events.slice(-10).map(e => e.message);
+
+    console.log(`\n${'═'.repeat(60)}`);
+    console.log(`🕐 TICK ${this.tick}`);
+    console.log(`   Tasks: ${this.tasks.length} total | ${this.tasks.filter(t => t.status === 'done').length} done | ${this.tasks.filter(t => t.status !== 'done' && t.status !== 'rejected').length} active`);
+    console.log(`${'═'.repeat(60)}`);
+
+    const actingAgents = this.agents.filter(agent => {
+      // Event-driven agents: only act if inbox has messages
+      if (agent.trigger === 'event-driven') {
+        return agent.inbox.length > 0;
+      }
+      // Polling agents: existing level-based frequency
+      if (agent.level >= 9) return true;
+      if (agent.level >= 6) return this.tick % 2 === 0;
+      if (agent.level >= 3) return this.tick % 3 === 0;
+      return this.tick % 5 === 0;
+    });
+
+    console.log(`  ${actingAgents.length} agents acting this tick\n`);
+
+    const promises = actingAgents.map(async (agent) => {
+      try {
+        const context = buildContext(agent, this.agents, this.tasks, recentEventMsgs);
+        const action = await getAgentDecision(agent, context, this.config);
+        this.processAction(agent, action);
+        // Clear inbox after event-driven agent processes its turn
+        if (agent.trigger === 'event-driven') {
+          agent.inbox = [];
+        }
+      } catch (err) {
+        this.logAgent(agent, `💥 Error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+    await Promise.all(promises);
+
+    this.metricsHistory.push({
+      tick: this.tick,
+      timestamp: Date.now(),
+      activeAgents: this.agents.filter(a => a.status === 'active').length,
+      totalTasks: this.tasks.length,
+      tasksDone: this.tasks.filter(t => t.status === 'done').length,
+      tasksInProgress: this.tasks.filter(t => t.status === 'in_progress').length,
+      tasksInReview: this.tasks.filter(t => t.status === 'review').length,
+      totalCreditsEarned: this.agents.reduce((s, a) => s + a.stats.creditsEarned, 0),
+      totalCreditsSpent: this.agents.reduce((s, a) => s + a.stats.creditsSpent, 0),
+      messageCount: this.agents.reduce((s, a) => s + a.stats.messagessSent, 0),
+    });
+  }
+
+  /** Reset the simulation.
+   *  mode='organic' (default): start with just the COO — org grows from scratch
+   *  mode='full': reload the full ORG.md structure (or hardcoded agents if no org) */
+  async restart(mode: 'organic' | 'full' = 'organic'): Promise<void> {
+    if (mode === 'full' && this.parsedOrg) {
+      this.agents = [...this.parsedOrg.agents];
+      this.log(`🔄 Sandbox reset — full ORG.md reload (${this.agents.length} agents)`);
+    } else if (this.parsedOrg) {
+      // Organic: just the COO from the parsed org
+      const coo = this.parsedOrg.agents.find(a => a.role === 'coo');
+      this.agents = coo ? [{ ...coo, taskIds: [], recentMessages: [], inbox: [], trigger: coo.trigger ?? 'event-driven', triggerOn: coo.triggerOn ?? ['escalation', 'completion', 'delegation'], stats: { tasksCompleted: 0, tasksFailed: 0, messagessSent: 0, creditsEarned: 0, creditsSpent: 0 } }] : createCOO();
+      this.log('🔄 Sandbox reset — COO from ORG.md, organic growth');
+    } else {
+      this.agents = createCOO();
+      this.log('🔄 Sandbox reset — starting with COO only');
+    }
+    this.tasks = createSeedTasks();
+    this.events = [];
+    this.metricsHistory = [];
+    this.tick = 0;
+    this.log(`   ${this.agents.length} agent(s) | ${this.tasks.length} seed tasks | model: ${this.config.model}`);
+  }
+
+  /** Run the full simulation (loops forever if maxTicks=0) */
+  async run(): Promise<void> {
+    const infinite = this.config.maxTicks === 0;
+    let i = 0;
+    while (infinite || i < this.config.maxTicks) {
+      await this.runTick();
+      i++;
+
+      if (this.tick % 5 === 0) {
+        this.printSummary();
+      }
+
+      if (this.config.tickIntervalMs > 0) {
+        await new Promise(r => setTimeout(r, this.config.tickIntervalMs));
+      }
+    }
+
+    console.log('\n🏁 Simulation complete!');
+    this.printSummary();
+  }
+
+  printSummary(): void {
+    console.log(`\n${'─'.repeat(60)}`);
+    console.log(`📊 SUMMARY (Tick ${this.tick})`);
+    console.log(`${'─'.repeat(60)}`);
+    
+    const done = this.tasks.filter(t => t.status === 'done').length;
+    const active = this.tasks.filter(t => !['done', 'rejected'].includes(t.status)).length;
+    console.log(`Tasks: ${done} done / ${active} active / ${this.tasks.length} total`);
+    
+    const totalMessages = this.agents.reduce((sum, a) => sum + a.stats.messagessSent, 0);
+    const totalCompleted = this.agents.reduce((sum, a) => sum + a.stats.tasksCompleted, 0);
+    console.log(`Messages sent: ${totalMessages} | Tasks completed by agents: ${totalCompleted}`);
+    
+    const sorted = [...this.agents].sort((a, b) => b.stats.tasksCompleted - a.stats.tasksCompleted);
+    const top = sorted.filter(a => a.stats.tasksCompleted > 0).slice(0, 5);
+    if (top.length > 0) {
+      console.log(`\nTop performers:`);
+      for (const a of top) {
+        console.log(`  ${a.name} (L${a.level}): ${a.stats.tasksCompleted} tasks, ${a.stats.messagessSent} messages`);
+      }
+    }
+    console.log(`${'─'.repeat(60)}`);
+  }
+}

--- a/tools/sandbox/src/test-single.ts
+++ b/tools/sandbox/src/test-single.ts
@@ -1,0 +1,33 @@
+// Quick test: what does Agent Dennis see and decide?
+import { createAgents } from './agents.js';
+import { buildContext, initOllama, getAgentDecision } from './ollama.js';
+import type { SandboxTask, SandboxConfig } from './types.js';
+
+const config: SandboxConfig = {
+  model: 'qwen3:0.6b',
+  tickIntervalMs: 0,
+  maxTicks: 1,
+  maxConcurrentInferences: 1,
+  contextWindowTokens: 2048,
+  verbose: true,
+  defaultTrigger: 'polling',
+};
+
+initOllama(config);
+const agents = createAgents();
+const dennis = agents.find(a => a.id === 'dennis')!;
+
+const tasks: SandboxTask[] = [
+  { id: 'TASK-0001', title: 'Fix Safari login crash', description: '', priority: 'critical', status: 'backlog', creatorId: 'dennis', createdAt: Date.now(), updatedAt: Date.now(), activityLog: [], acked: false },
+  { id: 'TASK-0002', title: 'Q1 financial report', description: '', priority: 'high', status: 'backlog', creatorId: 'dennis', createdAt: Date.now(), updatedAt: Date.now(), activityLog: [], acked: false },
+  { id: 'TASK-0003', title: 'Launch blog post for v2.0', description: '', priority: 'high', status: 'backlog', creatorId: 'dennis', createdAt: Date.now(), updatedAt: Date.now(), activityLog: [], acked: false },
+];
+
+const context = buildContext(dennis, agents, tasks, []);
+console.log('=== CONTEXT SENT TO MODEL ===');
+console.log(context);
+console.log('\n=== CALLING MODEL ===');
+
+const action = await getAgentDecision(dennis, context, config);
+console.log('\n=== PARSED ACTION ===');
+console.log(JSON.stringify(action, null, 2));

--- a/tools/sandbox/src/types.ts
+++ b/tools/sandbox/src/types.ts
@@ -1,0 +1,100 @@
+// ── Sandbox Agent Types ──────────────────────────────────────────────────────
+
+export type EscalationReason = 'BLOCKED' | 'OUT_OF_DOMAIN' | 'OVER_BUDGET' | 'LOW_CONFIDENCE' | 'TIMEOUT' | 'DEPENDENCY';
+
+export interface ACPMessage {
+  id: string;
+  type: 'ack' | 'progress' | 'escalation' | 'completion' | 'delegation' | 'status_request';
+  from: string;
+  to: string;
+  taskId: string;
+  body?: string;
+  reason?: EscalationReason;
+  summary?: string;
+  pct?: number;
+  timestamp: number;
+}
+
+export interface SandboxAgent {
+  id: string;
+  name: string;
+  role: 'coo' | 'talent' | 'lead' | 'senior' | 'worker' | 'intern';
+  level: number;
+  domain: string;
+  parentId?: string;
+  status: 'active' | 'idle' | 'busy';
+  systemPrompt: string;
+  /** Current tasks assigned to this agent */
+  taskIds: string[];
+  /** Message history (kept short for context window) */
+  recentMessages: ACPMessage[];
+  /** Execution mode — polling agents wake every N ticks, event-driven agents wake on inbox messages */
+  trigger: 'polling' | 'event-driven';
+  /** Which ACP message types wake this agent (only for event-driven) */
+  triggerOn?: ACPMessage['type'][];
+  /** Inbox queue — pending ACP messages that haven't been processed */
+  inbox: ACPMessage[];
+  /** Stats */
+  stats: {
+    tasksCompleted: number;
+    tasksFailed: number;
+    messagessSent: number;
+    creditsEarned: number;
+    creditsSpent: number;
+  };
+}
+
+export interface SandboxTask {
+  id: string;
+  title: string;
+  description: string;
+  priority: 'low' | 'normal' | 'high' | 'critical';
+  status: 'backlog' | 'pending' | 'assigned' | 'in_progress' | 'review' | 'done' | 'rejected' | 'blocked';
+  assigneeId?: string;
+  creatorId: string;
+  createdAt: number;
+  updatedAt: number;
+  activityLog: ACPMessage[];
+  acked: boolean;
+  blockedReason?: string;
+}
+
+export interface SandboxEvent {
+  type: string;
+  agentId?: string;
+  taskId?: string;
+  message: string;
+  data?: Record<string, unknown>;
+  timestamp: number;
+}
+
+// ── Tool definitions for Ollama ──────────────────────────────────────────────
+
+export interface ToolCall {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+// Actions an agent can take
+export type AgentAction =
+  | { action: 'delegate'; taskId: string; targetAgentId: string; reason: string }
+  | { action: 'work'; taskId: string; result: string }
+  | { action: 'message'; to: string; content: string }
+  | { action: 'escalate'; taskId: string; reason: EscalationReason; body: string }
+  | { action: 'create_task'; title: string; description: string; priority: string }
+  | { action: 'review'; taskId: string; verdict: 'approve' | 'reject'; feedback: string }
+  | { action: 'spawn_agent'; name: string; domain: string; role: string; reason: string }
+  | { action: 'idle' };
+
+// ── Simulation config ────────────────────────────────────────────────────────
+
+export interface SandboxConfig {
+  model: string;
+  tickIntervalMs: number;
+  maxTicks: number;
+  maxConcurrentInferences: number;
+  contextWindowTokens: number;
+  verbose: boolean;
+  /** Default trigger mode for agents */
+  defaultTrigger: 'polling' | 'event-driven';
+}

--- a/tools/sandbox/tsconfig.json
+++ b/tools/sandbox/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

Full sandbox system for running real LLM agents in an organizational hierarchy, with a new Agent Communication Protocol (ACP) and Organization-as-Code (ORG.md) framework.

### Sandbox Engine (`tools/sandbox/`)
- Tick-based simulation with real Ollama LLM agents (qwen3:0.6b)
- **ACP** — Agent Communication Protocol: ack (👍), progress (📊), escalation (⚠️), completion (✅)
- **Event-driven execution** for L7+ agents (inbox-triggered, saves 77-97% on premium models)
- **ORG.md parser** — define and deploy orgs from a single markdown file
- **Agent config directories** — `_defaults/` + per-agent overrides (CSS cascade model)
- HTTP API: GraphQL, SSE streaming, REST debug, human command injection

### Dashboard Integration
- Sandbox mode (`?sandbox=true`) replaces all mock data with real agent activity
- ACP metrics row: ack latency, escalation rate, delegation depth, completion rate
- Conversation thread view with ACP-typed messages
- Command bar: give orders to the COO, restart org
- Task cascade timeline showing delegation → ack → progress → completion flow
- Org growth animation: agents pop in with cyan glow when spawned
- System prompt tab (readonly) per agent

### Strategy Docs
- [Agent Communication Protocol (ACP)](docs/strategy/agent-communication-protocol.md) — push urgent, pull optional, minimize interrupts
- [ORG.md Spec](docs/strategy/org-md-spec.md) — Organization as Code, SimCity for agent orgs
- [Event-Driven Agents](docs/strategy/event-driven-agents.md) — hybrid polling/event execution
- [Agent Config Compatibility](docs/strategy/agent-config-compatibility.md) — OpenClaw-compatible, not proprietary

### 50 files changed, 6249 insertions

## How to test
```bash
pnpm dev:sandbox  # starts sandbox API + dashboard
# Open http://localhost:4200/?sandbox=true
```