### PR TITLE
fix: main content resizes when side panel opens

### DIFF
--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -729,8 +729,8 @@ export function Layout({ children }: LayoutProps) {
 
           {/* Main content + side panel */}
           <div className="flex flex-1 min-h-0">
-            <main ref={mainContentRef} className="flex-1 overflow-auto min-w-0">
-              <div className={`${fullBleedRoutes.has(location.pathname) ? 'h-full' : 'mx-auto px-3 py-3 sm:px-4 sm:py-4 md:px-6 md:py-6 max-w-7xl'} ${scenarioStatus ? 'pt-12' : ''} pb-24 sm:pb-20`}>{children}</div>
+            <main ref={mainContentRef} className="flex-1 overflow-y-auto overflow-x-hidden min-w-0">
+              <div className={`${fullBleedRoutes.has(location.pathname) ? 'h-full' : 'mx-auto px-3 py-3 sm:px-4 sm:py-4 md:px-6 md:py-6 max-w-7xl w-full'} ${scenarioStatus ? 'pt-12' : ''} pb-24 sm:pb-20`}>{children}</div>
             </main>
 
             {/* Global Side Panel - desktop: inline, mobile: full-screen overlay */}

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -547,18 +547,19 @@ function AgentVirtualGrid({
   const { presenceMap } = usePresence();
   const healthMap = useAgentHealth();
   const parentRef = useRef<HTMLDivElement>(null);
-  // Chunk agents into rows of 3 (matching lg:grid-cols-3)
-  // Responsive columns: 1 on mobile, 2 on tablet, 3 on desktop
+  // Responsive columns based on container width (not viewport — so side panel shrinks grid)
   const [colCount, setColCount] = useState(3);
   useEffect(() => {
-    const update = () => {
-      if (window.innerWidth < 640) setColCount(1);
-      else if (window.innerWidth < 1024) setColCount(2);
+    const el = parentRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0].contentRect.width;
+      if (w < 500) setColCount(1);
+      else if (w < 800) setColCount(2);
       else setColCount(3);
-    };
-    update();
-    window.addEventListener("resize", update);
-    return () => window.removeEventListener("resize", update);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
   }, []);
 
   const rows = useMemo(() => {
@@ -590,8 +591,9 @@ function AgentVirtualGrid({
                 left: 0,
                 width: "100%",
                 transform: `translateY(${virtualRow.start}px)`,
+                gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 300px), 1fr))',
               }}
-              className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 pb-4"
+              className="grid gap-3 sm:gap-4 pb-4"
             >
               <AnimatePresence mode="popLayout">
                 {rowAgents.map((agent) => {


### PR DESCRIPTION
Agent cards overlapped when side panel opened. Fixed by using ResizeObserver on container (not viewport breakpoints) for column count, auto-fill grid, and overflow-x-hidden on main.