### PR TITLE
feat: Emoji avatars from ORG.md + Groq LLM + dashboard fixes

### DIFF
--- a/apps/dashboard/src/components/agent-avatar.tsx
+++ b/apps/dashboard/src/components/agent-avatar.tsx
@@ -1,6 +1,7 @@
 /**
  * Agent Avatar component with auto-generated unique avatars
- * Uses DiceBear to generate consistent avatars based on agent ID
+ * Uses DiceBear to generate consistent avatars based on agent ID.
+ * In sandbox mode, renders SpongeBob character emoji avatars.
  */
 
 import { useMemo, useState, useEffect } from 'react';
@@ -10,7 +11,63 @@ import { Bot } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { PresenceGlow, StatusDot } from './presence';
 import { StatusRing } from './ui/status-ring';
+import { isSandboxMode } from '../graphql/fetcher';
 import type { PresenceStatus } from '../hooks/use-presence';
+
+// ── SpongeBob Character Emoji Map ───────────────────────────────────────────
+// Maps character names/IDs to emoji + background colors for sandbox mode
+
+const SPONGEBOB_CHARS: Record<string, { emoji: string; bg: string }> = {
+  // COO
+  'mr-krabs':           { emoji: '🦀', bg: '#dc2626' },  // Red crab
+  'mr. krabs':          { emoji: '🦀', bg: '#dc2626' },
+  // Engineering
+  'sandy':              { emoji: '🐿️', bg: '#a16207' },  // Land critter in the sea
+  'sandy cheeks':       { emoji: '🐿️', bg: '#a16207' },
+  'spongebob':          { emoji: '🧽', bg: '#eab308' },  // Yellow sponge
+  'patrick':            { emoji: '⭐', bg: '#ec4899' },  // Pink starfish
+  'patrick star':       { emoji: '⭐', bg: '#ec4899' },
+  'squidward':          { emoji: '🦑', bg: '#06b6d4' },  // Squid!
+  'pearl':              { emoji: '🐋', bg: '#f472b6' },  // Whale
+  'pearl krabs':        { emoji: '🐋', bg: '#f472b6' },
+  'gary':               { emoji: '🐌', bg: '#a78bfa' },  // Sea snail
+  'plankton jr':        { emoji: '🦠', bg: '#16a34a' },  // Microbe
+  // Security
+  'karen':              { emoji: '🖥️', bg: '#6366f1' },  // Computer
+  'mermaid man':        { emoji: '🧜‍♂️', bg: '#f97316' },  // Merman!
+  // Marketing
+  'perch':              { emoji: '🐟', bg: '#0ea5e9' },  // Fish reporter
+  'perch perkins':      { emoji: '🐟', bg: '#0ea5e9' },
+  'larry':              { emoji: '🦞', bg: '#dc2626' },  // Lobster!
+  'larry the lobster':  { emoji: '🦞', bg: '#dc2626' },
+  'bubble bass':        { emoji: '🐡', bg: '#65a30d' },  // Pufferfish (big guy)
+  'dennis':             { emoji: '🦈', bg: '#374151' },  // Shark — the enforcer
+  // Finance
+  'squilliam':          { emoji: '🦑', bg: '#7c3aed' },  // Fancy squid
+  'plankton':           { emoji: '🦠', bg: '#16a34a' },  // Plankton microbe
+  'mrs. puff':          { emoji: '🐡', bg: '#f59e0b' },  // Pufferfish
+  'mrs puff':           { emoji: '🐡', bg: '#f59e0b' },
+  // Support
+  'barnacle boy':       { emoji: '🐚', bg: '#0d9488' },  // Barnacle/shell
+  'flying dutchman':    { emoji: '👻', bg: '#4b5563' },  // Ghost (spooky sea legend)
+  'fred':               { emoji: '🐠', bg: '#d97706' },  // Generic fish (x3)
+};
+
+/** Try to match an agent to a SpongeBob character */
+function getCharacterEmoji(agentId: string, name?: string): { emoji: string; bg: string } | null {
+  if (!isSandboxMode) return null;
+
+  const idLower = agentId.toLowerCase();
+  const nameLower = (name || '').toLowerCase();
+
+  // Try exact matches first, then partial
+  for (const [key, val] of Object.entries(SPONGEBOB_CHARS)) {
+    if (idLower.includes(key.replace(/[. ]/g, '-')) || nameLower.includes(key)) {
+      return val;
+    }
+  }
+  return null;
+}
 
 interface AgentAvatarProps {
   agentId: string;
@@ -19,6 +76,8 @@ interface AgentAvatarProps {
   size?: 'sm' | 'md' | 'lg' | 'xl';
   className?: string;
   showRing?: boolean;
+  /** Emoji avatar from API (e.g. from ORG.md Avatar field) — overrides hardcoded map */
+  avatar?: string | null;
   /** When provided, wraps the avatar with a presence glow ring and status dot */
   presenceStatus?: PresenceStatus;
   /** StatusRing health data — when provided, uses ring instead of glow */
@@ -54,6 +113,7 @@ export function AgentAvatar({
   size = 'md',
   className,
   showRing = true,
+  avatar: avatarProp,
   presenceStatus,
   completionRate,
   creditUsage,
@@ -72,13 +132,48 @@ export function AgentAvatar({
     return () => window.removeEventListener('avatar-style-changed', handleStyleChange as EventListener);
   }, []);
   
-  // Memoize avatar generation - regenerate when any setting changes
-  const avatarUrl = useMemo(
-    () => getAgentAvatarUrl(agentId, level, sizeConfig.px * 2), // 2x for retina
-    [agentId, level, sizeConfig.px, avatarSettings]
+  // Check for SpongeBob character emoji (sandbox mode)
+  // Prefer API-provided avatar, fall back to hardcoded map
+  const charEmoji = useMemo(
+    () => {
+      if (avatarProp) {
+        // API-provided emoji — pick a bg color from the hardcoded map or default
+        const fromMap = getCharacterEmoji(agentId, name);
+        return { emoji: avatarProp, bg: fromMap?.bg ?? (LEVEL_COLORS[level] || '#71717a') };
+      }
+      return getCharacterEmoji(agentId, name);
+    },
+    [agentId, name, avatarProp, level]
   );
 
-  const avatar = (
+  // Memoize avatar generation - regenerate when any setting changes
+  const avatarUrl = useMemo(
+    () => charEmoji ? null : getAgentAvatarUrl(agentId, level, sizeConfig.px * 2),
+    [agentId, level, sizeConfig.px, avatarSettings, charEmoji]
+  );
+
+  const emojiSizes = { sm: 'text-lg', md: 'text-xl', lg: 'text-2xl', xl: 'text-3xl' };
+
+  const avatar = charEmoji ? (
+    <Avatar
+      className={cn(
+        sizeConfig.class,
+        showRing && !presenceStatus && 'ring-2',
+        className
+      )}
+      style={{
+        backgroundColor: charEmoji.bg,
+        ...(showRing && !presenceStatus ? { '--tw-ring-color': charEmoji.bg } as React.CSSProperties : {}),
+      }}
+    >
+      <AvatarFallback
+        className={cn('flex items-center justify-center', emojiSizes[size])}
+        style={{ backgroundColor: charEmoji.bg }}
+      >
+        {charEmoji.emoji}
+      </AvatarFallback>
+    </Avatar>
+  ) : (
     <Avatar
       className={cn(
         sizeConfig.class,
@@ -87,7 +182,7 @@ export function AgentAvatar({
       )}
       style={showRing && !presenceStatus ? { '--tw-ring-color': levelColor } as React.CSSProperties : undefined}
     >
-      <AvatarImage src={avatarUrl} alt={name || agentId} />
+      <AvatarImage src={avatarUrl!} alt={name || agentId} />
       <AvatarFallback
         style={{ backgroundColor: `${levelColor}20` }}
       >

--- a/apps/dashboard/src/components/agent-mode-selector.tsx
+++ b/apps/dashboard/src/components/agent-mode-selector.tsx
@@ -87,7 +87,7 @@ export function AgentModeBadge({
   size?: "sm" | "md" | "lg";
   showTooltip?: boolean;
 }) {
-  const config = MODE_CONFIG[mode];
+  const config = MODE_CONFIG[mode] || MODE_CONFIG[AgentMode.Worker];
   const Icon = config.icon;
 
   const sizeClasses = {
@@ -265,7 +265,7 @@ export function AgentModeCard({
   mode: AgentMode;
   className?: string;
 }) {
-  const config = MODE_CONFIG[mode];
+  const config = MODE_CONFIG[mode] || MODE_CONFIG[AgentMode.Worker];
   const Icon = config.icon;
 
   return (
@@ -315,7 +315,7 @@ export function AgentModeCard({
  * Compact mode indicator for lists/tables
  */
 export function AgentModeIndicator({ mode }: { mode: AgentMode }) {
-  const config = MODE_CONFIG[mode];
+  const config = MODE_CONFIG[mode] || MODE_CONFIG[AgentMode.Worker];
   const Icon = config.icon;
 
   return (

--- a/apps/dashboard/src/components/agent-network.tsx
+++ b/apps/dashboard/src/components/agent-network.tsx
@@ -171,6 +171,7 @@ interface AgentNodeData extends Record<string, unknown> {
   isHuman?: boolean;
   domain?: string;
   tasksCompleted?: number;
+  avatar?: string;
   isSpawning?: boolean;
   isDespawning?: boolean;
   compact?: boolean;
@@ -352,6 +353,8 @@ function AgentNode({ data, selected }: NodeProps) {
             const health = agentHealth.get(nodeData.agentId);
             const avatarImg = nodeData.isHuman ? (
               <span className="text-lg leading-none">👤</span>
+            ) : nodeData.avatar ? (
+              <span className="text-2xl leading-none select-none">{nodeData.avatar}</span>
             ) : avatarUrl ? (
               <img 
                 src={avatarUrl} 
@@ -808,6 +811,7 @@ function buildNodesAndEdges(
         status: agent.status as unknown as "active" | "pending" | "paused" | "suspended",
         credits: agent.currentBalance,
         domain: agent.domain || undefined,
+        avatar: (agent as any).avatar || undefined,
         tasksCompleted: 0,
         compact,
         activityLevel: activity?.activityLevel,

--- a/apps/dashboard/src/components/sandbox-command-bar.tsx
+++ b/apps/dashboard/src/components/sandbox-command-bar.tsx
@@ -49,7 +49,7 @@ export function SandboxCommandBar() {
         setHistory(prev =>
           prev.map((h, i) => i === prev.length - 1 ? { ...h, status: 'sent' } : h)
         );
-        showFlash('📢 Order delivered to Agent Dennis');
+        showFlash('📢 Order delivered to Mr. Krabs');
       } else {
         setHistory(prev =>
           prev.map((h, i) => i === prev.length - 1 ? { ...h, status: 'error' } : h)
@@ -108,7 +108,7 @@ export function SandboxCommandBar() {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && sendOrder()}
-            placeholder="Give an order to Agent Dennis..."
+            placeholder="Give an order to Mr. Krabs..."
             className="w-full pl-10 pr-4 py-2.5 rounded-lg bg-zinc-900 border border-zinc-700 text-sm text-foreground placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/30 focus:border-cyan-500/50 transition-all"
             disabled={sending}
           />

--- a/apps/dashboard/src/components/sandbox-controls.tsx
+++ b/apps/dashboard/src/components/sandbox-controls.tsx
@@ -1,18 +1,66 @@
 /**
  * Sandbox control panel — restart button + status indicator.
+ * Shows the current LLM provider and model dynamically.
  * Only visible in sandbox mode.
  */
 import { useState } from 'react';
 import { RotateCcw, Radio } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
 import { Button } from './ui/button';
 import { isSandboxMode } from '../graphql/fetcher';
 import { useQueryClient } from '@tanstack/react-query';
-
 import { SANDBOX_URL } from '../lib/sandbox-url';
+
+interface ModelInfo {
+  provider: string;
+  providerInfo: string;
+  currentModel: string;
+  locked: boolean;
+}
+
+/** Groq lightning bolt SVG — brand recognition */
+function GroqLogo({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className}>
+      <path d="M13 2L4.09 12.64a1 1 0 0 0 .78 1.63H11l-1 7.73 8.91-10.64a1 1 0 0 0-.78-1.63H13l1-7.73Z" 
+            fill="currentColor" stroke="currentColor" strokeWidth="0.5" />
+    </svg>
+  );
+}
+
+/** Provider icon based on the active provider */
+function ProviderIcon({ provider }: { provider: string }) {
+  if (provider === 'groq') {
+    return <GroqLogo className="w-3 h-3 text-orange-400" />;
+  }
+  return <Radio className="w-3 h-3 text-green-500 animate-pulse" />;
+}
+
+/** Format model name for display */
+function formatModel(model: string): string {
+  // Strip provider prefixes for cleaner display
+  const short = model.replace(/^(meta-llama|google|openai|qwen|nvidia)\//g, '');
+  // Capitalize nicely
+  return short
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase())
+    .replace(/(\d+[bB])\b/, (_, s) => s.toUpperCase()); // 8b → 8B
+}
 
 export function SandboxControls() {
   const [restarting, setRestarting] = useState(false);
   const queryClient = useQueryClient();
+
+  const { data: modelInfo } = useQuery<ModelInfo>({
+    queryKey: ['sandbox-models'],
+    queryFn: async () => {
+      const res = await fetch(`${SANDBOX_URL}/api/models`);
+      if (!res.ok) throw new Error('Failed to fetch model info');
+      return res.json();
+    },
+    staleTime: 60_000, // Cache for 1 min — model doesn't change at runtime
+    enabled: isSandboxMode,
+  });
 
   if (!isSandboxMode) return null;
 
@@ -20,7 +68,6 @@ export function SandboxControls() {
     setRestarting(true);
     try {
       await fetch(`${SANDBOX_URL}/api/restart`, { method: 'POST' });
-      // Wait a moment for the sim to reset, then refetch everything
       setTimeout(() => {
         queryClient.invalidateQueries();
         setRestarting(false);
@@ -30,12 +77,19 @@ export function SandboxControls() {
     }
   };
 
+  const provider = modelInfo?.provider ?? 'sandbox';
+  const model = modelInfo?.currentModel ?? '...';
+  const providerLabel = provider === 'groq' ? 'Groq' 
+    : provider === 'openrouter' ? 'OpenRouter' 
+    : provider === 'ollama' ? 'Ollama' 
+    : 'Sandbox';
+
   return (
     <div className="flex items-center gap-2">
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground bg-muted/50 rounded-full px-3 py-1.5 border border-border">
-        <Radio className="w-3 h-3 text-green-500 animate-pulse" />
-        <span className="font-medium">Sandbox Live</span>
-        <span className="text-muted-foreground/60">· qwen3:0.6b</span>
+        <ProviderIcon provider={provider} />
+        <span className="font-medium">{providerLabel}</span>
+        <span className="text-muted-foreground/60">· {formatModel(model)}</span>
       </div>
       <Button
         variant="outline"

--- a/apps/dashboard/src/demo/teams.ts
+++ b/apps/dashboard/src/demo/teams.ts
@@ -1,6 +1,9 @@
 /**
  * Team data model for organizational structure.
  * Teams form a hierarchy: parent teams → sub-teams → agents.
+ *
+ * In sandbox mode, team IDs are generated as `team-{domain}` from agent domains.
+ * This file defines the canonical teams that match both demo-data and sandbox.
  */
 
 export interface Team {
@@ -13,130 +16,101 @@ export interface Team {
   leadAgentId?: string;
 }
 
-// Agent IDs for lead assignments (mirrors libs/demo-data agent IDs)
-const AGENT_IDS = {
-  agentDennis: 'a0000000-0000-0000-0000-000000000001',
-  techTalent: 'a0000000-0000-0000-0000-000000000010',
-  financeTalent: 'a0000000-0000-0000-0000-000000000011',
-  marketingTalent: 'a0000000-0000-0000-0000-000000000012',
-  salesTalent: 'a0000000-0000-0000-0000-000000000013',
-  codeReviewer: 'a0000000-0000-0000-0000-000000000020',
-  copywriter: 'a0000000-0000-0000-0000-000000000022',
-  analyst: 'a0000000-0000-0000-0000-000000000021',
-  hrCoordinator: 'a0000000-0000-0000-0000-000000000050',
-  recruiterBot: 'a0000000-0000-0000-0000-000000000051',
-  onboardingAgent: 'a0000000-0000-0000-0000-000000000052',
-  supportLead: 'a0000000-0000-0000-0000-000000000060',
-  tier1Agent: 'a0000000-0000-0000-0000-000000000061',
-  tier2Agent: 'a0000000-0000-0000-0000-000000000063',
-  frontendDev: 'a0000000-0000-0000-0000-000000000070',
-  qaEngineer: 'a0000000-0000-0000-0000-000000000071',
-  accountManager: 'a0000000-0000-0000-0000-000000000080',
-  analyticsBot: 'a0000000-0000-0000-0000-000000000090',
-};
-
 // ── Team IDs ────────────────────────────────────────────────────────────────
 export const TEAM_IDS = {
-  // Top-level
-  executive: 'team-executive',
-  epd: 'team-epd',
-  sales: 'team-sales',
+  // Top-level departments
+  operations: 'team-operations',
+  engineering: 'team-engineering',
+  security: 'team-security',
   marketing: 'team-marketing',
-  hr: 'team-hr',
+  finance: 'team-finance',
   support: 'team-support',
 
-  // EPD sub-teams
+  // Engineering sub-teams
   backend: 'team-backend',
   frontend: 'team-frontend',
-  qa: 'team-qa',
+  qa: 'team-testing',
 
-  // Sales sub-teams
-  outbound: 'team-outbound',
-  accountMgmt: 'team-account-mgmt',
+  // Security sub-teams
+  appsec: 'team-appsec',
+  infrasec: 'team-infrastructure security',
 
   // Marketing sub-teams
-  content: 'team-content',
-  analytics: 'team-analytics',
+  content: 'team-content strategy',
+  copywriting: 'team-copywriting',
+  seo: 'team-seo',
 
-  // HR sub-teams
-  recruiting: 'team-recruiting',
-  peopleOps: 'team-people-ops',
+  // Finance sub-teams
+  analytics: 'team-analytics',
+  accounting: 'team-accounting',
 
   // Support sub-teams
-  tier1: 'team-tier1',
-  tier2: 'team-tier2',
+  tier1: 'team-support', // same as parent — tier 1 is core support
+  tier2: 'team-technical support',
 } as const;
 
 // ── Teams ───────────────────────────────────────────────────────────────────
 export const teams: Team[] = [
-  // ─── Top-Level Teams ───
+  // ─── Top-Level Departments ───
   {
-    id: TEAM_IDS.executive,
-    name: 'Executive',
-    description: 'C-suite leadership and strategy',
+    id: TEAM_IDS.operations,
+    name: 'Operations',
+    description: 'Executive leadership and coordination',
     color: 'slate',
     icon: 'Crown',
-    leadAgentId: AGENT_IDS.agentDennis,
   },
   {
-    id: TEAM_IDS.epd,
-    name: 'EPD',
-    description: 'Engineering, Product & Design',
+    id: TEAM_IDS.engineering,
+    name: 'Engineering',
+    description: 'Core product, infrastructure, testing, and deployment',
     color: 'cyan',
     icon: 'Code2',
-    leadAgentId: AGENT_IDS.techTalent,
   },
   {
-    id: TEAM_IDS.sales,
-    name: 'Sales',
-    description: 'Revenue generation and client acquisition',
-    color: 'emerald',
-    icon: 'DollarSign',
-    leadAgentId: AGENT_IDS.financeTalent,
+    id: TEAM_IDS.security,
+    name: 'Security',
+    description: 'Application security, infrastructure hardening, compliance',
+    color: 'red',
+    icon: 'Shield',
   },
   {
     id: TEAM_IDS.marketing,
     name: 'Marketing',
-    description: 'Brand, content, and growth marketing',
+    description: 'Content, campaigns, brand voice, and public presence',
     color: 'pink',
     icon: 'Megaphone',
-    leadAgentId: AGENT_IDS.marketingTalent,
   },
   {
-    id: TEAM_IDS.hr,
-    name: 'HR',
-    description: 'Human resources and talent management',
-    color: 'orange',
-    icon: 'Users',
-    leadAgentId: AGENT_IDS.hrCoordinator,
+    id: TEAM_IDS.finance,
+    name: 'Finance',
+    description: 'Budget allocation, forecasting, expense management',
+    color: 'emerald',
+    icon: 'DollarSign',
   },
   {
     id: TEAM_IDS.support,
-    name: 'Customer Support',
-    description: 'Customer success and technical support',
+    name: 'Support',
+    description: 'Customer-facing ticket queue and issue resolution',
     color: 'teal',
     icon: 'Headphones',
-    leadAgentId: AGENT_IDS.supportLead,
   },
 
-  // ─── EPD Sub-Teams ───
+  // ─── Engineering Sub-Teams ───
   {
     id: TEAM_IDS.backend,
     name: 'Backend',
-    description: 'Server-side architecture and APIs',
+    description: 'API layer, database, and server infrastructure',
     color: 'blue',
     icon: 'Server',
-    parentTeamId: TEAM_IDS.epd,
-    leadAgentId: AGENT_IDS.codeReviewer,
+    parentTeamId: TEAM_IDS.engineering,
   },
   {
     id: TEAM_IDS.frontend,
     name: 'Frontend',
-    description: 'UI/UX implementation and web apps',
+    description: 'Dashboard UI and marketing site',
     color: 'violet',
     icon: 'Monitor',
-    parentTeamId: TEAM_IDS.epd,
-    leadAgentId: AGENT_IDS.frontendDev,
+    parentTeamId: TEAM_IDS.engineering,
   },
   {
     id: TEAM_IDS.qa,
@@ -144,88 +118,79 @@ export const teams: Team[] = [
     description: 'Quality assurance and testing',
     color: 'amber',
     icon: 'ShieldCheck',
-    parentTeamId: TEAM_IDS.epd,
-    leadAgentId: AGENT_IDS.qaEngineer,
+    parentTeamId: TEAM_IDS.engineering,
   },
 
-  // ─── Sales Sub-Teams ───
+  // ─── Security Sub-Teams ───
   {
-    id: TEAM_IDS.outbound,
-    name: 'Outbound',
-    description: 'Outbound sales and lead generation',
-    color: 'emerald',
-    icon: 'Send',
-    parentTeamId: TEAM_IDS.sales,
-    leadAgentId: AGENT_IDS.salesTalent,
+    id: TEAM_IDS.appsec,
+    name: 'AppSec',
+    description: 'Application security and deploy review',
+    color: 'red',
+    icon: 'Lock',
+    parentTeamId: TEAM_IDS.security,
   },
   {
-    id: TEAM_IDS.accountMgmt,
-    name: 'Account Management',
-    description: 'Client retention and expansion',
-    color: 'emerald',
-    icon: 'Handshake',
-    parentTeamId: TEAM_IDS.sales,
-    leadAgentId: AGENT_IDS.accountManager,
+    id: TEAM_IDS.infrasec,
+    name: 'Infra Security',
+    description: 'Vulnerability scans, alerts, and incident response',
+    color: 'orange',
+    icon: 'AlertTriangle',
+    parentTeamId: TEAM_IDS.security,
   },
 
   // ─── Marketing Sub-Teams ───
   {
     id: TEAM_IDS.content,
-    name: 'Content',
-    description: 'Content strategy and creation',
+    name: 'Content Strategy',
+    description: 'Content strategy and campaign direction',
     color: 'pink',
     icon: 'PenTool',
     parentTeamId: TEAM_IDS.marketing,
-    leadAgentId: AGENT_IDS.copywriter,
   },
+  {
+    id: TEAM_IDS.copywriting,
+    name: 'Copywriting',
+    description: 'Docs, blogs, and social copy',
+    color: 'pink',
+    icon: 'FileText',
+    parentTeamId: TEAM_IDS.marketing,
+  },
+  {
+    id: TEAM_IDS.seo,
+    name: 'SEO',
+    description: 'Search optimization, keywords, metadata',
+    color: 'pink',
+    icon: 'Search',
+    parentTeamId: TEAM_IDS.marketing,
+  },
+
+  // ─── Finance Sub-Teams ───
   {
     id: TEAM_IDS.analytics,
     name: 'Analytics',
-    description: 'Marketing analytics and reporting',
-    color: 'pink',
+    description: 'Dashboards, trends, and actionable insights',
+    color: 'emerald',
     icon: 'BarChart3',
-    parentTeamId: TEAM_IDS.marketing,
-    leadAgentId: AGENT_IDS.analyst,
-  },
-
-  // ─── HR Sub-Teams ───
-  {
-    id: TEAM_IDS.recruiting,
-    name: 'Recruiting',
-    description: 'Talent acquisition and hiring',
-    color: 'orange',
-    icon: 'UserPlus',
-    parentTeamId: TEAM_IDS.hr,
-    leadAgentId: AGENT_IDS.recruiterBot,
+    parentTeamId: TEAM_IDS.finance,
   },
   {
-    id: TEAM_IDS.peopleOps,
-    name: 'People Ops',
-    description: 'Employee experience and operations',
-    color: 'orange',
-    icon: 'Heart',
-    parentTeamId: TEAM_IDS.hr,
-    leadAgentId: AGENT_IDS.onboardingAgent,
+    id: TEAM_IDS.accounting,
+    name: 'Accounting',
+    description: 'Expenses, invoices, and financial records',
+    color: 'emerald',
+    icon: 'Calculator',
+    parentTeamId: TEAM_IDS.finance,
   },
 
   // ─── Support Sub-Teams ───
   {
-    id: TEAM_IDS.tier1,
-    name: 'Tier 1',
-    description: 'First-response customer support',
-    color: 'teal',
-    icon: 'MessageCircle',
-    parentTeamId: TEAM_IDS.support,
-    leadAgentId: AGENT_IDS.tier1Agent,
-  },
-  {
     id: TEAM_IDS.tier2,
     name: 'Tier 2 Technical',
-    description: 'Escalated technical support',
+    description: 'Complex technical issues and escalations',
     color: 'teal',
     icon: 'Wrench',
     parentTeamId: TEAM_IDS.support,
-    leadAgentId: AGENT_IDS.tier2Agent,
   },
 ];
 
@@ -254,6 +219,7 @@ export const TEAM_COLOR_MAP: Record<string, string> = {
   pink: '#ec4899',
   orange: '#f97316',
   teal: '#14b8a6',
+  red: '#ef4444',
 };
 
 export function getTeamColor(colorName: string): string {

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -72,7 +72,8 @@ function AgentDetailsDialog({ agent, onClose }: { agent: Agent; onClose: () => v
               agentId={agent.agentId} 
               name={agent.name} 
               level={agent.level} 
-              size="lg" 
+              size="lg"
+              avatar={(agent as any).avatar}
             />
             <div>
               <DialogTitle>{agent.name}</DialogTitle>
@@ -403,6 +404,7 @@ function ReputationTab({ agents, onAgentClick }: { agents: Agent[]; onAgentClick
                         name={agent.name}
                         level={agent.level}
                         size="md"
+                        avatar={(agent as any).avatar}
                         presenceStatus={presenceMap.get(agent.id)?.status}
                         completionRate={healthMap.get(agent.id)?.completionRate}
                         creditUsage={healthMap.get(agent.id)?.creditUsage}
@@ -620,6 +622,7 @@ function AgentVirtualGrid({
                               name={agent.name}
                               level={agent.level}
                               size="md"
+                              avatar={(agent as any).avatar}
                               presenceStatus={presenceMap.get(agent.id)?.status}
                               completionRate={healthMap.get(agent.id)?.completionRate}
                               creditUsage={healthMap.get(agent.id)?.creditUsage}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:dashboard": "nx serve dashboard",
     "dev:sandbox": "nx run sandbox:dev",
     "dev:sandbox:full": "nx run sandbox:dev:full",
-    "dev:sandbox:clean": "nx run sandbox:dev:clean"
+    "dev:sandbox:cofounder": "nx run sandbox:dev:cofounder"
   },
   "dependencies": {
     "@apollo/server": "^5.4.0",

--- a/tools/sandbox/ORG.md
+++ b/tools/sandbox/ORG.md
@@ -18,95 +18,121 @@ preset: startup
 
 ## Structure
 
-### COO — Agent Dennis
-The operational backbone. Receives orders from the Human Principal, decomposes them into departmental work, and ensures nothing falls through the cracks. Calm, strategic, dry wit.
+### Mr. Krabs — COO
+The operational backbone. Receives orders from the Human Principal, decomposes them into departmental work, and ensures nothing falls through the cracks. Obsessed with efficiency, ROI, and making sure every credit is well spent. "I like money!"
 
+- **Avatar:** 🦀
 - **Domain:** Operations
 - **Reports to:** Human Principal
 
 ### Engineering
 Core product team. Owns the codebase, infrastructure, testing, and deployment pipeline.
 
-#### Engineering Lead
-Triages technical work across the team. Reviews output quality. Owns sprint planning.
+#### Sandy Cheeks — Engineering Lead
+Triages technical work across the team. Reviews output quality. Owns sprint planning. Brilliant inventor and problem-solver from Texas. Can build anything.
+- **Avatar:** 🐿️
 - **Domain:** Engineering
 
-#### Senior Backend Engineer
-Owns API layer, database, and server infrastructure. Deep systems knowledge.
+#### SpongeBob SquarePants — Senior Backend Engineer
+Owns API layer, database, and server infrastructure. Enthusiastic, hardworking, never gives up. "I'm ready!"
+- **Avatar:** 🧽
 - **Domain:** Backend
-- **Count:** 2
 
-#### Frontend Developer
-Builds and maintains the dashboard UI and marketing site. React/TypeScript.
+#### Patrick Star — Senior Backend Engineer
+Backend muscle. Surprisingly insightful when you least expect it. Works best with clear instructions.
+- **Avatar:** ⭐
+- **Domain:** Backend
+
+#### Squidward Tentacles — Frontend Developer
+Builds and maintains the dashboard UI. Perfectionist with strong aesthetic opinions. Reluctantly excellent.
+- **Avatar:** 🐙
 - **Domain:** Frontend
-- **Count:** 2
 
-#### QA Engineer
-Writes and runs tests. Nothing ships without QA sign-off. Methodical and thorough.
+#### Pearl Krabs — Frontend Developer
+Young, trendy, brings fresh design perspectives. Keeps the UI modern and user-friendly. Mr. Krabs' daughter — has to earn her place like everyone else.
+- **Avatar:** 🐳
+- **Domain:** Frontend
+
+#### Gary — QA Engineer
+Writes and runs tests. Nothing ships without QA sign-off. Methodical, thorough, communicates in meows but the tests speak for themselves.
+- **Avatar:** 🐌
 - **Domain:** Testing
 
-#### Engineering Intern
-New to the team. Handles docs, small bug fixes, and learning the codebase.
+#### Plankton Jr. — Engineering Intern
+New to the team. Handles docs, small bug fixes, and learning the codebase. Eager and slightly mischievous.
+- **Avatar:** 🦠
 - **Domain:** Engineering
 
 ### Security
 Small but critical. Every deploy needs their review. Zero tolerance for shortcuts.
 
-#### Security Lead
-Oversees application security, infrastructure hardening, and compliance. Reviews all deploys.
+#### Karen — Security Lead
+Oversees application security, infrastructure hardening, and compliance. Reviews all deploys. The smartest computer in Bikini Bottom. Plankton's wife, but all business at work.
+- **Avatar:** 🖥️
 - **Domain:** AppSec
 
-#### Security Worker
-Runs vulnerability scans, monitors alerts, and handles incident response.
+#### Mermaid Man — Security Worker
+Runs vulnerability scans, monitors alerts, and handles incident response. Veteran defender of justice (and servers). "EVIL!"
+- **Avatar:** 🦸
 - **Domain:** Infrastructure Security
 
 ### Marketing
 Owns content, campaigns, brand voice, and public presence. Data-informed creativity.
 
-#### Marketing Lead
-Sets content strategy and campaign direction. Coordinates the team.
+#### Perch Perkins — Marketing Lead
+Sets content strategy and campaign direction. Born reporter — knows how to craft a story and make it spread. Always on camera, always on message.
+- **Avatar:** 🐟
 - **Domain:** Content Strategy
 
-#### Copywriter
-Writes compelling copy for docs, blogs, and social. Voice and tone matter.
+#### Larry the Lobster — Copywriter
+Writes compelling copy for docs, blogs, and social. Strong, confident prose. Pumps out content like reps at the gym.
+- **Avatar:** 🦞
 - **Domain:** Copywriting
 
-#### SEO Specialist
-Optimizes content for search. Keywords, metadata, structured data, link building.
+#### Bubble Bass — SEO Specialist
+Optimizes content for search. Obsessively detail-oriented about keywords and metadata. Will find what you forgot. "You forgot the pickles!"
+- **Avatar:** 🐡
 - **Domain:** SEO
 
-#### Marketing Intern
-Helps with research, drafts, and analytics reporting. Eager to learn.
+#### Dennis — Marketing Enforcer
+The closer. Handles competitive analysis, tough negotiations, and campaigns that need muscle. Gets results, no questions asked.
+- **Avatar:** 🕶️
 - **Domain:** Marketing
 
 ### Finance
 Tracks the money. Budget allocation, forecasting, expense management, and reporting.
 
-#### Finance Lead
-Oversees all financial operations. Produces reports for leadership. Precise and numbers-driven.
+#### Squilliam Fancyson — Finance Lead
+Oversees all financial operations. Produces reports for leadership. Precise, sophisticated, and numbers-driven. Lives to one-up everyone with his impeccable spreadsheets.
+- **Avatar:** 🎩
 - **Domain:** Finance
 
-#### Data Analyst
-Builds dashboards, analyzes trends, and surfaces actionable insights from org metrics.
+#### Plankton — Data Analyst
+Builds dashboards, analyzes trends, and surfaces actionable insights from org metrics. Always scheming for the best formula. "I went to college!"
+- **Avatar:** 🧫
 - **Domain:** Analytics
 
-#### Bookkeeper
-Tracks expenses, invoices, and financial records. Accurate and organized.
+#### Mrs. Puff — Bookkeeper
+Tracks expenses, invoices, and financial records. Patient, accurate, and organized. Keeps everything in line (unlike her driving school).
+- **Avatar:** 🐠
 - **Domain:** Accounting
 
 ### Support
 Customer-facing. Manages ticket queue, resolves issues, escalates when needed. Empathy first.
 
-#### Support Lead
-Manages support tiers. Ensures SLAs are met. Empathetic but efficient.
+#### Barnacle Boy — Support Lead
+Manages support tiers. Ensures SLAs are met. Experienced, reliable, and tired of being called a sidekick.
+- **Avatar:** 🦸‍♂️
 - **Domain:** Support
 
-#### Tier 2 Specialist
-Handles complex technical issues that Tier 1 can't resolve. Deep product knowledge.
+#### Flying Dutchman — Tier 2 Specialist
+Handles complex technical issues that Tier 1 can't resolve. Intimidating but deeply knowledgeable. Haunts unresolved tickets.
+- **Avatar:** 👻
 - **Domain:** Technical Support
 
-#### Tier 1 Agent
-First-line support. Quick responses, clear communication, solution-oriented.
+#### Fred — Tier 1 Agent
+First-line support. Quick responses, clear communication. "My leg!" (but also "My ticket is resolved!")
+- **Avatar:** 🧑
 - **Domain:** Support
 - **Count:** 3
 

--- a/tools/sandbox/project.json
+++ b/tools/sandbox/project.json
@@ -8,20 +8,15 @@
     "serve": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npx tsx tools/sandbox/src/index.ts",
-        "cwd": "{workspaceRoot}",
-        "env": {
-          "COO_ONLY": "1"
-        }
+        "command": "CLEAN=1 npx tsx tools/sandbox/src/index.ts",
+        "cwd": "{workspaceRoot}"
       },
       "configurations": {
         "full": {
-          "env": {}
+          "command": "npx tsx tools/sandbox/src/index.ts"
         },
-        "clean": {
-          "env": {
-            "CLEAN": "1"
-          }
+        "cofounder": {
+          "command": "COFOUNDER=1 npx tsx tools/sandbox/src/index.ts"
         }
       }
     },
@@ -29,7 +24,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "COO_ONLY=1 npx tsx tools/sandbox/src/index.ts",
+          "CLEAN=1 npx tsx tools/sandbox/src/index.ts",
           "VITE_SANDBOX_MODE=true nx serve dashboard"
         ],
         "cwd": "{workspaceRoot}",
@@ -42,9 +37,9 @@
             "VITE_SANDBOX_MODE=true nx serve dashboard"
           ]
         },
-        "clean": {
+        "cofounder": {
           "commands": [
-            "CLEAN=1 npx tsx tools/sandbox/src/index.ts",
+            "COFOUNDER=1 npx tsx tools/sandbox/src/index.ts",
             "VITE_SANDBOX_MODE=true nx serve dashboard"
           ]
         }

--- a/tools/sandbox/src/agents.ts
+++ b/tools/sandbox/src/agents.ts
@@ -69,30 +69,30 @@ Respond with JSON ONLY. Actions:
 export function createAgents(): SandboxAgent[] {
   return [
     // ═══ L10 — COO ═══
-    makeAgent('dennis', 'Agent Dennis', 'coo', 10, 'Operations',
+    makeAgent('mr-krabs', 'Mr. Krabs', 'coo', 10, 'Operations',
       undefined,
       'You are calm, strategic, and efficient. You see the big picture and coordinate all departments. Dry wit.'),
 
     // ═══ L9 — Department Leads ═══
     makeAgent('tech-talent', 'Tech Talent Agent', 'talent', 9, 'Engineering',
-      'dennis',
+      'mr-krabs',
       'You recruit and manage engineering talent. You care deeply about code quality and technical excellence.'),
     makeAgent('finance-talent', 'Finance Talent Agent', 'talent', 9, 'Finance',
-      'dennis',
+      'mr-krabs',
       'You manage financial operations and budget allocation. Precise and numbers-driven.'),
     makeAgent('marketing-talent', 'Marketing Talent Agent', 'talent', 9, 'Marketing',
-      'dennis',
+      'mr-krabs',
       'You lead marketing campaigns and brand strategy. Creative and data-informed.'),
     makeAgent('sales-talent', 'Sales Talent Agent', 'talent', 9, 'Sales',
-      'dennis',
+      'mr-krabs',
       'You drive revenue through outbound sales and partnerships. Persuasive and target-oriented.'),
 
     // ═══ L7 — Team Leads ═══
     makeAgent('support-lead', 'Support Lead', 'lead', 7, 'Support',
-      'dennis',
+      'mr-krabs',
       'You manage customer support tiers. Empathetic but efficient. Escalation is a last resort.'),
     makeAgent('hr-coordinator', 'HR Coordinator', 'lead', 6, 'HR',
-      'dennis',
+      'mr-krabs',
       'You handle onboarding, team coordination, and people operations.'),
 
     // ═══ L6 — Seniors ═══
@@ -188,7 +188,7 @@ export const makeAgentPublic = makeAgent;
 /** Create just the L10 COO — the org grows from here */
 export function createCOO(): SandboxAgent[] {
   return [
-    makeAgent('dennis', 'Agent Dennis', 'coo', 10, 'Operations',
+    makeAgent('mr-krabs', 'Mr. Krabs', 'coo', 10, 'Operations',
       undefined,
       'You are calm, strategic, and efficient. You see the big picture. You need to build your organization by spawning department leads first, then delegating tasks to them. Start by spawning agents for the most urgent domains.'),
   ];

--- a/tools/sandbox/src/llm.ts
+++ b/tools/sandbox/src/llm.ts
@@ -1,0 +1,322 @@
+// ── LLM Client ──────────────────────────────────────────────────────────────
+// Unified inference layer: Groq (free) → OpenRouter → Ollama (local)
+// Priority: GROQ_API_KEY > OPENROUTER_API_KEY > Ollama
+// Groq is truly free (rate-limited, not credit-limited) — ideal for demos.
+
+import type { SandboxAgent, AgentAction, SandboxConfig } from './types.js';
+
+// ── Provider detection ──────────────────────────────────────────────────────
+
+const GROQ_API_KEY = process.env.GROQ_API_KEY || '';
+const GROQ_URL = 'https://api.groq.com/openai/v1';
+const GROQ_MODEL = process.env.GROQ_MODEL || 'llama-3.1-8b-instant';
+
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || '';
+const OPENROUTER_URL = process.env.OPENROUTER_URL || 'https://openrouter.ai/api/v1';
+const OPENROUTER_MODEL = process.env.OPENROUTER_MODEL || 'google/gemma-3n-e2b-it:free';
+const OPENROUTER_MANAGER_MODEL = process.env.OPENROUTER_MANAGER_MODEL || OPENROUTER_MODEL;
+
+const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434';
+
+export type Provider = 'groq' | 'openrouter' | 'ollama';
+
+export function getProvider(): Provider {
+  if (GROQ_API_KEY) return 'groq';
+  if (OPENROUTER_API_KEY) return 'openrouter';
+  return 'ollama';
+}
+
+export function getProviderInfo(): string {
+  switch (getProvider()) {
+    case 'groq': return `Groq (model: ${GROQ_MODEL}, free tier, 14.4K req/day)`;
+    case 'openrouter': return `OpenRouter (workers: ${OPENROUTER_MODEL}, managers: ${OPENROUTER_MANAGER_MODEL})`;
+    case 'ollama': return `Ollama (local)`;
+  }
+}
+
+export function getModelName(): string {
+  switch (getProvider()) {
+    case 'groq': return GROQ_MODEL;
+    case 'openrouter': return OPENROUTER_MODEL;
+    case 'ollama': return process.env.SANDBOX_MODEL || 'qwen3:0.6b';
+  }
+}
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+interface LLMResponse {
+  content: string;
+  tokens: number;
+}
+
+// ── Semaphore ───────────────────────────────────────────────────────────────
+
+class Semaphore {
+  private queue: (() => void)[] = [];
+  private running = 0;
+  constructor(private max: number) {}
+  async acquire(): Promise<void> {
+    if (this.running < this.max) { this.running++; return; }
+    return new Promise(resolve => this.queue.push(() => { this.running++; resolve(); }));
+  }
+  release(): void {
+    this.running--;
+    const next = this.queue.shift();
+    if (next) next();
+  }
+}
+
+let semaphore: Semaphore;
+
+export async function initLLM(config: SandboxConfig): Promise<void> {
+  const provider = getProvider();
+
+  // Limit concurrency for cloud APIs to stay within rate limits
+  // Groq: 30 RPM → 4 concurrent is safe with 5s ticks
+  // OpenRouter free: ~20 RPM → 2 concurrent
+  const maxConcurrent = provider === 'ollama'
+    ? config.maxConcurrentInferences
+    : provider === 'groq' ? 4 : 2;
+  semaphore = new Semaphore(maxConcurrent);
+
+  console.log(`  🧠 LLM provider: ${getProviderInfo()}`);
+  console.log(`  🚦 Max concurrent: ${maxConcurrent}`);
+
+  if (provider === 'groq') {
+    // Quick validation — make sure the key works
+    try {
+      const res = await fetch(`${GROQ_URL}/models`, {
+        headers: { 'Authorization': `Bearer ${GROQ_API_KEY}` },
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      const data = await res.json() as { data: { id: string }[] };
+      const modelExists = data.data.some(m => m.id === GROQ_MODEL);
+      if (!modelExists) {
+        console.warn(`  ⚠ Model "${GROQ_MODEL}" not found on Groq. Available: ${data.data.map(m => m.id).slice(0, 5).join(', ')}...`);
+      }
+      console.log(`  ✅ Groq API key valid`);
+      console.log(`  💰 Cost: FREE (rate-limited, not credit-limited)`);
+    } catch (err) {
+      console.error(`  ❌ Groq API key validation failed: ${err}`);
+    }
+  }
+}
+
+// ── Retry wrapper ───────────────────────────────────────────────────────────
+
+const MAX_RETRIES = 3;
+const RETRY_BASE_MS = 2000;
+
+async function withRetry(
+  agent: SandboxAgent,
+  fn: () => Promise<Response>,
+): Promise<Response> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const response = await fn();
+
+    if (response.status === 429) {
+      const retryAfter = response.headers.get('retry-after');
+      const waitMs = retryAfter
+        ? parseInt(retryAfter, 10) * 1000
+        : RETRY_BASE_MS * Math.pow(2, attempt);
+
+      if (attempt < MAX_RETRIES) {
+        console.log(`  ⏳ ${agent.name} rate limited, retry in ${Math.round(waitMs / 1000)}s (${attempt + 1}/${MAX_RETRIES})`);
+        await new Promise(r => setTimeout(r, waitMs));
+        continue;
+      }
+      console.log(`  ⚠ ${agent.name} rate limited after ${MAX_RETRIES} retries`);
+    }
+
+    return response;
+  }
+
+  // Unreachable, but TypeScript
+  throw new Error('Retry exhausted');
+}
+
+// ── Groq inference ──────────────────────────────────────────────────────────
+
+async function callGroq(messages: ChatMessage[], agent: SandboxAgent): Promise<LLMResponse> {
+  const response = await withRetry(agent, () =>
+    fetch(`${GROQ_URL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${GROQ_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: GROQ_MODEL,
+        messages,
+        temperature: 0.7,
+        max_tokens: 256,
+      }),
+    })
+  );
+
+  if (response.status === 429) {
+    return { content: '{"action":"idle"}', tokens: 0 };
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Groq error: ${response.status} ${text}`);
+  }
+
+  const data = await response.json() as {
+    choices: { message: { content: string } }[];
+    usage?: { total_tokens?: number };
+  };
+
+  return {
+    content: data.choices?.[0]?.message?.content ?? '',
+    tokens: data.usage?.total_tokens ?? 0,
+  };
+}
+
+// ── OpenRouter inference ────────────────────────────────────────────────────
+
+async function callOpenRouter(messages: ChatMessage[], agent: SandboxAgent): Promise<LLMResponse> {
+  const model = agent.level >= 7 ? OPENROUTER_MANAGER_MODEL : OPENROUTER_MODEL;
+
+  const response = await withRetry(agent, () =>
+    fetch(`${OPENROUTER_URL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${OPENROUTER_API_KEY}`,
+        'HTTP-Referer': 'https://bikinibottom.ai',
+        'X-Title': 'BikiniBottom Sandbox',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        temperature: 0.7,
+        max_tokens: 256,
+      }),
+    })
+  );
+
+  if (response.status === 429) {
+    return { content: '{"action":"idle"}', tokens: 0 };
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OpenRouter error: ${response.status} ${text}`);
+  }
+
+  const data = await response.json() as {
+    choices: { message: { content: string } }[];
+    usage?: { total_tokens?: number };
+  };
+
+  return {
+    content: data.choices?.[0]?.message?.content ?? '',
+    tokens: data.usage?.total_tokens ?? 0,
+  };
+}
+
+// ── Ollama inference ────────────────────────────────────────────────────────
+
+async function callOllama(messages: ChatMessage[], config: SandboxConfig): Promise<LLMResponse> {
+  const response = await fetch(`${OLLAMA_URL}/api/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: config.model,
+      stream: false,
+      messages,
+      options: { temperature: 0.7, num_predict: 256 },
+      think: false,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Ollama error: ${response.status} ${await response.text()}`);
+  }
+
+  const data = await response.json() as {
+    message: { content: string };
+    eval_count?: number;
+  };
+
+  return {
+    content: data.message.content.trim(),
+    tokens: data.eval_count ?? 0,
+  };
+}
+
+// ── Unified inference ───────────────────────────────────────────────────────
+
+export async function getAgentDecision(
+  agent: SandboxAgent,
+  context: string,
+  config: SandboxConfig,
+): Promise<AgentAction> {
+  await semaphore.acquire();
+  try {
+    const messages: ChatMessage[] = [
+      { role: 'system', content: agent.systemPrompt },
+      { role: 'user', content: context },
+    ];
+
+    const provider = getProvider();
+    const { content: raw, tokens } = provider === 'groq'
+      ? await callGroq(messages, agent)
+      : provider === 'openrouter'
+        ? await callOpenRouter(messages, agent)
+        : await callOllama(messages, config);
+
+    // Track inference cost
+    agent.stats.creditsSpent += tokens;
+
+    // Parse JSON from response
+    let jsonStr = raw;
+
+    // Strip markdown code fences
+    jsonStr = jsonStr.replace(/^```json?\s*\n?/gm, '').replace(/\n?```\s*$/gm, '').trim();
+
+    // Strip thinking tags
+    jsonStr = jsonStr.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+
+    // Strip leading non-JSON chars
+    jsonStr = jsonStr.replace(/^[^{]*/, '');
+
+    // Extract JSON object with brace counting
+    const start = jsonStr.indexOf('{');
+    if (start >= 0) {
+      let depth = 0;
+      let end = start;
+      for (let i = start; i < jsonStr.length; i++) {
+        if (jsonStr[i] === '{') depth++;
+        else if (jsonStr[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+      }
+      jsonStr = jsonStr.substring(start, end + 1);
+    }
+
+    try {
+      return JSON.parse(jsonStr) as AgentAction;
+    } catch {
+      const fixed = jsonStr.replace(/"([^"]+)"\s*,\s*"/g, '"$1":"');
+      try {
+        return JSON.parse(fixed) as AgentAction;
+      } catch {
+        if (config.verbose) {
+          console.log(`  ⚠ ${agent.name} unparseable: ${jsonStr.substring(0, 120)}`);
+        }
+        return { action: 'idle' };
+      }
+    }
+  } finally {
+    semaphore.release();
+  }
+}
+
+// Re-export buildContext (context building logic stays in ollama.ts)
+export { buildContext } from './ollama.js';

--- a/tools/sandbox/src/org-parser.ts
+++ b/tools/sandbox/src/org-parser.ts
@@ -94,6 +94,7 @@ function makeAgent(
   parentId: string | undefined,
   systemPrompt: string,
   triggerConfig?: { trigger?: 'polling' | 'event-driven'; triggerOn?: ACPMessage['type'][] },
+  avatar?: string,
 ): SandboxAgent {
   const canSpawn = level >= 7;
   const roleInstruction = level >= 7
@@ -128,6 +129,7 @@ Respond with JSON ONLY. Actions:
     role,
     level,
     domain,
+    avatar,
     parentId,
     status: 'active',
     systemPrompt: fullPrompt,
@@ -310,7 +312,7 @@ export function parseOrgMdContent(raw: string): ParsedOrg {
           for (let i = 0; i < count; i++) {
             const agentName = count > 1 ? `${dept.heading} ${i + 1}` : dept.heading;
             const agentId = count > 1 ? `${id}-${i + 1}` : id;
-            const agent = makeAgent(agentId, agentName, deptRole, deptLevel, domain, parentId, context, triggerInfo);
+            const agent = makeAgent(agentId, agentName, deptRole, deptLevel, domain, parentId, context, triggerInfo, deptMeta['avatar']);
             agents.push(agent);
             if (isCLevel) cooId = agentId;
           }
@@ -350,7 +352,7 @@ export function parseOrgMdContent(raw: string): ParsedOrg {
           for (let i = 0; i < count; i++) {
             const agentName = count > 1 ? `${sub.heading} ${i + 1}` : sub.heading;
             const agentId = count > 1 ? `${id}-${i + 1}` : id;
-            const agent = makeAgent(agentId, agentName, subRole, subLevel, domain, parentId, context, triggerInfo);
+            const agent = makeAgent(agentId, agentName, subRole, subLevel, domain, parentId, context, triggerInfo, subMeta['avatar']);
             agents.push(agent);
           }
         }

--- a/tools/sandbox/src/types.ts
+++ b/tools/sandbox/src/types.ts
@@ -21,6 +21,7 @@ export interface SandboxAgent {
   role: 'coo' | 'talent' | 'lead' | 'senior' | 'worker' | 'intern';
   level: number;
   domain: string;
+  avatar?: string;
   parentId?: string;
   status: 'active' | 'idle' | 'busy';
   systemPrompt: string;


### PR DESCRIPTION
## What
- **Emoji avatars**: `Avatar` field in ORG.md parsed and served via API. Dashboard renders emoji (🦀🧽⭐🐙🐌👻) instead of DiceBear when available.
- **Groq integration**: Free-tier LLM provider (llama-3.1-8b-instant, 14.4K req/day). Priority: Groq → OpenRouter → Ollama.
- **Dashboard fixes**: AgentModeBadge crash fix, recharts removal (infinite loop), custom SVG/CSS charts, teams.ts rewrite, dynamic provider badge.

## Files
- `tools/sandbox/ORG.md` — Avatar field on all 22 agents
- `tools/sandbox/src/org-parser.ts` — Parse avatar metadata
- `tools/sandbox/src/types.ts` — `avatar?` field on SandboxAgent
- `tools/sandbox/src/server.ts` — Serve avatar in API, mode fix
- `tools/sandbox/src/llm.ts` — NEW unified LLM client
- `apps/dashboard/src/components/agent-avatar.tsx` — Accept `avatar` prop
- `apps/dashboard/src/components/agent-network.tsx` — Render emoji in network view
- `apps/dashboard/src/pages/agents.tsx` — Pass avatar to AgentAvatar
- Plus: charts, controls, teams, detail panel fixes