### PR TITLE
fix: full-width layout for network & messages pages

### DIFF
--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -62,6 +62,9 @@ interface LayoutProps {
   children: ReactNode;
 }
 
+/** Routes that should span full width with no max-width or padding constraints */
+const fullBleedRoutes = new Set(["/network", "/messages"]);
+
 const navigation: { name: string; href: string; icon: typeof LayoutDashboard; tourId?: string }[] = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard, tourId: "dashboard" },
   { name: "Network", href: "/network", icon: Network, tourId: "network" },
@@ -727,7 +730,7 @@ export function Layout({ children }: LayoutProps) {
           {/* Main content + side panel */}
           <div className="flex flex-1 min-h-0">
             <main ref={mainContentRef} className="flex-1 overflow-auto min-w-0">
-              <div className={`mx-auto px-3 py-3 sm:px-4 sm:py-4 md:px-6 md:py-6 max-w-7xl ${scenarioStatus ? 'pt-12' : ''} pb-24 sm:pb-20`}>{children}</div>
+              <div className={`${fullBleedRoutes.has(location.pathname) ? 'h-full' : 'mx-auto px-3 py-3 sm:px-4 sm:py-4 md:px-6 md:py-6 max-w-7xl'} ${scenarioStatus ? 'pt-12' : ''} pb-24 sm:pb-20`}>{children}</div>
             </main>
 
             {/* Global Side Panel - desktop: inline, mobile: full-screen overlay */}

--- a/apps/dashboard/src/pages/network.tsx
+++ b/apps/dashboard/src/pages/network.tsx
@@ -53,7 +53,7 @@ export function NetworkPage() {
   }
 
   return (
-    <div className="h-[calc(100vh-theme(spacing.16))] -m-6 lg:-m-6 -mx-4 sm:-mx-6">
+    <div className="h-[calc(100vh-theme(spacing.16))]">
       {/* Header bar with title + stats + view toggle */}
       <div className="absolute top-4 sm:top-6 left-1/2 -translate-x-1/2 z-10
         bg-card/90 backdrop-blur border border-border


### PR DESCRIPTION
Removes the `max-w-7xl` constraint and padding on ReactFlow pages (network, messages) so the graph uses the full viewport width.

- Adds a `fullBleedRoutes` set in layout.tsx — routes in this set get `h-full` instead of max-width + padding
- Removes the negative margin hack (`-m-6 -mx-4`) from network page since the layout no longer adds padding
- Should give a much better default zoom level for the agent network graph on desktop