### PR TITLE
feat: dashboard scenario experience (context banner, phase transitions, event alerts, speed control)

### DIFF
--- a/apps/dashboard/src/components/first-visit-overlay.tsx
+++ b/apps/dashboard/src/components/first-visit-overlay.tsx
@@ -1,0 +1,40 @@
+/**
+ * First-Visit Context Overlay — shows once per session for 10 seconds.
+ */
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { isSandboxMode } from '../graphql/fetcher';
+
+const STORAGE_KEY = 'openspawn-first-visit-shown';
+
+export function FirstVisitOverlay() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isSandboxMode) return;
+    if (sessionStorage.getItem(STORAGE_KEY)) return;
+
+    sessionStorage.setItem(STORAGE_KEY, '1');
+    setVisible(true);
+    const timer = setTimeout(() => setVisible(false), 10000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!isSandboxMode) return null;
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.5 }}
+          className="fixed top-10 left-1/2 -translate-x-1/2 z-[55] px-4 py-2 rounded-full bg-slate-800/90 border border-slate-600/50 backdrop-blur-sm text-sm text-slate-300 whitespace-nowrap max-w-[90vw] truncate"
+        >
+          You're watching an AI organization handle two client projects simultaneously.
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -51,6 +51,10 @@ import { ActiveAgentsBadge } from "./presence";
 import { NotificationCenter } from "./notification-center";
 import { useOnboarding } from "./onboarding/onboarding-provider";
 import { SandboxCommandBar } from "./sandbox-command-bar";
+import { ScenarioContextBanner, useScenarioStatus } from "./sandbox-scenario-banner";
+import { PhaseTransitionOverlay } from "./phase-transition-overlay";
+import { ScenarioEventToasts } from "./scenario-event-toasts";
+import { FirstVisitOverlay } from "./first-visit-overlay";
 import type { ReactNode } from "react";
 
 interface LayoutProps {
@@ -112,6 +116,7 @@ export function Layout({ children }: LayoutProps) {
   const { resetOnboarding, hasCompletedOnboarding } = useOnboarding();
   const { collapsed: sidebarCollapsed, toggle: toggleSidebar } = useSidebarCollapsed();
   const sidePanel = useSidePanel();
+  const { status: scenarioStatus, phaseTransition, setPhaseTransition } = useScenarioStatus();
 
   const sidebarWidth = sidebarCollapsed ? SIDEBAR_COLLAPSED_W : SIDEBAR_EXPANDED_W;
 
@@ -794,6 +799,15 @@ export function Layout({ children }: LayoutProps) {
         {/* Sandbox command bar — fixed at bottom */}
         <SandboxCommandBar />
       </div>
+
+      {/* Scenario experience overlays */}
+      <ScenarioContextBanner status={scenarioStatus} />
+      <PhaseTransitionOverlay
+        transition={phaseTransition}
+        onDismiss={() => setPhaseTransition(null)}
+      />
+      <ScenarioEventToasts />
+      <FirstVisitOverlay />
     </TooltipProvider>
   );
 }

--- a/apps/dashboard/src/components/phase-transition-overlay.tsx
+++ b/apps/dashboard/src/components/phase-transition-overlay.tsx
@@ -1,0 +1,71 @@
+/**
+ * Phase Transition Overlay — cinematic full-screen banner when phases change.
+ */
+import { useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+const PHASE_ICONS = ['📋', '⚡', '⚔️', '🚀'];
+
+interface PhaseTransitionProps {
+  transition: {
+    phaseName: string;
+    phaseIndex: number;
+    narrative: string;
+    epics: string[];
+  } | null;
+  onDismiss: () => void;
+}
+
+export function PhaseTransitionOverlay({ transition, onDismiss }: PhaseTransitionProps) {
+  useEffect(() => {
+    if (!transition) return;
+    const timer = setTimeout(onDismiss, 5000);
+    return () => clearTimeout(timer);
+  }, [transition, onDismiss]);
+
+  return (
+    <AnimatePresence>
+      {transition && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.6 }}
+          className="fixed inset-0 z-[70] flex items-center justify-center backdrop-blur-md bg-black/60"
+          onClick={onDismiss}
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 30, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -20, scale: 0.95 }}
+            transition={{ duration: 0.5, delay: 0.1 }}
+            className="text-center px-6 max-w-lg"
+          >
+            <div className="text-5xl mb-4">
+              {PHASE_ICONS[transition.phaseIndex] ?? '🎯'}
+            </div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-white tracking-wide mb-2">
+              PHASE {transition.phaseIndex + 1}: {transition.phaseName.toUpperCase()}
+            </h1>
+            {transition.narrative && (
+              <p className="text-slate-300 text-sm sm:text-base mb-4">
+                {transition.narrative}
+              </p>
+            )}
+            {transition.epics.length > 0 && (
+              <ul className="text-left mx-auto max-w-sm space-y-1 text-sm text-slate-400">
+                {transition.epics.map((epic, i) => (
+                  <li key={i} className="flex items-start gap-2">
+                    <span className="text-cyan-400 mt-0.5">•</span>
+                    <span>{epic}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <p className="text-xs text-slate-600 mt-4">Click to dismiss</p>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/apps/dashboard/src/components/sandbox-scenario-banner.tsx
+++ b/apps/dashboard/src/components/sandbox-scenario-banner.tsx
@@ -1,0 +1,134 @@
+/**
+ * Scenario Context Banner — persistent top bar showing scenario progress.
+ * Only visible in sandbox mode when a scenario is active.
+ */
+import { useState, useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { isSandboxMode } from '../graphql/fetcher';
+import { SANDBOX_URL } from '../lib/sandbox-url';
+
+export interface ScenarioStatus {
+  active: boolean;
+  scenarioId?: string;
+  scenarioName?: string;
+  currentPhase?: string;
+  currentPhaseIndex?: number;
+  tick?: number;
+  decisionCount?: number;
+  epics?: { id: string; title: string; status: string; completionPct: number }[];
+  eventsFired?: number;
+  scores?: Record<string, number>;
+  resources?: { id: string; name: string; current: number; initial: number; pct: number }[];
+}
+
+const TOTAL_TICKS = 400;
+
+export function useScenarioStatus() {
+  const [status, setStatus] = useState<ScenarioStatus | null>(null);
+  const prevPhaseRef = useRef<number>(-1);
+  const prevEventsRef = useRef<number>(0);
+  const [phaseTransition, setPhaseTransition] = useState<{
+    phaseName: string;
+    phaseIndex: number;
+    narrative: string;
+    epics: string[];
+  } | null>(null);
+  const [newEventCount, setNewEventCount] = useState(0);
+
+  useEffect(() => {
+    if (!isSandboxMode) return;
+    let disposed = false;
+
+    const poll = async () => {
+      try {
+        const res = await fetch(`${SANDBOX_URL}/api/scenario/status`);
+        if (!res.ok) return;
+        const data: ScenarioStatus = await res.json();
+        if (disposed) return;
+        setStatus(data);
+
+        if (data.active && data.currentPhaseIndex !== undefined) {
+          // Detect phase change
+          if (prevPhaseRef.current >= 0 && data.currentPhaseIndex > prevPhaseRef.current) {
+            setPhaseTransition({
+              phaseName: data.currentPhase ?? '',
+              phaseIndex: data.currentPhaseIndex,
+              narrative: '', // filled by phase data
+              epics: (data.epics ?? [])
+                .filter(e => e.status !== 'locked')
+                .map(e => e.title)
+                .slice(0, 5),
+            });
+          }
+          prevPhaseRef.current = data.currentPhaseIndex;
+
+          // Detect new events
+          const fired = data.eventsFired ?? 0;
+          if (prevEventsRef.current > 0 && fired > prevEventsRef.current) {
+            setNewEventCount(fired - prevEventsRef.current);
+          }
+          prevEventsRef.current = fired;
+        }
+      } catch {
+        // ignore
+      }
+    };
+
+    poll();
+    const interval = setInterval(poll, 2000);
+    return () => { disposed = true; clearInterval(interval); };
+  }, []);
+
+  return { status, phaseTransition, setPhaseTransition, newEventCount, setNewEventCount };
+}
+
+export function ScenarioContextBanner({ status }: { status: ScenarioStatus | null }) {
+  if (!isSandboxMode || !status?.active) return null;
+
+  const tick = status.tick ?? 0;
+  const progressPct = Math.min((tick / TOTAL_TICKS) * 100, 100);
+  const decisions = status.decisionCount ?? 0;
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[60] bg-slate-900/95 backdrop-blur-sm border-b border-slate-700/50">
+      <div className="max-w-7xl mx-auto px-3 py-1.5 flex items-center gap-3 text-xs sm:text-sm">
+        {/* Scenario name */}
+        <span className="font-semibold text-cyan-400 shrink-0 hidden sm:inline">
+          {status.scenarioName}
+        </span>
+        <span className="font-semibold text-cyan-400 shrink-0 sm:hidden">
+          🏢 Sprint
+        </span>
+
+        {/* Divider */}
+        <span className="text-slate-600 hidden sm:inline">|</span>
+
+        {/* Phase */}
+        <span className="text-slate-300 shrink-0">
+          <span className="text-slate-500">Phase {(status.currentPhaseIndex ?? 0) + 1}:</span>{' '}
+          {status.currentPhase}
+        </span>
+
+        {/* Spacer */}
+        <div className="flex-1 min-w-0">
+          {/* Progress bar */}
+          <div className="h-1.5 bg-slate-800 rounded-full overflow-hidden">
+            <motion.div
+              className="h-full bg-gradient-to-r from-cyan-500 to-blue-500 rounded-full"
+              animate={{ width: `${progressPct}%` }}
+              transition={{ duration: 0.5 }}
+            />
+          </div>
+        </div>
+
+        {/* Stats */}
+        <span className="text-slate-400 shrink-0 tabular-nums hidden md:inline">
+          {decisions.toLocaleString()} decisions
+        </span>
+        <span className="text-slate-500 shrink-0 tabular-nums">
+          Tick {tick}/{TOTAL_TICKS}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/scenario-event-toasts.tsx
+++ b/apps/dashboard/src/components/scenario-event-toasts.tsx
@@ -1,0 +1,101 @@
+/**
+ * Scenario Event Toasts — slide-in alerts for scenario events.
+ */
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X } from 'lucide-react';
+import { isSandboxMode } from '../graphql/fetcher';
+import { useSandboxSSE, type SandboxSSEEvent } from '../hooks/use-sandbox-sse';
+
+interface EventToast {
+  id: string;
+  message: string;
+  type: 'interrupt' | 'disruption' | 'expansion' | 'default';
+  timestamp: number;
+}
+
+const TYPE_STYLES: Record<string, string> = {
+  interrupt: 'border-red-500/50 bg-red-950/80 text-red-200',
+  disruption: 'border-yellow-500/50 bg-yellow-950/80 text-yellow-200',
+  expansion: 'border-blue-500/50 bg-blue-950/80 text-blue-200',
+  default: 'border-slate-500/50 bg-slate-900/80 text-slate-200',
+};
+
+const MAX_TOASTS = 3;
+const AUTO_DISMISS_MS = 6000;
+
+export function ScenarioEventToasts() {
+  const [toasts, setToasts] = useState<EventToast[]>([]);
+  const toastIdRef = useRef(0);
+
+  const addToast = useCallback((message: string, type: EventToast['type'] = 'default') => {
+    const id = `toast-${++toastIdRef.current}`;
+    setToasts(prev => {
+      const next = [...prev, { id, message, type, timestamp: Date.now() }];
+      return next.slice(-MAX_TOASTS);
+    });
+  }, []);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts(prev => prev.filter(t => t.id !== id));
+  }, []);
+
+  // Auto-dismiss
+  useEffect(() => {
+    if (toasts.length === 0) return;
+    const timers = toasts.map(t => {
+      const remaining = AUTO_DISMISS_MS - (Date.now() - t.timestamp);
+      if (remaining <= 0) {
+        removeToast(t.id);
+        return null;
+      }
+      return setTimeout(() => removeToast(t.id), remaining);
+    });
+    return () => timers.forEach(t => t && clearTimeout(t));
+  }, [toasts, removeToast]);
+
+  // Listen for scenario events via SSE
+  useSandboxSSE(useCallback((event: SandboxSSEEvent) => {
+    if (!isSandboxMode) return;
+    if (event.type === 'scenario_event') {
+      const msg = event.message ?? 'Scenario event occurred';
+      // Guess type from message content
+      let type: EventToast['type'] = 'default';
+      if (msg.includes('🔥') || msg.includes('outage') || msg.includes('down') || msg.includes('critical') || msg.includes('🚨')) {
+        type = 'interrupt';
+      } else if (msg.includes('dispute') || msg.includes('sick') || msg.includes('breaks') || msg.includes('🦠')) {
+        type = 'disruption';
+      } else if (msg.includes('scope') || msg.includes('new') || msg.includes('expansion')) {
+        type = 'expansion';
+      }
+      addToast(msg, type);
+    }
+  }, [addToast]));
+
+  if (!isSandboxMode) return null;
+
+  return (
+    <div className="fixed top-12 right-4 z-[65] flex flex-col gap-2 w-80 max-w-[calc(100vw-2rem)]">
+      <AnimatePresence>
+        {toasts.map(toast => (
+          <motion.div
+            key={toast.id}
+            initial={{ opacity: 0, x: 100, scale: 0.95 }}
+            animate={{ opacity: 1, x: 0, scale: 1 }}
+            exit={{ opacity: 0, x: 100, scale: 0.95 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+            className={`rounded-lg border px-3 py-2.5 text-sm shadow-lg backdrop-blur-sm flex items-start gap-2 ${TYPE_STYLES[toast.type]}`}
+          >
+            <span className="flex-1">{toast.message}</span>
+            <button
+              onClick={() => removeToast(toast.id)}
+              className="shrink-0 opacity-50 hover:opacity-100 transition-opacity"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}


### PR DESCRIPTION
## Dashboard Scenario Experience

Adds storytelling components for the auto-started AI Dev Agency scenario:

### New Components
- **ScenarioContextBanner** — fixed top bar showing scenario name, current phase, decision count, tick progress bar. Polls `/api/scenario/status` every 2s.
- **PhaseTransitionOverlay** — cinematic full-screen overlay with framer-motion when phase changes. Shows phase name, emoji, epic list. Auto-dismisses after 5s.
- **ScenarioEventToasts** — color-coded toasts (red/yellow/blue) sliding in from right on SSE `scenario_event`. Max 3 stacked, 6s auto-dismiss.
- **FirstVisitOverlay** — one-line context overlay for first 10s of session (sessionStorage gated).

### Enhanced Components
- **SandboxCommandBar** — added speed control pills (1x/2x/5x/10x) and pause/play toggle. Calls `PUT /api/speed`.

### Integration
- All components conditionally rendered in `layout.tsx` (sandbox mode only)
- No existing components modified beyond additive imports
- TypeScript clean (only pre-existing TS6306 error)