### PR TITLE
fix: mobile side panel layout issues

### DIFF
--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -744,7 +744,8 @@ export function Layout({ children }: LayoutProps) {
                     animate={{ x: 0 }}
                     exit={{ x: "100%" }}
                     transition={{ type: "spring", damping: 30, stiffness: 300 }}
-                    className="fixed inset-0 z-50 bg-background md:hidden"
+                    className="fixed inset-0 z-50 bg-background md:hidden overflow-hidden"
+                    style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
                   >
                     <SidePanelShell
                       title={sidePanel.title}

--- a/apps/dashboard/src/components/ui/side-panel.tsx
+++ b/apps/dashboard/src/components/ui/side-panel.tsx
@@ -1,6 +1,5 @@
 import { useRef, useCallback, type ReactNode } from "react";
-import { motion } from "framer-motion";
-import { X } from "lucide-react";
+import { X, ChevronLeft } from "lucide-react";
 import { Button } from "./button";
 import { ScrollArea } from "./scroll-area";
 
@@ -48,7 +47,7 @@ export function SidePanelShell({ children, title, onClose, width, onWidthChange 
   }, [width, onWidthChange]);
 
   return (
-    <div className="h-full flex flex-col bg-background relative">
+    <div className="h-full flex flex-col bg-background relative overflow-x-hidden w-full md:w-auto">
       {/* Drag handle on left edge */}
       <div
         onMouseDown={handleMouseDown}
@@ -61,23 +60,35 @@ export function SidePanelShell({ children, title, onClose, width, onWidthChange 
         </div>
       </div>
 
-      {/* Header */}
-      {title && (
-        <div className="flex-shrink-0 flex items-center justify-between px-6 py-4 border-b border-border">
-          <h2 className="text-lg font-semibold truncate">{title}</h2>
+      {/* Header — always visible with prominent close button */}
+      <div className="flex-shrink-0 flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border"
+           style={{ paddingTop: "max(0.75rem, env(safe-area-inset-top))" }}>
+        <div className="flex items-center gap-2 min-w-0">
+          {/* Back button for mobile */}
           <Button
             variant="ghost"
             size="icon"
             onClick={onClose}
-            className="hover:bg-destructive/10 hover:text-destructive flex-shrink-0"
+            className="md:hidden min-w-[44px] min-h-[44px] hover:bg-destructive/10 hover:text-destructive flex-shrink-0"
+            aria-label="Close panel"
           >
-            <X className="h-5 w-5" />
+            <ChevronLeft className="h-5 w-5" />
           </Button>
+          {title && <h2 className="text-lg font-semibold truncate">{title}</h2>}
         </div>
-      )}
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          className="hover:bg-destructive/10 hover:text-destructive flex-shrink-0 min-w-[44px] min-h-[44px]"
+          aria-label="Close panel"
+        >
+          <X className="h-5 w-5" />
+        </Button>
+      </div>
 
       {/* Content */}
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 overflow-x-hidden">
         {children}
       </ScrollArea>
     </div>


### PR DESCRIPTION
## Changes

### Mobile side panel close button hidden behind header
- Added a prominent back/close button (ChevronLeft) on mobile that's always visible in the panel header
- Close button meets 44x44px minimum touch target size
- Header is always rendered (not conditional on title) so close button is always accessible

### Side panel wider than phone screen
- Added `w-full md:w-auto` to SidePanelShell root so it fills viewport on mobile
- Added `overflow-x-hidden` to prevent horizontal scroll on both container and ScrollArea
- Mobile overlay wrapper also gets `overflow-hidden`

### General mobile responsiveness
- Added `env(safe-area-inset-top)` padding for notched phones
- Added `env(safe-area-inset-bottom)` padding on mobile overlay
- Removed unused `framer-motion` import

## Testing
- `nx typecheck dashboard` ✅
- `nx lint dashboard` — no new errors (pre-existing warnings/errors unchanged)