### PR TITLE
fix: remove global CSS reset killing all Tailwind padding + nuke stale SW

### DIFF
--- a/apps/website/app/styles/globals.css
+++ b/apps/website/app/styles/globals.css
@@ -17,12 +17,6 @@
   --color-emerald-500: #10b981;
 }
 
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
 html {
   scroll-behavior: smooth;
 }

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -10,14 +10,13 @@
   <body>
     <div id="root"></div>
     <script>
-      // Unregister any stale service workers at root scope
-      // (dashboard SW was previously registered at / before moving to /app/)
+      // Kill any stale service workers at root scope.
+      // Dashboard PWA was previously registered at / before moving to /app/.
+      // Register a self-destroying SW that replaces the old one and nukes caches.
       if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.getRegistrations().then(function(regs) {
-          regs.forEach(function(r) {
-            if (r.scope === location.origin + '/') r.unregister();
-          });
-        });
+        navigator.serviceWorker.register('/sw.js', { scope: '/' })
+          .then(function(reg) { reg.update(); })
+          .catch(function() {});
       }
     </script>
     <script type="module" src="/app/main.tsx"></script>

--- a/apps/website/public/sw.js
+++ b/apps/website/public/sw.js
@@ -1,0 +1,8 @@
+// Self-destroying service worker.
+// Replaces any previously-registered SW at this scope,
+// then immediately unregisters itself and clears all caches.
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => {
+  self.registration.unregister();
+  caches.keys().then(names => names.forEach(n => caches.delete(n)));
+});


### PR DESCRIPTION
Two root causes found:\n1. `* { padding: 0 }` in globals.css (outside @layer) overrides all Tailwind padding utilities\n2. Stale dashboard service worker at root scope serves cached dashboard instead of website\n\nFixes: remove the global reset, add self-destroying sw.js, register it on page load.