### PR TITLE
feat: replay engine — fuzzy scenario matching with timed playback

### DIFF
--- a/tools/sandbox/scenarios/build-mobile-app.md
+++ b/tools/sandbox/scenarios/build-mobile-app.md
@@ -1,0 +1,46 @@
+---
+scenario: Build a mobile app for customers
+recorded: 2026-02-13T18:00:00Z
+model: qwen2.5:7b-instruct
+ticks: 8
+agents: 4
+keywords: mobile, app, customer, build, develop
+---
+
+# Scenario: Build a mobile app for customers
+
+## Tick 1 — Mr. Krabs (COO, L10)
+- Action: delegate
+- Target: Sandy Cheeks
+- Task: new: Mobile app development project
+- Message: Sandy, I need you to lead the mobile app development. We need a customer-facing app with login, dashboard, and notifications. Coordinate frontend with Squidward and get Pearl on the UI components.
+
+## Tick 2 — Sandy Cheeks (LEAD, L7)
+- Action: delegate
+- Target: Pearl Krabs
+- Task: new: Implement user authentication and login flow
+- Message: Pearl, take ownership of the login flow. We need OAuth with Google and Apple sign-in. Start with the auth service and work with Larry on the API endpoints.
+
+## Tick 2 — Sandy Cheeks (LEAD, L7)
+- Action: delegate
+- Target: Larry Lobster
+- Task: new: Build REST API endpoints for mobile app
+- Message: Larry, handle the backend API. We need endpoints for user profiles, notifications, and the main dashboard feed. Check with Pearl on auth requirements.
+
+## Tick 3 — Sandy Cheeks (LEAD, L7)
+- Action: message
+- Target: Mr. Krabs
+- Task: none
+- Message: Project kicked off. Pearl is handling auth, Larry is on the API. I'll coordinate frontend with Squidward once the API contracts are defined. Estimated 2 weeks for MVP.
+
+## Tick 5 — Sandy Cheeks (LEAD, L7)
+- Action: delegate
+- Target: Squidward Tentacles
+- Task: new: Frontend UI components for mobile app
+- Message: Squidward, the API contracts are taking shape. Start building the mobile UI — we need the login screen, main dashboard, and notification center. Use the design system we established.
+
+## Tick 7 — Sandy Cheeks (LEAD, L7)
+- Action: message
+- Target: Mr. Krabs
+- Task: none
+- Message: Status update — auth flow is 60% complete, API endpoints are scaffolded, and Squidward started on the UI. On track for the 2-week estimate.

--- a/tools/sandbox/scenarios/hire-engineers.md
+++ b/tools/sandbox/scenarios/hire-engineers.md
@@ -1,0 +1,40 @@
+---
+scenario: Hire more frontend engineers
+recorded: 2026-02-13T18:00:00Z
+model: qwen2.5:7b-instruct
+ticks: 5
+agents: 3
+keywords: hire, recruit, engineer, frontend, developer, team, grow, expand
+---
+
+# Scenario: Hire more frontend engineers
+
+## Tick 1 — Mr. Krabs (COO, L10)
+- Action: message
+- Target: Sandy Cheeks
+- Task: none
+- Message: Sandy, we're growing fast and the frontend team is overloaded. I want to bring on two more frontend engineers. What skill sets do we need most?
+
+## Tick 2 — Sandy Cheeks (LEAD, L7)
+- Action: message
+- Target: Mr. Krabs
+- Task: none
+- Message: We definitely need someone strong in React Native for the mobile work, and another engineer with accessibility and design system experience. Squidward is stretched thin covering both areas.
+
+## Tick 3 — Mr. Krabs (COO, L10)
+- Action: hire
+- Target: none
+- Task: new: Hire React Native specialist
+- Message: Approved. Let's bring on a React Native specialist first — the mobile app is our top priority. I'll have Talent Agent start sourcing candidates.
+
+## Tick 4 — Mr. Krabs (COO, L10)
+- Action: hire
+- Target: none
+- Task: new: Hire accessibility/design system engineer
+- Message: Second hire approved — an accessibility and design system engineer. This will take pressure off Squidward and improve our product quality across the board.
+
+## Tick 5 — Mr. Krabs (COO, L10)
+- Action: message
+- Target: Sandy Cheeks
+- Task: none
+- Message: Two hires approved and sourcing is underway. Should have candidates within the week. Let Squidward know help is coming.

--- a/tools/sandbox/scenarios/security-audit.md
+++ b/tools/sandbox/scenarios/security-audit.md
@@ -1,0 +1,40 @@
+---
+scenario: Run a comprehensive security audit
+recorded: 2026-02-13T18:00:00Z
+model: qwen2.5:7b-instruct
+ticks: 6
+agents: 3
+keywords: security, audit, vulnerability, penetration, review, compliance
+---
+
+# Scenario: Run a comprehensive security audit
+
+## Tick 1 — Mr. Krabs (COO, L10)
+- Action: delegate
+- Target: Karen
+- Task: new: Comprehensive security audit
+- Message: Karen, I need a full security audit of our systems. Check for vulnerabilities, review access controls, and ensure we're compliant with our security policies. Report findings with severity levels.
+
+## Tick 2 — Karen (LEAD, L7)
+- Action: delegate
+- Target: Plankton
+- Task: new: Vulnerability scanning and penetration testing
+- Message: Plankton, run vulnerability scans across all our services. Focus on the API endpoints, authentication flows, and database access patterns. Document everything with severity ratings.
+
+## Tick 3 — Karen (LEAD, L7)
+- Action: delegate
+- Target: Gary Wilson
+- Task: new: Access control and compliance review
+- Message: Gary, review all access control policies and permissions across our infrastructure. Check for over-provisioned accounts and ensure we meet SOC2 requirements.
+
+## Tick 4 — Karen (LEAD, L7)
+- Action: message
+- Target: Mr. Krabs
+- Task: none
+- Message: Audit is underway. Plankton is running vulnerability scans and Gary is reviewing access controls. I'll compile the findings into a comprehensive report once both complete.
+
+## Tick 6 — Karen (LEAD, L7)
+- Action: escalate
+- Target: Mr. Krabs
+- Task: none
+- Message: Early finding — we have 3 critical vulnerabilities in the authentication service and 2 high-severity issues in the API rate limiting. Recommending immediate patching before we continue the broader audit.

--- a/tools/sandbox/src/decision-executor.ts
+++ b/tools/sandbox/src/decision-executor.ts
@@ -1,0 +1,217 @@
+// ── Shared Decision Executor ────────────────────────────────────────────────
+// Extracted from LLMSimulation so both LLM and Replay engines can use it.
+
+import { resolveAgentId, type AgentDecision } from './markdown-decision.js';
+import { makeAgentPublic } from './agents.js';
+import type { SandboxAgent, SandboxTask, ACPMessage } from './types.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+let executorTaskCounter = 20000;
+function nextExecutorTaskId(): string {
+  return `TASK-${String(++executorTaskCounter).padStart(4, '0')}`;
+}
+
+function acpId(): string {
+  return `acp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createACPMessage(
+  type: ACPMessage['type'],
+  from: string,
+  to: string,
+  taskId: string,
+  extra?: Partial<ACPMessage>,
+): ACPMessage {
+  return { id: acpId(), type, from, to, taskId, timestamp: Date.now(), ...extra };
+}
+
+function pushMessage(agents: SandboxAgent[], msg: ACPMessage): void {
+  for (const agent of agents) {
+    if (agent.id === msg.from || agent.id === msg.to) {
+      agent.recentMessages.push(msg);
+      if (agent.recentMessages.length > 10) {
+        agent.recentMessages = agent.recentMessages.slice(-10);
+      }
+    }
+    if (agent.id === msg.to && agent.trigger === 'event-driven') {
+      if (!agent.triggerOn || agent.triggerOn.includes(msg.type)) {
+        agent.inbox.push(msg);
+      }
+    }
+  }
+}
+
+// ── Context for execution ───────────────────────────────────────────────────
+
+export interface ExecutionContext {
+  agents: SandboxAgent[];
+  tasks: SandboxTask[];
+  parsedOrgAgents?: SandboxAgent[];
+}
+
+// ── Executor ────────────────────────────────────────────────────────────────
+
+export function executeDecision(
+  agent: SandboxAgent,
+  decision: AgentDecision,
+  ctx: ExecutionContext,
+): void {
+  switch (decision.action) {
+    case 'delegate':
+      executeDelegation(agent, decision, ctx);
+      break;
+    case 'escalate':
+      executeEscalation(agent, decision, ctx);
+      break;
+    case 'complete':
+      executeCompletion(agent, decision, ctx);
+      break;
+    case 'message':
+      executeMessage(agent, decision, ctx);
+      break;
+    case 'hire':
+      executeHire(agent, decision, ctx);
+      break;
+  }
+}
+
+function resolveTask(taskRef: string, agent: SandboxAgent, tasks: SandboxTask[]): SandboxTask | undefined {
+  if (!taskRef || taskRef === 'none') return undefined;
+  const byId = tasks.find(t => t.id === taskRef);
+  if (byId) return byId;
+  const upper = taskRef.toUpperCase();
+  return tasks.find(t => t.id === upper) ||
+    tasks.find(t => t.assigneeId === agent.id && !['done', 'rejected'].includes(t.status));
+}
+
+function createTask(title: string, creator: SandboxAgent, tasks: SandboxTask[]): SandboxTask {
+  const task: SandboxTask = {
+    id: nextExecutorTaskId(),
+    title,
+    description: title,
+    priority: 'high',
+    status: 'backlog',
+    creatorId: creator.id,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    activityLog: [],
+    acked: false,
+  };
+  tasks.push(task);
+  return task;
+}
+
+function executeDelegation(agent: SandboxAgent, decision: AgentDecision, ctx: ExecutionContext): void {
+  const targetId = resolveAgentId(decision.target, ctx.agents);
+  const target = targetId ? ctx.agents.find(a => a.id === targetId) : undefined;
+  if (!target) {
+    console.log(`  ⚠️ ${agent.name}: delegate target "${decision.target}" not found`);
+    return;
+  }
+
+  let task = resolveTask(decision.task, agent, ctx.tasks);
+  if (!task) {
+    const title = decision.task.replace(/^new:\s*/i, '').trim() || decision.message.slice(0, 80);
+    task = createTask(title, agent, ctx.tasks);
+  }
+
+  task.assigneeId = target.id;
+  task.status = 'assigned';
+  if (!target.taskIds.includes(task.id)) target.taskIds.push(task.id);
+
+  const msg = createACPMessage('delegation', agent.id, target.id, task.id, {
+    body: decision.message || `Delegating "${task.title}" to ${target.name}`,
+  });
+  pushMessage(ctx.agents, msg);
+  task.activityLog.push(msg);
+  agent.stats.messagessSent++;
+
+  const ack = createACPMessage('ack', target.id, agent.id, task.id, {
+    body: `Acknowledged: "${task.title}"`,
+  });
+  pushMessage(ctx.agents, ack);
+  task.activityLog.push(ack);
+  task.acked = true;
+}
+
+function executeEscalation(agent: SandboxAgent, decision: AgentDecision, ctx: ExecutionContext): void {
+  const parent = agent.parentId ? ctx.agents.find(a => a.id === agent.parentId) : undefined;
+  if (!parent) return;
+
+  const task = resolveTask(decision.task, agent, ctx.tasks);
+  const taskId = task?.id ?? '';
+
+  const msg = createACPMessage('escalation', agent.id, parent.id, taskId, {
+    reason: 'BLOCKED',
+    body: decision.message || `Escalating: ${decision.task}`,
+  });
+  pushMessage(ctx.agents, msg);
+  if (task) task.activityLog.push(msg);
+  agent.stats.messagessSent++;
+}
+
+function executeCompletion(agent: SandboxAgent, decision: AgentDecision, ctx: ExecutionContext): void {
+  const task = resolveTask(decision.task, agent, ctx.tasks);
+  if (!task) return;
+
+  task.status = 'done';
+  task.updatedAt = Date.now();
+  agent.stats.tasksCompleted++;
+  agent.stats.creditsEarned += task.priority === 'critical' ? 100 : task.priority === 'high' ? 50 : 25;
+
+  const parent = agent.parentId ? ctx.agents.find(a => a.id === agent.parentId) : undefined;
+  if (parent) {
+    const msg = createACPMessage('completion', agent.id, parent.id, task.id, {
+      summary: decision.message || `Completed: "${task.title}"`,
+      body: `Completed: "${task.title}"`,
+    });
+    pushMessage(ctx.agents, msg);
+    task.activityLog.push(msg);
+    agent.stats.messagessSent++;
+  }
+}
+
+function executeMessage(agent: SandboxAgent, decision: AgentDecision, ctx: ExecutionContext): void {
+  const targetId = resolveAgentId(decision.target, ctx.agents);
+  if (!targetId) return;
+
+  const task = resolveTask(decision.task, agent, ctx.tasks);
+  const msg = createACPMessage('status_request', agent.id, targetId, task?.id ?? '', {
+    body: decision.message,
+  });
+  pushMessage(ctx.agents, msg);
+  agent.stats.messagessSent++;
+}
+
+function executeHire(agent: SandboxAgent, decision: AgentDecision, ctx: ExecutionContext): void {
+  const roster = ctx.parsedOrgAgents || [];
+  const notYetHired = roster.filter(r => !ctx.agents.find(a => a.id === r.id));
+
+  const domain = decision.task.replace(/^new:\s*/i, '').trim() || agent.domain;
+  const candidate = notYetHired.find(r =>
+    r.domain?.toLowerCase().includes(domain.toLowerCase())
+  ) || notYetHired[0];
+
+  if (candidate) {
+    candidate.parentId = agent.id;
+    candidate.status = 'active';
+    ctx.agents.push(candidate);
+
+    const msg = createACPMessage('delegation', agent.id, candidate.id, '', {
+      body: decision.message || `Welcome aboard, ${candidate.name}!`,
+    });
+    pushMessage(ctx.agents, msg);
+    agent.stats.messagessSent++;
+    console.log(`  🐣 ${agent.name} hired ${candidate.name} (L${candidate.level} ${candidate.domain})`);
+  } else {
+    const name = decision.target !== 'none' ? decision.target : `${domain} Worker`;
+    const id = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    if (!ctx.agents.find(a => a.id === id)) {
+      const newAgent = makeAgentPublic(id, name, 'worker', 4, domain, agent.id, `Hired by ${agent.name}`);
+      newAgent.status = 'active';
+      ctx.agents.push(newAgent);
+      console.log(`  🐣 ${agent.name} created ${name} (L4 ${domain})`);
+    }
+  }
+}

--- a/tools/sandbox/src/index.ts
+++ b/tools/sandbox/src/index.ts
@@ -140,9 +140,13 @@ const simMode = process.env.SIMULATION_MODE || 'deterministic';
 const useLLM = simMode === 'llm';
 const useHybrid = simMode === 'hybrid' || simMode === 'record';
 const useRecording = simMode === 'record';
+const useReplay = simMode === 'replay';
 
 let sim: DeterministicSimulation | Simulation;
-if (useHybrid || useRecording) {
+if (useReplay) {
+  const { ReplaySimulation } = await import('./replay-engine.js');
+  sim = new ReplaySimulation(agents, config, cleanSlate, parsedOrg);
+} else if (useHybrid || useRecording) {
   const { LLMSimulation } = await import('./llm-simulation.js');
   sim = new LLMSimulation(agents, config, cleanSlate, parsedOrg, useRecording);
 } else if (useLLM) {
@@ -151,8 +155,8 @@ if (useHybrid || useRecording) {
   sim = new DeterministicSimulation(agents, config, cleanSlate, parsedOrg);
 }
 
-if (!useLLM && !useHybrid && !useRecording) {
-  console.log(`\n🎯 Deterministic mode (set SIMULATION_MODE=hybrid|record|llm for LLM-driven agents)`);
+if (!useLLM && !useHybrid && !useRecording && !useReplay) {
+  console.log(`\n🎯 Deterministic mode (set SIMULATION_MODE=replay|hybrid|record|llm for other modes)`);
 }
 
 // Start HTTP API server for dashboard integration

--- a/tools/sandbox/src/replay-engine.ts
+++ b/tools/sandbox/src/replay-engine.ts
@@ -1,0 +1,307 @@
+// ── Replay Engine ───────────────────────────────────────────────────────────
+// Loads recorded scenario markdown files and plays them back deterministically.
+// Powers the hosted demo at zero LLM cost.
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DeterministicSimulation } from './deterministic.js';
+import { resolveAgentId, type DecisionAction, type AgentDecision } from './markdown-decision.js';
+import { executeDecision, type ExecutionContext } from './decision-executor.js';
+import type { SandboxAgent, SandboxConfig } from './types.js';
+import type { ParsedOrg } from './org-parser.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface ReplayScenario {
+  name: string;
+  keywords: string[];
+  decisions: ReplayDecision[];
+  metadata: { model: string; recorded: string; ticks: number; agents: number };
+}
+
+export interface ReplayDecision {
+  tick: number;
+  agentId: string;
+  agentName: string;
+  agentRole: string;
+  agentLevel: number;
+  action: DecisionAction;
+  target: string;
+  task: string;
+  message: string;
+}
+
+// ── Stop words ──────────────────────────────────────────────────────────────
+
+const STOP_WORDS = new Set([
+  'a', 'an', 'the', 'for', 'our', 'my', 'your', 'their', 'his', 'her', 'its',
+  'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'to', 'of', 'in', 'on', 'at', 'by', 'with', 'from',
+  'and', 'or', 'but', 'not', 'no', 'so', 'if', 'then',
+  'i', 'we', 'you', 'they', 'he', 'she', 'it',
+  'do', 'does', 'did', 'will', 'would', 'can', 'could', 'should',
+  'have', 'has', 'had', 'get', 'got',
+  'that', 'this', 'these', 'those', 'what', 'which', 'who',
+  'more', 'some', 'any', 'all', 'each', 'every',
+  'up', 'out', 'about', 'into', 'over', 'just', 'also',
+  'need', 'want', 'run', 'make',
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 1 && !STOP_WORDS.has(w));
+}
+
+// ── Scenario Loader ─────────────────────────────────────────────────────────
+
+export function loadScenarios(dir: string): ReplayScenario[] {
+  const scenarios: ReplayScenario[] = [];
+  const dirs = [dir];
+  const recordedDir = join(dir, 'recorded');
+  if (existsSync(recordedDir)) dirs.push(recordedDir);
+
+  for (const d of dirs) {
+    if (!existsSync(d)) continue;
+    const files = readdirSync(d).filter(f => f.endsWith('.md'));
+    for (const file of files) {
+      try {
+        const content = readFileSync(join(d, file), 'utf8');
+        const scenario = parseScenarioFile(content);
+        if (scenario) scenarios.push(scenario);
+      } catch (err) {
+        console.log(`  ⚠️ Failed to parse scenario ${file}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+
+  return scenarios;
+}
+
+function parseScenarioFile(content: string): ReplayScenario | null {
+  // Parse YAML frontmatter
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return null;
+
+  const fm = fmMatch[1];
+  const get = (key: string): string => {
+    const m = fm.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+    return m?.[1]?.trim() ?? '';
+  };
+
+  const name = get('scenario');
+  if (!name) return null;
+
+  const metadata = {
+    model: get('model') || 'unknown',
+    recorded: get('recorded') || new Date().toISOString(),
+    ticks: parseInt(get('ticks')) || 10,
+    agents: parseInt(get('agents')) || 1,
+  };
+
+  // Extract keywords from frontmatter + scenario name
+  const fmKeywords = get('keywords').split(',').map(k => k.trim().toLowerCase()).filter(Boolean);
+  const nameKeywords = tokenize(name);
+
+  // Parse decisions
+  const decisions: ReplayDecision[] = [];
+  const tickRegex = /^## Tick (\d+) — (.+?) \((\w+),\s*L(\d+)\)/gm;
+  let match: RegExpExecArray | null;
+
+  while ((match = tickRegex.exec(content)) !== null) {
+    const tick = parseInt(match[1]);
+    const agentName = match[2].trim();
+    const agentRole = match[3].trim().toLowerCase();
+    const agentLevel = parseInt(match[4]);
+
+    // Find the block after this header until next ## or end
+    const startIdx = match.index + match[0].length;
+    const nextHeader = content.indexOf('\n## ', startIdx);
+    const block = content.slice(startIdx, nextHeader === -1 ? undefined : nextHeader);
+
+    const action = (block.match(/- Action:\s*(\w+)/)?.[1] ?? 'message') as DecisionAction;
+    const target = block.match(/- Target:\s*(.+)/)?.[1]?.trim() ?? 'none';
+    const task = block.match(/- Task:\s*(.+)/)?.[1]?.trim() ?? '';
+    const message = block.match(/- Message:\s*(.+)/)?.[1]?.trim() ?? '';
+
+    decisions.push({
+      tick,
+      agentId: '', // resolved at runtime
+      agentName,
+      agentRole,
+      agentLevel,
+      action,
+      target,
+      task,
+      message,
+    });
+  }
+
+  if (decisions.length === 0) return null;
+
+  // Build keyword list: frontmatter + name + decision messages
+  const messageKeywords = decisions.flatMap(d => tokenize(d.message)).slice(0, 30);
+  const allKeywords = [...new Set([...fmKeywords, ...nameKeywords, ...messageKeywords])];
+
+  return { name, keywords: allKeywords, decisions, metadata };
+}
+
+// ── Scenario Matcher ────────────────────────────────────────────────────────
+
+export function matchScenario(order: string, scenarios: ReplayScenario[]): ReplayScenario | null {
+  if (scenarios.length === 0) return null;
+
+  const orderTokens = tokenize(order);
+  const orderLower = order.toLowerCase();
+  let bestScore = 0;
+  let bestScenario: ReplayScenario | null = null;
+
+  for (const scenario of scenarios) {
+    const scenarioLower = scenario.name.toLowerCase();
+
+    // Substring containment bonus
+    let score = 0;
+    if (orderLower.includes(scenarioLower) || scenarioLower.includes(orderLower)) {
+      score = 0.8;
+    }
+
+    // Keyword overlap
+    const matchingKeywords = orderTokens.filter(t => scenario.keywords.includes(t));
+    const totalKeywords = Math.max(orderTokens.length, 1);
+    const keywordScore = matchingKeywords.length / totalKeywords;
+    score = Math.max(score, keywordScore);
+
+    // Also score by how many scenario keywords match the order
+    const reverseMatching = scenario.keywords.filter(k => orderTokens.includes(k));
+    const reverseScore = reverseMatching.length / Math.max(scenario.keywords.length, 1);
+    score = Math.max(score, (keywordScore + reverseScore) / 2 + reverseScore * 0.3);
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestScenario = scenario;
+    }
+  }
+
+  if (bestScenario && bestScore > 0.3) {
+    console.log(`[Replay] Matched "${bestScenario.name}" (score: ${bestScore.toFixed(2)}) for order: "${order.slice(0, 60)}..."`);
+    return bestScenario;
+  }
+
+  console.log(`[Replay] No scenario matched for order: "${order.slice(0, 60)}..." (best score: ${bestScore.toFixed(2)})`);
+  return null;
+}
+
+// ── Replay Simulation ───────────────────────────────────────────────────────
+
+export class ReplaySimulation extends DeterministicSimulation {
+  private scenarios: ReplayScenario[];
+  private queuedDecisions: Map<number, ReplayDecision[]> = new Map();
+  private replayActive = false;
+  private replayMaxTick = 0;
+
+  constructor(
+    agents: SandboxAgent[],
+    config: SandboxConfig,
+    skipSeedTasks = false,
+    parsedOrg?: ParsedOrg,
+  ) {
+    super(agents, config, skipSeedTasks, parsedOrg);
+
+    const scenariosDir = resolve(__dirname, '..', 'scenarios');
+    this.scenarios = loadScenarios(scenariosDir);
+    console.log(`\n🔁 Replay Simulation`);
+    console.log(`   Loaded ${this.scenarios.length} scenario(s) from ${scenariosDir}`);
+    for (const s of this.scenarios) {
+      console.log(`   • "${s.name}" (${s.decisions.length} decisions, ${s.metadata.ticks} ticks)`);
+    }
+  }
+
+  processOrder(order: string): void {
+    const matched = matchScenario(order, this.scenarios);
+
+    if (matched) {
+      this.replayActive = true;
+      this.queuedDecisions.clear();
+
+      // Map replay ticks proportionally
+      const maxRecordedTick = Math.max(...matched.decisions.map(d => d.tick), 1);
+      const replayScale = Math.ceil(maxRecordedTick * 2.5);
+      this.replayMaxTick = replayScale;
+
+      for (const decision of matched.decisions) {
+        const replayTick = Math.max(1, Math.round((decision.tick / maxRecordedTick) * replayScale));
+        if (!this.queuedDecisions.has(replayTick)) {
+          this.queuedDecisions.set(replayTick, []);
+        }
+        this.queuedDecisions.get(replayTick)!.push(decision);
+      }
+
+      const tickList = [...this.queuedDecisions.keys()].sort((a, b) => a - b);
+      console.log(`[Replay] Queued ${matched.decisions.length} decisions across ticks: ${tickList.join(', ')}`);
+
+      // Still call parent to set up the COO order handling (creates tasks, hires leads, etc.)
+      // but the replay decisions will override L7+ behavior
+      super.processOrder(order);
+    } else {
+      // No match — pure deterministic fallback
+      super.processOrder(order);
+    }
+  }
+
+  async runTick(): Promise<void> {
+    // Execute any queued replay decisions for this tick BEFORE the deterministic tick
+    if (this.replayActive && this.queuedDecisions.has(this.tick + 1)) {
+      // peek at next tick since super.runTick() increments this.tick
+    }
+
+    // Let deterministic tick run first (it increments this.tick)
+    await super.runTick();
+
+    // Now execute replay decisions for the current tick
+    if (this.replayActive) {
+      const decisions = this.queuedDecisions.get(this.tick);
+      if (decisions) {
+        const ctx: ExecutionContext = {
+          agents: this.agents,
+          tasks: this.tasks,
+          parsedOrgAgents: this.parsedOrg?.agents,
+        };
+
+        for (const decision of decisions) {
+          // Resolve agent
+          const agentId = resolveAgentId(decision.agentName, this.agents);
+          const agent = agentId ? this.agents.find(a => a.id === agentId) : undefined;
+
+          if (!agent) {
+            console.log(`  🔁 ⚠️ Agent "${decision.agentName}" not found, skipping replay decision`);
+            continue;
+          }
+
+          const agentDecision: AgentDecision = {
+            action: decision.action,
+            target: decision.target,
+            task: decision.task,
+            message: decision.message,
+            raw: `[replay] ${decision.action} → ${decision.target}`,
+          };
+
+          console.log(`  🔁 ${agent.name}: ${decision.action} → ${decision.target} | ${decision.message.slice(0, 60)}`);
+          executeDecision(agent, agentDecision, ctx);
+        }
+
+        this.queuedDecisions.delete(this.tick);
+      }
+
+      // Check if replay is done
+      if (this.queuedDecisions.size === 0 && this.tick >= this.replayMaxTick) {
+        this.replayActive = false;
+        console.log(`[Replay] All replay decisions executed. Continuing in deterministic mode.`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Replay Engine (Phase 2)

Loads recorded scenario markdown files and plays them back deterministically when a user sends an order. Powers the hosted demo at zero LLM cost.

### Changes
- **`replay-engine.ts`** — Core replay logic: `loadScenarios()`, `matchScenario()`, `ReplaySimulation` class
- **`decision-executor.ts`** — Shared decision execution extracted from `LLMSimulation` (DRY)
- **3 curated scenarios** — build-mobile-app, security-audit, hire-engineers
- **`index.ts`** — Added `SIMULATION_MODE=replay` support

### How it works
1. On startup, loads all `.md` files from `scenarios/` (+ `recorded/` subdir)
2. Parses YAML frontmatter + tick/decision blocks
3. On order, fuzzy-matches via keyword overlap (>30% threshold) + substring containment
4. Maps recorded tick numbers proportionally across simulation timeline
5. Falls back to deterministic mode if no scenario matches

### Testing
```bash
SIMULATION_MODE=replay node --import tsx src/index.ts
curl -X POST http://localhost:3333/api/order -H 'Content-Type: application/json' -d '{"order": "Build a mobile app for our customers"}'
```