### PR TITLE
fix: kill stale service worker at root scope

### DIFF
--- a/apps/dashboard/vite.config.mts
+++ b/apps/dashboard/vite.config.mts
@@ -67,8 +67,8 @@ export default defineConfig(() => ({
     nxCopyAssetsPlugin(["*.md"]),
     fixBaseHref(),
     VitePWA({
-      // Disable SW in sandbox mode to prevent stale cache issues
-      selfDestroying: process.env.VITE_SANDBOX_MODE === 'true',
+      // Disable SW to prevent stale cache issues (dashboard at /app/, not root)
+      selfDestroying: true,
       registerType: "autoUpdate",
       // We supply our own manifest.json in public/
       manifest: false,

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -9,6 +9,17 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // Unregister any stale service workers at root scope
+      // (dashboard SW was previously registered at / before moving to /app/)
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.getRegistrations().then(function(regs) {
+          regs.forEach(function(r) {
+            if (r.scope === location.origin + '/') r.unregister();
+          });
+        });
+      }
+    </script>
     <script type="module" src="/app/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Root cause of padding not appearing: dashboard PWA service worker was registered at `/` scope, intercepting website requests and serving cached dashboard instead. Adds SW cleanup to website + makes dashboard SW self-destroying.