### PR TITLE
ci: use repo secrets for CF cache purge instead of SSH

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,17 +98,9 @@ jobs:
 
       - name: Purge Cloudflare cache
         if: success()
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_SSH_KEY }}
-          script: |
-            set -e
-            cd /opt/bikinibottom
-            source .env
-            curl -sf -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
-              -H "Authorization: Bearer ${CLOUDFLARE_PURGE_CACHE_API_TOKEN}" \
-              -H "Content-Type: application/json" \
-              -d '{"purge_everything":true}' > /dev/null
-            echo "✅ Cloudflare cache purged"
+        run: |
+          curl -sf -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_PURGE_CACHE_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"purge_everything":true}' > /dev/null
+          echo "✅ Cloudflare cache purged"


### PR DESCRIPTION
Simpler — runs curl directly on the GH Actions runner using repo secrets instead of SSH-ing into VPS to read .env.