### PR TITLE
fix: ScenarioContextBanner no longer overlaps content on mobile

### DIFF
--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -744,7 +744,7 @@ export function Layout({ children }: LayoutProps) {
                     animate={{ x: 0 }}
                     exit={{ x: "100%" }}
                     transition={{ type: "spring", damping: 30, stiffness: 300 }}
-                    className="fixed inset-0 z-50 bg-background md:hidden overflow-hidden"
+                    className="fixed inset-0 z-[70] bg-background md:hidden overflow-hidden"
                     style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
                   >
                     <SidePanelShell


### PR DESCRIPTION
Bump mobile side panel z-index from z-50 to z-[70] so it renders above the ScenarioContextBanner (z-[60]) on mobile devices.