### PR TITLE
feat: bikinibottom CLI — npx bikinibottom init/start/status

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,85 @@
+# 🍍 BikiniBottom
+
+**AI agent orchestration control plane** — run 32 agents locally with A2A + MCP support.
+
+BikiniBottom is the control plane your AI agents deserve. Define your organization in a simple Markdown file, and watch agents coordinate tasks in real-time with protocol-native communication.
+
+## Quick Start
+
+```bash
+npx bikinibottom init my-org
+cd my-org
+bikinibottom start
+```
+
+Open [http://localhost:3333](http://localhost:3333) to see the real-time dashboard.
+
+## Features
+
+- **🤖 32 Agents** — Define your agent org chart in `ORG.md`
+- **🔗 A2A Protocol** — Agent-to-Agent communication via Google's A2A spec
+- **🔌 MCP Support** — Model Context Protocol for tool integration
+- **🧠 Model Router** — Intelligent routing across Ollama, Groq, OpenRouter, and more
+- **📊 Real-time Dashboard** — Watch agents coordinate tasks live
+- **🎯 Deterministic Simulation** — Reproducible agent behavior for testing
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `bikinibottom init [name]` | Scaffold a new agent organization |
+| `bikinibottom start` | Start the local control plane server |
+| `bikinibottom status` | Show current server status |
+| `bikinibottom demo` | Start with a demo scenario running |
+
+## Configuration
+
+After `init`, edit `bikinibottom.config.json`:
+
+```json
+{
+  "port": 3333,
+  "orgFile": "ORG.md",
+  "simulation": {
+    "mode": "deterministic",
+    "tickInterval": 3000,
+    "startMode": "full"
+  },
+  "router": {
+    "preferLocal": true,
+    "providers": ["ollama", "groq"]
+  },
+  "protocols": {
+    "a2a": true,
+    "mcp": true
+  }
+}
+```
+
+## Agent Organization
+
+Define agents in `ORG.md` using simple Markdown:
+
+```markdown
+### CEO (Level 10)
+- Name: The Boss
+- Avatar: 👑
+- Domain: operations
+- Role: coo
+```
+
+Agents inherit hierarchy from heading levels and communicate via A2A protocol.
+
+## Protocols
+
+- **A2A** → `http://localhost:3333/.well-known/agent.json`
+- **MCP** → `http://localhost:3333/mcp`
+
+## Links
+
+- 🌐 **Live Demo:** [bikinibottom.ai](https://bikinibottom.ai)
+- 📖 **GitHub:** [openspawn/openspawn](https://github.com/openspawn/openspawn)
+
+## License
+
+MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "bikinibottom",
+  "version": "0.1.0",
+  "description": "AI agent orchestration control plane — run 32 agents locally with A2A + MCP support",
+  "type": "module",
+  "bin": {
+    "bikinibottom": "./dist/cli.js"
+  },
+  "files": ["dist/", "README.md", "templates/"],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/cli.ts"
+  },
+  "keywords": ["ai", "agents", "a2a", "mcp", "orchestration", "multi-agent"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openspawn/openspawn"
+  },
+  "homepage": "https://bikinibottom.ai",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// BikiniBottom CLI — AI agent orchestration control plane
+
+import { showHelp, getVersion } from './help.js';
+import { initCommand } from './commands/init.js';
+import { startCommand } from './commands/start.js';
+import { statusCommand } from './commands/status.js';
+import { demoCommand } from './commands/demo.js';
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (!command || command === '--help' || command === '-h') {
+  showHelp();
+} else if (command === '--version' || command === '-v') {
+  console.log(getVersion());
+} else if (command === 'init') {
+  initCommand(args[1]);
+} else if (command === 'start') {
+  startCommand();
+} else if (command === 'status') {
+  statusCommand();
+} else if (command === 'demo') {
+  demoCommand();
+} else {
+  console.log(`\x1b[31mUnknown command: ${command}\x1b[0m\n`);
+  showHelp();
+  process.exit(1);
+}

--- a/packages/cli/src/commands/demo.ts
+++ b/packages/cli/src/commands/demo.ts
@@ -1,0 +1,28 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function demoCommand(): void {
+  const configPath = join(process.cwd(), 'bikinibottom.config.json');
+
+  if (!existsSync(configPath)) {
+    console.log(`
+\x1b[31m✗\x1b[0m No bikinibottom.config.json found in current directory.
+
+Run \x1b[33mbikinibottom init\x1b[0m first to scaffold a project.
+`);
+    process.exit(1);
+  }
+
+  console.log(`
+\x1b[33m🍍 Starting BikiniBottom Demo...\x1b[0m
+
+Sending demo task: "Build a REST API for user management"
+Watch the agents coordinate at http://localhost:3333
+
+\x1b[2mNote: Full local server requires the sandbox package.
+For now, try the live demo at https://bikinibottom.ai
+
+Or run from the monorepo:
+  cd tools/sandbox && npm start\x1b[0m
+`);
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const DEFAULT_CONFIG = {
+  port: 3333,
+  orgFile: 'ORG.md',
+  simulation: {
+    mode: 'deterministic',
+    tickInterval: 3000,
+    startMode: 'full',
+  },
+  router: {
+    preferLocal: true,
+    providers: ['ollama', 'groq'],
+  },
+  protocols: {
+    a2a: true,
+    mcp: true,
+  },
+};
+
+export function initCommand(name?: string): void {
+  const targetDir = name ? resolve(process.cwd(), name) : process.cwd();
+
+  if (name && !existsSync(targetDir)) {
+    mkdirSync(targetDir, { recursive: true });
+  }
+
+  // Write ORG.md from template
+  const templatePath = join(__dirname, '..', 'templates', 'ORG.md');
+  let orgTemplate: string;
+  try {
+    orgTemplate = readFileSync(templatePath, 'utf-8');
+  } catch {
+    // Fallback if templates dir is alongside dist
+    const altPath = join(__dirname, '..', '..', 'templates', 'ORG.md');
+    orgTemplate = readFileSync(altPath, 'utf-8');
+  }
+
+  writeFileSync(join(targetDir, 'ORG.md'), orgTemplate);
+  writeFileSync(join(targetDir, 'bikinibottom.config.json'), JSON.stringify(DEFAULT_CONFIG, null, 2) + '\n');
+  writeFileSync(join(targetDir, '.gitignore'), 'node_modules/\n.env\ndata/\n');
+
+  const prefix = name ? `  cd ${name}\n` : '';
+
+  console.log(`
+\x1b[33m🍍 BikiniBottom initialized!\x1b[0m
+
+Created:
+  ORG.md                 — Define your agent organization
+  bikinibottom.config.json — Configuration
+  .gitignore
+
+Next steps:
+${prefix}  1. Edit ORG.md to customize your agents
+  2. Run: bikinibottom start
+  3. Open: http://localhost:3333
+
+Protocols enabled:
+  🔗 A2A  → http://localhost:3333/.well-known/agent.json
+  🔌 MCP  → http://localhost:3333/mcp
+`);
+}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,0 +1,34 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function startCommand(): void {
+  const configPath = join(process.cwd(), 'bikinibottom.config.json');
+
+  if (!existsSync(configPath)) {
+    console.log(`
+\x1b[31m✗\x1b[0m No bikinibottom.config.json found in current directory.
+
+Run \x1b[33mbikinibottom init\x1b[0m first to scaffold a project.
+`);
+    process.exit(1);
+  }
+
+  const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+  const port = config.port ?? 3333;
+  const a2a = config.protocols?.a2a ? '✓' : '✗';
+  const mcp = config.protocols?.mcp ? '✓' : '✗';
+
+  console.log(`
+\x1b[33m🍍 Starting BikiniBottom...\x1b[0m
+
+Port:       ${port}
+Agents:     Loading from ${config.orgFile ?? 'ORG.md'}...
+Protocols:  A2A ${a2a}  MCP ${mcp}
+
+\x1b[2mNote: Full local server requires the sandbox package.
+For now, try the live demo at https://bikinibottom.ai
+
+Or run from the monorepo:
+  cd tools/sandbox && npm start\x1b[0m
+`);
+}

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,44 @@
+import { request } from 'node:http';
+
+export function statusCommand(): void {
+  const port = 3333;
+  const url = `http://localhost:${port}/api/agents`;
+
+  const req = request(url, { timeout: 3000 }, (res) => {
+    let data = '';
+    res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+    res.on('end', () => {
+      try {
+        const agents = JSON.parse(data);
+        const total = Array.isArray(agents) ? agents.length : 0;
+        const active = Array.isArray(agents) ? agents.filter((a: Record<string, unknown>) => a.status === 'active' || a.status === 'working').length : 0;
+        const idle = total - active;
+
+        console.log(`
+\x1b[33m🍍 BikiniBottom Status\x1b[0m
+
+Server:     http://localhost:${port} \x1b[32m✓\x1b[0m
+Agents:     ${total} (${active} active, ${idle} idle)
+Protocols:  A2A ✓  MCP ✓
+`);
+      } catch {
+        showOffline();
+      }
+    });
+  });
+
+  req.on('error', () => { showOffline(); });
+  req.on('timeout', () => { req.destroy(); showOffline(); });
+  req.end();
+}
+
+function showOffline(): void {
+  console.log(`
+\x1b[33m🍍 BikiniBottom Status\x1b[0m
+
+Server:     \x1b[31mNot running\x1b[0m
+
+No server detected on localhost:3333.
+Start with: \x1b[33mbikinibottom start\x1b[0m
+`);
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export function getVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+    return pkg.version;
+  } catch {
+    return '0.1.0';
+  }
+}
+
+export function showHelp(): void {
+  console.log(`
+\x1b[33m🍍 BikiniBottom\x1b[0m — AI Agent Orchestration
+
+  The control plane your AI agents deserve.
+  32 agents. A2A + MCP protocols. Real-time dashboard.
+
+\x1b[1mCommands:\x1b[0m
+  init [name]    Scaffold a new agent organization
+  start          Start the local control plane server
+  status         Show current server status
+  demo           Start with a demo scenario running
+
+\x1b[1mOptions:\x1b[0m
+  --help, -h     Show this help
+  --version, -v  Show version
+
+\x1b[1mExamples:\x1b[0m
+  $ npx bikinibottom init my-org
+  $ cd my-org && bikinibottom start
+  $ bikinibottom status
+
+Learn more: \x1b[36mhttps://bikinibottom.ai\x1b[0m
+GitHub:     \x1b[36mhttps://github.com/openspawn/openspawn\x1b[0m
+`);
+}

--- a/packages/cli/templates/ORG.md
+++ b/packages/cli/templates/ORG.md
@@ -1,0 +1,37 @@
+# My Agent Organization
+
+## Identity
+- Name: My Org
+- Mission: AI-powered operations
+
+## Structure
+
+### CEO (Level 10)
+- Name: The Boss
+- Avatar: 👑
+- Domain: operations
+- Role: coo
+
+### Engineering Lead (Level 7)
+- Name: Tech Lead
+- Avatar: 💻
+- Domain: engineering
+- Role: lead
+
+### Frontend Developer (Level 4)
+- Name: UI Builder  
+- Avatar: 🎨
+- Domain: frontend
+- Role: worker
+
+### Backend Developer (Level 4)
+- Name: API Builder
+- Avatar: ⚙️
+- Domain: backend
+- Role: worker
+
+### QA Engineer (Level 3)
+- Name: Bug Hunter
+- Avatar: 🔍
+- Domain: testing
+- Role: worker

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## BikiniBottom CLI

Zero-dependency CLI package for AI agent orchestration.

### Commands
- `bikinibottom init [name]` — Scaffold a new agent organization
- `bikinibottom start` — Start the control plane server
- `bikinibottom status` — Check server status
- `bikinibottom demo` — Start with demo scenario

### Key decisions
- **Zero dependencies** — Node.js built-ins only (fs, path, http, child_process)
- **TypeScript strict mode** — Full type safety
- **Node 18+** — Uses native fetch-compatible http module
- `start`/`demo` are placeholders until `@openspawn/sandbox` is published to npm

### Files
- `packages/cli/` — New CLI package (`bikinibottom` on npm)
- Templates for `ORG.md` and `bikinibottom.config.json`