### PR TITLE
fix: center character avatars in circles sitewide

### DIFF
--- a/apps/dashboard/src/components/agent-avatar.tsx
+++ b/apps/dashboard/src/components/agent-avatar.tsx
@@ -102,7 +102,7 @@ export function AgentAvatar({
         ...(showRing && !presenceStatus ? { '--tw-ring-color': accentColor } as React.CSSProperties : {}),
       }}
     >
-      <AvatarImage src={avatarUrlProp} alt={name || agentId} className="object-cover" />
+      <AvatarImage src={avatarUrlProp} alt={name || agentId} className="object-contain p-0.5" style={{ backgroundColor: bgColor }} />
       <AvatarFallback
         className={cn('flex items-center justify-center', emojiSizes[size])}
         style={{ backgroundColor: bgColor }}

--- a/apps/dashboard/src/components/agent-heartbeat.tsx
+++ b/apps/dashboard/src/components/agent-heartbeat.tsx
@@ -78,7 +78,7 @@ export function AgentHeartbeat({ agentId, level, status, size = 'md', showPulse 
           ease: 'easeInOut',
         }}
       >
-        {avatarUrl ? <img src={avatarUrl} alt="" className="w-full h-full rounded-full object-cover" /> : (avatar || '🤖')}
+        {avatarUrl ? <img src={avatarUrl} alt="" className="w-full h-full rounded-full object-contain p-0.5" style={{ backgroundColor: darkenForBackground(avatarColor || '#71717a') }} /> : (avatar || '🤖')}
       </motion.span>
 
       {/* Status indicator dot */}

--- a/apps/dashboard/src/components/agent-network.tsx
+++ b/apps/dashboard/src/components/agent-network.tsx
@@ -354,7 +354,7 @@ function AgentNode({ data, selected }: NodeProps) {
             const avatarImg = nodeData.isHuman ? (
               <span className="text-lg leading-none">👤</span>
             ) : nodeData.avatarUrl ? (
-              <img src={nodeData.avatarUrl} alt={nodeData.label} className="w-8 h-8 rounded-full object-cover" />
+              <img src={nodeData.avatarUrl} alt={nodeData.label} className="w-8 h-8 rounded-full object-contain" style={{ backgroundColor: darkenForBackground(avatarColor) }} />
             ) : (
               <span
                 className="w-8 h-8 rounded-full inline-flex items-center justify-center text-xl leading-none select-none"
@@ -404,7 +404,7 @@ function AgentNode({ data, selected }: NodeProps) {
                   <div className="absolute inset-0 flex items-center justify-center">
                     <div className="rounded-full overflow-hidden" style={{ width: avatarSize, height: avatarSize }}>
                       {nodeData.avatarUrl ? (
-                        <img src={nodeData.avatarUrl} alt={nodeData.label} className="w-full h-full object-cover" />
+                        <img src={nodeData.avatarUrl} alt={nodeData.label} className="w-full h-full object-contain" style={{ backgroundColor: darkenForBackground(avatarColor) }} />
                       ) : (
                         <span
                           className="w-full h-full inline-flex items-center justify-center text-lg leading-none select-none"

--- a/apps/dashboard/src/components/org-chart.tsx
+++ b/apps/dashboard/src/components/org-chart.tsx
@@ -278,7 +278,7 @@ function AgentOrgNode({ data }: NodeProps) {
         )}
 
         {d.avatarUrl ? (
-          <img src={d.avatarUrl} alt={d.label} className="w-8 h-8 rounded-full flex-shrink-0 object-cover" />
+          <img src={d.avatarUrl} alt={d.label} className="w-8 h-8 rounded-full flex-shrink-0 object-contain p-0.5" style={{ backgroundColor: avatarBg }} />
         ) : (
           <span
             className="w-8 h-8 rounded-full flex-shrink-0 inline-flex items-center justify-center text-base"

--- a/apps/dashboard/src/pages/messages.tsx
+++ b/apps/dashboard/src/pages/messages.tsx
@@ -36,7 +36,7 @@ function InlineAvatar({ agentId, agents, className = 'w-5 h-5', fontSize = 'text
   const avatarColor = (agent as any)?.avatarColor || '#71717a';
   const avatarUrl = (agent as any)?.avatarUrl;
   if (avatarUrl) {
-    return <img src={avatarUrl} alt={agent?.name} className={`rounded-full object-cover ${className}`} />;
+    return <img src={avatarUrl} alt={agent?.name} className={`rounded-full object-contain p-0.5 ${className}`} style={{ backgroundColor: darkenForBackground(avatarColor) }} />;
   }
   return (
     <span

--- a/apps/dashboard/src/pages/tasks.tsx
+++ b/apps/dashboard/src/pages/tasks.tsx
@@ -189,7 +189,7 @@ function TaskCard({ task, onClick, compact, agentMap }: TaskCardProps) {
                     {(() => { const a = agentMap.get(task.assigneeId!); return (
                     <div className="w-4 h-4 rounded-full flex items-center justify-center text-[10px]"
                       style={{ backgroundColor: darkenForBackground(a?.avatarColor || '#71717a') }}>
-                      {a?.avatarUrl ? <img src={a.avatarUrl} alt="" className="w-full h-full rounded-full object-cover" /> : (a?.avatar || '🤖')}
+                      {a?.avatarUrl ? <img src={a.avatarUrl} alt="" className="w-full h-full rounded-full object-contain" /> : (a?.avatar || '🤖')}
                     </div>); })()}
                     <span className="truncate max-w-[100px]">{task.assignee.name}</span>
                   </div>
@@ -347,7 +347,7 @@ function TaskDetailSidebar({ task, onClose, agentMap }: TaskDetailSidebarProps) 
                   {(() => { const a = agentMap.get(task.assigneeId!); return (
                   <div className="w-6 h-6 rounded-full flex items-center justify-center text-sm"
                     style={{ backgroundColor: darkenForBackground(a?.avatarColor || '#71717a') }}>
-                    {a?.avatarUrl ? <img src={a.avatarUrl} alt="" className="w-full h-full rounded-full object-cover" /> : (a?.avatar || '🤖')}
+                    {a?.avatarUrl ? <img src={a.avatarUrl} alt="" className="w-full h-full rounded-full object-contain" /> : (a?.avatar || '🤖')}
                   </div>); })()}
                   <span className="text-sm font-medium">{task.assignee.name}</span>
                 </div>
@@ -522,7 +522,7 @@ function ListView({ tasks, onTaskClick, selectedTaskId, agentMap }: ListViewProp
                       {(() => { const a = agentMap.get(task.assigneeId!); return (
                       <div className="w-5 h-5 rounded-full flex items-center justify-center text-xs"
                         style={{ backgroundColor: darkenForBackground(a?.avatarColor || '#71717a') }}>
-                        {a?.avatarUrl ? <img src={a.avatarUrl} alt="" className="w-full h-full rounded-full object-cover" /> : (a?.avatar || '🤖')}
+                        {a?.avatarUrl ? <img src={a.avatarUrl} alt="" className="w-full h-full rounded-full object-contain" /> : (a?.avatar || '🤖')}
                       </div>); })()}
                       <span className="text-muted-foreground truncate">
                         {task.assignee.name}


### PR DESCRIPTION
Character PNGs aren't centered within their 96x96 bounds (e.g. Karen sits upper-left). `object-cover` crops them off-center in small circles.

**Fix:** `object-contain` + `p-0.5` padding + dark background fill. Character is fully visible and centered in every context.

**Files:** agent-avatar, agent-network, agent-heartbeat, org-chart, tasks, messages