### PR TITLE
fix: remove login route in demo/sandbox mode

### DIFF
--- a/apps/dashboard/src/app/app.tsx
+++ b/apps/dashboard/src/app/app.tsx
@@ -99,9 +99,13 @@ export function App() {
               <FeatureTour />
               <CompletionCelebration />
               <Routes>
-                {/* Public routes */}
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/auth/callback" element={<AuthCallbackPage />} />
+                {/* Public routes — hidden in demo/sandbox mode */}
+                {!isDemoMode && !isSandboxMode && (
+                  <>
+                    <Route path="/login" element={<LoginPage />} />
+                    <Route path="/auth/callback" element={<AuthCallbackPage />} />
+                  </>
+                )}
                 
                 {/* Protected routes */}
                 <Route


### PR DESCRIPTION
Login page was still accessible at /login in demo/sandbox mode even though auth was bypassed. Now the routes aren't rendered at all.