### PR TITLE
feat: add 'Built with OpenSpawn' badge + rename CLI to openspawn

### DIFF
--- a/apps/platform/app/main.tsx
+++ b/apps/platform/app/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { LandingPage } from "./landing-page";
+import "./styles/globals.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <LandingPage />
+  </StrictMode>
+);

--- a/apps/platform/app/styles/globals.css
+++ b/apps/platform/app/styles/globals.css
@@ -1,0 +1,94 @@
+@import "tailwindcss";
+
+@theme {
+  --color-navy-950: #0a1929;
+  --color-navy-900: #0d2137;
+  --color-navy-800: #122d4d;
+  --color-navy-700: #1a3a5c;
+  --color-navy-600: #234b6e;
+  --color-cyan-400: #22d3ee;
+  --color-cyan-500: #06b6d4;
+  --color-cyan-600: #0891b2;
+  --color-violet-400: #a78bfa;
+  --color-violet-500: #8b5cf6;
+  --color-amber-400: #fbbf24;
+  --color-amber-500: #f59e0b;
+  --color-emerald-400: #34d399;
+  --color-emerald-500: #10b981;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0a1929;
+  color: #e2e8f0;
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+}
+
+.gradient-text {
+  background: linear-gradient(135deg, #06b6d4, #8b5cf6, #f59e0b);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.glow-cyan {
+  box-shadow: 0 0 20px rgba(6, 182, 212, 0.3), 0 0 60px rgba(6, 182, 212, 0.1);
+}
+
+.terminal {
+  background: #0d1117;
+  border: 1px solid #1e3a5f;
+  border-radius: 12px;
+  overflow: hidden;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 0.875rem;
+  line-height: 1.7;
+}
+
+.terminal-header {
+  background: #161b22;
+  padding: 10px 16px;
+  display: flex;
+  gap: 8px;
+  border-bottom: 1px solid #1e3a5f;
+}
+
+.terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+@keyframes blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+.cursor-blink {
+  animation: blink 1s infinite;
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in-up {
+  animation: fadeInUp 0.6s ease-out forwards;
+}
+
+.animate-delay-100 { animation-delay: 0.1s; opacity: 0; }
+.animate-delay-200 { animation-delay: 0.2s; opacity: 0; }
+.animate-delay-300 { animation-delay: 0.3s; opacity: 0; }
+.animate-delay-400 { animation-delay: 0.4s; opacity: 0; }
+.animate-delay-500 { animation-delay: 0.5s; opacity: 0; }
+
+::-webkit-scrollbar { width: 8px; }
+::-webkit-scrollbar-track { background: #0a1929; }
+::-webkit-scrollbar-thumb { background: #1e3a5f; border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: #234b6e; }

--- a/apps/platform/index.html
+++ b/apps/platform/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenSpawn — The org chart for AI agents</title>
+    <meta name="description" content="One agent needs a prompt. A team needs an org. Open-source coordination layer for AI agent teams. Define structure in markdown." />
+    <meta property="og:title" content="OpenSpawn — The org chart for AI agents" />
+    <meta property="og:description" content="One agent needs a prompt. A team needs an org. Open-source coordination for AI agent teams." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://openspawn.ai" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪸</text></svg>" />
+</head>
+<body class="bg-navy-950 text-slate-200">
+    <div id="root"></div>
+    <script type="module" src="/app/main.tsx"></script>
+</body>
+</html>

--- a/apps/platform/postcss.config.js
+++ b/apps/platform/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/apps/platform/project.json
+++ b/apps/platform/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "platform",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/platform/app",
+  "projectType": "application",
+  "tags": [],
+  "targets": {
+    "build": {
+      "command": "vite build",
+      "options": { "cwd": "apps/platform" },
+      "cache": true,
+      "inputs": ["default", "^default"],
+      "outputs": ["{workspaceRoot}/dist/apps/platform"]
+    },
+    "serve": {
+      "command": "vite serve",
+      "options": { "cwd": "apps/platform" }
+    }
+  }
+}

--- a/apps/platform/tsconfig.json
+++ b/apps/platform/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client"]
+  },
+  "include": ["app/**/*"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/platform/tsconfig.node.json
+++ b/apps/platform/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.mts"]
+}

--- a/apps/platform/vite.config.mts
+++ b/apps/platform/vite.config.mts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
+
+export default defineConfig({
+  root: import.meta.dirname,
+  cacheDir: "../../node_modules/.vite/apps/platform",
+  base: "/",
+  server: { port: 4301, host: "0.0.0.0" },
+  plugins: [react(), nxViteTsPaths()],
+  build: {
+    outDir: "../../dist/apps/platform",
+    emptyOutDir: true,
+    reportCompressedSize: true,
+  },
+});

--- a/apps/website/app/routes/index.tsx
+++ b/apps/website/app/routes/index.tsx
@@ -8,7 +8,7 @@ const features = [
  { emoji: "🔌", title: "MCP Tools", description: "7 tools via Streamable HTTP. Your agents become MCP servers — connect from Claude Desktop, Cursor, or any MCP client.", color: "text-violet-400" },
  { emoji: "🔀", title: "Model Router", description: "Intelligent routing with fallback chains. Local-first with Ollama, cloud when needed. Cost tracking per provider.", color: "text-emerald-400" },
  { emoji: "📊", title: "Live Dashboard", description: "Real-time visualization of your agent organization. Network graph, task timeline, cost charts, router metrics.", color: "text-amber-400" },
- { emoji: "💻", title: "CLI", description: "npx bikinibottom init — zero config, instant setup. Scaffold, start, and deploy in seconds.", color: "text-cyan-400" },
+ { emoji: "💻", title: "CLI", description: "npx openspawn init — zero config, instant setup. Scaffold, start, and deploy in seconds.", color: "text-cyan-400" },
 ];
 
 const frameworks = [
@@ -73,6 +73,10 @@ export function LandingPage() {
 
  return (
   <div className="px-5 sm:px-6">
+   {/* Built with OpenSpawn */}
+   <div className="text-center py-2 text-xs text-slate-500">
+    Built with <a href="https://openspawn.ai" className="text-cyan-400 hover:text-cyan-300 transition font-medium">🪸 OpenSpawn</a>
+   </div>
    {/* Hero */}
    <section className="relative overflow-hidden pb-20 pt-24 md:pt-32">
     <div className="pointer-events-none absolute inset-0">
@@ -107,11 +111,11 @@ export function LandingPage() {
      <div className="animate-fade-in-up animate-delay-500 mb-16">
       <div className="group relative mx-auto inline-flex items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-5 py-3 font-mono text-sm text-slate-300 transition hover:border-white/20 hover:bg-white/[0.08]">
        <span className="text-slate-500">$</span>
-       <span>npx bikinibottom init my-reef</span>
+       <span>npx openspawn init my-reef</span>
        <button
         type="button"
         className="ml-1 rounded p-1 text-slate-500 transition hover:bg-white/10 hover:text-cyan-400"
-        onClick={() => { navigator.clipboard.writeText("npx bikinibottom init my-reef"); }}
+        onClick={() => { navigator.clipboard.writeText("npx openspawn init my-reef"); }}
         aria-label="Copy to clipboard"
        >
         <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,15 +1,15 @@
-# 🍍 BikiniBottom
+# 🪸 OpenSpawn
 
 **AI agent orchestration control plane** — run 32 agents locally with A2A + MCP support.
 
-BikiniBottom is the control plane your AI agents deserve. Define your organization in a simple Markdown file, and watch agents coordinate tasks in real-time with protocol-native communication.
+OpenSpawn is the control plane your AI agents deserve. Define your organization in a simple Markdown file, and watch agents coordinate tasks in real-time with protocol-native communication.
 
 ## Quick Start
 
 ```bash
-npx bikinibottom init my-org
+npx openspawn init my-org
 cd my-org
-bikinibottom start
+openspawn start
 ```
 
 Open [http://localhost:3333](http://localhost:3333) to see the real-time dashboard.
@@ -27,14 +27,14 @@ Open [http://localhost:3333](http://localhost:3333) to see the real-time dashboa
 
 | Command | Description |
 |---------|-------------|
-| `bikinibottom init [name]` | Scaffold a new agent organization |
-| `bikinibottom start` | Start the local control plane server |
-| `bikinibottom status` | Show current server status |
-| `bikinibottom demo` | Start with a demo scenario running |
+| `openspawn init [name]` | Scaffold a new agent organization |
+| `openspawn start` | Start the local control plane server |
+| `openspawn status` | Show current server status |
+| `openspawn demo` | Start with the BikiniBottom demo scenario |
 
 ## Configuration
 
-After `init`, edit `bikinibottom.config.json`:
+After `init`, edit `openspawn.config.json`:
 
 ```json
 {
@@ -75,9 +75,14 @@ Agents inherit hierarchy from heading levels and communicate via A2A protocol.
 - **A2A** → `http://localhost:3333/.well-known/agent.json`
 - **MCP** → `http://localhost:3333/mcp`
 
+## Showcase
+
+Check out the [BikiniBottom demo](https://bikinibottom.ai) — a 32-agent SpongeBob-themed showcase built with OpenSpawn.
+
 ## Links
 
-- 🌐 **Live Demo:** [bikinibottom.ai](https://bikinibottom.ai)
+- 🌐 **Website:** [openspawn.ai](https://openspawn.ai)
+- 🍍 **Live Demo:** [bikinibottom.ai](https://bikinibottom.ai)
 - 📖 **GitHub:** [openspawn/openspawn](https://github.com/openspawn/openspawn)
 
 ## License

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "bikinibottom",
+  "name": "openspawn",
   "version": "0.1.0",
-  "description": "AI agent orchestration control plane — run 32 agents locally with A2A + MCP support",
+  "description": "OpenSpawn — AI agent orchestration control plane with A2A + MCP support",
   "type": "module",
   "bin": {
-    "bikinibottom": "./dist/cli.js"
+    "openspawn": "./dist/cli.js"
   },
   "files": ["dist/", "README.md", "templates/"],
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/cli.ts"
   },
-  "keywords": ["ai", "agents", "a2a", "mcp", "orchestration", "multi-agent"],
+  "keywords": ["ai", "agents", "a2a", "mcp", "orchestration", "multi-agent", "openspawn"],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/openspawn/openspawn"
   },
-  "homepage": "https://bikinibottom.ai",
+  "homepage": "https://openspawn.ai",
   "engines": {
     "node": ">=18"
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// BikiniBottom CLI — AI agent orchestration control plane
+// OpenSpawn CLI — AI agent orchestration control plane
 
 import { showHelp, getVersion } from './help.js';
 import { initCommand } from './commands/init.js';

--- a/packages/cli/src/commands/demo.ts
+++ b/packages/cli/src/commands/demo.ts
@@ -2,20 +2,22 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 export function demoCommand(): void {
-  const configPath = join(process.cwd(), 'bikinibottom.config.json');
+  const configPath = join(process.cwd(), 'openspawn.config.json');
+  const legacyConfigPath = join(process.cwd(), 'bikinibottom.config.json');
 
-  if (!existsSync(configPath)) {
+  if (!existsSync(configPath) && !existsSync(legacyConfigPath)) {
     console.log(`
-\x1b[31m✗\x1b[0m No bikinibottom.config.json found in current directory.
+\x1b[31m✗\x1b[0m No openspawn.config.json found in current directory.
 
-Run \x1b[33mbikinibottom init\x1b[0m first to scaffold a project.
+Run \x1b[36mopenspawn init\x1b[0m first to scaffold a project.
 `);
     process.exit(1);
   }
 
   console.log(`
-\x1b[33m🍍 Starting BikiniBottom Demo...\x1b[0m
+\x1b[36m🪸 Starting OpenSpawn Demo...\x1b[0m
 
+Loading the BikiniBottom 🍍 demo scenario.
 Sending demo task: "Build a REST API for user management"
 Watch the agents coordinate at http://localhost:3333
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -42,22 +42,22 @@ export function initCommand(name?: string): void {
   }
 
   writeFileSync(join(targetDir, 'ORG.md'), orgTemplate);
-  writeFileSync(join(targetDir, 'bikinibottom.config.json'), JSON.stringify(DEFAULT_CONFIG, null, 2) + '\n');
+  writeFileSync(join(targetDir, 'openspawn.config.json'), JSON.stringify(DEFAULT_CONFIG, null, 2) + '\n');
   writeFileSync(join(targetDir, '.gitignore'), 'node_modules/\n.env\ndata/\n');
 
   const prefix = name ? `  cd ${name}\n` : '';
 
   console.log(`
-\x1b[33m🍍 BikiniBottom initialized!\x1b[0m
+\x1b[36m🪸 OpenSpawn initialized!\x1b[0m
 
 Created:
   ORG.md                 — Define your agent organization
-  bikinibottom.config.json — Configuration
+  openspawn.config.json  — Configuration
   .gitignore
 
 Next steps:
 ${prefix}  1. Edit ORG.md to customize your agents
-  2. Run: bikinibottom start
+  2. Run: openspawn start
   3. Open: http://localhost:3333
 
 Protocols enabled:

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -3,28 +3,30 @@ import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 
 export function startCommand(): void {
-  const configPath = join(process.cwd(), 'bikinibottom.config.json');
+  const configPath = join(process.cwd(), 'openspawn.config.json');
+  const legacyConfigPath = join(process.cwd(), 'bikinibottom.config.json');
+  const actualConfigPath = existsSync(configPath) ? configPath : legacyConfigPath;
 
-  if (!existsSync(configPath)) {
+  if (!existsSync(actualConfigPath)) {
     console.log(`
-\x1b[31m✗\x1b[0m No bikinibottom.config.json found in current directory.
+\x1b[31m✗\x1b[0m No openspawn.config.json found in current directory.
 
-Run \x1b[33mbikinibottom init\x1b[0m first to scaffold a project.
+Run \x1b[36mopenspawn init\x1b[0m first to scaffold a project.
 `);
     process.exit(1);
   }
 
-  const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+  const config = JSON.parse(readFileSync(actualConfigPath, 'utf-8'));
   const port = config.port ?? 3333;
   const orgFile = config.orgFile ?? 'ORG.md';
 
   if (!existsSync(join(process.cwd(), orgFile))) {
-    console.log(`\x1b[31m✗\x1b[0m ${orgFile} not found. Create one or run \x1b[33mbikinibottom init\x1b[0m.`);
+    console.log(`\x1b[31m✗\x1b[0m ${orgFile} not found. Create one or run \x1b[36mopenspawn init\x1b[0m.`);
     process.exit(1);
   }
 
   console.log(`
-\x1b[33m🍍 Starting BikiniBottom...\x1b[0m
+\x1b[36m🪸 Starting OpenSpawn...\x1b[0m
 
 Port:       ${port}
 Org:        ${orgFile}
@@ -51,7 +53,7 @@ Protocols:  A2A ${config.protocols?.a2a ? '✓' : '✗'}  MCP ${config.protocols
       console.error(`\x1b[31m✗\x1b[0m Failed to start server: ${err.message}`);
       console.log(`
 \x1b[2mMake sure you have the sandbox package installed:
-  npm install bikinibottom
+  npm install openspawn
 
 Or run from the monorepo:
   cd tools/sandbox && npx tsx src/server.ts\x1b[0m
@@ -86,7 +88,7 @@ function findServerEntry(): string | null {
     join(process.cwd(), '..', '..', 'tools', 'sandbox', 'src', 'server.ts'),
     join(process.cwd(), 'tools', 'sandbox', 'src', 'server.ts'),
     // npm installed package
-    join(process.cwd(), 'node_modules', 'bikinibottom', 'sandbox', 'src', 'server.ts'),
+    join(process.cwd(), 'node_modules', 'openspawn', 'sandbox', 'src', 'server.ts'),
   ];
 
   for (const candidate of candidates) {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -15,7 +15,7 @@ export function statusCommand(): void {
         const idle = total - active;
 
         console.log(`
-\x1b[33m🍍 BikiniBottom Status\x1b[0m
+\x1b[36m🪸 OpenSpawn Status\x1b[0m
 
 Server:     http://localhost:${port} \x1b[32m✓\x1b[0m
 Agents:     ${total} (${active} active, ${idle} idle)
@@ -34,11 +34,11 @@ Protocols:  A2A ✓  MCP ✓
 
 function showOffline(): void {
   console.log(`
-\x1b[33m🍍 BikiniBottom Status\x1b[0m
+\x1b[36m🪸 OpenSpawn Status\x1b[0m
 
 Server:     \x1b[31mNot running\x1b[0m
 
 No server detected on localhost:3333.
-Start with: \x1b[33mbikinibottom start\x1b[0m
+Start with: \x1b[36mopenspawn start\x1b[0m
 `);
 }

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -16,7 +16,7 @@ export function getVersion(): string {
 
 export function showHelp(): void {
   console.log(`
-\x1b[33m🍍 BikiniBottom\x1b[0m — AI Agent Orchestration
+\x1b[36m🪸 OpenSpawn\x1b[0m — AI Agent Orchestration
 
   The control plane your AI agents deserve.
   32 agents. A2A + MCP protocols. Real-time dashboard.
@@ -32,11 +32,11 @@ export function showHelp(): void {
   --version, -v  Show version
 
 \x1b[1mExamples:\x1b[0m
-  $ npx bikinibottom init my-org
-  $ cd my-org && bikinibottom start
-  $ bikinibottom status
+  $ npx openspawn init my-org
+  $ cd my-org && openspawn start
+  $ openspawn status
 
-Learn more: \x1b[36mhttps://bikinibottom.ai\x1b[0m
+Learn more: \x1b[36mhttps://openspawn.ai\x1b[0m
 GitHub:     \x1b[36mhttps://github.com/openspawn/openspawn\x1b[0m
 `);
 }


### PR DESCRIPTION
## Changes

- Added subtle 'Built with OpenSpawn' badge on BikiniBottom landing page
- Updated install command to `npx openspawn init`
- Renamed CLI package from `bikinibottom` to `openspawn`
- Updated all CLI help text, banners, and console output
- Config file renamed to `openspawn.config.json` (with legacy fallback)
- CLI README rewritten for OpenSpawn branding
- Demo command references BikiniBottom as the showcase scenario

BikiniBottom keeps its 🍍 theming as the demo app built with OpenSpawn.