### PR TITLE
feat: A2A & MCP protocol badges + activity in dashboard

### DIFF
--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -52,6 +52,8 @@ import { NotificationCenter } from "./notification-center";
 import { useOnboarding } from "./onboarding/onboarding-provider";
 import { isSandboxMode } from "../graphql/fetcher";
 import { SandboxCommandBar } from "./sandbox-command-bar";
+import { ProtocolStatus } from "./protocol-status";
+import { ProtocolActivity } from "./protocol-activity";
 import { ScenarioContextBanner, useScenarioStatus } from "./sandbox-scenario-banner";
 import { PhaseTransitionOverlay } from "./phase-transition-overlay";
 import { ScenarioEventToasts } from "./scenario-event-toasts";
@@ -404,6 +406,20 @@ export function Layout({ children }: LayoutProps) {
                 <TooltipContent side="right" sideOffset={8}>GitHub</TooltipContent>
               </Tooltip>
             </div>
+          )}
+
+          {/* Protocol Status */}
+          {isSandboxMode && (
+            !sidebarCollapsed ? (
+              <div className="border-t border-border px-3 py-2 space-y-2">
+                <ProtocolStatus />
+                <ProtocolActivity />
+              </div>
+            ) : (
+              <div className="border-t border-border py-2 flex flex-col items-center gap-1">
+                <ProtocolStatus compact />
+              </div>
+            )
           )}
 
           {/* User & Footer */}

--- a/apps/dashboard/src/components/protocol-activity.tsx
+++ b/apps/dashboard/src/components/protocol-activity.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState, useRef } from 'react';
+import { Link2, Plug } from 'lucide-react';
+import { isSandboxMode } from '../graphql/fetcher';
+import { SANDBOX_URL } from '../lib/sandbox-url';
+
+export function ProtocolActivity() {
+  const [a2aCount, setA2aCount] = useState(0);
+  const [mcpCount, setMcpCount] = useState(0);
+  const [a2aPulse, setA2aPulse] = useState(false);
+  const [mcpPulse, setMcpPulse] = useState(false);
+  const a2aTimer = useRef<ReturnType<typeof setTimeout>>();
+  const mcpTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    if (!isSandboxMode) return;
+
+    const source = new EventSource(`${SANDBOX_URL}/api/stream`);
+
+    source.onmessage = (e) => {
+      try {
+        const event = JSON.parse(e.data);
+        if (event.type === 'connected') return;
+
+        const isA2A = event.type?.startsWith('a2a') || event.type === 'human_order' ||
+          event.message?.includes('A2A');
+        const isMCP = event.type?.startsWith('mcp') || event.message?.includes('MCP');
+
+        if (isA2A) {
+          setA2aCount(c => c + 1);
+          setA2aPulse(true);
+          clearTimeout(a2aTimer.current);
+          a2aTimer.current = setTimeout(() => setA2aPulse(false), 2000);
+        }
+        if (isMCP) {
+          setMcpCount(c => c + 1);
+          setMcpPulse(true);
+          clearTimeout(mcpTimer.current);
+          mcpTimer.current = setTimeout(() => setMcpPulse(false), 2000);
+        }
+      } catch { /* ignore */ }
+    };
+
+    return () => {
+      source.close();
+      clearTimeout(a2aTimer.current);
+      clearTimeout(mcpTimer.current);
+    };
+  }, []);
+
+  if (!isSandboxMode) return null;
+
+  return (
+    <div className="flex items-center gap-3 text-xs">
+      <div className={`flex items-center gap-1.5 text-cyan-400 transition-all ${a2aPulse ? 'scale-110' : ''}`}>
+        <div className="relative">
+          <Link2 className="h-3.5 w-3.5" />
+          {a2aPulse && (
+            <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-cyan-400 animate-ping" />
+          )}
+        </div>
+        <span>A2A: {a2aCount}</span>
+      </div>
+      <div className={`flex items-center gap-1.5 text-violet-400 transition-all ${mcpPulse ? 'scale-110' : ''}`}>
+        <div className="relative">
+          <Plug className="h-3.5 w-3.5" />
+          {mcpPulse && (
+            <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-violet-400 animate-ping" />
+          )}
+        </div>
+        <span>MCP: {mcpCount}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/protocol-status.tsx
+++ b/apps/dashboard/src/components/protocol-status.tsx
@@ -1,0 +1,81 @@
+import { useState, useRef, useEffect } from 'react';
+import { Link2, Plug } from 'lucide-react';
+
+interface ProtocolBadgeProps {
+  label: string;
+  icon: typeof Link2;
+  color: string;
+  hoverColor: string;
+  details: { version: string; info: string; link: string; linkLabel: string };
+}
+
+function ProtocolBadge({ label, icon: Icon, color, hoverColor, details }: ProtocolBadgeProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(!open)}
+        className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${color} hover:${hoverColor}`}
+      >
+        <Icon className="h-3 w-3" />
+        {label} ✓
+      </button>
+      {open && (
+        <div className="absolute bottom-full mb-2 left-0 z-50 w-56 rounded-lg border border-border bg-popover p-3 shadow-lg text-xs space-y-2">
+          <div className="font-medium text-foreground">{details.version}</div>
+          <div className="text-muted-foreground">{details.info}</div>
+          <a
+            href={details.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`inline-flex items-center gap-1 ${color.includes('cyan') ? 'text-cyan-400' : 'text-violet-400'} hover:underline`}
+          >
+            {details.linkLabel}
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ProtocolStatus({ compact }: { compact?: boolean }) {
+  return (
+    <div className={`flex items-center gap-2 ${compact ? '' : 'flex-wrap'}`}>
+      <ProtocolBadge
+        label="A2A"
+        icon={Link2}
+        color="text-cyan-400 border-cyan-500/30 bg-cyan-500/10"
+        hoverColor="bg-cyan-500/20"
+        details={{
+          version: 'A2A v0.3 — 22 agents discoverable',
+          info: 'Agent-to-Agent protocol for cross-system task delegation',
+          link: '/.well-known/agent.json',
+          linkLabel: '/.well-known/agent.json',
+        }}
+      />
+      <ProtocolBadge
+        label="MCP"
+        icon={Plug}
+        color="text-violet-400 border-violet-500/30 bg-violet-500/10"
+        hoverColor="bg-violet-500/20"
+        details={{
+          version: 'MCP — 7 tools available',
+          info: 'Model Context Protocol for tool-based agent interaction',
+          link: '/mcp',
+          linkLabel: '/mcp',
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/sandbox-activity-feed.tsx
+++ b/apps/dashboard/src/components/sandbox-activity-feed.tsx
@@ -112,6 +112,12 @@ export function SandboxActivityFeed({ taskId, agentId, maxEvents = 50 }: Sandbox
               {event.agentName && (
                 <span className="text-cyan-400 shrink-0">[{event.agentName}]</span>
               )}
+              {(event.type.startsWith('a2a') || event.message.includes('A2A')) && (
+                <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-cyan-500/20 text-cyan-400 border border-cyan-500/30">A2A</span>
+              )}
+              {(event.type.startsWith('mcp') || event.message.includes('MCP')) && (
+                <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-violet-500/20 text-violet-400 border border-violet-500/30">MCP</span>
+              )}
               <span className="text-gray-300">{event.message}</span>
             </div>
           ))

--- a/apps/dashboard/src/pages/intro.tsx
+++ b/apps/dashboard/src/pages/intro.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ArrowRight, Github, BookOpen, Users, Network, CheckSquare } from 'lucide-react';
+import { ArrowRight, Github, BookOpen, Users, Network, CheckSquare, Link2, Plug } from 'lucide-react';
 import { useAgents } from '../hooks/use-agents';
 import { useTasks } from '../hooks/use-tasks';
 
@@ -101,13 +101,15 @@ export function IntroPage() {
           {[
             { icon: Users, label: `${agentCount} Agents` },
             { icon: Network, label: activeAgents > 0 ? `${activeAgents} Active Now` : 'Live Network' },
-            { icon: CheckSquare, label: `${taskCount}+ Tasks` },
-          ].map(({ icon: Icon, label }) => (
+            { icon: CheckSquare, label: `${taskCount}+ Tasks`, color: 'text-cyan-400' },
+            { icon: Link2, label: 'A2A v0.3', color: 'text-cyan-400', borderColor: 'border-cyan-500/50' },
+            { icon: Plug, label: 'MCP 7 tools', color: 'text-violet-400', borderColor: 'border-violet-500/50' },
+          ].map(({ icon: Icon, label, color, borderColor }) => (
             <span
               key={label}
-              className="flex items-center gap-2 px-4 py-2 rounded-full bg-slate-800/60 border border-slate-700/50 text-sm text-slate-300"
+              className={`flex items-center gap-2 px-4 py-2 rounded-full bg-slate-800/60 border ${borderColor || 'border-slate-700/50'} text-sm text-slate-300`}
             >
-              <Icon className="h-4 w-4 text-cyan-400" />
+              <Icon className={`h-4 w-4 ${color || 'text-cyan-400'}`} />
               {label}
             </span>
           ))}

--- a/apps/dashboard/src/pages/tasks.tsx
+++ b/apps/dashboard/src/pages/tasks.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Plus, Search, GripVertical, X, Clock, User, Coins, Calendar, FileText, CheckCircle2, ArrowUpDown, AlertTriangle, RefreshCw, ShieldAlert, History, Webhook } from "lucide-react";
+import { Plus, Search, GripVertical, X, Clock, User, Coins, Calendar, FileText, CheckCircle2, ArrowUpDown, AlertTriangle, RefreshCw, ShieldAlert, History, Webhook, Link2, Plug } from "lucide-react";
 import { Card, CardContent } from "../components/ui/card";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
@@ -147,6 +147,18 @@ function TaskCard({ task, onClick, compact, agentMap }: TaskCardProps) {
                   <Badge variant="outline" className="text-xs text-cyan-500 border-cyan-500/30">
                     <Webhook className="w-3 h-3 mr-1" />
                     webhook
+                  </Badge>
+                )}
+                {(task as any).source === 'a2a' && (
+                  <Badge variant="outline" className="text-xs text-cyan-400 border-cyan-500/30 bg-cyan-500/10">
+                    <Link2 className="w-3 h-3 mr-1" />
+                    A2A
+                  </Badge>
+                )}
+                {(task as any).source === 'mcp' && (
+                  <Badge variant="outline" className="text-xs text-violet-400 border-violet-500/30 bg-violet-500/10">
+                    <Plug className="w-3 h-3 mr-1" />
+                    MCP
                   </Badge>
                 )}
                 {hasRejection && (


### PR DESCRIPTION
## What

Adds protocol visualization to the BikiniBottom dashboard so visitors can see A2A and MCP activity in real-time.

### New Components
- **`protocol-status.tsx`** — Clickable A2A ✓ / MCP ✓ badge pills with dropdown details (version, endpoint links)
- **`protocol-activity.tsx`** — Live SSE-connected counters with pulse animation on new A2A/MCP requests

### Modified
- **`sandbox-activity-feed.tsx`** — Cyan A2A and violet MCP badges on protocol events
- **`layout.tsx`** — Protocol badges + activity in sidebar (sandbox mode)
- **`intro.tsx`** — A2A v0.3 and MCP 7 tools pills in feature section
- **`tasks.tsx`** — Source badges (A2A/MCP) on task cards
- **`server.ts`** — Emits `a2a_task_received` and `mcp_tool_call` SSE events; adds `source` field to mapped tasks

Follows up on #313 (A2A) and #314 (MCP).