### PR TITLE
feat: TanStack Start website at apps/website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY tools/sandbox/org/ ./tools/sandbox/org/
 
 ENV VITE_SANDBOX_MODE=true
 RUN pnpm nx run dashboard:build --configuration=production
+RUN pnpm nx run website:build
 
 # Stage 2: Minimal runtime
 FROM node:24-alpine AS runtime
@@ -36,9 +37,11 @@ COPY tools/sandbox/src/ ./src/
 COPY tools/sandbox/ORG.md ./
 COPY tools/sandbox/org/ ./org/
 
-# Copy built dashboard
+# Copy built dashboard and website
 COPY --from=build /app/dist/apps/dashboard ./dashboard-dist
+COPY --from=build /app/dist/apps/website ./website-dist
 
+ENV WEBSITE_DIR=/app/website-dist
 ENV NODE_ENV=production
 ENV SANDBOX_PORT=3333
 ENV SERVE_DASHBOARD=1

--- a/apps/website/app/components/docs-layout.tsx
+++ b/apps/website/app/components/docs-layout.tsx
@@ -1,0 +1,88 @@
+import { Link } from "@tanstack/react-router";
+import { useState, type ReactNode } from "react";
+
+const sidebar = [
+  { label: "Overview", to: "/docs" },
+  { label: "Getting Started", to: "/docs/getting-started" },
+  {
+    label: "Protocols",
+    children: [
+      { label: "A2A Protocol", to: "/docs/protocols/a2a" },
+      { label: "MCP Tools", to: "/docs/protocols/mcp" },
+    ],
+  },
+  {
+    label: "Features",
+    children: [
+      { label: "Dashboard", to: "/docs/features/dashboard" },
+      { label: "Model Router", to: "/docs/features/model-router" },
+    ],
+  },
+];
+
+export function DocsLayout({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-10">
+      <div className="md:hidden mb-4">
+        <button
+          onClick={() => setOpen(!open)}
+          className="rounded-lg border border-white/10 px-4 py-2 text-sm text-slate-300"
+        >
+          ☰ Menu
+        </button>
+      </div>
+      <div className="flex gap-10">
+        <aside className={`w-56 shrink-0 ${open ? "block" : "hidden"} md:block`}>
+          <nav className="sticky top-20 space-y-1">
+            {sidebar.map((item) =>
+              "children" in item ? (
+                <div key={item.label} className="mt-4">
+                  <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    {item.label}
+                  </div>
+                  {item.children.map((child) => (
+                    <Link
+                      key={child.to}
+                      to={child.to}
+                      className="block rounded-md px-3 py-1.5 text-sm text-slate-400 transition hover:bg-white/5 hover:text-cyan-400 [&.active]:text-cyan-400 [&.active]:bg-cyan-500/10"
+                    >
+                      {child.label}
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  className="block rounded-md px-3 py-1.5 text-sm text-slate-400 transition hover:bg-white/5 hover:text-cyan-400 [&.active]:text-cyan-400 [&.active]:bg-cyan-500/10"
+                >
+                  {item.label}
+                </Link>
+              )
+            )}
+          </nav>
+        </aside>
+        <div className="min-w-0 flex-1">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CodeBlock({ children, title }: { children: string; title?: string }) {
+  return (
+    <div className="terminal my-4">
+      {title && (
+        <div className="terminal-header">
+          <span className="text-xs text-slate-500">{title}</span>
+        </div>
+      )}
+      <pre className="overflow-x-auto p-4 text-sm leading-relaxed text-slate-300">
+        <code>{children}</code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/website/app/components/feature-card.tsx
+++ b/apps/website/app/components/feature-card.tsx
@@ -1,0 +1,16 @@
+interface FeatureCardProps {
+  emoji: string;
+  title: string;
+  description: string;
+  color: string;
+}
+
+export function FeatureCard({ emoji, title, description, color }: FeatureCardProps) {
+  return (
+    <div className="group rounded-xl border border-white/5 bg-white/[0.02] p-6 transition hover:border-white/10 hover:bg-white/[0.04]">
+      <div className="mb-3 text-3xl">{emoji}</div>
+      <h3 className={`mb-2 text-lg font-semibold ${color}`}>{title}</h3>
+      <p className="text-sm leading-relaxed text-slate-400">{description}</p>
+    </div>
+  );
+}

--- a/apps/website/app/components/footer.tsx
+++ b/apps/website/app/components/footer.tsx
@@ -1,0 +1,43 @@
+export function Footer() {
+  return (
+    <footer className="border-t border-white/5 bg-navy-950 py-12">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="grid gap-8 md:grid-cols-4">
+          <div>
+            <div className="mb-3 text-lg font-bold">
+              <span className="mr-2">🍍</span>
+              <span className="gradient-text">BikiniBottom</span>
+            </div>
+            <p className="text-sm text-slate-500">The control plane your AI agents deserve.</p>
+          </div>
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-slate-300">Product</h4>
+            <ul className="space-y-2 text-sm text-slate-500">
+              <li><a href="/app/" className="hover:text-cyan-400 transition">Dashboard</a></li>
+              <li><a href="/docs/getting-started" className="hover:text-cyan-400 transition">Getting Started</a></li>
+              <li><a href="/docs/protocols/a2a" className="hover:text-cyan-400 transition">A2A Protocol</a></li>
+              <li><a href="/docs/protocols/mcp" className="hover:text-cyan-400 transition">MCP Tools</a></li>
+            </ul>
+          </div>
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-slate-300">Features</h4>
+            <ul className="space-y-2 text-sm text-slate-500">
+              <li><a href="/docs/features/model-router" className="hover:text-cyan-400 transition">Model Router</a></li>
+              <li><a href="/docs/features/dashboard" className="hover:text-cyan-400 transition">Live Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-slate-300">Community</h4>
+            <ul className="space-y-2 text-sm text-slate-500">
+              <li><a href="https://github.com/openspawn/openspawn" target="_blank" rel="noopener" className="hover:text-cyan-400 transition">GitHub</a></li>
+              <li><span className="text-slate-600">MIT License</span></li>
+            </ul>
+          </div>
+        </div>
+        <div className="mt-10 border-t border-white/5 pt-6 text-center text-xs text-slate-600">
+          © {new Date().getFullYear()} OpenSpawn. Open source under MIT.
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/website/app/components/nav.tsx
+++ b/apps/website/app/components/nav.tsx
@@ -1,0 +1,36 @@
+import { Link } from "@tanstack/react-router";
+
+export function Nav() {
+  return (
+    <nav className="sticky top-0 z-50 border-b border-white/5 bg-navy-950/80 backdrop-blur-xl">
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <Link to="/" className="flex items-center gap-2 text-lg font-bold">
+          <span className="text-2xl">🍍</span>
+          <span className="gradient-text">BikiniBottom</span>
+        </Link>
+        <div className="hidden items-center gap-8 md:flex">
+          <Link to="/docs" className="text-sm text-slate-400 transition hover:text-cyan-400">
+            Docs
+          </Link>
+          <Link to="/docs/protocols/a2a" className="text-sm text-slate-400 transition hover:text-cyan-400">
+            Protocols
+          </Link>
+          <a
+            href="https://github.com/openspawn/openspawn"
+            target="_blank"
+            rel="noopener"
+            className="text-sm text-slate-400 transition hover:text-cyan-400"
+          >
+            GitHub
+          </a>
+        </div>
+        <a
+          href="/app/"
+          className="rounded-lg bg-cyan-500/10 px-4 py-2 text-sm font-medium text-cyan-400 ring-1 ring-cyan-500/20 transition hover:bg-cyan-500/20"
+        >
+          Launch Demo →
+        </a>
+      </div>
+    </nav>
+  );
+}

--- a/apps/website/app/components/protocol-badge.tsx
+++ b/apps/website/app/components/protocol-badge.tsx
@@ -1,0 +1,17 @@
+interface ProtocolBadgeProps {
+  label: string;
+  variant?: "protocol" | "core";
+}
+
+export function ProtocolBadge({ label, variant = "protocol" }: ProtocolBadgeProps) {
+  const styles =
+    variant === "protocol"
+      ? "border-cyan-500/20 bg-cyan-500/10 text-cyan-400"
+      : "border-violet-500/20 bg-violet-500/10 text-violet-400";
+
+  return (
+    <span className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium ${styles}`}>
+      {label}
+    </span>
+  );
+}

--- a/apps/website/app/components/terminal-demo.tsx
+++ b/apps/website/app/components/terminal-demo.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+
+const lines = [
+  { text: "$ npx bikinibottom init my-reef", color: "text-slate-300", delay: 0 },
+  { text: "🍍 Created ORG.md, config, .gitignore", color: "text-emerald-400", delay: 800 },
+  { text: "", color: "", delay: 1200 },
+  { text: "$ npx bikinibottom start", color: "text-slate-300", delay: 1400 },
+  { text: "🌐 Server running at http://localhost:3333", color: "text-cyan-400", delay: 2200 },
+  { text: "🔗 A2A: /.well-known/agent.json", color: "text-violet-400", delay: 2600 },
+  { text: "🔌 MCP: /mcp (7 tools)", color: "text-amber-400", delay: 3000 },
+  { text: "🔀 Router: 3 providers configured", color: "text-emerald-400", delay: 3400 },
+  { text: "📊 Dashboard: http://localhost:3333", color: "text-cyan-400", delay: 3800 },
+];
+
+export function TerminalDemo() {
+  const [visibleLines, setVisibleLines] = useState(0);
+
+  useEffect(() => {
+    const timers = lines.map((line, i) =>
+      setTimeout(() => setVisibleLines(i + 1), line.delay)
+    );
+    return () => timers.forEach(clearTimeout);
+  }, []);
+
+  return (
+    <div className="terminal glow-cyan mx-auto max-w-2xl">
+      <div className="terminal-header">
+        <div className="terminal-dot bg-red-500/80" />
+        <div className="terminal-dot bg-yellow-500/80" />
+        <div className="terminal-dot bg-green-500/80" />
+      </div>
+      <div className="p-5 min-h-[260px]">
+        {lines.slice(0, visibleLines).map((line, i) => (
+          <div key={i} className={`${line.color} ${i === visibleLines - 1 ? "animate-fade-in-up" : ""}`}>
+            {line.text || "\u00A0"}
+          </div>
+        ))}
+        {visibleLines < lines.length && (
+          <span className="cursor-blink text-slate-500">▋</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/website/app/main.tsx
+++ b/apps/website/app/main.tsx
@@ -1,0 +1,19 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { RouterProvider, createRouter } from "@tanstack/react-router";
+import { routeTree } from "./route-tree";
+import "./styles/globals.css";
+
+const router = createRouter({ routeTree, basePath: "/" });
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <RouterProvider router={router} />
+  </StrictMode>
+);

--- a/apps/website/app/route-tree.tsx
+++ b/apps/website/app/route-tree.tsx
@@ -1,0 +1,69 @@
+import { createRootRoute, createRoute } from "@tanstack/react-router";
+import { RootLayout } from "./routes/__root";
+import { LandingPage } from "./routes/index";
+import { DocsIndex } from "./routes/docs/index";
+import { GettingStarted } from "./routes/docs/getting-started";
+import { A2AProtocol } from "./routes/docs/protocols/a2a";
+import { MCPTools } from "./routes/docs/protocols/mcp";
+import { DashboardDocs } from "./routes/docs/features/dashboard";
+import { ModelRouterDocs } from "./routes/docs/features/model-router";
+
+const rootRoute = createRootRoute({ component: RootLayout });
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: LandingPage,
+});
+
+const docsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/docs",
+});
+
+const docsIndexRoute = createRoute({
+  getParentRoute: () => docsRoute,
+  path: "/",
+  component: DocsIndex,
+});
+
+const gettingStartedRoute = createRoute({
+  getParentRoute: () => docsRoute,
+  path: "/getting-started",
+  component: GettingStarted,
+});
+
+const a2aRoute = createRoute({
+  getParentRoute: () => docsRoute,
+  path: "/protocols/a2a",
+  component: A2AProtocol,
+});
+
+const mcpRoute = createRoute({
+  getParentRoute: () => docsRoute,
+  path: "/protocols/mcp",
+  component: MCPTools,
+});
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => docsRoute,
+  path: "/features/dashboard",
+  component: DashboardDocs,
+});
+
+const modelRouterRoute = createRoute({
+  getParentRoute: () => docsRoute,
+  path: "/features/model-router",
+  component: ModelRouterDocs,
+});
+
+const docsRouteTree = docsRoute.addChildren([
+  docsIndexRoute,
+  gettingStartedRoute,
+  a2aRoute,
+  mcpRoute,
+  dashboardRoute,
+  modelRouterRoute,
+]);
+
+export const routeTree = rootRoute.addChildren([indexRoute, docsRouteTree]);

--- a/apps/website/app/routes/__root.tsx
+++ b/apps/website/app/routes/__root.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from "@tanstack/react-router";
+import { Nav } from "../components/nav";
+import { Footer } from "../components/footer";
+
+export function RootLayout() {
+  return (
+    <div className="min-h-screen flex flex-col bg-navy-950 text-slate-200">
+      <Nav />
+      <main className="flex-1">
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/website/app/routes/docs/features/dashboard.tsx
+++ b/apps/website/app/routes/docs/features/dashboard.tsx
@@ -1,0 +1,46 @@
+import { DocsLayout, CodeBlock } from "../../../components/docs-layout";
+
+export function DashboardDocs() {
+  return (
+    <DocsLayout>
+      <h1 className="mb-2 text-4xl font-bold text-slate-100">Dashboard</h1>
+      <p className="mb-8 text-lg text-slate-400">
+        Real-time React dashboard with network graph, task timeline, cost charts, and agent monitoring.
+      </p>
+
+      <div className="mb-8 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        💡 See it live at <a href="https://bikinibottom.ai" className="underline">bikinibottom.ai</a>
+      </div>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Overview</h2>
+      <p className="mb-4 text-slate-400">The dashboard starts automatically when you run <code className="rounded bg-white/10 px-1.5 py-0.5 text-cyan-400">npx bikinibottom start</code>. It provides:</p>
+      <ul className="mb-6 ml-4 list-disc space-y-2 text-slate-400">
+        <li><strong className="text-slate-200">Agent network graph</strong> — Visualize the org hierarchy and active connections</li>
+        <li><strong className="text-slate-200">Task timeline</strong> — Real-time feed of task creation, delegation, and completion</li>
+        <li><strong className="text-slate-200">Cost charts</strong> — Per-provider spending, savings calculator</li>
+        <li><strong className="text-slate-200">Agent status</strong> — Idle, busy, offline for every agent</li>
+        <li><strong className="text-slate-200">Router metrics</strong> — Provider health, latency, fallback frequency</li>
+      </ul>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Pages</h2>
+      <h3 className="mt-6 mb-2 text-lg font-semibold text-slate-200">Home</h3>
+      <p className="mb-4 text-slate-400">Main view with agent network graph showing live task flows. Agents light up when working.</p>
+      <h3 className="mt-6 mb-2 text-lg font-semibold text-slate-200">Tasks</h3>
+      <p className="mb-4 text-slate-400">All tasks with filtering by state (submitted, working, completed, failed). Click any task for full delegation chain.</p>
+      <h3 className="mt-6 mb-2 text-lg font-semibold text-slate-200">Agents</h3>
+      <p className="mb-4 text-slate-400">Grid view of all agents showing level, domain, status, and current task.</p>
+      <h3 className="mt-6 mb-2 text-lg font-semibold text-slate-200">Router</h3>
+      <p className="mb-4 text-slate-400">Provider status dashboard: online/offline, rate limits, cost breakdown, and latency distribution.</p>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">API Endpoints</h2>
+      <CodeBlock title="bash">{`# Org stats
+curl https://bikinibottom.ai/api/org/stats
+
+# Agent list
+curl https://bikinibottom.ai/api/agents
+
+# Task list
+curl https://bikinibottom.ai/api/tasks`}</CodeBlock>
+    </DocsLayout>
+  );
+}

--- a/apps/website/app/routes/docs/features/model-router.tsx
+++ b/apps/website/app/routes/docs/features/model-router.tsx
@@ -1,0 +1,61 @@
+import { DocsLayout, CodeBlock } from "../../../components/docs-layout";
+
+export function ModelRouterDocs() {
+  return (
+    <DocsLayout>
+      <h1 className="mb-2 text-4xl font-bold text-slate-100">Model Router</h1>
+      <p className="mb-8 text-lg text-slate-400">
+        Smart LLM routing across Ollama, Groq, and OpenRouter with automatic fallbacks and cost tracking.
+      </p>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Overview</h2>
+      <p className="mb-4 text-slate-400">
+        Not every agent needs GPT-4. A Level 3 worker writing unit tests uses a local 7B model. A Level 10 executive making strategic decisions gets Claude 3.5 Sonnet.
+      </p>
+      <CodeBlock>{`Agent Level → Tier Selection → Provider → Model → Fallback if needed`}</CodeBlock>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Routing Tiers</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left">
+          <thead>
+            <tr className="border-b border-white/10 text-slate-400">
+              <th className="py-2 pr-4 font-medium">Agent Level</th>
+              <th className="py-2 pr-4 font-medium">Tier</th>
+              <th className="py-2 pr-4 font-medium">Provider</th>
+              <th className="py-2 pr-4 font-medium">Model</th>
+              <th className="py-2 font-medium">Cost</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-300">
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-4">L9–L10</td><td className="py-2 pr-4">Executive</td><td className="py-2 pr-4">OpenRouter</td><td className="py-2 pr-4 text-slate-400">Claude 3.5, GPT-4o</td><td className="py-2 text-amber-400">$$$</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-4">L7–L8</td><td className="py-2 pr-4">Lead</td><td className="py-2 pr-4">Groq</td><td className="py-2 pr-4 text-slate-400">Llama 3.1 70B</td><td className="py-2 text-amber-400">$</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-4">L1–L6</td><td className="py-2 pr-4">Worker</td><td className="py-2 pr-4">Ollama</td><td className="py-2 pr-4 text-slate-400">Qwen 2.5 7B</td><td className="py-2 text-emerald-400">Free</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Fallback Chains</h2>
+      <p className="mb-4 text-slate-400">When a provider is unavailable, the router automatically falls back:</p>
+      <CodeBlock>{`L9-10: OpenRouter → Groq (70B) → Ollama
+L7-8:  Groq (70B) → OpenRouter → Ollama
+L1-6:  Ollama (60%) / Groq 8B (40%) → OpenRouter (cheapest)`}</CodeBlock>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Providers</h2>
+      <h3 className="mt-6 mb-2 text-lg font-semibold text-slate-200">Ollama (Local)</h3>
+      <p className="mb-4 text-slate-400">$0 cost, 40–150ms latency. Runs Qwen 2.5 7B on your hardware. Best for L1–L6 workers.</p>
+      <h3 className="mt-6 mb-2 text-lg font-semibold text-slate-200">Groq</h3>
+      <p className="mb-4 text-slate-400">$0.05–$0.79/1K tokens, 80–300ms latency. Llama 3.1 8B/70B. Best for L7–L8 leads.</p>
+      <h3 className="mt-6 mb-2 text-lg font-semibold text-slate-200">OpenRouter</h3>
+      <p className="mb-4 text-slate-400">$2.50–$15/1K tokens, 200–800ms. Claude 3.5 Sonnet, GPT-4o. Best for L9–L10 executives.</p>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Metrics</h2>
+      <CodeBlock title="bash">{`curl https://bikinibottom.ai/api/router/metrics`}</CodeBlock>
+    </DocsLayout>
+  );
+}

--- a/apps/website/app/routes/docs/getting-started.tsx
+++ b/apps/website/app/routes/docs/getting-started.tsx
@@ -1,0 +1,57 @@
+import { DocsLayout, CodeBlock } from "../../components/docs-layout";
+
+export function GettingStarted() {
+  return (
+    <DocsLayout>
+      <h1 className="mb-2 text-4xl font-bold text-slate-100">Getting Started</h1>
+      <p className="mb-8 text-lg text-slate-400">
+        Get BikiniBottom running in 2 minutes with the live demo or locally via CLI.
+      </p>
+
+      <div className="mb-8 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        💡 Visit <a href="https://bikinibottom.ai" className="underline">bikinibottom.ai</a> — agents running right now. No setup required.
+      </div>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Quick Start (Local)</h2>
+
+      <h3 className="mt-6 mb-3 text-lg font-semibold text-slate-200">1. Scaffold your project</h3>
+      <CodeBlock title="bash">{`npx bikinibottom init my-reef\ncd my-reef`}</CodeBlock>
+      <p className="text-slate-400">This creates <code className="rounded bg-white/10 px-1.5 py-0.5 text-cyan-400">ORG.md</code> and <code className="rounded bg-white/10 px-1.5 py-0.5 text-cyan-400">bikinibottom.config.json</code>.</p>
+
+      <h3 className="mt-6 mb-3 text-lg font-semibold text-slate-200">2. Start the server</h3>
+      <CodeBlock title="bash">{`npx bikinibottom start`}</CodeBlock>
+      <p className="text-slate-400">Open <code className="rounded bg-white/10 px-1.5 py-0.5 text-cyan-400">http://localhost:3333</code> — your dashboard is live.</p>
+
+      <h3 className="mt-6 mb-3 text-lg font-semibold text-slate-200">3. Discover your agents via A2A</h3>
+      <CodeBlock title="bash">{`curl http://localhost:3333/.well-known/agent.json`}</CodeBlock>
+      <CodeBlock title="Response">{`{
+  "name": "My Reef",
+  "url": "http://localhost:3333",
+  "protocolVersion": "0.3",
+  "capabilities": { "streaming": true },
+  "skills": [{ "id": "task-delegation", "name": "Task Delegation" }]
+}`}</CodeBlock>
+
+      <h3 className="mt-6 mb-3 text-lg font-semibold text-slate-200">4. Send a task</h3>
+      <CodeBlock title="bash">{`curl -X POST http://localhost:3333/a2a/message/send \\
+  -H 'Content-Type: application/json' \\
+  -d '{
+    "message": {
+      "role": "user",
+      "parts": [{ "kind": "text", "text": "Build a REST API for user management" }]
+    }
+  }'`}</CodeBlock>
+
+      <h3 className="mt-6 mb-3 text-lg font-semibold text-slate-200">5. Use as MCP tool server</h3>
+      <CodeBlock title="bash">{`curl -X POST http://localhost:3333/mcp \\
+  -H 'Content-Type: application/json' \\
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'`}</CodeBlock>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Try the live demo</h2>
+      <CodeBlock title="bash">{`curl https://bikinibottom.ai/.well-known/agent.json`}</CodeBlock>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Customize your organization</h2>
+      <p className="text-slate-400">Edit <code className="rounded bg-white/10 px-1.5 py-0.5 text-cyan-400">ORG.md</code> to define your agents, teams, and hierarchy. Changes are picked up on restart.</p>
+    </DocsLayout>
+  );
+}

--- a/apps/website/app/routes/docs/index.tsx
+++ b/apps/website/app/routes/docs/index.tsx
@@ -1,0 +1,34 @@
+import { DocsLayout } from "../../components/docs-layout";
+import { Link } from "@tanstack/react-router";
+
+const sections = [
+  { to: "/docs/getting-started", emoji: "🚀", title: "Getting Started", desc: "Get BikiniBottom running in 2 minutes." },
+  { to: "/docs/protocols/a2a", emoji: "🔗", title: "A2A Protocol", desc: "Agent-to-Agent discovery, tasks, and streaming." },
+  { to: "/docs/protocols/mcp", emoji: "🔌", title: "MCP Tools", desc: "7 tools via Streamable HTTP." },
+  { to: "/docs/features/dashboard", emoji: "📊", title: "Dashboard", desc: "Real-time agent visualization." },
+  { to: "/docs/features/model-router", emoji: "🔀", title: "Model Router", desc: "Smart LLM routing with fallbacks." },
+];
+
+export function DocsIndex() {
+  return (
+    <DocsLayout>
+      <h1 className="mb-2 text-4xl font-bold text-slate-100">Documentation</h1>
+      <p className="mb-10 text-lg text-slate-400">
+        Learn how to set up, configure, and integrate with BikiniBottom.
+      </p>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {sections.map((s) => (
+          <Link
+            key={s.to}
+            to={s.to}
+            className="group rounded-xl border border-white/5 bg-white/[0.02] p-5 transition hover:border-cyan-500/20 hover:bg-cyan-500/5 no-underline"
+          >
+            <div className="mb-2 text-2xl">{s.emoji}</div>
+            <div className="font-semibold text-slate-200 group-hover:text-cyan-400">{s.title}</div>
+            <div className="text-sm text-slate-500">{s.desc}</div>
+          </Link>
+        ))}
+      </div>
+    </DocsLayout>
+  );
+}

--- a/apps/website/app/routes/docs/protocols/a2a.tsx
+++ b/apps/website/app/routes/docs/protocols/a2a.tsx
@@ -1,0 +1,57 @@
+import { DocsLayout, CodeBlock } from "../../../components/docs-layout";
+
+export function A2AProtocol() {
+  return (
+    <DocsLayout>
+      <h1 className="mb-2 text-4xl font-bold text-slate-100">A2A Protocol</h1>
+      <p className="mb-8 text-lg text-slate-400">
+        BikiniBottom implements Google's Agent-to-Agent protocol v0.3 for agent discovery, task sending, and streaming.
+      </p>
+
+      <div className="mb-8 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        💡 Try it live: <code className="rounded bg-white/10 px-1.5 py-0.5">curl https://bikinibottom.ai/.well-known/agent.json</code>
+      </div>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Agent Discovery</h2>
+      <p className="mb-4 text-slate-400">Every BikiniBottom instance publishes an Agent Card at <code className="rounded bg-white/10 px-1.5 py-0.5 text-cyan-400">/.well-known/agent.json</code>:</p>
+      <CodeBlock title="bash">{`curl https://bikinibottom.ai/.well-known/agent.json`}</CodeBlock>
+      <CodeBlock title="Response">{`{
+  "name": "BikiniBottom HQ",
+  "description": "Multi-agent coordination control plane",
+  "url": "https://bikinibottom.ai",
+  "version": "1.0.0",
+  "protocolVersion": "0.3",
+  "capabilities": { "streaming": true, "pushNotifications": false },
+  "skills": [
+    { "id": "task-delegation", "name": "Task Delegation" },
+    { "id": "agent-coordination", "name": "Agent Coordination" }
+  ]
+}`}</CodeBlock>
+
+      <h3 className="mt-6 mb-3 text-lg font-semibold text-slate-200">Per-agent cards</h3>
+      <p className="mb-4 text-slate-400">Each agent has its own card at <code className="rounded bg-white/10 px-1.5 py-0.5 text-cyan-400">/a2a/agents/:id/agent.json</code>.</p>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Sending Tasks</h2>
+      <CodeBlock title="bash">{`curl -X POST https://bikinibottom.ai/a2a/message/send \\
+  -H 'Content-Type: application/json' \\
+  -d '{
+    "message": {
+      "role": "user",
+      "parts": [{ "kind": "text", "text": "Build a REST API" }]
+    }
+  }'`}</CodeBlock>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Streaming</h2>
+      <p className="mb-4 text-slate-400">Use <code className="rounded bg-white/10 px-1.5 py-0.5 text-cyan-400">/a2a/message/stream</code> for SSE streaming of task progress and results.</p>
+      <CodeBlock title="bash">{`curl -N -X POST https://bikinibottom.ai/a2a/message/stream \\
+  -H 'Content-Type: application/json' \\
+  -d '{"message":{"role":"user","parts":[{"kind":"text","text":"Design a landing page"}]}}'`}</CodeBlock>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Task Management</h2>
+      <p className="text-slate-400">
+        Query task status, cancel running tasks, and retrieve artifacts via the A2A task endpoints.
+        See the <a href="https://a2a-protocol.org" target="_blank" rel="noopener" className="text-cyan-400 underline">A2A protocol specification</a> for full details.
+      </p>
+    </DocsLayout>
+  );
+}

--- a/apps/website/app/routes/docs/protocols/mcp.tsx
+++ b/apps/website/app/routes/docs/protocols/mcp.tsx
@@ -1,0 +1,61 @@
+import { DocsLayout, CodeBlock } from "../../../components/docs-layout";
+
+export function MCPTools() {
+  return (
+    <DocsLayout>
+      <h1 className="mb-2 text-4xl font-bold text-slate-100">MCP Tools</h1>
+      <p className="mb-8 text-lg text-slate-400">
+        BikiniBottom exposes 7 tools via the Model Context Protocol using Streamable HTTP transport at <code className="rounded bg-white/10 px-1.5 py-0.5 text-cyan-400">POST /mcp</code>.
+      </p>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Quick Start</h2>
+      <CodeBlock title="Initialize">{`curl -X POST https://bikinibottom.ai/mcp \\
+  -H 'Content-Type: application/json' \\
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'`}</CodeBlock>
+      <CodeBlock title="List tools">{`curl -X POST https://bikinibottom.ai/mcp \\
+  -H 'Content-Type: application/json' \\
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'`}</CodeBlock>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Available Tools</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left">
+          <thead>
+            <tr className="border-b border-white/10 text-slate-400">
+              <th className="py-2 pr-4 font-medium">Tool</th>
+              <th className="py-2 pr-4 font-medium">Description</th>
+              <th className="py-2 font-medium">Required Params</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-300">
+            {[
+              ["delegate_task", "Send a task to the agent org", "task"],
+              ["list_agents", "List all agents in the org", "—"],
+              ["get_agent", "Get details about a specific agent", "agentId"],
+              ["list_tasks", "List current tasks", "—"],
+              ["get_task", "Get task details", "taskId"],
+              ["send_message", "Send an ACP message to an agent", "agentId, message"],
+              ["get_org_stats", "Get organization-wide statistics", "—"],
+            ].map(([tool, desc, params]) => (
+              <tr key={tool} className="border-b border-white/5">
+                <td className="py-2 pr-4"><code className="rounded bg-white/10 px-1.5 py-0.5 text-cyan-400">{tool}</code></td>
+                <td className="py-2 pr-4 text-slate-400">{desc}</td>
+                <td className="py-2 text-slate-500">{params}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Claude Desktop / Cursor</h2>
+      <p className="mb-4 text-slate-400">Add to your MCP client config:</p>
+      <CodeBlock title="mcp_config.json">{`{
+  "mcpServers": {
+    "bikinibottom": {
+      "url": "https://bikinibottom.ai/mcp",
+      "transport": "streamable-http"
+    }
+  }
+}`}</CodeBlock>
+    </DocsLayout>
+  );
+}

--- a/apps/website/app/routes/index.tsx
+++ b/apps/website/app/routes/index.tsx
@@ -1,0 +1,126 @@
+import { TerminalDemo } from "../components/terminal-demo";
+import { FeatureCard } from "../components/feature-card";
+import { ProtocolBadge } from "../components/protocol-badge";
+
+const features = [
+  { emoji: "🔗", title: "A2A Protocol", description: "Every agent is discoverable. Native Agent-to-Agent protocol support with streaming, task management, and per-agent cards.", color: "text-cyan-400" },
+  { emoji: "🔌", title: "MCP Tools", description: "7 tools via Streamable HTTP. Your agents become MCP servers — connect from Claude Desktop, Cursor, or any MCP client.", color: "text-violet-400" },
+  { emoji: "🔀", title: "Model Router", description: "Intelligent routing with fallback chains. Local-first with Ollama, cloud when needed. Cost tracking per provider.", color: "text-emerald-400" },
+  { emoji: "📊", title: "Live Dashboard", description: "Real-time visualization of your agent organization. Network graph, task timeline, cost charts, router metrics.", color: "text-amber-400" },
+  { emoji: "💻", title: "CLI", description: "npx bikinibottom init — zero config, instant setup. Scaffold, start, and deploy in seconds.", color: "text-cyan-400" },
+  { emoji: "🏗️", title: "ORG.md", description: "Define your org in markdown. Agents, teams, hierarchy, culture — all version-controlled.", color: "text-violet-400" },
+];
+
+export function LandingPage() {
+  return (
+    <div>
+      {/* Hero */}
+      <section className="relative overflow-hidden pb-20 pt-24 md:pt-32">
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute left-1/2 top-0 -translate-x-1/2 h-[600px] w-[800px] rounded-full bg-cyan-500/5 blur-[120px]" />
+          <div className="absolute right-1/4 top-20 h-[400px] w-[400px] rounded-full bg-violet-500/5 blur-[100px]" />
+        </div>
+
+        <div className="relative mx-auto max-w-4xl px-6 text-center">
+          <div className="animate-fade-in-up mb-6 text-7xl md:text-8xl">🍍</div>
+          <h1 className="animate-fade-in-up animate-delay-100 mb-6 text-5xl font-extrabold tracking-tight md:text-7xl">
+            <span className="gradient-text">BikiniBottom</span>
+          </h1>
+          <p className="animate-fade-in-up animate-delay-200 mx-auto mb-8 max-w-xl text-lg text-slate-400 md:text-xl">
+            The control plane your AI agents deserve.
+            <br />
+            <span className="text-slate-500">A2A + MCP native orchestration with real-time dashboard.</span>
+          </p>
+
+          <div className="animate-fade-in-up animate-delay-300 mb-10 flex flex-wrap items-center justify-center gap-4">
+            <a
+              href="/app/"
+              className="glow-cyan rounded-xl bg-cyan-500 px-8 py-3 text-base font-semibold text-navy-950 transition hover:bg-cyan-400"
+            >
+              Launch Live Demo →
+            </a>
+            <a
+              href="/docs/getting-started"
+              className="rounded-xl border border-white/10 bg-white/5 px-8 py-3 text-base font-semibold text-slate-200 transition hover:bg-white/10"
+            >
+              Get Started
+            </a>
+          </div>
+
+          <div className="animate-fade-in-up animate-delay-400 mb-16 flex flex-wrap items-center justify-center gap-3">
+            <ProtocolBadge label="A2A Protocol" />
+            <ProtocolBadge label="MCP" />
+            <ProtocolBadge label="Model Router" />
+            <ProtocolBadge label="TypeScript" variant="core" />
+            <ProtocolBadge label="Python" variant="core" />
+          </div>
+
+          <div className="animate-fade-in-up animate-delay-500">
+            <TerminalDemo />
+          </div>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className="py-20">
+        <div className="mx-auto max-w-6xl px-6">
+          <h2 className="mb-4 text-center text-3xl font-bold text-slate-100 md:text-4xl">
+            Everything you need for{" "}
+            <span className="gradient-text">multi-agent orchestration</span>
+          </h2>
+          <p className="mx-auto mb-14 max-w-2xl text-center text-slate-400">
+            Built on open protocols. Deploy anywhere. Scale from laptop to cloud.
+          </p>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {features.map((f) => (
+              <FeatureCard key={f.title} {...f} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Stats */}
+      <section className="border-y border-white/5 py-16">
+        <div className="mx-auto flex max-w-4xl flex-wrap items-center justify-center gap-12 px-6 text-center">
+          <div>
+            <div className="text-4xl font-bold text-cyan-400">22</div>
+            <div className="mt-1 text-sm text-slate-500">Agents</div>
+          </div>
+          <div className="h-8 w-px bg-white/10" />
+          <div>
+            <div className="text-4xl font-bold text-violet-400">5</div>
+            <div className="mt-1 text-sm text-slate-500">Departments</div>
+          </div>
+          <div className="h-8 w-px bg-white/10" />
+          <div>
+            <div className="text-4xl font-bold text-emerald-400">7</div>
+            <div className="mt-1 text-sm text-slate-500">MCP Tools</div>
+          </div>
+          <div className="h-8 w-px bg-white/10" />
+          <div>
+            <div className="text-4xl font-bold text-amber-400">3</div>
+            <div className="mt-1 text-sm text-slate-500">LLM Providers</div>
+          </div>
+        </div>
+      </section>
+
+      {/* Open Source */}
+      <section className="py-20 text-center">
+        <div className="mx-auto max-w-2xl px-6">
+          <h2 className="mb-4 text-3xl font-bold text-slate-100">Open Source</h2>
+          <p className="mb-8 text-slate-400">
+            BikiniBottom is MIT licensed. Star us on GitHub, contribute, or fork and build your own.
+          </p>
+          <a
+            href="https://github.com/openspawn/openspawn"
+            target="_blank"
+            rel="noopener"
+            className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-6 py-3 font-medium text-slate-200 transition hover:bg-white/10"
+          >
+            ⭐ Star on GitHub
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/website/app/styles/globals.css
+++ b/apps/website/app/styles/globals.css
@@ -1,0 +1,100 @@
+@import "tailwindcss";
+
+@theme {
+  --color-navy-950: #0a1929;
+  --color-navy-900: #0d2137;
+  --color-navy-800: #122d4d;
+  --color-navy-700: #1a3a5c;
+  --color-navy-600: #234b6e;
+  --color-cyan-400: #22d3ee;
+  --color-cyan-500: #06b6d4;
+  --color-cyan-600: #0891b2;
+  --color-violet-400: #a78bfa;
+  --color-violet-500: #8b5cf6;
+  --color-amber-400: #fbbf24;
+  --color-amber-500: #f59e0b;
+  --color-emerald-400: #34d399;
+  --color-emerald-500: #10b981;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0a1929;
+  color: #e2e8f0;
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+}
+
+.gradient-text {
+  background: linear-gradient(135deg, #06b6d4, #8b5cf6, #f59e0b);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.glow-cyan {
+  box-shadow: 0 0 20px rgba(6, 182, 212, 0.3), 0 0 60px rgba(6, 182, 212, 0.1);
+}
+
+.terminal {
+  background: #0d1117;
+  border: 1px solid #1e3a5f;
+  border-radius: 12px;
+  overflow: hidden;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 0.875rem;
+  line-height: 1.7;
+}
+
+.terminal-header {
+  background: #161b22;
+  padding: 10px 16px;
+  display: flex;
+  gap: 8px;
+  border-bottom: 1px solid #1e3a5f;
+}
+
+.terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+@keyframes blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+.cursor-blink {
+  animation: blink 1s infinite;
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in-up {
+  animation: fadeInUp 0.6s ease-out forwards;
+}
+
+.animate-delay-100 { animation-delay: 0.1s; opacity: 0; }
+.animate-delay-200 { animation-delay: 0.2s; opacity: 0; }
+.animate-delay-300 { animation-delay: 0.3s; opacity: 0; }
+.animate-delay-400 { animation-delay: 0.4s; opacity: 0; }
+.animate-delay-500 { animation-delay: 0.5s; opacity: 0; }
+
+::-webkit-scrollbar { width: 8px; }
+::-webkit-scrollbar-track { background: #0a1929; }
+::-webkit-scrollbar-thumb { background: #1e3a5f; border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: #234b6e; }

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BikiniBottom — The control plane your AI agents deserve</title>
+    <meta name="description" content="A2A + MCP native orchestration with real-time dashboard. Open source multi-agent coordination." />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/app/main.tsx"></script>
+  </body>
+</html>

--- a/apps/website/postcss.config.js
+++ b/apps/website/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/apps/website/project.json
+++ b/apps/website/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "website",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/website/app",
+  "projectType": "application",
+  "tags": [],
+  "targets": {
+    "build": {
+      "command": "vite build",
+      "options": { "cwd": "apps/website" },
+      "cache": true,
+      "inputs": ["default", "^default"],
+      "outputs": ["{workspaceRoot}/dist/apps/website"]
+    },
+    "serve": {
+      "command": "vite serve",
+      "options": { "cwd": "apps/website" }
+    }
+  }
+}

--- a/apps/website/public/favicon.svg
+++ b/apps/website/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🍍</text></svg>

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client"]
+  },
+  "include": ["app/**/*"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/website/tsconfig.node.json
+++ b/apps/website/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.mts"]
+}

--- a/apps/website/vite.config.mts
+++ b/apps/website/vite.config.mts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
+
+export default defineConfig({
+  root: import.meta.dirname,
+  cacheDir: "../../node_modules/.vite/apps/website",
+  base: "/",
+  server: { port: 4300, host: "0.0.0.0" },
+  plugins: [react(), nxViteTsPaths()],
+  build: {
+    outDir: "../../dist/apps/website",
+    emptyOutDir: true,
+    reportCompressedSize: true,
+  },
+});


### PR DESCRIPTION
## Website Landing Page + Docs

Adds a Vite + React + TanStack Router SPA at `apps/website/` for bikinibottom.ai root (`/`).

### What's included
- **Landing page**: Hero with animated terminal demo, feature cards (A2A, MCP, Model Router, Dashboard, CLI, ORG.md), stats section, open source CTA
- **Docs pages**: Getting Started, A2A Protocol, MCP Tools, Dashboard, Model Router — content ported from the Starlight docs branch
- **Ocean theme**: Deep navy background, cyan/violet/amber accents, dark mode only
- **Docs sidebar layout** with mobile hamburger menu
- **Dockerfile updated** to build and copy website-dist

### Architecture
- Vite + React SPA (static output to `dist/apps/website/`)
- TanStack Router for client-side routing
- Tailwind CSS v4 with ocean theme
- Nx project config with explicit build target

### Build
```bash
pnpm nx run website:build  # → dist/apps/website/
```

Dashboard build/typecheck unaffected. No existing files modified except Dockerfile.