### PR TITLE
fix: VPS deploy — add compose files + fix workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,22 +35,48 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
 
-      - name: Deploy to VPS
-        uses: appleboy/ssh-action@v1
+      - name: Copy deploy files to VPS
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          source: "deploy/docker-compose.yml,deploy/Caddyfile"
+          target: /opt/bikinibottom
+          strip_components: 1
+
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          envs: GH_TOKEN
           script: |
+            set -e
             cd /opt/bikinibottom
+
+            # Create .env.production if it doesn't exist
+            touch .env.production
+
+            # Log in to GHCR to pull the image
+            echo "${GH_TOKEN}" | docker login ghcr.io -u github-actions --password-stdin
+
+            # Pull and restart
             docker compose pull
             docker compose up -d --remove-orphans
+
+            # Prune old images
+            docker image prune -f
+
             # Health check
-            sleep 5
+            sleep 10
             if curl -sf http://localhost:3333/api/state > /dev/null; then
               echo "✅ Deploy successful"
             else
-              echo "❌ Health check failed — rolling back"
-              docker compose up -d --remove-orphans
+              echo "❌ Health check failed"
+              docker compose logs --tail=50 app
               exit 1
             fi

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,23 @@
+# ── BikiniBottom Caddy Config ─────────────────────────────────────────────────
+# Auto-HTTPS via Let's Encrypt. Place at /opt/bikinibottom/Caddyfile
+
+bikinibottom.ai {
+	reverse_proxy app:3333
+
+	header {
+		# Security headers
+		X-Content-Type-Options nosniff
+		X-Frame-Options DENY
+		Referrer-Policy strict-origin-when-cross-origin
+		# Remove server identity
+		-Server
+	}
+
+	# Cache hashed assets forever (Vite fingerprints them)
+	@assets path /assets/*
+	header @assets Cache-Control "public, max-age=31536000, immutable"
+
+	# Don't cache HTML (so deploys are picked up immediately)
+	@html path /
+	header @html Cache-Control "no-cache"
+}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,44 @@
+# ── BikiniBottom VPS Docker Compose ───────────────────────────────────────────
+# Lean demo: sandbox server + dashboard (single container) behind Caddy reverse proxy
+#
+# Expected at /opt/bikinibottom/docker-compose.yml on the VPS
+
+services:
+  app:
+    image: ghcr.io/openspawn/openspawn:latest
+    container_name: bikinibottom
+    restart: unless-stopped
+    environment:
+      - SANDBOX_PORT=3333
+      - SERVE_DASHBOARD=1
+      - SANDBOX_READONLY=1
+      - NODE_ENV=production
+    env_file:
+      - .env.production
+    expose:
+      - "3333"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3333/api/state"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  caddy:
+    image: caddy:2-alpine
+    container_name: bikinibottom-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      app:
+        condition: service_healthy
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
The deploy action was doing `docker compose pull/up` on the VPS but no compose file existed there.

**Added:**
- `deploy/docker-compose.yml` — lean sandbox app + Caddy for auto-HTTPS
- `deploy/Caddyfile` — reverse proxy with security headers + cache rules
- SCP step to copy deploy files before SSH deploy
- GHCR auth on VPS via envs
- Image pruning + better error logging on health check failure