### PR TITLE
fix: clarify MCP uses Streamable HTTP, not deprecated SSE

### DIFF
--- a/tools/sandbox/src/server.ts
+++ b/tools/sandbox/src/server.ts
@@ -457,7 +457,7 @@ export function startServer(sim: Simulation): void {
 
     // ── MCP Protocol Endpoint ─────────────────────────────────────────────
 
-    // GET /mcp — no server-initiated SSE for now
+    // GET /mcp — Streamable HTTP transport: return 405 (server-initiated streams not implemented)
     if (path === '/mcp' && req.method === 'GET') {
       res.writeHead(405, {
         'Content-Type': 'application/json',
@@ -487,7 +487,7 @@ export function startServer(sim: Simulation): void {
           }
 
           const result = mcp.handleRequest(parsed);
-          // Emit SSE event for MCP tool calls
+          // Emit activity event for dashboard feed
           if (parsed.method === 'tools/call' && parsed.params?.name) {
             sim.events.push({
               type: 'mcp_tool_call',


### PR DESCRIPTION
Updated misleading comments. Our MCP implementation correctly uses Streamable HTTP transport (POST /mcp → JSON), not the deprecated SSE transport from the 2024-11-05 spec.