### PR TITLE
fix: health check IPv6 — use 127.0.0.1

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     expose:
       - "3333"
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3333/api/state"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3333/api/state"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Alpine resolves localhost to ::1 (IPv6). Node listens on 0.0.0.0 (IPv4). wget connection refused inside container.