### PR TITLE
fix: API build fails in CI (TS6305 composite errors)

### DIFF
--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -2,8 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "composite": true,
-    "declaration": true,
     "module": "commonjs",
     "types": ["node"],
     "experimentalDecorators": true,
@@ -17,13 +15,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
-  "references": [
-    {
-      "path": "../../libs/shared-types/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/database/tsconfig.lib.json"
-    }
-  ]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
The typecheck PR (#284/#285) added `composite: true` and `references` to `apps/api/tsconfig.app.json`. But the API builds with webpack, not `tsc --build`, so it doesn't use project references — it resolves `@openspawn/database` via tsconfig path aliases.

With `composite: true` on the referenced libs, webpack's ts-loader sees TS6305 errors because the `.d.ts` outputs haven't been pre-built.

**Fix:** Remove `composite`, `declaration`, and `references` from the API app tsconfig. Libs keep `composite` for Nx typecheck plugin compatibility.