### PR TITLE
fix: full avatar audit — use emoji avatars everywhere, eliminate DiceBear

### DIFF
--- a/apps/dashboard/src/components/agent-efficiency.tsx
+++ b/apps/dashboard/src/components/agent-efficiency.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Badge } from './ui/badge';
 import { Progress } from './ui/progress';
 import { cn } from '../lib/utils';
-import { getAgentAvatarUrl } from '../lib/avatar';
+import { darkenForBackground } from '../lib/avatar-utils';
 
 interface AgentEfficiency {
   id: string;
@@ -130,11 +130,12 @@ export function AgentEfficiencyLeaderboard() {
               </div>
 
               {/* Avatar */}
-              <img
-                src={getAgentAvatarUrl(agent.id, agent.level)}
-                alt={agent.name}
-                className="w-10 h-10 rounded-full ring-2 ring-white/10"
-              />
+              <span
+                className="w-10 h-10 rounded-full ring-2 ring-white/10 inline-flex items-center justify-center text-xl"
+                style={{ backgroundColor: darkenForBackground('#71717a') }}
+              >
+                🤖
+              </span>
 
               {/* Info */}
               <div className="flex-1 min-w-0">

--- a/apps/dashboard/src/components/agent-heartbeat.tsx
+++ b/apps/dashboard/src/components/agent-heartbeat.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '../lib/utils';
-import { getAgentAvatarUrl } from '../lib/avatar';
+import { darkenForBackground } from '../lib/avatar-utils';
 
 interface AgentHeartbeatProps {
   agentId: string;
@@ -9,9 +9,11 @@ interface AgentHeartbeatProps {
   status: 'ACTIVE' | 'IDLE' | 'PENDING' | 'SUSPENDED';
   size?: 'sm' | 'md' | 'lg';
   showPulse?: boolean;
+  avatar?: string | null;
+  avatarColor?: string | null;
 }
 
-export function AgentHeartbeat({ agentId, level, status, size = 'md', showPulse = true }: AgentHeartbeatProps) {
+export function AgentHeartbeat({ agentId, level, status, size = 'md', showPulse = true, avatar, avatarColor }: AgentHeartbeatProps) {
   const [isWorking, setIsWorking] = useState(status === 'ACTIVE');
 
   // Simulate activity changes in demo mode (not sandbox mode)
@@ -58,14 +60,14 @@ export function AgentHeartbeat({ agentId, level, status, size = 'md', showPulse 
   return (
     <div className="relative inline-block">
       {/* Avatar */}
-      <motion.img
-        src={getAgentAvatarUrl(agentId, level)}
-        alt=""
+      <motion.span
         className={cn(
-          'rounded-full ring-2 transition-all',
+          'rounded-full ring-2 transition-all inline-flex items-center justify-center',
           sizeClasses[size],
+          size === 'sm' ? 'text-base' : size === 'md' ? 'text-xl' : 'text-2xl',
           isWorking && status === 'ACTIVE' ? ringColors[status] : 'ring-border'
         )}
+        style={{ backgroundColor: darkenForBackground(avatarColor || '#71717a') }}
         animate={isWorking && status === 'ACTIVE' ? {
           scale: [1, 1.05, 1],
         } : {}}
@@ -74,7 +76,9 @@ export function AgentHeartbeat({ agentId, level, status, size = 'md', showPulse 
           repeat: Infinity,
           ease: 'easeInOut',
         }}
-      />
+      >
+        {avatar || '🤖'}
+      </motion.span>
 
       {/* Status indicator dot */}
       <span
@@ -150,7 +154,7 @@ export function AgentHeartbeat({ agentId, level, status, size = 'md', showPulse 
 }
 
 // Row of agent heartbeats for overview
-export function AgentHeartbeatRow({ agents }: { agents: { id: string; level: number; status: string; name: string }[] }) {
+export function AgentHeartbeatRow({ agents }: { agents: { id: string; level: number; status: string; name: string; avatar?: string; avatarColor?: string }[] }) {
   return (
     <div className="flex items-center gap-2">
       {agents.map((agent) => (
@@ -160,6 +164,8 @@ export function AgentHeartbeatRow({ agents }: { agents: { id: string; level: num
             level={agent.level}
             status={agent.status as AgentHeartbeatProps['status']}
             size="sm"
+            avatar={agent.avatar}
+            avatarColor={agent.avatarColor}
           />
           <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-muted rounded text-xs whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
             {agent.name}

--- a/apps/dashboard/src/components/org-chart.tsx
+++ b/apps/dashboard/src/components/org-chart.tsx
@@ -47,7 +47,7 @@ import {
 import { teams, type Team, getTeamColor, getSubTeams } from '../demo/teams';
 import { useTeamStats } from '../hooks/use-teams';
 import { useAgents, type Agent } from '../hooks/use-agents';
-import { getAgentAvatarUrl } from '../lib/avatar';
+import { darkenForBackground } from '../lib/avatar-utils';
 import { isSandboxMode } from '../graphql/fetcher';
 import { useSandboxSSE, type SandboxSSEEvent } from '../hooks/use-sandbox-sse';
 
@@ -203,12 +203,15 @@ interface AgentNodeData extends Record<string, unknown> {
   status: string;
   isLead: boolean;
   teamColor: string;
+  avatar?: string;
+  avatarColor?: string;
 }
 
 function AgentOrgNode({ data }: NodeProps) {
   const d = data as unknown as AgentNodeData & { isNew?: boolean };
   const teamColor = getTeamColor(d.teamColor);
-  const avatarUrl = getAgentAvatarUrl(d.agentId, d.level, 32);
+  const avatarEmoji = d.avatar || '🤖';
+  const avatarBg = darkenForBackground(d.avatarColor || '#71717a');
   const isActive = d.status === 'ACTIVE';
   const isNew = d.isNew === true;
   const statusColor = isActive
@@ -273,13 +276,12 @@ function AgentOrgNode({ data }: NodeProps) {
           </div>
         )}
 
-        {avatarUrl ? (
-          <img src={avatarUrl} alt={d.label} className="w-8 h-8 rounded-full flex-shrink-0" />
-        ) : (
-          <div className="w-8 h-8 rounded-full bg-zinc-800 flex items-center justify-center text-xs flex-shrink-0">
-            🤖
-          </div>
-        )}
+        <span
+          className="w-8 h-8 rounded-full flex-shrink-0 inline-flex items-center justify-center text-base"
+          style={{ backgroundColor: avatarBg }}
+        >
+          {avatarEmoji}
+        </span>
         <div className="min-w-0 flex-1">
           <div className="text-xs font-semibold text-foreground truncate">{d.label}</div>
           <div className="text-[10px] text-zinc-400">L{d.level}</div>
@@ -421,6 +423,8 @@ function buildOrgGraph(
           status: agent.status,
           isLead: agent.id === team.leadAgentId,
           teamColor: team.color,
+          avatar: (agent as any).avatar,
+          avatarColor: (agent as any).avatarColor,
         } as AgentNodeData,
       });
 
@@ -461,6 +465,8 @@ function buildOrgGraph(
           status: agent.status,
           isLead: agent.id === team.leadAgentId,
           teamColor: team.color,
+          avatar: (agent as any).avatar,
+          avatarColor: (agent as any).avatarColor,
         } as AgentNodeData,
       });
 

--- a/apps/dashboard/src/components/thread-view.tsx
+++ b/apps/dashboard/src/components/thread-view.tsx
@@ -9,8 +9,8 @@ import { Button } from './ui/button';
 import { Badge } from './ui/badge';
 import { ScrollArea } from './ui/scroll-area';
 import { cn } from '../lib/utils';
-import { getAgentAvatarUrl } from '../lib/avatar';
-import type { Message } from '../hooks';
+import { darkenForBackground } from '../lib/avatar-utils';
+import { useAgents, type Message } from '../hooks';
 
 interface ThreadViewProps {
   /** All messages in this conversation (between two agents) */
@@ -54,6 +54,13 @@ function formatThreadTime(dateStr: string) {
 }
 
 export function ThreadView({ messages, onClose }: ThreadViewProps) {
+  const { agents } = useAgents();
+  const agentMap = useMemo(() => {
+    const map = new Map<string, any>();
+    agents.forEach((a: any) => map.set(a.id, a));
+    return map;
+  }, [agents]);
+
   const sorted = useMemo(
     () =>
       [...messages].sort(
@@ -163,13 +170,19 @@ export function ThreadView({ messages, onClose }: ThreadViewProps) {
                 >
                   {/* Avatar (only when sender changes) */}
                   <div className="w-7 shrink-0">
-                    {showAvatar && sender && (
-                      <img
-                        src={getAgentAvatarUrl(msg.fromAgentId, sender.level)}
-                        className="w-7 h-7 rounded-full"
-                        alt={sender.name}
-                      />
-                    )}
+                    {showAvatar && sender && (() => {
+                      const agentData = agentMap.get(msg.fromAgentId);
+                      const emoji = agentData?.avatar || '🤖';
+                      const color = agentData?.avatarColor || '#71717a';
+                      return (
+                        <span
+                          className="w-7 h-7 rounded-full inline-flex items-center justify-center text-sm"
+                          style={{ backgroundColor: darkenForBackground(color) }}
+                        >
+                          {emoji}
+                        </span>
+                      );
+                    })()}
                   </div>
 
                   {/* Bubble — ACP-styled or default */}


### PR DESCRIPTION
## Summary
Replace all `getAgentAvatarUrl()` (DiceBear) usage across dashboard components with emoji avatars using `avatar`/`avatarColor` from agent data.

### Changes
- **messages.tsx** — Replaced ~10 `<img>` DiceBear tags with `InlineAvatar` helper component
- **agent-network.tsx** — Removed DiceBear URL generation, renders emoji from node data with dark background
- **thread-view.tsx** — Replaced DiceBear img with emoji, added `useAgents()` hook for avatar data lookup
- **org-chart.tsx** — Replaced DiceBear img, passes `avatar`/`avatarColor` through node data
- **agent-heartbeat.tsx** — Added `avatar`/`avatarColor` props, renders emoji instead of DiceBear
- **agent-efficiency.tsx** — Replaced DiceBear img with emoji fallback (hardcoded mock data)

### Already verified
- `trust-leaderboard.tsx` — already passes avatar props via `(entry as any).avatar`
- `idle-agents-widget.tsx`, `agent-detail-panel.tsx`, `team-view.tsx`, `task-timeline.tsx` — all already fixed

### Typecheck
`npx nx typecheck dashboard` passes ✅