### PR TITLE
ci: add Cloudflare cache purge as final deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,3 +95,20 @@ jobs:
             echo "=== Container status ==="
             docker compose ps
             exit 1
+
+      - name: Purge Cloudflare cache
+        if: success()
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/bikinibottom
+            source .env
+            curl -sf -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+              -H "Authorization: Bearer ${CLOUDFLARE_PURGE_CACHE_API_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d '{"purge_everything":true}' > /dev/null
+            echo "✅ Cloudflare cache purged"


### PR DESCRIPTION
Reads CLOUDFLARE_ZONE_ID and CLOUDFLARE_PURGE_CACHE_API_TOKEN from VPS .env file and purges entire CF cache after successful deploy. No more stale JS/HTML.