### PR TITLE
feat(website): polish landing page

### DIFF
--- a/apps/website/app/components/nav.tsx
+++ b/apps/website/app/components/nav.tsx
@@ -1,6 +1,9 @@
+import { useState } from "react";
 import { Link } from "@tanstack/react-router";
 
 export function Nav() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <nav className="sticky top-0 z-50 border-b border-white/5 bg-navy-950/80 backdrop-blur-xl">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-8 sm:px-6">
@@ -24,13 +27,49 @@ export function Nav() {
             GitHub
           </a>
         </div>
-        <a
-          href="/app/"
-          className="rounded-lg bg-cyan-500/10 px-4 py-2 text-sm font-medium text-cyan-400 ring-1 ring-cyan-500/20 transition hover:bg-cyan-500/20"
-        >
-          Launch Demo →
-        </a>
+        <div className="flex items-center gap-3">
+          <a
+            href="/app/"
+            className="rounded-lg bg-cyan-500/10 px-4 py-2 text-sm font-medium text-cyan-400 ring-1 ring-cyan-500/20 transition hover:bg-cyan-500/20"
+          >
+            Launch Demo →
+          </a>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-lg p-2 text-slate-400 transition hover:bg-white/10 hover:text-cyan-400 md:hidden"
+            onClick={() => setMenuOpen((v) => !v)}
+            aria-label="Toggle menu"
+          >
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              {menuOpen ? (
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              ) : (
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
+              )}
+            </svg>
+          </button>
+        </div>
       </div>
+      {menuOpen && (
+        <div className="border-t border-white/5 bg-navy-950/95 backdrop-blur-xl md:hidden">
+          <div className="flex flex-col gap-1 px-8 py-4">
+            <Link to="/docs" className="rounded-lg px-3 py-2 text-sm text-slate-400 transition hover:bg-white/5 hover:text-cyan-400" onClick={() => setMenuOpen(false)}>
+              Docs
+            </Link>
+            <Link to="/docs/protocols/a2a" className="rounded-lg px-3 py-2 text-sm text-slate-400 transition hover:bg-white/5 hover:text-cyan-400" onClick={() => setMenuOpen(false)}>
+              Protocols
+            </Link>
+            <a
+              href="https://github.com/openspawn/openspawn"
+              target="_blank"
+              rel="noopener"
+              className="rounded-lg px-3 py-2 text-sm text-slate-400 transition hover:bg-white/5 hover:text-cyan-400"
+            >
+              GitHub
+            </a>
+          </div>
+        </div>
+      )}
     </nav>
   );
 }

--- a/apps/website/app/components/terminal-demo.tsx
+++ b/apps/website/app/components/terminal-demo.tsx
@@ -2,14 +2,16 @@ import { useState, useEffect } from "react";
 
 const lines = [
   { text: "$ npx bikinibottom init my-reef", color: "text-slate-300", delay: 0 },
-  { text: "🍍 Created ORG.md, config, .gitignore", color: "text-emerald-400", delay: 800 },
-  { text: "", color: "", delay: 1200 },
-  { text: "$ npx bikinibottom start", color: "text-slate-300", delay: 1400 },
-  { text: "🌐 Server running at http://localhost:3333", color: "text-cyan-400", delay: 2200 },
-  { text: "🔗 A2A: /.well-known/agent.json", color: "text-violet-400", delay: 2600 },
-  { text: "🔌 MCP: /mcp (7 tools)", color: "text-amber-400", delay: 3000 },
-  { text: "🔀 Router: 3 providers configured", color: "text-emerald-400", delay: 3400 },
-  { text: "📊 Dashboard: http://localhost:3333", color: "text-cyan-400", delay: 3800 },
+  { text: "🍍 Created ORG.md, config, .gitignore", color: "text-emerald-400", delay: 900 },
+  { text: "", color: "", delay: 1300 },
+  { text: "$ npx bikinibottom start", color: "text-slate-300", delay: 1500 },
+  { text: "🌐 Server running at http://localhost:3333", color: "text-cyan-400", delay: 2400 },
+  { text: "🔗 A2A: /.well-known/agent.json", color: "text-violet-400", delay: 2850 },
+  { text: "🔌 MCP: /mcp (7 tools)", color: "text-amber-400", delay: 3250 },
+  { text: "🔀 Router: 3 providers configured", color: "text-emerald-400", delay: 3700 },
+  { text: "📊 Dashboard: http://localhost:3333", color: "text-cyan-400", delay: 4100 },
+  { text: "", color: "", delay: 4600 },
+  { text: "✨ 22 agents ready. Visit http://localhost:3333", color: "text-cyan-300 font-semibold", delay: 5200 },
 ];
 
 export function TerminalDemo() {
@@ -17,7 +19,7 @@ export function TerminalDemo() {
 
   useEffect(() => {
     const timers = lines.map((line, i) =>
-      setTimeout(() => setVisibleLines(i + 1), line.delay)
+      setTimeout(() => setVisibleLines(i + 1), line.delay + Math.random() * 80)
     );
     return () => timers.forEach(clearTimeout);
   }, []);
@@ -35,9 +37,7 @@ export function TerminalDemo() {
             {line.text || "\u00A0"}
           </div>
         ))}
-        {visibleLines < lines.length && (
-          <span className="cursor-blink text-slate-500">▋</span>
-        )}
+        <span className="cursor-blink text-slate-500">▋</span>
       </div>
     </div>
   );

--- a/apps/website/app/routes/__root.tsx
+++ b/apps/website/app/routes/__root.tsx
@@ -5,6 +5,15 @@ import { Footer } from "../components/footer";
 export function RootLayout() {
   return (
     <div className="min-h-screen flex flex-col bg-navy-950 text-slate-200 overflow-x-hidden">
+      {/* Subtle ocean backdrop */}
+      <div
+        className="pointer-events-none fixed inset-0 -z-10"
+        style={{
+          background:
+            "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(34,211,238,0.04) 0%, transparent 60%), " +
+            "radial-gradient(ellipse 60% 50% at 80% 100%, rgba(139,92,246,0.03) 0%, transparent 60%)",
+        }}
+      />
       <Nav />
       <main className="flex-1">
         <Outlet />

--- a/apps/website/app/routes/index.tsx
+++ b/apps/website/app/routes/index.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { TerminalDemo } from "../components/terminal-demo";
 import { FeatureCard } from "../components/feature-card";
 import { ProtocolBadge } from "../components/protocol-badge";
@@ -12,6 +13,17 @@ const features = [
 ];
 
 export function LandingPage() {
+  const [agentCount, setAgentCount] = useState(22);
+
+  useEffect(() => {
+    fetch("https://bikinibottom.ai/api/health")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.agents) setAgentCount(d.agents);
+      })
+      .catch(() => {});
+  }, []);
+
   return (
     <div>
       {/* Hero */}
@@ -83,7 +95,7 @@ export function LandingPage() {
       <section className="border-y border-white/5 py-16">
         <div className="mx-auto flex max-w-4xl flex-wrap items-center justify-center gap-8 sm:gap-12 px-8 sm:px-6 text-center">
           <div>
-            <div className="text-4xl font-bold text-cyan-400">22</div>
+            <div className="text-4xl font-bold text-cyan-400">{agentCount}</div>
             <div className="mt-1 text-sm text-slate-500">Agents</div>
           </div>
           <div className="h-8 w-px bg-white/10" />


### PR DESCRIPTION
## Changes

1. **Live agent count** — Stats section fetches from `/api/health` for dynamic agent count
2. **Ocean backdrop** — Subtle fixed CSS radial gradients (cyan/violet) behind all pages
3. **Better terminal demo** — Blinking cursor persists, varied delays, success line at end
4. **Mobile hamburger menu** — Toggle dropdown for nav links on small screens

Build verified with `nx build website`.