### PR TITLE
feat(dashboard): BikiniBottom branding with pineapple house logo

### DIFF
--- a/apps/dashboard/public/favicon.svg
+++ b/apps/dashboard/public/favicon.svg
@@ -1,24 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
   <defs>
-    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#58a6ff"/>
-      <stop offset="100%" style="stop-color:#a371f7"/>
+    <linearGradient id="fg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00e5ff"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
     </linearGradient>
   </defs>
-  <!-- Robot head background -->
-  <rect x="8" y="12" width="48" height="44" rx="8" fill="url(#grad)"/>
-  <!-- Antenna -->
-  <circle cx="32" cy="6" r="4" fill="#58a6ff"/>
-  <rect x="30" y="6" width="4" height="10" fill="#58a6ff"/>
-  <!-- Eyes -->
-  <rect x="16" y="24" width="12" height="12" rx="2" fill="#0d1117"/>
-  <rect x="36" y="24" width="12" height="12" rx="2" fill="#0d1117"/>
-  <!-- Eye glow -->
-  <rect x="18" y="26" width="4" height="4" rx="1" fill="#3fb950"/>
-  <rect x="38" y="26" width="4" height="4" rx="1" fill="#3fb950"/>
-  <!-- Mouth/display -->
-  <rect x="20" y="42" width="24" height="8" rx="2" fill="#0d1117"/>
-  <rect x="22" y="44" width="4" height="4" rx="1" fill="#3fb950"/>
-  <rect x="28" y="44" width="4" height="4" rx="1" fill="#3fb950"/>
-  <rect x="34" y="44" width="4" height="4" rx="1" fill="#3fb950"/>
+  <path d="M16 4L9 11v13a3 3 0 003 3h8a3 3 0 003-3V11L16 4z" fill="url(#fg)"/>
+  <rect x="13" y="17" width="6" height="8" rx="3" fill="#0f172a" opacity="0.7"/>
+  <circle cx="17" cy="21.5" r="0.7" fill="#00e5ff"/>
+  <path d="M16 4V1.5" stroke="#00e5ff" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M16 4C15 2 13 1 12 1.5s0 3 1 3.5" stroke="#00e5ff" stroke-width="1" fill="none" stroke-linecap="round"/>
+  <path d="M16 4C17 2 19 1 20 1.5s0 3-1 3.5" stroke="#00e5ff" stroke-width="1" fill="none" stroke-linecap="round"/>
 </svg>

--- a/apps/dashboard/src/assets/logo.svg
+++ b/apps/dashboard/src/assets/logo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="bb-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00e5ff"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="bb-grad-light" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00e5ff" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0.1"/>
+    </linearGradient>
+  </defs>
+  <!-- Pineapple house body -->
+  <path d="M32 8L18 22v24a6 6 0 006 6h16a6 6 0 006-6V22L32 8z" fill="url(#bb-grad)" opacity="0.9"/>
+  <!-- Cross-hatch pattern (pineapple texture) -->
+  <line x1="24" y1="20" x2="40" y2="20" stroke="white" stroke-opacity="0.25" stroke-width="1"/>
+  <line x1="22" y1="28" x2="42" y2="28" stroke="white" stroke-opacity="0.25" stroke-width="1"/>
+  <line x1="22" y1="36" x2="42" y2="36" stroke="white" stroke-opacity="0.25" stroke-width="1"/>
+  <line x1="22" y1="44" x2="42" y2="44" stroke="white" stroke-opacity="0.25" stroke-width="1"/>
+  <!-- Door (agent portal) -->
+  <rect x="27" y="34" width="10" height="14" rx="5" fill="#0f172a" opacity="0.7"/>
+  <circle cx="35" cy="42" r="1.2" fill="#00e5ff"/>
+  <!-- Leaf/antenna top -->
+  <path d="M32 8C30 4 26 2 24 3s0 6 2 7" stroke="url(#bb-grad)" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M32 8C34 4 38 2 40 3s0 6-2 7" stroke="url(#bb-grad)" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M32 8V3" stroke="url(#bb-grad)" stroke-width="2" stroke-linecap="round"/>
+  <!-- Bubbles -->
+  <circle cx="48" cy="14" r="3" fill="url(#bb-grad-light)" stroke="#00e5ff" stroke-opacity="0.4" stroke-width="0.8"/>
+  <circle cx="52" cy="8" r="2" fill="url(#bb-grad-light)" stroke="#00e5ff" stroke-opacity="0.3" stroke-width="0.6"/>
+  <circle cx="46" cy="6" r="1.5" fill="url(#bb-grad-light)" stroke="#00e5ff" stroke-opacity="0.3" stroke-width="0.5"/>
+</svg>

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { Logo } from "./ui/logo";
 import { Link, useLocation, useSearchParams } from "react-router-dom";
 import { motion } from "framer-motion";
 import {
@@ -7,7 +8,6 @@ import {
   CheckSquare,
   Coins,
   Activity,
-  Bot,
   Network,
   Play,
   Square,
@@ -180,7 +180,7 @@ export function Layout({ children }: LayoutProps) {
           {/* Logo + collapse toggle */}
           <div className="flex h-16 items-center gap-2 border-b border-border px-4 relative overflow-hidden">
             <div className="absolute inset-0 opacity-5 bg-gradient-to-r from-cyan-500 to-blue-600 pointer-events-none" />
-            <Bot className="h-6 w-6 flex-shrink-0 text-primary" style={{ animation: "wave-subtle 6s ease-in-out infinite" }} />
+            <Logo size="sm" style={{ animation: "wave-subtle 6s ease-in-out infinite" }} />
             {!sidebarCollapsed && (
               <motion.div
                 initial={{ opacity: 0, width: 0 }}
@@ -513,7 +513,7 @@ export function Layout({ children }: LayoutProps) {
           <div className="flex h-16 items-center justify-between border-b border-border px-4 relative overflow-hidden">
             <div className="absolute inset-0 opacity-5 bg-gradient-to-r from-cyan-500 to-blue-600 pointer-events-none" />
             <div className="flex items-center gap-2">
-              <Bot className="h-6 w-6 text-primary" style={{ animation: "wave-subtle 6s ease-in-out infinite" }} />
+              <Logo size="sm" style={{ animation: "wave-subtle 6s ease-in-out infinite" }} />
               <div className="flex flex-col">
               <span className="text-lg font-semibold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">
                 BikiniBottom
@@ -645,7 +645,7 @@ export function Layout({ children }: LayoutProps) {
               <Menu className="h-5 w-5" />
             </Button>
             <div className="flex items-center gap-2">
-              <Bot className="h-6 w-6 text-primary" style={{ animation: "wave-subtle 6s ease-in-out infinite" }} />
+              <Logo size="sm" style={{ animation: "wave-subtle 6s ease-in-out infinite" }} />
               <div className="flex flex-col">
               <span className="text-lg font-semibold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">
                 BikiniBottom

--- a/apps/dashboard/src/components/ui/logo.tsx
+++ b/apps/dashboard/src/components/ui/logo.tsx
@@ -1,0 +1,30 @@
+import logoSvg from '../../assets/logo.svg';
+
+const sizes = {
+  sm: 24,
+  md: 32,
+  lg: 48,
+  xl: 64,
+} as const;
+
+type LogoSize = keyof typeof sizes;
+
+interface LogoProps {
+  size?: LogoSize;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function Logo({ size = 'md', className = '', style }: LogoProps) {
+  const px = sizes[size];
+  return (
+    <img
+      src={logoSvg}
+      alt="BikiniBottom"
+      width={px}
+      height={px}
+      className={`flex-shrink-0 ${className}`}
+      style={style}
+    />
+  );
+}

--- a/apps/dashboard/src/demo/DemoWelcome.tsx
+++ b/apps/dashboard/src/demo/DemoWelcome.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Play, Users, Zap, Building2, Rocket, TrendingUp, Sparkles, Layers, Wallet, Eye, Compass } from 'lucide-react';
+import { X, Play, Users, Building2, Rocket, TrendingUp, Sparkles, Layers, Wallet, Eye, Compass } from 'lucide-react';
+import { Logo } from '../components/ui/logo';
 import { Button } from '../components/ui/button';
 import { useDemo, type ScenarioName } from './DemoProvider';
 import { useOnboarding } from '../components/onboarding/onboarding-provider';
@@ -138,8 +139,8 @@ export function DemoWelcome() {
                     transition={{ type: 'spring', damping: 20, stiffness: 200, delay: 0.1 }}
                     className="relative mb-6"
                   >
-                    <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-cyan-500 to-blue-600 flex items-center justify-center shadow-lg shadow-cyan-500/25">
-                      <Zap className="w-10 h-10 text-white" />
+                    <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-cyan-500/10 to-blue-600/10 flex items-center justify-center shadow-lg shadow-cyan-500/25 border border-cyan-500/20">
+                      <Logo size="xl" />
                     </div>
                     <motion.div
                       animate={{ scale: [1, 1.4], opacity: [0.3, 0] }}


### PR DESCRIPTION
## Changes

- **SVG Logo**: Stylized pineapple house (SpongeBob's iconic home) with cyan-to-blue gradient, bubbles, and agent door motif
- **Logo Component**: `apps/dashboard/src/components/ui/logo.tsx` — configurable sizes (sm=24, md=32, lg=48, xl=64)
- **Sidebar**: Replaced `Bot` lucide icon with Logo in desktop sidebar header
- **Mobile**: Added Logo to mobile drawer header and mobile top bar
- **DemoWelcome**: Replaced Zap icon with prominent Logo in welcome modal
- **Favicon**: New pineapple house favicon matching the brand

All existing animations (wave-subtle) and gradient text preserved.