### PR TITLE
fix: Dockerfile for Nx monorepo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,46 @@
 # ── BikiniBottom Live Demo ────────────────────────────────────────────────────
 # Multi-stage build: dashboard (static) + sandbox server (Node)
 
-# Stage 1: Install dependencies
-FROM node:22-slim AS deps
+# Stage 1: Install dependencies + build dashboard
+FROM node:22-slim AS build
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@latest --activate
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY apps/dashboard/package.json apps/dashboard/
-COPY libs/demo-data/package.json libs/demo-data/
-COPY tools/sandbox/package.json tools/sandbox/
+
+# Copy everything needed for install
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml nx.json tsconfig.base.json ./
+COPY apps/ ./apps/
+COPY libs/ ./libs/
+COPY tools/sandbox/package.json tools/sandbox/tsconfig.json tools/sandbox/
+
 RUN pnpm install --frozen-lockfile
 
-# Stage 2: Build dashboard
-FROM deps AS dashboard-build
-COPY . .
+# Copy sandbox source
+COPY tools/sandbox/src/ ./tools/sandbox/src/
+COPY tools/sandbox/ORG.md ./tools/sandbox/
+COPY tools/sandbox/org/ ./tools/sandbox/org/
+# scenarios are inside src/
+
+# Build dashboard
 ENV VITE_SANDBOX_MODE=true
 RUN pnpm nx run dashboard:build --configuration=production
-# Output: apps/dashboard/dist/
 
-# Stage 3: Production runtime
+# Stage 2: Production runtime
 FROM node:22-slim AS runtime
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-# Copy sandbox + deps
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/tools/sandbox/node_modules ./tools/sandbox/node_modules
-COPY tools/sandbox/ ./tools/sandbox/
+# Copy workspace root
+COPY --from=build /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/tsconfig.base.json ./
+COPY --from=build /app/node_modules ./node_modules
+
+# Copy sandbox
+COPY --from=build /app/tools/sandbox ./tools/sandbox
+
+# Copy libs (needed for imports)
+COPY --from=build /app/libs ./libs
 
 # Copy built dashboard
-COPY --from=dashboard-build /app/dist/apps/dashboard ./dashboard-dist
-
-# Copy workspace config (needed for module resolution)
-COPY package.json pnpm-workspace.yaml tsconfig.base.json ./
-COPY libs/ ./libs/
+COPY --from=build /app/dist/apps/dashboard ./dashboard-dist
 
 ENV NODE_ENV=production
 ENV SANDBOX_PORT=3333


### PR DESCRIPTION
Fixes Docker build — monorepo uses single root package.json, not per-project.