### PR TITLE
feat: add Simulated badges to model router UI

### DIFF
--- a/apps/dashboard/src/components/model-router-widget.tsx
+++ b/apps/dashboard/src/components/model-router-widget.tsx
@@ -59,8 +59,8 @@ export function ModelRouterWidget() {
   useEffect(() => {
     if (!isSandboxMode) return;
     const fetchData = () => {
-      fetch(`${SANDBOX_URL}/api/router/metrics`).then(r => r.json()).then(setMetrics).catch(() => {});
-      fetch(`${SANDBOX_URL}/api/router/decisions?limit=5`).then(r => r.json()).then(setDecisions).catch(() => {});
+      fetch(`${SANDBOX_URL}/api/router/metrics`).then(r => r.json()).then(setMetrics).catch(() => { /* ignore */ });
+      fetch(`${SANDBOX_URL}/api/router/decisions?limit=5`).then(r => r.json()).then(setDecisions).catch(() => { /* ignore */ });
     };
     fetchData();
     const interval = setInterval(fetchData, 3000);
@@ -78,7 +78,10 @@ export function ModelRouterWidget() {
     <div className="rounded-xl border border-white/5 bg-white/[0.02] p-4 space-y-3">
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-white/80">🔀 Model Router</h3>
-        <span className="text-xs text-white/40">{metrics.totalRequests} requests</span>
+        <div className="flex items-center gap-2">
+          <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/10 text-amber-400/70 border border-amber-500/15">sim</span>
+          <span className="text-xs text-white/40">{metrics.totalRequests} requests</span>
+        </div>
       </div>
 
       {/* Provider status */}

--- a/apps/dashboard/src/components/sandbox-activity-feed.tsx
+++ b/apps/dashboard/src/components/sandbox-activity-feed.tsx
@@ -118,6 +118,9 @@ export function SandboxActivityFeed({ taskId, agentId, maxEvents = 50 }: Sandbox
               {(event.type.startsWith('mcp') || event.message.includes('MCP')) && (
                 <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-violet-500/20 text-violet-400 border border-violet-500/30">MCP</span>
               )}
+              {event.type === 'router_decision' && (
+                <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-500/15 text-amber-400/70 border border-amber-500/20">SIM</span>
+              )}
               <span className="text-gray-300">{event.message}</span>
             </div>
           ))

--- a/apps/dashboard/src/pages/router.tsx
+++ b/apps/dashboard/src/pages/router.tsx
@@ -69,9 +69,9 @@ export function RouterPage() {
   useEffect(() => {
     if (!isSandboxMode) return;
     const fetchAll = () => {
-      fetch(`${SANDBOX_URL}/api/router/config`).then(r => r.json()).then(d => setProviders(d.providers || [])).catch(() => {});
-      fetch(`${SANDBOX_URL}/api/router/metrics`).then(r => r.json()).then(setMetrics).catch(() => {});
-      fetch(`${SANDBOX_URL}/api/router/decisions?limit=30`).then(r => r.json()).then(setDecisions).catch(() => {});
+      fetch(`${SANDBOX_URL}/api/router/config`).then(r => r.json()).then(d => setProviders(d.providers || [])).catch(() => { /* ignore */ });
+      fetch(`${SANDBOX_URL}/api/router/metrics`).then(r => r.json()).then(setMetrics).catch(() => { /* ignore */ });
+      fetch(`${SANDBOX_URL}/api/router/decisions?limit=30`).then(r => r.json()).then(setDecisions).catch(() => { /* ignore */ });
     };
     fetchAll();
     const interval = setInterval(fetchAll, 3000);
@@ -88,9 +88,14 @@ export function RouterPage() {
 
   return (
     <div className="space-y-6 p-4 md:p-6 max-w-7xl mx-auto">
-      <div>
-        <h1 className="text-2xl font-bold text-white">Model Router</h1>
-        <p className="text-sm text-white/50 mt-1">Intelligent LLM routing with provider fallback chains and cost tracking</p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Model Router</h1>
+          <p className="text-sm text-white/50 mt-1">Intelligent LLM routing with provider fallback chains and cost tracking</p>
+        </div>
+        <span className="shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium bg-amber-500/10 text-amber-400 border border-amber-500/20">
+          ⚡ Simulated
+        </span>
       </div>
 
       {/* Cost savings banner */}


### PR DESCRIPTION
Makes it clear that routing decisions, costs, and fallbacks are simulated for the demo — not real API calls.

- **Router page**: amber 'Simulated' pill in header
- **Dashboard widget**: subtle 'sim' badge
- **Activity feed**: 'SIM' badge on router_decision events (matches A2A/MCP badge style)
- **Bonus**: Fixed all 5 remaining lint errors (0 errors now)