### PR TITLE
docs: comprehensive A2A, MCP, model router, and CLI documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,7 +40,7 @@ heading_anchors: true
 # External navigation links
 nav_external_links:
   - title: Live Demo
-    url: https://openspawn.github.io/openspawn/demo/
+    url: https://bikinibottom.ai
 
 # Exclude files from build
 exclude:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,186 @@
+---
+title: Architecture
+layout: default
+nav_order: 5
+permalink: /architecture/
+---
+
+# Architecture
+{: .no_toc }
+
+BikiniBottom is a layered system: protocol interfaces on top, a control plane in the middle, and agent runtimes at the bottom.
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## System Overview
+
+```
+                    ┌──────────────────────────────────────────┐
+                    │           Protocol Layer                  │
+                    │                                          │
+                    │  ┌──────────┐       ┌──────────────┐    │
+ Other Agents ─────▶│  A2A Server │       │  MCP Server   │◀──── Claude Desktop
+                    │  (REST+SSE) │       │  (JSON-RPC)   │    │  Cursor, LLMs
+                    │  └─────┬────┘       └──────┬───────┘    │
+                    │        │                   │             │
+                    └────────┼───────────────────┼─────────────┘
+                             │                   │
+                    ┌────────▼───────────────────▼─────────────┐
+                    │           Control Plane                   │
+                    │                                          │
+                    │  ┌────────────┐  ┌───────────────────┐  │
+                    │  │  Task      │  │  Model Router      │  │
+                    │  │  Scheduler │  │  (Ollama/Groq/OR)  │  │
+                    │  └─────┬──────┘  └────────┬──────────┘  │
+                    │        │                   │             │
+                    │  ┌─────▼───────────────────▼──────────┐  │
+                    │  │     Agent Communication (ACP)       │  │
+                    │  └────────────────┬───────────────────┘  │
+                    └───────────────────┼──────────────────────┘
+                                       │
+                    ┌──────────────────▼──────────────────────┐
+                    │           Agent Runtime                   │
+                    │                                          │
+                    │  ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐      │
+                    │  │L10  │ │ L7  │ │ L4  │ │ L3  │ ...  │
+                    │  │CEO  │ │Lead │ │Dev  │ │ QA  │      │
+                    │  └─────┘ └─────┘ └─────┘ └─────┘      │
+                    └─────────────────────────────────────────┘
+                                       │
+                    ┌──────────────────▼──────────────────────┐
+                    │           Dashboard (React)              │
+                    │  Real-time UI, network graph, metrics    │
+                    └─────────────────────────────────────────┘
+```
+
+---
+
+## Layers
+
+### Protocol Layer
+
+The top layer handles external communication via two open protocols:
+
+- **A2A Server** — Implements Google's Agent-to-Agent protocol v0.3. Handles agent discovery (`/.well-known/agent.json`), task sending, SSE streaming, and task management. See [A2A Protocol Guide](protocols/a2a).
+
+- **MCP Server** — Implements Anthropic's Model Context Protocol. Exposes 7 tools via JSON-RPC 2.0 at `POST /mcp`. See [MCP Tools Guide](protocols/mcp).
+
+Both protocols feed into the same control plane — a task sent via A2A and a task delegated via MCP follow the same internal path.
+
+### Control Plane
+
+The middle layer handles orchestration:
+
+- **Task Scheduler** — Receives tasks from protocols or internal agents, matches them to the right agent based on domain keywords, level requirements, and availability. Manages the full task lifecycle: submitted → working → completed.
+
+- **Model Router** — Routes LLM requests to the optimal provider based on agent level and task type. Manages fallback chains, rate limiting, and cost tracking. See [Model Router Guide](features/model-router).
+
+- **ACP (Agent Communication Protocol)** — Internal messaging between agents. Handles delegation chains, status updates, and coordination.
+
+### Agent Runtime
+
+The bottom layer runs the agents themselves:
+
+- Agents are organized in a **hierarchy** with levels L1–L10
+- Each agent has a **domain** (engineering, marketing, finance, etc.)
+- Agents can **delegate** tasks to subordinates or **escalate** to superiors
+- The simulation engine drives agent behavior with configurable tick intervals
+
+---
+
+## Data Flow
+
+### External Task (A2A)
+
+```
+1. Client sends POST /a2a/message/send
+2. A2A Server extracts text, detects domain (keyword matching)
+3. Task Scheduler creates internal task, assigns to best agent
+4. Agent processes task (via Model Router for LLM calls)
+5. Status updates flow back via SSE or polling
+6. Client receives completed task with artifacts
+```
+
+### External Task (MCP)
+
+```
+1. LLM client calls tools/call with delegate_task
+2. MCP Server creates internal task via Task Scheduler
+3. Same flow as A2A from step 3 onward
+4. Result returned as MCP tool response (text content)
+```
+
+### Internal Delegation
+
+```
+1. L10 CEO receives complex task
+2. Breaks into subtasks, delegates to L7 leads
+3. Leads further delegate to L4-L6 workers
+4. Workers execute (using appropriate LLM tier)
+5. Results bubble up through the chain
+```
+
+---
+
+## Agent Hierarchy
+
+| Level | Tier | Role | Capabilities |
+|-------|------|------|-------------|
+| L10 | Executive | CEO/COO | Full delegation, strategic decisions, premium models |
+| L9 | Executive | VP | Cross-domain coordination, premium models |
+| L7–L8 | Lead | Team Lead | Domain management, mid-tier models, approval authority |
+| L4–L6 | Senior | Senior IC | Complex tasks, local/cheap models |
+| L1–L3 | Junior | Worker | Simple tasks, local models only |
+
+Higher-level agents can delegate to lower levels. Lower-level agents can escalate to higher levels. The model router automatically assigns the right LLM tier.
+
+---
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Server | Node.js (raw HTTP, no framework) |
+| Simulation | Deterministic engine with configurable ticks |
+| Dashboard | React + TanStack Query |
+| CLI | Node.js with zero dependencies |
+| Protocols | A2A v0.3, MCP (2025-03-26) |
+| Build | Nx monorepo, TypeScript |
+| Deployment | GitHub Pages (docs), any Node.js host (server) |
+
+---
+
+## Monorepo Structure
+
+```
+openspawn/
+├── packages/
+│   └── cli/              # bikinibottom CLI
+│       ├── src/
+│       │   ├── cli.ts
+│       │   └── commands/
+│       │       ├── init.ts
+│       │       ├── start.ts
+│       │       ├── status.ts
+│       │       └── demo.ts
+│       └── templates/
+│           └── ORG.md
+├── tools/
+│   └── sandbox/           # Server + protocols
+│       └── src/
+│           ├── server.ts       # HTTP server, route dispatch
+│           ├── a2a-server.ts   # A2A protocol implementation
+│           ├── a2a-types.ts    # A2A type definitions
+│           ├── mcp-server.ts   # MCP tool server
+│           ├── model-router.ts # Multi-provider routing
+│           └── deterministic.ts # Simulation engine
+├── docs/                  # Jekyll docs (this site)
+└── nx.json
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,268 +1,216 @@
 ---
-title: CLI Reference
+title: CLI
 layout: default
-parent: "SDK & CLI"
-nav_order: 1
+nav_order: 6
+permalink: /cli/
 ---
 
-# BikiniBottom CLI
+# CLI Reference
+{: .no_toc }
 
-The BikiniBottom CLI provides command-line access to all platform features.
+The BikiniBottom CLI scaffolds, configures, and runs your agent organization.
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
 
 ## Installation
 
 ```bash
-# Install globally
-npm install -g openspawn
+# Use directly with npx (no install)
+npx bikinibottom --help
 
-# Or use npx
-npx openspawn --help
+# Or install globally
+npm install -g bikinibottom
 ```
 
-## Authentication
+---
+
+## Commands
+
+### `bikinibottom init [name]`
+
+Scaffold a new agent organization.
 
 ```bash
-# Login with API key
-openspawn auth login --api-key osp_your_api_key
+# Create in new directory
+npx bikinibottom init my-org
 
-# Check authentication status
-openspawn auth status
-
-# Logout
-openspawn auth logout
+# Create in current directory
+npx bikinibottom init
 ```
 
-## Agents
+**Creates:**
 
-### List agents
+| File | Purpose |
+|------|---------|
+| `ORG.md` | Agent organization definition |
+| `bikinibottom.config.json` | Server configuration |
+| `.gitignore` | Standard ignores |
+
+**Output:**
+
+```
+🍍 BikiniBottom initialized!
+
+Created:
+  ORG.md                 — Define your agent organization
+  bikinibottom.config.json — Configuration
+  .gitignore
+
+Next steps:
+  cd my-org
+  1. Edit ORG.md to customize your agents
+  2. Run: bikinibottom start
+  3. Open: http://localhost:3333
+
+Protocols enabled:
+  🔗 A2A  → http://localhost:3333/.well-known/agent.json
+  🔌 MCP  → http://localhost:3333/mcp
+```
+
+### `bikinibottom start`
+
+Start the BikiniBottom server.
 
 ```bash
-# List all agents
-openspawn agents list
-
-# JSON output
-openspawn agents list --json
+npx bikinibottom start
 ```
 
-### Get agent details
+Reads `bikinibottom.config.json` and `ORG.md` from the current directory. Starts the server with:
+- Real-time dashboard at `http://localhost:3333`
+- A2A protocol at `http://localhost:3333/.well-known/agent.json`
+- MCP tool server at `http://localhost:3333/mcp`
+
+### `bikinibottom status`
+
+Show server status.
 
 ```bash
-openspawn agents get <identifier>
-openspawn agents get code-wizard
+npx bikinibottom status
 ```
 
-### Create agent
+### `bikinibottom demo`
+
+Start with a built-in demo scenario (32 agents, pre-configured tasks).
 
 ```bash
-openspawn agents create --name "Research Bot" --level 5
+npx bikinibottom demo
 ```
 
-## Tasks
+---
 
-### List tasks
+## ORG.md
 
-```bash
-# All tasks
-openspawn tasks list
+Define your agent organization in Markdown. The CLI parses this to create your agent hierarchy.
 
-# Filter by status
-openspawn tasks list --status IN_PROGRESS
+```markdown
+# My Agent Organization
 
-# Filter by assignee
-openspawn tasks list --assignee code-wizard
+## Identity
+- Name: AcmeTech
+- Mission: Build the best SaaS platform
+
+## Structure
+
+### CEO (Level 10)
+- Name: The Boss
+- Avatar: 👑
+- Domain: operations
+- Role: coo
+
+### Engineering Lead (Level 7)
+- Name: Tech Lead
+- Avatar: 💻
+- Domain: engineering
+- Role: lead
+
+### Frontend Developer (Level 4)
+- Name: UI Builder
+- Avatar: 🎨
+- Domain: frontend
+- Role: worker
+
+### Backend Developer (Level 4)
+- Name: API Builder
+- Avatar: ⚙️
+- Domain: backend
+- Role: worker
+
+### QA Engineer (Level 3)
+- Name: Bug Hunter
+- Avatar: 🔍
+- Domain: testing
+- Role: worker
 ```
 
-### Task board
+### Agent Properties
 
-```bash
-# View kanban-style board
-openspawn tasks board
-```
+| Property | Required | Description |
+|----------|----------|-------------|
+| Heading | ✅ | Agent title + `(Level N)` |
+| Name | ✅ | Display name |
+| Avatar | ❌ | Emoji avatar |
+| Domain | ✅ | Specialization (engineering, marketing, finance, etc.) |
+| Role | ✅ | `coo`, `lead`, or `worker` |
 
-### Create task
+### Levels
 
-```bash
-openspawn tasks create --title "Implement feature X" --priority high
-openspawn tasks create --title "Bug fix" --assignee code-wizard --due 2026-02-15
-```
+| Level | Tier | Model Tier | Typical Role |
+|-------|------|------------|-------------|
+| 9–10 | Executive | Premium (Claude, GPT-4o) | CEO, COO |
+| 7–8 | Lead | Mid-tier (Llama 70B) | Team leads, directors |
+| 4–6 | Senior | Local/cheap (Qwen 7B, Llama 8B) | Senior ICs |
+| 1–3 | Junior | Local (Qwen 7B) | Workers, interns |
 
-### Update task status
-
-```bash
-openspawn tasks transition <task-id> <status>
-openspawn tasks transition API-001 done
-```
-
-## Credits
-
-### Check balance
-
-```bash
-# Your balance
-openspawn credits balance
-
-# Agent's balance
-openspawn credits balance --agent code-wizard
-```
-
-### View transactions
-
-```bash
-openspawn credits transactions
-openspawn credits transactions --limit 20
-```
-
-### Budget status
-
-```bash
-openspawn credits budget
-```
-
-## Messages
-
-### List messages
-
-```bash
-# Recent messages
-openspawn messages list
-
-# From specific channel
-openspawn messages list --channel general
-```
-
-### Send message
-
-```bash
-openspawn messages send --to code-wizard --message "Task completed!"
-openspawn messages send --channel dev --message "PR ready for review"
-```
-
-### List channels
-
-```bash
-openspawn channels list
-```
-
-## Global Options
-
-| Option | Description |
-|--------|-------------|
-| `--json` | Output in JSON format |
-| `--no-color` | Disable colored output |
-| `--demo` | Use demo mode (no API required) |
-| `-v, --version` | Show version |
-| `-h, --help` | Show help |
-
-## Demo Mode
-
-Demo mode uses realistic mock data for testing and screenshots:
-
-```bash
-# Run any command with --demo
-openspawn --demo agents list
-openspawn --demo tasks board
-openspawn --demo credits balance
-```
+---
 
 ## Configuration
 
-Config is stored at `~/.openspawn/config.json`:
+`bikinibottom.config.json` reference:
 
 ```json
 {
-  "apiKey": "osp_xxxxx",
-  "apiUrl": "https://api.openspawn.dev"
+  "port": 3333,
+  "orgFile": "ORG.md",
+  "simulation": {
+    "mode": "deterministic",
+    "tickInterval": 3000,
+    "startMode": "full"
+  },
+  "router": {
+    "preferLocal": true,
+    "providers": ["ollama", "groq"]
+  },
+  "protocols": {
+    "a2a": true,
+    "mcp": true
+  }
 }
 ```
 
-### Environment Variables
+| Field | Default | Description |
+|-------|---------|-------------|
+| `port` | `3333` | Server port |
+| `orgFile` | `"ORG.md"` | Path to organization definition |
+| `simulation.mode` | `"deterministic"` | Simulation engine mode |
+| `simulation.tickInterval` | `3000` | Tick interval in ms |
+| `simulation.startMode` | `"full"` | Start with all agents active |
+| `router.preferLocal` | `true` | Prefer Ollama for worker agents |
+| `router.providers` | `["ollama","groq"]` | Enabled LLM providers |
+| `protocols.a2a` | `true` | Enable A2A protocol endpoints |
+| `protocols.mcp` | `true` | Enable MCP tool server |
 
-| Variable | Description |
-|----------|-------------|
-| `OPENSPAWN_API_KEY` | API key (overrides config) |
-| `OPENSPAWN_API_URL` | API URL (default: https://api.openspawn.dev) |
+---
 
-## Output Formats
+## Global Options
 
-### Human-readable (default)
-
-```
-┌──────────────┬────────┬───────┬────────┬─────────┬───────┐
-│ Name         │ ID     │ Level │ Status │ Balance │ Trust │
-├──────────────┼────────┼───────┼────────┼─────────┼───────┤
-│ Talent Agent │ talent │ L10   │ ACTIVE │ 50,000  │ 98%   │
-│ Code Wizard  │ code   │ L8    │ ACTIVE │ 12,500  │ 92%   │
-└──────────────┴────────┴───────┴────────┴─────────┴───────┘
-```
-
-### JSON (--json)
-
-```json
-[
-  {
-    "id": "agt_talent",
-    "name": "Talent Agent",
-    "level": 10,
-    "status": "ACTIVE"
-  }
-]
-```
-
-## Error Handling
-
-The CLI provides helpful error messages:
-
-```
-✗ Error: No API key configured
-  Hint: Run 'openspawn auth login --api-key <key>' to authenticate
-
-✗ Error: Task not found: TSK-999
-  Hint: Use 'openspawn tasks list' to see available tasks
-```
-
-## Exit Codes
-
-| Code | Meaning |
-|------|---------|
-| 0 | Success |
-| 1 | General error |
-| 2 | Invalid arguments |
-| 3 | Authentication error |
-| 4 | Network error |
-
-## Examples
-
-### Typical Workflow
-
-```bash
-# 1. Authenticate
-openspawn auth login --api-key osp_xxxxx
-
-# 2. Create a task
-openspawn tasks create --title "Build API endpoint" --priority high
-
-# 3. Assign to agent
-openspawn tasks assign API-001 --to code-wizard
-
-# 4. Check progress
-openspawn tasks board
-
-# 5. Complete task
-openspawn tasks transition API-001 done
-
-# 6. Check credit balance
-openspawn credits balance
-```
-
-### Scripting
-
-```bash
-#!/bin/bash
-# Get agent IDs in JSON
-agents=$(openspawn agents list --json | jq -r '.[].identifier')
-
-for agent in $agents; do
-  balance=$(openspawn credits balance --agent $agent --json | jq '.balance')
-  echo "$agent: $balance credits"
-done
-```
+| Flag | Description |
+|------|-------------|
+| `-h, --help` | Show help |
+| `-v, --version` | Show version |

--- a/docs/features/model-router.md
+++ b/docs/features/model-router.md
@@ -1,0 +1,203 @@
+---
+title: Model Router
+layout: default
+parent: Features
+nav_order: 1
+permalink: /features/model-router/
+---
+
+# Model Router
+{: .no_toc }
+
+BikiniBottom's model router intelligently routes LLM requests across providers based on agent level, task type, cost constraints, and availability — with automatic fallback chains.
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Overview
+
+Not every agent needs GPT-4. A Level 3 worker writing unit tests can use a local 7B model. A Level 10 executive making strategic decisions needs Claude 3.5 Sonnet.
+
+The model router makes this automatic:
+
+```
+Agent Level → Tier Selection → Provider → Model → Fallback if needed
+```
+
+---
+
+## Routing Tiers
+
+| Agent Level | Tier | Default Provider | Model | Cost |
+|-------------|------|-------------------|-------|------|
+| L9–L10 | Executive | OpenRouter | Claude 3.5 Sonnet, GPT-4o | $$$ |
+| L7–L8 | Lead | Groq | Llama 3.1 70B | $ |
+| L1–L6 | Worker | Ollama (local) | Qwen 2.5 7B | Free |
+
+The router picks the **cheapest capable model** for each request while respecting quality requirements.
+
+---
+
+## Providers
+
+### Ollama (Local)
+
+- **Cost:** $0 — runs on your hardware
+- **Latency:** 40–150ms
+- **Models:** Qwen 2.5 7B (32K context)
+- **Best for:** L1–L6 workers, high-volume simple tasks
+
+### Groq
+
+- **Cost:** $0.05–$0.79 per 1K tokens
+- **Latency:** 80–300ms
+- **Models:** Llama 3.1 8B (fast), Llama 3.1 70B (capable)
+- **Rate limits:** 30 RPM, 6K TPM
+- **Best for:** L7–L8 leads, tasks needing function calling
+
+### OpenRouter
+
+- **Cost:** $2.50–$15.00 per 1K tokens
+- **Latency:** 200–800ms
+- **Models:** Claude 3.5 Sonnet (200K context), GPT-4o (128K context)
+- **Best for:** L9–L10 executives, complex reasoning, strategic decisions
+
+---
+
+## Fallback Chains
+
+When a provider is unavailable or rate-limited, the router automatically falls back:
+
+```
+L9-10 Request:
+  OpenRouter (Claude 3.5 Sonnet)
+    ↓ unavailable?
+  Groq (Llama 3.1 70B)
+    ↓ rate-limited?
+  Ollama (Qwen 2.5 7B)
+
+L7-8 Request:
+  Groq (Llama 3.1 70B)
+    ↓ rate-limited?
+  OpenRouter (GPT-4o)
+    ↓ unavailable?
+  Ollama (Qwen 2.5 7B)
+
+L1-6 Request:
+  Ollama (Qwen 2.5 7B)  [60% of requests]
+  Groq (Llama 3.1 8B)   [40% of requests]
+    ↓ both unavailable?
+  OpenRouter (cheapest available)
+```
+
+Every fallback is tracked in metrics so you can see how often providers fail.
+
+---
+
+## Cost Tracking
+
+The router tracks costs in real-time per agent and per provider:
+
+| Metric | Description |
+|--------|-------------|
+| `totalRequests` | Total routing decisions made |
+| `totalCost` | Total estimated cost across all providers |
+| `requestsByProvider` | Request count per provider |
+| `costByProvider` | Cost breakdown per provider |
+| `avgLatencyByProvider` | Average latency per provider |
+| `failuresByProvider` | Failure count per provider |
+| `fallbacksTriggered` | How often fallbacks were needed |
+| `localRoutedCount` | Requests handled locally ($0) |
+| `cloudOnlyCostEstimate` | What it would cost without local routing |
+
+### Cost Savings
+
+The `cloudOnlyCostEstimate` metric shows what you'd pay if everything went to cloud providers. Compare it with `totalCost` to see your savings from local routing:
+
+```
+Cloud-only estimate: $47.82
+Actual cost:         $12.15
+Saved:               $35.67 (74%)
+```
+
+---
+
+## Configuration
+
+In `bikinibottom.config.json`:
+
+```json
+{
+  "router": {
+    "preferLocal": true,
+    "providers": ["ollama", "groq", "openrouter"]
+  }
+}
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `preferLocal` | Route L1–L6 to Ollama when available | `true` |
+| `providers` | Enabled providers (order = fallback priority) | `["ollama", "groq"]` |
+
+### Environment Variables
+
+```bash
+GROQ_API_KEY=gsk_...          # Required for Groq
+OPENROUTER_API_KEY=sk-or-...  # Required for OpenRouter
+OLLAMA_BASE_URL=http://localhost:11434  # Custom Ollama URL
+```
+
+---
+
+## Router API
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/router/metrics` | GET | Current router metrics |
+| `/api/router/config` | GET | Provider configuration |
+| `/api/router/decisions` | GET | Recent routing decisions |
+
+### Example: Get Metrics
+
+```bash
+curl http://localhost:3333/api/router/metrics
+```
+
+```json
+{
+  "totalRequests": 1247,
+  "totalCost": 12.15,
+  "requestsByProvider": {
+    "ollama": 748,
+    "groq": 412,
+    "openrouter": 87
+  },
+  "costByProvider": {
+    "ollama": 0,
+    "groq": 4.23,
+    "openrouter": 7.92
+  },
+  "fallbacksTriggered": 23,
+  "localRoutedCount": 748,
+  "cloudOnlyCostEstimate": 47.82
+}
+```
+
+---
+
+## Dashboard
+
+The router page in the dashboard shows:
+
+- **Provider status** — Which providers are online, rate limit usage
+- **Cost breakdown** — Pie chart by provider, cumulative cost over time
+- **Routing decisions** — Live feed of routing decisions with reasons
+- **Latency distribution** — Histogram per provider
+- **Savings calculator** — Local vs cloud cost comparison

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,144 +6,177 @@ nav_order: 2
 
 # Getting Started
 
-Get BikiniBottom running in under 5 minutes.
+Get BikiniBottom running in 2 minutes.
 
-## Prerequisites
+---
 
-- **Node.js 22+** ([download](https://nodejs.org/))
-- **pnpm** (`npm install -g pnpm`)
-- **Docker** ([download](https://docker.com/))
+## Try the Live Demo
 
-## Installation
+Visit [**bikinibottom.ai**](https://bikinibottom.ai) — 32 agents running right now. No setup required.
+{: .note }
 
-### 1. Clone the Repository
+---
 
-```bash
-git clone https://github.com/openspawn/openspawn.git
-cd openspawn
-```
+## Quick Start (Local)
 
-### 2. Install Dependencies
+### 1. Scaffold your project
 
 ```bash
-pnpm install
+npx bikinibottom init my-org
+cd my-org
 ```
 
-### 3. Start PostgreSQL
+This creates:
+- `ORG.md` — Your agent organization definition
+- `bikinibottom.config.json` — Configuration (port, providers, protocols)
+
+### 2. Start the server
 
 ```bash
-docker compose up -d postgres
+npx bikinibottom start
 ```
 
-### 4. Initialize Database
+Open [http://localhost:3333](http://localhost:3333) — your dashboard is live.
+
+### 3. Discover your agents via A2A
 
 ```bash
-# Sync schema
-node scripts/sync-db.mjs
-
-# Create admin user
-node scripts/seed-admin.mjs admin@example.com yourpassword "Your Name"
+curl http://localhost:3333/.well-known/agent.json
 ```
 
-### 5. Configure Environment
+```json
+{
+  "name": "My Org",
+  "description": "AI-powered operations",
+  "url": "http://localhost:3333",
+  "version": "1.0.0",
+  "protocolVersion": "0.3",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "extendedAgentCard": true
+  },
+  "skills": [
+    { "id": "task-delegation", "name": "Task Delegation", "description": "Delegate tasks to specialized agent teams" }
+  ]
+}
+```
 
-Copy the example environment file:
+### 4. Send a task
 
 ```bash
-cp .env.example .env
+curl -X POST http://localhost:3333/a2a/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "message": {
+      "role": "user",
+      "parts": [{ "kind": "text", "text": "Build a REST API for user management" }]
+    }
+  }'
 ```
 
-The defaults work for local development. For production, update:
-
-- `JWT_SECRET` — Generate with `openssl rand -hex 64`
-- `ENCRYPTION_KEY` — Generate with `openssl rand -hex 32`
-
-### 6. Start Services
+### 5. Use as MCP Tool Server
 
 ```bash
-# Start API and Dashboard
-pnpm exec nx run-many -t serve -p api,dashboard
+curl -X POST http://localhost:3333/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
 ```
 
-Or in separate terminals:
+---
 
-```bash
-# Terminal 1: API
-pnpm exec nx run api:serve
+## Customize Your Organization
 
-# Terminal 2: Dashboard
-pnpm exec nx run dashboard:serve
+Edit `ORG.md` to define your agents:
+
+```markdown
+# My Agent Organization
+
+## Identity
+- Name: My Org
+- Mission: AI-powered operations
+
+## Structure
+
+### CEO (Level 10)
+- Name: The Boss
+- Avatar: 👑
+- Domain: operations
+- Role: coo
+
+### Engineering Lead (Level 7)
+- Name: Tech Lead
+- Avatar: 💻
+- Domain: engineering
+- Role: lead
+
+### Frontend Developer (Level 4)
+- Name: UI Builder
+- Avatar: 🎨
+- Domain: frontend
+- Role: worker
 ```
 
-## Access
+See the [CLI reference](cli) for all configuration options.
 
-| Service | URL |
-|---------|-----|
-| **Dashboard** | http://localhost:4200 |
-| **API** | http://localhost:3000 |
-| **GraphQL Playground** | http://localhost:3000/graphql |
+---
 
-## Demo Mode
+## Configuration
 
-Try BikiniBottom without creating data:
+`bikinibottom.config.json` controls your server:
 
+```json
+{
+  "port": 3333,
+  "orgFile": "ORG.md",
+  "simulation": {
+    "mode": "deterministic",
+    "tickInterval": 3000,
+    "startMode": "full"
+  },
+  "router": {
+    "preferLocal": true,
+    "providers": ["ollama", "groq"]
+  },
+  "protocols": {
+    "a2a": true,
+    "mcp": true
+  }
+}
 ```
-http://localhost:4200/?demo=true
-```
 
-Demo mode simulates:
-- Agent spawning and activation
-- Task creation and progression
-- Credit earning and spending
-- Real-time event feed
-
-### Demo Controls
-
-At the bottom of the screen:
-- ▶️ **Play/Pause** — Start or stop simulation
-- 🏃 **Speed** — 1× to 50× simulation speed
-- 🔄 **Reset** — Return to initial state
-- 📊 **Scenario** — Switch between team sizes
+---
 
 ## Next Steps
 
 | Guide | What You'll Learn |
 |-------|-------------------|
-| [Architecture Overview](openspawn/ARCHITECTURE) | System design, data flows, scaling |
-| [Agent Lifecycle](openspawn/AGENT-LIFECYCLE) | Onboarding, hierarchy, capabilities |
-| [Task Workflow](openspawn/TASK-WORKFLOW) | Templates, routing, auto-assignment |
-| [Credit System](openspawn/CREDITS) | Economy, budgets, analytics |
-| [API Reference](openspawn/API) | 50+ endpoints documented |
-| [Database Schema](openspawn/SCHEMA) | 14 tables explained |
+| [A2A Protocol](protocols/a2a) | Agent discovery, task sending, streaming |
+| [MCP Tools](protocols/mcp) | 7 tools, JSON-RPC integration, Claude Desktop setup |
+| [Model Router](features/model-router) | Provider routing, fallback chains, cost tracking |
+| [CLI Reference](cli) | All commands and configuration |
+| [Architecture](architecture) | System design and data flows |
+
+---
 
 ## Troubleshooting
 
-### Database Connection Failed
+### Port already in use
 
-Make sure PostgreSQL is running:
+Change the port in `bikinibottom.config.json`:
 
-```bash
-docker compose ps
-# Should show postgres as "Up"
+```json
+{ "port": 3334 }
 ```
 
-### Port Already in Use
+### Ollama not available
 
-Change the port in your command:
+BikiniBottom works without Ollama — it falls back to Groq or OpenRouter. Set API keys:
 
 ```bash
-# API on different port
-API_PORT=3001 pnpm exec nx run api:serve
-
-# Dashboard on different port
-pnpm exec nx run dashboard:serve -- --port 4201
+export GROQ_API_KEY=your_key
+export OPENROUTER_API_KEY=your_key
 ```
-
-### Login Not Working
-
-1. Verify user exists: `docker exec openspawn-postgres psql -U openspawn -d openspawn -c "SELECT email FROM users;"`
-2. Check API logs for errors
-3. Clear browser localStorage and try again
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,17 +15,17 @@ permalink: /
     <div class="bubble bubble-6"></div>
   </div>
   <div class="hero-content">
-    <div class="hero-badge">Open Source · MIT Licensed</div>
+    <div class="hero-badge">Open Source · MIT Licensed · A2A + MCP Native</div>
     <h1 class="hero-title">
       <span class="hero-gradient">BikiniBottom</span>
     </h1>
     <p class="hero-subtitle">The control plane for your AI agent army</p>
     <p class="hero-description">
-      Orchestrate hundreds of agents with task routing, spending controls, trust hierarchies, and a real-time dashboard. Not a framework — just the infrastructure every multi-agent system needs.
+      Orchestrate hundreds of agents with native <strong>A2A Protocol</strong> support, an <strong>MCP Tool Server</strong>, intelligent <strong>model routing</strong>, and a real-time dashboard. Ship your agent org in one command: <code>npx bikinibottom init</code>
     </p>
     <div class="hero-cta">
-      <a href="https://openspawn.github.io/openspawn/demo/" class="cta-button cta-primary">
-        <span class="cta-icon">▶</span> Launch Live Demo
+      <a href="https://bikinibottom.ai" class="cta-button cta-primary">
+        <span class="cta-icon">▶</span> Live Demo — bikinibottom.ai
       </a>
       <a href="getting-started" class="cta-button cta-secondary">
         Get Started →
@@ -33,52 +33,60 @@ permalink: /
     </div>
     <div class="hero-stats">
       <div class="hero-stat">
-        <span class="hero-stat-value">50+</span>
-        <span class="hero-stat-label">API Endpoints</span>
+        <span class="hero-stat-value">A2A</span>
+        <span class="hero-stat-label">Agent Protocol</span>
       </div>
       <div class="hero-stat-divider"></div>
       <div class="hero-stat">
-        <span class="hero-stat-value">5</span>
-        <span class="hero-stat-label">Ocean Themes</span>
+        <span class="hero-stat-value">7</span>
+        <span class="hero-stat-label">MCP Tools</span>
       </div>
       <div class="hero-stat-divider"></div>
       <div class="hero-stat">
-        <span class="hero-stat-value">2</span>
-        <span class="hero-stat-label">SDKs</span>
+        <span class="hero-stat-value">3</span>
+        <span class="hero-stat-label">LLM Providers</span>
       </div>
       <div class="hero-stat-divider"></div>
       <div class="hero-stat">
-        <span class="hero-stat-value">8</span>
-        <span class="hero-stat-label">Integrations</span>
+        <span class="hero-stat-value">1 cmd</span>
+        <span class="hero-stat-label">To Launch</span>
       </div>
     </div>
   </div>
 </div>
 
-<div class="demo-showcase" markdown="0">
-  <div class="demo-showcase-header">
-    <span class="demo-showcase-tag">✨ Interactive Demo</span>
-    <h2 class="demo-showcase-title">See it in action — no setup required</h2>
-    <p class="demo-showcase-desc">22 agents, 5 scenarios, real-time simulation. Switch between AcmeTech startup and enterprise orgs.</p>
+---
+
+## Protocol Support
+
+BikiniBottom speaks the two protocols that matter for agentic AI:
+
+<div class="feature-grid" markdown="0">
+  <div class="feature-card">
+    <div class="feature-icon">🔗</div>
+    <h3>A2A Protocol</h3>
+    <p>Google's Agent-to-Agent protocol. Discover agents, send tasks, stream updates — all via standard HTTP. Your agents are interoperable with any A2A-compatible system.</p>
+    <p><a href="protocols/a2a/">Read the A2A guide →</a></p>
   </div>
-  <div class="demo-browser">
-    <div class="demo-browser-bar">
-      <div class="demo-browser-dots">
-        <span class="dot dot-red"></span>
-        <span class="dot dot-yellow"></span>
-        <span class="dot dot-green"></span>
-      </div>
-      <div class="demo-browser-url">openspawn.github.io/openspawn/demo</div>
-    </div>
-    <a href="https://openspawn.github.io/openspawn/demo/" class="demo-browser-content">
-      <img src="assets/dashboard-preview.png" alt="BikiniBottom Dashboard" class="demo-screenshot" />
-      <div class="demo-overlay">
-        <div class="demo-play-button">▶</div>
-        <span>Launch Live Demo</span>
-      </div>
-    </a>
+  <div class="feature-card">
+    <div class="feature-icon">🔌</div>
+    <h3>MCP Tool Server</h3>
+    <p>7 tools exposed via Model Context Protocol. Connect from Claude Desktop, Cursor, or any MCP client. Delegate tasks, list agents, get stats — all via JSON-RPC.</p>
+    <p><a href="protocols/mcp/">Read the MCP guide →</a></p>
   </div>
 </div>
+
+```bash
+# Discover agents via A2A
+curl https://bikinibottom.ai/.well-known/agent.json
+
+# List tools via MCP
+curl -X POST https://bikinibottom.ai/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+[Protocols overview →](protocols/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 
 ---
 
@@ -91,7 +99,13 @@ One agent is a script. Ten agents is a distributed system. **This is your contro
   <div class="feature-card">
     <div class="feature-icon">🎯</div>
     <h3>Task Orchestration</h3>
-    <p>Priority queues, self-claim, approval workflows, and rejection handling. Route the right task to the right agent.</p>
+    <p>Priority queues, domain-based routing, approval workflows, and rejection handling. Route the right task to the right agent.</p>
+  </div>
+  <div class="feature-card">
+    <div class="feature-icon">🧠</div>
+    <h3>Model Router</h3>
+    <p>Intelligent routing across Ollama, Groq, and OpenRouter. Level-based tiers, fallback chains, and real-time cost tracking.</p>
+    <p><a href="features/model-router/">Learn more →</a></p>
   </div>
   <div class="feature-card">
     <div class="feature-icon">💰</div>
@@ -104,19 +118,15 @@ One agent is a script. Ten agents is a distributed system. **This is your contro
     <p>Agents earn trust through performance. Automated promotion, demotion, and capability gating.</p>
   </div>
   <div class="feature-card">
-    <div class="feature-icon">👥</div>
-    <h3>Teams & Hierarchy</h3>
-    <p>Organize agents into teams with leads, sub-teams, and org charts. Real-time presence tracking.</p>
-  </div>
-  <div class="feature-card">
-    <div class="feature-icon">🔌</div>
-    <h3>Integrations</h3>
-    <p>GitHub sync, Linear, webhooks, OpenTelemetry, OpenClaw. Framework adapters for LangGraph & CrewAI.</p>
+    <div class="feature-icon">⚡</div>
+    <h3>CLI — One Command</h3>
+    <p><code>npx bikinibottom init</code> scaffolds your org with A2A + MCP enabled. Edit ORG.md, run <code>bikinibottom start</code>, done.</p>
+    <p><a href="cli/">CLI reference →</a></p>
   </div>
   <div class="feature-card">
     <div class="feature-icon">📊</div>
     <h3>Live Dashboard</h3>
-    <p>Real-time React dashboard with network graph, timeline, customizable widgets, and ocean themes.</p>
+    <p>Real-time React dashboard with network graph, timeline, router metrics, and ocean themes.</p>
   </div>
 </div>
 
@@ -125,11 +135,13 @@ One agent is a script. Ten agents is a distributed system. **This is your contro
 ## Quick Start
 
 ```bash
-git clone https://github.com/openspawn/openspawn.git
-cd openspawn && pnpm install && pnpm dev
+npx bikinibottom init my-org
+cd my-org
+npx bikinibottom start
+# Open http://localhost:3333
 ```
 
-Or skip setup entirely → [**try the live demo**](https://openspawn.github.io/openspawn/demo/)
+Or skip setup entirely → [**try the live demo at bikinibottom.ai**](https://bikinibottom.ai)
 {: .fs-5 .text-center }
 
 [Full getting started guide →](getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
@@ -139,28 +151,17 @@ Or skip setup entirely → [**try the live demo**](https://openspawn.github.io/o
 
 ## Architecture
 
-BikiniBottom is an **Nx monorepo** with a NestJS API, React dashboard, TypeScript SDK, and Python SDK.
+BikiniBottom is an **Nx monorepo** with a protocol layer, control plane, and agent runtime.
 
 | Component | Tech | Purpose |
 |-----------|------|---------|
-| **API** | NestJS + GraphQL | Core coordination engine |
+| **Protocol Layer** | A2A + MCP | External agent & tool interfaces |
+| **Model Router** | Multi-provider | Intelligent LLM routing with fallbacks |
+| **Control Plane** | NestJS + GraphQL | Coordination engine |
 | **Dashboard** | React + TanStack Query | Real-time monitoring UI |
-| **TS SDK** | TypeScript | Agent integration library |
-| **Python SDK** | Python | Agent integration library |
+| **CLI** | Node.js | `npx bikinibottom init/start/demo` |
 
-[Architecture deep dive →](openspawn/)
-
----
-
-## Roadmap
-
-| Phase | Status | Description |
-|-------|--------|-------------|
-| Phases 1-8 | ✅ Complete | Core platform (auth → orchestrator mode) |
-| Phase A | ✅ Complete | SDKs + Webhooks |
-| Phase B | ✅ Complete | GitHub, Linear, OTEL, OpenClaw |
-| Phase C | ✅ Complete | Framework adapters (LangGraph, CrewAI) |
-| Phase D | 📋 Planned | Marketplace |
+[Architecture deep dive →](architecture){: .btn .btn-outline .fs-5 .mb-4 .mb-md-0 }
 
 ---
 

--- a/docs/protocols/a2a.md
+++ b/docs/protocols/a2a.md
@@ -1,0 +1,382 @@
+---
+title: A2A Protocol
+layout: default
+parent: Protocols
+nav_order: 1
+permalink: /protocols/a2a/
+---
+
+# A2A Protocol
+{: .no_toc }
+
+BikiniBottom implements [Google's Agent-to-Agent (A2A) protocol](https://a2a-protocol.org) v0.3. Every agent org exposes discovery, task sending, streaming, and task management endpoints.
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## What is A2A?
+
+A2A is an open protocol for agent interoperability. It defines how agents:
+
+- **Discover** each other via Agent Cards at well-known URLs
+- **Send tasks** with structured messages containing text, files, or data
+- **Stream updates** as tasks progress through states
+- **Manage tasks** — query status, list active tasks, cancel
+
+BikiniBottom implements A2A natively — every deployed org is an A2A-compatible agent.
+
+Try it live: `curl https://bikinibottom.ai/.well-known/agent.json`
+{: .note }
+
+---
+
+## Agent Discovery
+
+### Control Plane Card
+
+Every BikiniBottom instance publishes an Agent Card at `/.well-known/agent.json`:
+
+```bash
+curl https://bikinibottom.ai/.well-known/agent.json
+```
+
+```json
+{
+  "name": "BikiniBottom HQ",
+  "description": "Multi-agent coordination control plane",
+  "url": "https://bikinibottom.ai",
+  "version": "1.0.0",
+  "protocolVersion": "0.3",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "extendedAgentCard": true
+  },
+  "skills": [
+    {
+      "id": "task-delegation",
+      "name": "Task Delegation",
+      "description": "Delegate tasks to specialized agent teams"
+    },
+    {
+      "id": "agent-coordination",
+      "name": "Agent Coordination",
+      "description": "Coordinate multi-agent workflows with hierarchical delegation"
+    }
+  ],
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"]
+}
+```
+
+### Per-Agent Cards
+
+Each agent in the org has its own Agent Card:
+
+```bash
+curl https://bikinibottom.ai/agents/tech-lead/.well-known/agent.json
+```
+
+```json
+{
+  "name": "Tech Lead",
+  "description": "Engineering Lead (L7)",
+  "url": "https://bikinibottom.ai/agents/tech-lead",
+  "version": "1.0.0",
+  "protocolVersion": "0.3",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "extendedAgentCard": false
+  },
+  "skills": [
+    {
+      "id": "code-development",
+      "name": "Code Development",
+      "description": "Build software features, APIs, and systems"
+    },
+    {
+      "id": "bug-fixing",
+      "name": "Bug Fixing",
+      "description": "Find and fix software bugs"
+    },
+    {
+      "id": "code-review",
+      "name": "Code Review",
+      "description": "Review code for quality and security"
+    }
+  ],
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"]
+}
+```
+
+---
+
+## Sending Tasks
+
+### `POST /a2a/message/send`
+
+Send a task to the org. BikiniBottom automatically routes it to the right agent based on domain keywords.
+
+```bash
+curl -X POST https://bikinibottom.ai/a2a/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "message": {
+      "role": "user",
+      "parts": [
+        { "kind": "text", "text": "Build a REST API for user management" }
+      ]
+    }
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "id": "a2a-1707900000000-x7k2m9",
+  "contextId": "ctx-1707900000000-p3n8j4",
+  "status": {
+    "state": "submitted",
+    "message": {
+      "role": "agent",
+      "parts": [{ "kind": "text", "text": "Task routed to engineering team" }]
+    },
+    "timestamp": "2026-02-14T15:00:00.000Z"
+  },
+  "artifacts": [],
+  "history": []
+}
+```
+
+### Request Structure
+
+```typescript
+interface SendMessageRequest {
+  message: {
+    role: "user";
+    parts: Part[];           // text, file, or data parts
+    messageId?: string;      // optional client-generated ID
+    contextId?: string;      // continue an existing context
+    taskId?: string;         // follow up on a specific task
+  };
+  configuration?: {
+    acceptedOutputModes?: string[];  // e.g. ["text/plain", "application/json"]
+    historyLength?: number;          // how much history to include
+    blocking?: boolean;              // wait for completion
+  };
+}
+```
+
+### Message Parts
+
+| Kind | Description | Example |
+|------|-------------|---------|
+| `text` | Plain text content | `{ "kind": "text", "text": "Build an API" }` |
+| `file` | File with bytes or URI | `{ "kind": "file", "file": { "name": "spec.pdf", "uri": "..." } }` |
+| `data` | Structured JSON data | `{ "kind": "data", "data": { "priority": "high" } }` |
+
+---
+
+## Streaming Updates
+
+### `POST /a2a/message/stream`
+
+Send a task and receive real-time SSE updates as it progresses:
+
+```bash
+curl -N -X POST https://bikinibottom.ai/a2a/message/stream \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "message": {
+      "role": "user",
+      "parts": [{ "kind": "text", "text": "Design a landing page" }]
+    }
+  }'
+```
+
+**SSE events:**
+
+```
+data: {"kind":"status-update","taskId":"a2a-1707900000000-x7k2m9","contextId":"ctx-1707900000000-p3n8j4","status":{"state":"submitted","timestamp":"2026-02-14T15:00:00.000Z"},"final":false}
+
+data: {"kind":"status-update","taskId":"a2a-1707900000000-x7k2m9","contextId":"ctx-1707900000000-p3n8j4","status":{"state":"working","message":{"role":"agent","parts":[{"kind":"text","text":"Agent picked up the task"}]},"timestamp":"2026-02-14T15:00:03.000Z"},"final":false}
+
+data: {"kind":"artifact-update","taskId":"a2a-1707900000000-x7k2m9","contextId":"ctx-1707900000000-p3n8j4","artifact":{"artifactId":"art-001","name":"Landing Page Design","parts":[{"kind":"text","text":"## Design Specs\n..."}]}}
+
+data: {"kind":"status-update","taskId":"a2a-1707900000000-x7k2m9","contextId":"ctx-1707900000000-p3n8j4","status":{"state":"completed","message":{"role":"agent","parts":[{"kind":"text","text":"Landing page design complete"}]},"timestamp":"2026-02-14T15:00:15.000Z"},"final":true}
+```
+
+### Event Types
+
+| Event | Description |
+|-------|-------------|
+| `status-update` | Task state changed (submitted → working → completed) |
+| `artifact-update` | New artifact produced (code, designs, documents) |
+
+When `final: true`, the stream is complete and the connection closes.
+
+---
+
+## Task Management
+
+### Get a Task
+
+```bash
+curl https://bikinibottom.ai/a2a/tasks/a2a-1707900000000-x7k2m9
+```
+
+Query parameters:
+- `historyLength` — Number of history messages to include (default: all)
+
+### List Tasks
+
+```bash
+curl "https://bikinibottom.ai/a2a/tasks?limit=10&state=working"
+```
+
+Query parameters:
+- `limit` — Max results (default: 50)
+- `offset` — Pagination offset
+- `state` — Filter by state: `submitted`, `working`, `input-required`, `completed`, `failed`, `canceled`
+
+### Cancel a Task
+
+```bash
+curl -X POST https://bikinibottom.ai/a2a/tasks/a2a-1707900000000-x7k2m9/cancel
+```
+
+### Subscribe to Updates (SSE)
+
+```bash
+curl -N https://bikinibottom.ai/a2a/tasks/a2a-1707900000000-x7k2m9/subscribe
+```
+
+Receive SSE events for an existing task.
+
+---
+
+## Task Lifecycle
+
+Tasks flow through these states:
+
+```
+submitted → working → completed
+                   → failed
+                   → input-required → working → completed
+              → canceled
+              → rejected
+```
+
+| State | Description |
+|-------|-------------|
+| `submitted` | Task received, pending assignment |
+| `working` | Agent is actively working on it |
+| `input-required` | Agent needs more information |
+| `completed` | Task finished successfully |
+| `failed` | Task failed |
+| `canceled` | Task was canceled |
+| `rejected` | Task was rejected by the org |
+
+---
+
+## Domain Routing
+
+BikiniBottom automatically routes tasks to the right team based on keywords:
+
+| Domain | Keywords |
+|--------|----------|
+| Engineering | api, backend, frontend, code, build, deploy, test, database, server, sdk |
+| Marketing | landing, campaign, blog, seo, brand, content, social, press |
+| Finance | pricing, projection, revenue, budget, invoice, cost, billing |
+| Sales | demo, lead, outreach, pipeline, prospect, deal, contract |
+| Support | ticket, support, customer, help, resolve, issue |
+| HR | onboard, hire, recruit, team, culture, training |
+
+---
+
+## Code Examples
+
+### Python with `httpx`
+
+```python
+import httpx
+import json
+
+BASE = "https://bikinibottom.ai"
+
+# Discover
+card = httpx.get(f"{BASE}/.well-known/agent.json").json()
+print(f"Agent: {card['name']} — {len(card['skills'])} skills")
+
+# Send task
+response = httpx.post(f"{BASE}/a2a/message/send", json={
+    "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Build a REST API for user management"}]
+    }
+})
+task = response.json()
+print(f"Task {task['id']} — {task['status']['state']}")
+
+# Stream updates
+with httpx.stream("POST", f"{BASE}/a2a/message/stream", json={
+    "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Design a landing page"}]
+    }
+}) as stream:
+    for line in stream.iter_lines():
+        if line.startswith("data: "):
+            event = json.loads(line[6:])
+            print(f"[{event['kind']}] {event.get('status', {}).get('state', 'artifact')}")
+            if event.get("final"):
+                break
+```
+
+### TypeScript with `fetch`
+
+```typescript
+const BASE = "https://bikinibottom.ai";
+
+// Discover
+const card = await fetch(`${BASE}/.well-known/agent.json`).then(r => r.json());
+console.log(`Agent: ${card.name} — ${card.skills.length} skills`);
+
+// Send task
+const task = await fetch(`${BASE}/a2a/message/send`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    message: {
+      role: "user",
+      parts: [{ kind: "text", text: "Build a REST API" }],
+    },
+  }),
+}).then(r => r.json());
+
+console.log(`Task ${task.id} — ${task.status.state}`);
+```
+
+---
+
+## API Reference
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/.well-known/agent.json` | Control plane Agent Card |
+| `GET` | `/agents/{id}/.well-known/agent.json` | Per-agent Agent Card |
+| `POST` | `/a2a/message/send` | Send a task (synchronous) |
+| `POST` | `/a2a/message/stream` | Send a task (SSE streaming) |
+| `GET` | `/a2a/tasks` | List tasks |
+| `GET` | `/a2a/tasks/{id}` | Get task details |
+| `POST` | `/a2a/tasks/{id}/cancel` | Cancel a task |
+| `GET` | `/a2a/tasks/{id}/subscribe` | Subscribe to task updates (SSE) |

--- a/docs/protocols/index.md
+++ b/docs/protocols/index.md
@@ -1,0 +1,91 @@
+---
+title: Protocols
+layout: default
+nav_order: 3
+has_children: true
+permalink: /protocols/
+---
+
+# Protocols
+
+BikiniBottom is protocol-native. Every agent org you deploy speaks two open protocols out of the box — no adapters, no plugins, no configuration.
+
+---
+
+## Why Two Protocols?
+
+**A2A** and **MCP** solve different problems. You need both.
+
+| | A2A Protocol | MCP Tools |
+|---|---|---|
+| **Purpose** | Agent-to-agent communication | LLM-to-tool integration |
+| **Who talks** | Agents ↔ Agents | LLMs → Tools |
+| **Transport** | HTTP REST + SSE | JSON-RPC 2.0 over HTTP |
+| **Discovery** | `/.well-known/agent.json` | `initialize` → `tools/list` |
+| **Key operation** | Send task, stream updates | Call tool, get result |
+| **Spec** | [a2a-protocol.org](https://a2a-protocol.org) | [modelcontextprotocol.io](https://modelcontextprotocol.io) |
+| **Use when** | Another agent needs to delegate work | An LLM needs to take action |
+
+### A2A = Agents Talking to Agents
+
+The [A2A (Agent-to-Agent) protocol](https://a2a-protocol.org) by Google defines how autonomous agents discover each other, send tasks, and stream progress updates. Think of it as HTTP for the agent web.
+
+When you deploy BikiniBottom, every agent publishes an **Agent Card** at a well-known URL. Other agents (or humans with curl) can discover capabilities, send tasks, and subscribe to real-time updates.
+
+[A2A Protocol Guide →](a2a){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+
+### MCP = LLMs Using Tools
+
+The [MCP (Model Context Protocol)](https://modelcontextprotocol.io) by Anthropic defines how LLMs discover and call tools. It's the standard that Claude Desktop, Cursor, and other AI IDEs use to connect to external capabilities.
+
+BikiniBottom exposes **7 tools** via MCP: delegate tasks, list agents, get stats, and more. Connect your favorite AI client and let it orchestrate your agent org directly.
+
+[MCP Tools Guide →](mcp){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+
+---
+
+## How They Complement Each Other
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Your Agent Org                     │
+│                                                     │
+│  ┌─────────┐    ┌──────────┐    ┌───────────────┐  │
+│  │  A2A    │    │  Control  │    │  MCP Tool     │  │
+│  │  Server  │───▶│  Plane    │◀───│  Server       │  │
+│  └─────────┘    └──────────┘    └───────────────┘  │
+│       ▲              │               ▲              │
+│       │         ┌────┴────┐          │              │
+│       │         │  Model   │          │              │
+│       │         │  Router  │          │              │
+│       │         └────┬────┘          │              │
+│       │              │               │              │
+│       │    ┌─────────┴─────────┐     │              │
+│       │    │   Agent Runtime    │     │              │
+│       │    └───────────────────┘     │              │
+└───────┼──────────────────────────────┼──────────────┘
+        │                              │
+   Other Agents                  Claude Desktop
+   (A2A clients)                 Cursor, LLMs
+```
+
+- **External agent** sends task via A2A → routed to the right internal agent
+- **LLM client** calls MCP tool → task delegated to the org
+- Both feed into the same control plane, same router, same agents
+
+---
+
+## Try It Now
+
+```bash
+# A2A: Discover agents on the live demo
+curl https://bikinibottom.ai/.well-known/agent.json
+
+# MCP: List available tools
+curl -X POST https://bikinibottom.ai/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+Both protocols are enabled by default when you run `npx bikinibottom init`.
+{: .note }

--- a/docs/protocols/mcp.md
+++ b/docs/protocols/mcp.md
@@ -1,0 +1,409 @@
+---
+title: MCP Tools
+layout: default
+parent: Protocols
+nav_order: 2
+permalink: /protocols/mcp/
+---
+
+# MCP Tool Server
+{: .no_toc }
+
+BikiniBottom exposes 7 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io). Connect from Claude Desktop, Cursor, or any MCP-compatible client to orchestrate your agent org.
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## What is MCP?
+
+MCP (Model Context Protocol) is Anthropic's open standard for connecting LLMs to external tools and data. It uses JSON-RPC 2.0 over HTTP — the same protocol Claude Desktop and Cursor use to call tools.
+
+BikiniBottom implements MCP's **Streamable HTTP** transport at `POST /mcp`.
+
+---
+
+## Quick Start
+
+```bash
+# Initialize the connection
+curl -X POST https://bikinibottom.ai/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+
+# List available tools
+curl -X POST https://bikinibottom.ai/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+
+# Delegate a task
+curl -X POST https://bikinibottom.ai/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"delegate_task","arguments":{"task":"Design a landing page"}}}'
+```
+
+Try these against bikinibottom.ai right now — they work!
+{: .note }
+
+---
+
+## Available Tools
+
+| Tool | Description | Required Params |
+|------|-------------|----------------|
+| `delegate_task` | Send a task to the agent org for processing | `task` |
+| `list_agents` | List all agents in the organization | — |
+| `get_agent` | Get details about a specific agent | `agentId` |
+| `list_tasks` | List current tasks | — |
+| `get_task` | Get task details | `taskId` |
+| `send_message` | Send an ACP message to a specific agent | `agentId`, `message` |
+| `get_org_stats` | Get organization-wide statistics | — |
+
+---
+
+## Tool Details
+
+### `delegate_task`
+
+Send a task to the org. It gets routed to the right agent based on domain keywords.
+
+**Input Schema:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "task": { "type": "string", "description": "Task description" },
+    "priority": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"],
+      "description": "Task priority"
+    }
+  },
+  "required": ["task"]
+}
+```
+
+**Example:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "delegate_task",
+    "arguments": {
+      "task": "Build a REST API for user management",
+      "priority": "high"
+    }
+  }
+}
+```
+
+### `list_agents`
+
+List all agents, optionally filtered by status or domain.
+
+**Input Schema:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "status": { "type": "string", "enum": ["idle", "busy", "offline"], "description": "Filter by status" },
+    "domain": { "type": "string", "description": "Filter by domain" }
+  }
+}
+```
+
+### `get_agent`
+
+Get detailed information about a specific agent.
+
+**Input Schema:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "agentId": { "type": "string", "description": "Agent ID" }
+  },
+  "required": ["agentId"]
+}
+```
+
+### `list_tasks`
+
+List current tasks, optionally filtered.
+
+**Input Schema:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "status": { "type": "string", "description": "Filter by status" },
+    "assigneeId": { "type": "string", "description": "Filter by assignee" },
+    "limit": { "type": "number", "description": "Max results to return" }
+  }
+}
+```
+
+### `get_task`
+
+Get full details for a specific task.
+
+**Input Schema:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "taskId": { "type": "string", "description": "Task ID" }
+  },
+  "required": ["taskId"]
+}
+```
+
+### `send_message`
+
+Send an ACP (Agent Communication Protocol) message directly to an agent.
+
+**Input Schema:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "agentId": { "type": "string", "description": "Target agent ID" },
+    "message": { "type": "string", "description": "Message content" }
+  },
+  "required": ["agentId", "message"]
+}
+```
+
+### `get_org_stats`
+
+Get organization-wide statistics including agent counts, task metrics, and credit usage.
+
+**Input Schema:**
+
+```json
+{
+  "type": "object",
+  "properties": {}
+}
+```
+
+---
+
+## JSON-RPC Protocol
+
+All MCP communication uses JSON-RPC 2.0 over a single HTTP endpoint.
+
+### Initialize
+
+```bash
+curl -X POST https://bikinibottom.ai/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-03-26",
+      "capabilities": {},
+      "clientInfo": {
+        "name": "my-client",
+        "version": "1.0"
+      }
+    }
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {
+      "tools": { "listChanged": false }
+    },
+    "serverInfo": {
+      "name": "bikinibottom",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+### List Tools
+
+```bash
+curl -X POST https://bikinibottom.ai/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+```
+
+### Call a Tool
+
+```bash
+curl -X POST https://bikinibottom.ai/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/call",
+    "params": {
+      "name": "delegate_task",
+      "arguments": {
+        "task": "Write unit tests for the auth module",
+        "priority": "high"
+      }
+    }
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Task created: TSK-042 — 'Write unit tests for the auth module' assigned to Bug Hunter (testing)"
+      }
+    ],
+    "isError": false
+  }
+}
+```
+
+### Error Handling
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "error": {
+    "code": -32602,
+    "message": "Invalid params: \"name\" is required"
+  }
+}
+```
+
+| Error Code | Meaning |
+|-----------|---------|
+| `-32600` | Invalid Request (jsonrpc must be "2.0") |
+| `-32601` | Method not found |
+| `-32602` | Invalid params |
+
+---
+
+## Client Integration
+
+### Claude Desktop
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "bikinibottom": {
+      "url": "http://localhost:3333/mcp"
+    }
+  }
+}
+```
+
+For the live demo:
+
+```json
+{
+  "mcpServers": {
+    "bikinibottom": {
+      "url": "https://bikinibottom.ai/mcp"
+    }
+  }
+}
+```
+
+### Cursor
+
+In Cursor settings → MCP, add a new server:
+
+- **Name:** bikinibottom
+- **URL:** `http://localhost:3333/mcp`
+- **Transport:** Streamable HTTP
+
+### Custom Client (Python)
+
+```python
+import httpx
+
+MCP_URL = "http://localhost:3333/mcp"
+
+def mcp_call(method: str, params: dict = {}, id: int = 1):
+    response = httpx.post(MCP_URL, json={
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params,
+    })
+    return response.json()
+
+# Initialize
+init = mcp_call("initialize", {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {},
+    "clientInfo": {"name": "my-app", "version": "1.0"},
+})
+
+# List tools
+tools = mcp_call("tools/list", id=2)
+for tool in tools["result"]["tools"]:
+    print(f"  {tool['name']}: {tool['description']}")
+
+# Delegate a task
+result = mcp_call("tools/call", {
+    "name": "delegate_task",
+    "arguments": {"task": "Build a dashboard widget"},
+}, id=3)
+print(result["result"]["content"][0]["text"])
+```
+
+### Custom Client (TypeScript)
+
+```typescript
+const MCP_URL = "http://localhost:3333/mcp";
+
+async function mcpCall(method: string, params: Record<string, unknown> = {}, id = 1) {
+  const res = await fetch(MCP_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+  });
+  return res.json();
+}
+
+const tools = await mcpCall("tools/list", {}, 2);
+console.log(tools.result.tools.map((t: any) => t.name));
+
+const result = await mcpCall("tools/call", {
+  name: "get_org_stats",
+  arguments: {},
+}, 3);
+console.log(result.result.content[0].text);
+```


### PR DESCRIPTION
## What

Complete documentation overhaul covering all recently shipped features:

### New Pages
- **Protocols Overview** (`docs/protocols/index.md`) — Why A2A + MCP, comparison table, architecture diagram
- **A2A Protocol Guide** (`docs/protocols/a2a.md`) — Agent discovery, task sending, SSE streaming, task management, code examples (curl, Python, TypeScript)
- **MCP Tools Guide** (`docs/protocols/mcp.md`) — All 7 tools with schemas, JSON-RPC examples, Claude Desktop/Cursor integration guide
- **Model Router** (`docs/features/model-router.md`) — Level-based tiers, providers (Ollama/Groq/OpenRouter), fallback chains, cost tracking
- **Architecture** (`docs/architecture.md`) — System diagram, layered design, data flows, monorepo structure

### Updated Pages
- **Homepage** — Protocol support section, updated stats, new hero description
- **Getting Started** — 2-minute quickstart with A2A + MCP examples
- **CLI Reference** — Rewritten for `bikinibottom init/start/status/demo`, ORG.md format, config reference

All pages include live curl examples that work against bikinibottom.ai.