### PR TITLE
fix: mobile agent detail panel - responsive header, compact tabs

### DIFF
--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -15,5 +15,13 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../../libs/shared-types/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/database/tsconfig.lib.json"
+    }
+  ]
 }

--- a/apps/dashboard/src/components/agent-detail-panel.tsx
+++ b/apps/dashboard/src/components/agent-detail-panel.tsx
@@ -725,98 +725,98 @@ export function AgentDetailPanel({ agentId, onClose }: AgentDetailPanelProps) {
     <>
           {/* Header */}
           <div 
-            className="flex-shrink-0 p-6 border-b border-border"
+            className="flex-shrink-0 p-4 md:p-6 border-b border-border"
             style={{ 
               background: `linear-gradient(135deg, ${levelColor}15 0%, transparent 100%)`,
             }}
           >
-            <div className="flex items-start justify-between">
-              <div className="flex items-center gap-4">
-                <AgentAvatar 
-                  agentId={agent.agentId} 
-                  name={agent.name} 
-                  level={agent.level} 
-                  size="lg"
-                  avatar={(agent as any).avatar}
-                  avatarColor={(agent as any).avatarColor}
-                />
-                <div>
-                  <div className="flex items-center gap-2">
-                    <h2 className="text-2xl font-bold">{agent.name}</h2>
+            <div className="flex items-start gap-3">
+              <AgentAvatar 
+                agentId={agent.agentId} 
+                name={agent.name} 
+                level={agent.level} 
+                size="lg"
+                avatar={(agent as any).avatar}
+                avatarColor={(agent as any).avatarColor}
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <h2 className="text-xl md:text-2xl font-bold truncate">{agent.name}</h2>
+                    <p className="text-sm text-muted-foreground truncate">@{agent.agentId}</p>
                   </div>
-                  <p className="text-sm text-muted-foreground">@{agent.agentId}</p>
-                  <div className="flex flex-wrap gap-1.5 mt-2">
-                    <Badge variant={getStatusVariant(agent.status)} className="text-[10px]">{agent.status}</Badge>
-                    <Badge variant="outline" className="text-[10px]">{agent.role}</Badge>
-                    <Badge className="text-[10px]" style={{ backgroundColor: `${levelColor}20`, color: levelColor, borderColor: levelColor }}>
-                      L{agent.level} • {getLevelLabel(agent.level)}
-                    </Badge>
-                    <TeamBadge teamId={agent.teamId} />
-                  </div>
+                  <Button 
+                    variant="ghost" 
+                    size="icon"
+                    onClick={onClose}
+                    className="hover:bg-destructive/10 hover:text-destructive flex-shrink-0 min-w-[44px] min-h-[44px]"
+                  >
+                    <X className="h-5 w-5" />
+                  </Button>
+                </div>
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  <Badge variant={getStatusVariant(agent.status)} className="text-[10px]">{agent.status}</Badge>
+                  <Badge variant="outline" className="text-[10px]">{agent.role}</Badge>
+                  <Badge className="text-[10px]" style={{ backgroundColor: `${levelColor}20`, color: levelColor, borderColor: levelColor }}>
+                    L{agent.level} • {getLevelLabel(agent.level)}
+                  </Badge>
+                  <TeamBadge teamId={agent.teamId} />
                 </div>
               </div>
-              <Button 
-                variant="ghost" 
-                size="icon"
-                onClick={onClose}
-                className="hover:bg-destructive/10 hover:text-destructive"
-              >
-                <X className="h-5 w-5" />
-              </Button>
             </div>
           </div>
 
           {/* Tabs */}
           <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 flex flex-col">
-            <div className="flex-shrink-0 border-b border-border px-6 pt-3 overflow-x-auto">
-              <TabsList className="w-max justify-start bg-transparent h-auto p-0 gap-6">
+            <div className="flex-shrink-0 border-b border-border px-4 md:px-6 pt-3 overflow-x-auto scrollbar-none">
+              <TabsList className="w-max justify-start bg-transparent h-auto p-0 gap-3 md:gap-6">
                 <TabsTrigger 
                   value="overview"
                   className="data-[state=active]:bg-transparent data-[state=active]:shadow-none border-b-2 border-transparent data-[state=active]:border-primary rounded-none pb-3 px-0"
                 >
-                  <Activity className="h-4 w-4 mr-2" />
+                  <Activity className="h-4 w-4 mr-2 hidden sm:block" />
                   Overview
                 </TabsTrigger>
                 <TabsTrigger 
                   value="prompt"
                   className="data-[state=active]:bg-transparent data-[state=active]:shadow-none border-b-2 border-transparent data-[state=active]:border-primary rounded-none pb-3 px-0"
                 >
-                  <Terminal className="h-4 w-4 mr-2" />
+                  <Terminal className="h-4 w-4 mr-2 hidden sm:block" />
                   Prompt
                 </TabsTrigger>
                 <TabsTrigger 
                   value="tasks"
                   className="data-[state=active]:bg-transparent data-[state=active]:shadow-none border-b-2 border-transparent data-[state=active]:border-primary rounded-none pb-3 px-0"
                 >
-                  <Zap className="h-4 w-4 mr-2" />
+                  <Zap className="h-4 w-4 mr-2 hidden sm:block" />
                   Tasks
                 </TabsTrigger>
                 <TabsTrigger 
                   value="credits"
                   className="data-[state=active]:bg-transparent data-[state=active]:shadow-none border-b-2 border-transparent data-[state=active]:border-primary rounded-none pb-3 px-0"
                 >
-                  <Coins className="h-4 w-4 mr-2" />
+                  <Coins className="h-4 w-4 mr-2 hidden sm:block" />
                   Credits
                 </TabsTrigger>
                 <TabsTrigger 
                   value="messages"
                   className="data-[state=active]:bg-transparent data-[state=active]:shadow-none border-b-2 border-transparent data-[state=active]:border-primary rounded-none pb-3 px-0"
                 >
-                  <MessageSquare className="h-4 w-4 mr-2" />
+                  <MessageSquare className="h-4 w-4 mr-2 hidden sm:block" />
                   Messages
                 </TabsTrigger>
                 <TabsTrigger 
                   value="timeline"
                   className="data-[state=active]:bg-transparent data-[state=active]:shadow-none border-b-2 border-transparent data-[state=active]:border-primary rounded-none pb-3 px-0"
                 >
-                  <Clock className="h-4 w-4 mr-2" />
+                  <Clock className="h-4 w-4 mr-2 hidden sm:block" />
                   Timeline
                 </TabsTrigger>
                 <TabsTrigger 
                   value="settings"
                   className="data-[state=active]:bg-transparent data-[state=active]:shadow-none border-b-2 border-transparent data-[state=active]:border-primary rounded-none pb-3 px-0"
                 >
-                  <Settings className="h-4 w-4 mr-2" />
+                  <Settings className="h-4 w-4 mr-2 hidden sm:block" />
                   Settings
                 </TabsTrigger>
               </TabsList>
@@ -824,7 +824,7 @@ export function AgentDetailPanel({ agentId, onClose }: AgentDetailPanelProps) {
 
             {/* Tab Content with ScrollArea */}
             <ScrollArea className="flex-1">
-              <div className="p-6">
+              <div className="p-4 md:p-6">
                 <AnimatePresence mode="wait">
                   <TabsContent value="overview" className="mt-0">
                     <OverviewTab agent={agent} />

--- a/apps/dashboard/src/components/ui/side-panel.tsx
+++ b/apps/dashboard/src/components/ui/side-panel.tsx
@@ -60,32 +60,33 @@ export function SidePanelShell({ children, title, onClose, width, onWidthChange 
         </div>
       </div>
 
-      {/* Header — always visible with prominent close button */}
-      <div className="flex-shrink-0 flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border"
-           style={{ paddingTop: "max(0.75rem, env(safe-area-inset-top))" }}>
-        <div className="flex items-center gap-2 min-w-0">
-          {/* Back button for mobile */}
+      {/* Header — only render if title is provided (panels with their own header skip this) */}
+      {title && (
+        <div className="flex-shrink-0 flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border"
+             style={{ paddingTop: "max(0.75rem, env(safe-area-inset-top))" }}>
+          <div className="flex items-center gap-2 min-w-0">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              className="md:hidden min-w-[44px] min-h-[44px] hover:bg-destructive/10 hover:text-destructive flex-shrink-0"
+              aria-label="Close panel"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </Button>
+            <h2 className="text-lg font-semibold truncate">{title}</h2>
+          </div>
           <Button
             variant="ghost"
             size="icon"
             onClick={onClose}
-            className="md:hidden min-w-[44px] min-h-[44px] hover:bg-destructive/10 hover:text-destructive flex-shrink-0"
+            className="hover:bg-destructive/10 hover:text-destructive flex-shrink-0 min-w-[44px] min-h-[44px]"
             aria-label="Close panel"
           >
-            <ChevronLeft className="h-5 w-5" />
+            <X className="h-5 w-5" />
           </Button>
-          {title && <h2 className="text-lg font-semibold truncate">{title}</h2>}
         </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onClose}
-          className="hover:bg-destructive/10 hover:text-destructive flex-shrink-0 min-w-[44px] min-h-[44px]"
-          aria-label="Close panel"
-        >
-          <X className="h-5 w-5" />
-        </Button>
-      </div>
+      )}
 
       {/* Content */}
       <ScrollArea className="flex-1 overflow-x-hidden">

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -374,6 +374,15 @@
   }
 }
 
+/* Hide scrollbar but keep scrolling */
+.scrollbar-none {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
 @keyframes bioluminescent-glow {
   0%, 100% {
     filter: drop-shadow(0 0 8px rgba(34, 211, 238, 0.5));


### PR DESCRIPTION
Fixes mobile layout issues in agent detail side panel:

- **Header**: Restructured to use flex with min-w-0 for proper truncation, reduced padding on mobile
- **Close button**: 44x44px touch target, always visible and not obscured
- **Tabs**: Reduced gap on mobile (gap-3 vs gap-6), hidden tab icons on small screens, hidden scrollbar
- **Content padding**: Reduced from p-6 to p-4 on mobile
- **SidePanelShell**: Only renders its own header when title is provided (avoids duplicate header with agent panel's built-in header)
- **scrollbar-none utility**: Added CSS utility for hidden scrollbars on overflow-x-auto tabs