### PR TITLE
fix: correct dashboard-dist path resolution in sandbox server

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - SANDBOX_PORT=3333
       - SERVE_DASHBOARD=1
       - SANDBOX_READONLY=1
+      - DASHBOARD_DIR=/app/dashboard-dist
       - NODE_ENV=production
     env_file:
       - .env.production

--- a/tools/sandbox/src/server.ts
+++ b/tools/sandbox/src/server.ts
@@ -636,7 +636,7 @@ export function startServer(sim: Simulation): void {
         '.svg': 'image/svg+xml', '.ico': 'image/x-icon', '.woff2': 'font/woff2',
         '.woff': 'font/woff', '.ttf': 'font/ttf', '.map': 'application/json',
       };
-      const dashboardDir = process.env.DASHBOARD_DIR || join(__dirname, '..', '..', '..', 'dashboard-dist');
+      const dashboardDir = process.env.DASHBOARD_DIR || join(__dirname, '..', 'dashboard-dist');
       
       // Try to serve the file
       let filePath = join(dashboardDir, path === '/' ? 'index.html' : path);


### PR DESCRIPTION
The default dashboardDir path was `join(__dirname, '..', '..', '..', 'dashboard-dist')` which resolved to `/dashboard-dist` in the Docker container (since tsx sets __dirname to `/app/src`). Fixed to `join(__dirname, '..', 'dashboard-dist')` = `/app/dashboard-dist`. Also added explicit `DASHBOARD_DIR` env var in docker-compose.yml.