### PR TITLE
refactor: Decouple theme from code — zero character references in source

### DIFF
--- a/apps/dashboard/src/components/agent-detail-panel.tsx
+++ b/apps/dashboard/src/components/agent-detail-panel.tsx
@@ -75,6 +75,7 @@ function OverviewTab({ agent }: { agent: Agent }) {
           level={agent.level} 
           size="lg"
           avatar={(agent as any).avatar}
+          avatarColor={(agent as any).avatarColor}
         />
         <div className="flex-1">
           <h2 className="text-2xl font-bold">{agent.name}</h2>

--- a/apps/dashboard/src/components/command-palette.tsx
+++ b/apps/dashboard/src/components/command-palette.tsx
@@ -34,14 +34,14 @@ const actions = [
 ];
 
 const demoAgents = [
-  { name: 'SpongeBob', role: 'Task Runner', id: 'spongebob' },
-  { name: 'Patrick', role: 'Load Balancer', id: 'patrick' },
-  { name: 'Squidward', role: 'Code Reviewer', id: 'squidward' },
-  { name: 'Sandy', role: 'Security Analyst', id: 'sandy' },
-  { name: 'Mr. Krabs', role: 'Cost Optimizer', id: 'mrkrabs' },
-  { name: 'Plankton', role: 'Data Scraper', id: 'plankton' },
-  { name: 'Gary', role: 'Log Monitor', id: 'gary' },
-  { name: 'Karen', role: 'AI Assistant', id: 'karen' },
+  { name: 'Alpha', role: 'Task Runner', id: 'alpha' },
+  { name: 'Bravo', role: 'Load Balancer', id: 'bravo' },
+  { name: 'Charlie', role: 'Code Reviewer', id: 'charlie' },
+  { name: 'Delta', role: 'Security Analyst', id: 'delta' },
+  { name: 'Echo', role: 'Cost Optimizer', id: 'echo' },
+  { name: 'Foxtrot', role: 'Data Analyst', id: 'foxtrot' },
+  { name: 'Golf', role: 'Log Monitor', id: 'golf' },
+  { name: 'Hotel', role: 'AI Assistant', id: 'hotel' },
 ];
 
 export function CommandPalette() {

--- a/apps/dashboard/src/components/sandbox-command-bar.tsx
+++ b/apps/dashboard/src/components/sandbox-command-bar.tsx
@@ -49,7 +49,7 @@ export function SandboxCommandBar() {
         setHistory(prev =>
           prev.map((h, i) => i === prev.length - 1 ? { ...h, status: 'sent' } : h)
         );
-        showFlash('📢 Order delivered to Mr. Krabs');
+        showFlash('📢 Order delivered to the COO');
       } else {
         setHistory(prev =>
           prev.map((h, i) => i === prev.length - 1 ? { ...h, status: 'error' } : h)
@@ -108,7 +108,7 @@ export function SandboxCommandBar() {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && sendOrder()}
-            placeholder="Give an order to Mr. Krabs..."
+            placeholder="Give an order to the COO..."
             className="w-full pl-10 pr-4 py-2.5 rounded-lg bg-zinc-900 border border-zinc-700 text-sm text-foreground placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/30 focus:border-cyan-500/50 transition-all"
             disabled={sending}
           />

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -74,6 +74,7 @@ function AgentDetailsDialog({ agent, onClose }: { agent: Agent; onClose: () => v
               level={agent.level} 
               size="lg"
               avatar={(agent as any).avatar}
+                        avatarColor={(agent as any).avatarColor}
             />
             <div>
               <DialogTitle>{agent.name}</DialogTitle>
@@ -405,6 +406,7 @@ function ReputationTab({ agents, onAgentClick }: { agents: Agent[]; onAgentClick
                         level={agent.level}
                         size="md"
                         avatar={(agent as any).avatar}
+                        avatarColor={(agent as any).avatarColor}
                         presenceStatus={presenceMap.get(agent.id)?.status}
                         completionRate={healthMap.get(agent.id)?.completionRate}
                         creditUsage={healthMap.get(agent.id)?.creditUsage}
@@ -623,6 +625,7 @@ function AgentVirtualGrid({
                               level={agent.level}
                               size="md"
                               avatar={(agent as any).avatar}
+                              avatarColor={(agent as any).avatarColor}
                               presenceStatus={presenceMap.get(agent.id)?.status}
                               completionRate={healthMap.get(agent.id)?.completionRate}
                               creditUsage={healthMap.get(agent.id)?.creditUsage}

--- a/libs/demo-data/src/fixtures/telemetry.ts
+++ b/libs/demo-data/src/fixtures/telemetry.ts
@@ -58,7 +58,7 @@ export const mockTraces: MockTraceSpan[] = [
     attributes: {
       "task.id": "task-001",
       "task.phase": "assigned",
-      "agent.id": "agent-spongebob",
+      "agent.id": "agent-alpha",
     },
   },
   {

--- a/tools/sandbox/ORG.md
+++ b/tools/sandbox/ORG.md
@@ -22,6 +22,7 @@ preset: startup
 The operational backbone. Receives orders from the Human Principal, decomposes them into departmental work, and ensures nothing falls through the cracks. Obsessed with efficiency, ROI, and making sure every credit is well spent. "I like money!"
 
 - **Avatar:** 🦀
+- **Avatar Color:** #dc2626
 - **Domain:** Operations
 - **Reports to:** Human Principal
 
@@ -31,36 +32,43 @@ Core product team. Owns the codebase, infrastructure, testing, and deployment pi
 #### Sandy Cheeks — Engineering Lead
 Triages technical work across the team. Reviews output quality. Owns sprint planning. Brilliant inventor and problem-solver from Texas. Can build anything.
 - **Avatar:** 🐿️
+- **Avatar Color:** #a16207
 - **Domain:** Engineering
 
 #### SpongeBob SquarePants — Senior Backend Engineer
 Owns API layer, database, and server infrastructure. Enthusiastic, hardworking, never gives up. "I'm ready!"
 - **Avatar:** 🧽
+- **Avatar Color:** #eab308
 - **Domain:** Backend
 
 #### Patrick Star — Senior Backend Engineer
 Backend muscle. Surprisingly insightful when you least expect it. Works best with clear instructions.
 - **Avatar:** ⭐
+- **Avatar Color:** #ec4899
 - **Domain:** Backend
 
 #### Squidward Tentacles — Frontend Developer
 Builds and maintains the dashboard UI. Perfectionist with strong aesthetic opinions. Reluctantly excellent.
 - **Avatar:** 🐙
+- **Avatar Color:** #06b6d4
 - **Domain:** Frontend
 
 #### Pearl Krabs — Frontend Developer
 Young, trendy, brings fresh design perspectives. Keeps the UI modern and user-friendly. Mr. Krabs' daughter — has to earn her place like everyone else.
 - **Avatar:** 🐳
+- **Avatar Color:** #f472b6
 - **Domain:** Frontend
 
 #### Gary — QA Engineer
 Writes and runs tests. Nothing ships without QA sign-off. Methodical, thorough, communicates in meows but the tests speak for themselves.
 - **Avatar:** 🐌
+- **Avatar Color:** #a78bfa
 - **Domain:** Testing
 
 #### Plankton Jr. — Engineering Intern
 New to the team. Handles docs, small bug fixes, and learning the codebase. Eager and slightly mischievous.
 - **Avatar:** 🦠
+- **Avatar Color:** #16a34a
 - **Domain:** Engineering
 
 ### Security
@@ -69,11 +77,13 @@ Small but critical. Every deploy needs their review. Zero tolerance for shortcut
 #### Karen — Security Lead
 Oversees application security, infrastructure hardening, and compliance. Reviews all deploys. The smartest computer in Bikini Bottom. Plankton's wife, but all business at work.
 - **Avatar:** 🖥️
+- **Avatar Color:** #6366f1
 - **Domain:** AppSec
 
 #### Mermaid Man — Security Worker
 Runs vulnerability scans, monitors alerts, and handles incident response. Veteran defender of justice (and servers). "EVIL!"
 - **Avatar:** 🦸
+- **Avatar Color:** #f97316
 - **Domain:** Infrastructure Security
 
 ### Marketing
@@ -82,21 +92,25 @@ Owns content, campaigns, brand voice, and public presence. Data-informed creativ
 #### Perch Perkins — Marketing Lead
 Sets content strategy and campaign direction. Born reporter — knows how to craft a story and make it spread. Always on camera, always on message.
 - **Avatar:** 🐟
+- **Avatar Color:** #0ea5e9
 - **Domain:** Content Strategy
 
 #### Larry the Lobster — Copywriter
 Writes compelling copy for docs, blogs, and social. Strong, confident prose. Pumps out content like reps at the gym.
 - **Avatar:** 🦞
+- **Avatar Color:** #dc2626
 - **Domain:** Copywriting
 
 #### Bubble Bass — SEO Specialist
 Optimizes content for search. Obsessively detail-oriented about keywords and metadata. Will find what you forgot. "You forgot the pickles!"
 - **Avatar:** 🐡
+- **Avatar Color:** #65a30d
 - **Domain:** SEO
 
 #### Dennis — Marketing Enforcer
 The closer. Handles competitive analysis, tough negotiations, and campaigns that need muscle. Gets results, no questions asked.
 - **Avatar:** 🕶️
+- **Avatar Color:** #374151
 - **Domain:** Marketing
 
 ### Finance
@@ -105,16 +119,19 @@ Tracks the money. Budget allocation, forecasting, expense management, and report
 #### Squilliam Fancyson — Finance Lead
 Oversees all financial operations. Produces reports for leadership. Precise, sophisticated, and numbers-driven. Lives to one-up everyone with his impeccable spreadsheets.
 - **Avatar:** 🎩
+- **Avatar Color:** #7c3aed
 - **Domain:** Finance
 
 #### Plankton — Data Analyst
 Builds dashboards, analyzes trends, and surfaces actionable insights from org metrics. Always scheming for the best formula. "I went to college!"
 - **Avatar:** 🧫
+- **Avatar Color:** #16a34a
 - **Domain:** Analytics
 
 #### Mrs. Puff — Bookkeeper
 Tracks expenses, invoices, and financial records. Patient, accurate, and organized. Keeps everything in line (unlike her driving school).
 - **Avatar:** 🐠
+- **Avatar Color:** #f59e0b
 - **Domain:** Accounting
 
 ### Support
@@ -123,16 +140,19 @@ Customer-facing. Manages ticket queue, resolves issues, escalates when needed. E
 #### Barnacle Boy — Support Lead
 Manages support tiers. Ensures SLAs are met. Experienced, reliable, and tired of being called a sidekick.
 - **Avatar:** 🦸‍♂️
+- **Avatar Color:** #0d9488
 - **Domain:** Support
 
 #### Flying Dutchman — Tier 2 Specialist
 Handles complex technical issues that Tier 1 can't resolve. Intimidating but deeply knowledgeable. Haunts unresolved tickets.
 - **Avatar:** 👻
+- **Avatar Color:** #4b5563
 - **Domain:** Technical Support
 
 #### Fred — Tier 1 Agent
 First-line support. Quick responses, clear communication. "My leg!" (but also "My ticket is resolved!")
 - **Avatar:** 🧑
+- **Avatar Color:** #d97706
 - **Domain:** Support
 - **Count:** 3
 

--- a/tools/sandbox/src/org-parser.ts
+++ b/tools/sandbox/src/org-parser.ts
@@ -95,6 +95,7 @@ function makeAgent(
   systemPrompt: string,
   triggerConfig?: { trigger?: 'polling' | 'event-driven'; triggerOn?: ACPMessage['type'][] },
   avatar?: string,
+  avatarColor?: string,
 ): SandboxAgent {
   const canSpawn = level >= 7;
   const roleInstruction = level >= 7
@@ -130,6 +131,7 @@ Respond with JSON ONLY. Actions:
     level,
     domain,
     avatar,
+    avatarColor,
     parentId,
     status: 'active',
     systemPrompt: fullPrompt,
@@ -312,7 +314,7 @@ export function parseOrgMdContent(raw: string): ParsedOrg {
           for (let i = 0; i < count; i++) {
             const agentName = count > 1 ? `${dept.heading} ${i + 1}` : dept.heading;
             const agentId = count > 1 ? `${id}-${i + 1}` : id;
-            const agent = makeAgent(agentId, agentName, deptRole, deptLevel, domain, parentId, context, triggerInfo, deptMeta['avatar']);
+            const agent = makeAgent(agentId, agentName, deptRole, deptLevel, domain, parentId, context, triggerInfo, deptMeta['avatar'], deptMeta['avatar_color']);
             agents.push(agent);
             if (isCLevel) cooId = agentId;
           }
@@ -352,7 +354,7 @@ export function parseOrgMdContent(raw: string): ParsedOrg {
           for (let i = 0; i < count; i++) {
             const agentName = count > 1 ? `${sub.heading} ${i + 1}` : sub.heading;
             const agentId = count > 1 ? `${id}-${i + 1}` : id;
-            const agent = makeAgent(agentId, agentName, subRole, subLevel, domain, parentId, context, triggerInfo, subMeta['avatar']);
+            const agent = makeAgent(agentId, agentName, subRole, subLevel, domain, parentId, context, triggerInfo, subMeta['avatar'], subMeta['avatar_color']);
             agents.push(agent);
           }
         }

--- a/tools/sandbox/src/server.ts
+++ b/tools/sandbox/src/server.ts
@@ -83,6 +83,7 @@ function mapAgent(agent: SandboxAgent, allAgents: SandboxAgent[]) {
     lastPromotionAt: null,
     teamId: domainToTeamId(agent.domain),
     avatar: agent.avatar ?? null,
+    avatarColor: agent.avatarColor ?? null,
     systemPrompt: agent.systemPrompt,
     trigger: agent.trigger,
     triggerOn: agent.triggerOn ?? null,

--- a/tools/sandbox/src/types.ts
+++ b/tools/sandbox/src/types.ts
@@ -22,6 +22,7 @@ export interface SandboxAgent {
   level: number;
   domain: string;
   avatar?: string;
+  avatarColor?: string;
   parentId?: string;
   status: 'active' | 'idle' | 'busy';
   systemPrompt: string;


### PR DESCRIPTION
## What
Dashboard is now fully **theme-agnostic**. All character/emoji/color data flows from ORG.md config through the API. Zero SpongeBob references in source code.

## Changes
- **Deleted** `SPONGEBOB_CHARS` map from `agent-avatar.tsx` (40+ lines of hardcoded character→emoji mapping)
- **`agent-avatar.tsx`** rewritten: accepts `avatar` + `avatarColor` props from API only
- **ORG.md**: Added `Avatar Color` field for all 22 agents
- **Parser + types + server**: Extract and serve `avatarColor`
- **command-palette.tsx**: Generic agent names (Alpha, Bravo, Charlie...)
- **sandbox-command-bar.tsx**: 'Give an order to the COO...' instead of Mr. Krabs
- **telemetry fixture**: `agent-spongebob` → `agent-alpha`

## Why
- IP safety for public launch
- Theme-agnostic platform: swap ORG.md for Marvel/Pokémon/military theme, dashboard doesn't care
- Single source of truth: ORG.md is the only place characters are defined