### PR TITLE
fix: replace hardcoded localhost:3333 with SANDBOX_URL + pineapple emoji favicon

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -10,10 +10,8 @@
     <meta name="theme-color" content="#0a1929" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#1a2942" media="(prefers-color-scheme: light)" />
     
-    <!-- Favicons -->
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <!-- Favicon (pineapple emoji) -->
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍍</text></svg>" />
     
     <!-- PWA -->
     <link rel="manifest" href="/manifest.json" />

--- a/apps/dashboard/src/components/agent-detail-panel.tsx
+++ b/apps/dashboard/src/components/agent-detail-panel.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, TrendingUp, TrendingDown, Calendar, Zap, MessageSquare, Settings, Activity, Award, Coins, Clock, Terminal } from "lucide-react";
 import { isSandboxMode } from "../graphql/fetcher";
+import { SANDBOX_URL } from "../lib/sandbox-url";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
@@ -410,7 +411,7 @@ function MessagesTab({ agent }: { agent: Agent }) {
   const { data: sandboxMessages } = useQuery({
     queryKey: ['sandbox-agent-messages', agent.agentId],
     queryFn: async () => {
-      const res = await fetch(`http://localhost:3333/api/agent/${agent.agentId}/messages`);
+      const res = await fetch(`${SANDBOX_URL}/api/agent/${agent.agentId}/messages`);
       return res.json();
     },
     enabled: isSandboxMode,
@@ -562,7 +563,7 @@ function PromptTab({ agent }: { agent: Agent }) {
   const { data: sandboxAgents } = useQuery({
     queryKey: ['sandbox-agents-for-prompt'],
     queryFn: async () => {
-      const res = await fetch('http://localhost:3333/api/agents');
+      const res = await fetch(`${SANDBOX_URL}/api/agents`);
       return res.json();
     },
     enabled: isSandboxMode,

--- a/apps/dashboard/src/hooks/use-sandbox-sse.ts
+++ b/apps/dashboard/src/hooks/use-sandbox-sse.ts
@@ -4,6 +4,7 @@
  */
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { isSandboxMode } from '../graphql/fetcher';
+import { SANDBOX_URL } from '../lib/sandbox-url';
 
 export interface SandboxSSEEvent {
   type: string;
@@ -36,7 +37,7 @@ export function useSandboxSSE(callback: SSECallback) {
 
     function connect() {
       if (disposed) return;
-      es = new EventSource('http://localhost:3333/api/stream');
+      es = new EventSource(`${SANDBOX_URL}/api/stream`);
 
       es.onmessage = (ev) => {
         try {


### PR DESCRIPTION
## Changes

- **use-sandbox-sse.ts**: Use `SANDBOX_URL` instead of hardcoded `http://localhost:3333/api/stream`
- **agent-detail-panel.tsx**: Use `SANDBOX_URL` for agent messages and agents fetch calls
- **index.html**: Replace favicon.svg/ico/apple-touch-icon with inline pineapple emoji (🍍) SVG

## Problem
Deployed site at bikinibottom.ai was spamming `ERR_CONNECTION_REFUSED` every 3s trying to connect to `localhost:3333/api/stream`. The SSE hook and agent detail panel had hardcoded localhost URLs instead of using the `SANDBOX_URL` utility (which returns `''` for same-origin in production).