### PR TITLE
feat: auto-start scenario experience + speed API

### DIFF
--- a/tools/sandbox/src/scenarios/ai-dev-agency.ts
+++ b/tools/sandbox/src/scenarios/ai-dev-agency.ts
@@ -12,7 +12,7 @@ export const aiDevAgencyScenario: ScenarioDefinition = {
     description: 'BikiniBottom AI takes on two client projects and an internal platform upgrade simultaneously. Ship features, fight fires, bill hours.',
     duration: '20 minutes',
     targetDecisions: 1800,
-    tickIntervalMs: 500,
+    tickIntervalMs: 800,
     seed: 'random',
     difficulty: 'normal',
     totalTicks: 400,


### PR DESCRIPTION
Auto-starts ai-dev-agency scenario by default. Uses scenario tick interval (800ms). Speed control API for dashboard integration.