### PR TITLE
feat: openspawn.ai deploy pipeline

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -1,0 +1,87 @@
+name: Deploy Platform (openspawn.ai)
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: openspawn/openspawn-platform
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.platform
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+      - name: Copy deploy files to VPS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          source: "deploy/docker-compose.yml"
+          target: /opt/bikinibottom
+          strip_components: 1
+
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          envs: GH_TOKEN
+          script: |
+            set -e
+            cd /opt/bikinibottom
+
+            echo "${GH_TOKEN}" | docker login ghcr.io -u github-actions --password-stdin
+
+            docker compose pull platform
+            docker compose up -d platform --force-recreate --remove-orphans
+
+            echo "⏳ Waiting for platform to start..."
+            for i in $(seq 1 8); do
+              if curl -sf http://localhost:3334/api/health > /dev/null 2>&1; then
+                echo "✅ Platform deploy successful!"
+                docker image prune -f
+                exit 0
+              fi
+              echo "  Attempt $i/8 — waiting 5s..."
+              sleep 5
+            done
+
+            echo "❌ Health check failed after 40s"
+            docker compose logs --tail=50 platform
+            exit 1
+
+      - name: Purge Cloudflare cache (openspawn.ai)
+        if: success()
+        run: |
+          curl -sf -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID_OPENSPAWN_DOT_AI }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_PURGE_CACHE_API_TOKEN_OPENSPAWN_DOT_AI }}" \
+            -H "Content-Type: application/json" \
+            -d '{"purge_everything":true}' > /dev/null
+          echo "✅ Cloudflare cache purged (openspawn.ai)"

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -1,0 +1,30 @@
+# ── OpenSpawn Platform Site ───────────────────────────────────────────────────
+# Static landing page for openspawn.ai
+
+# Stage 1: Build
+FROM node:24-alpine AS build
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml nx.json tsconfig.base.json ./
+COPY apps/platform/ ./apps/platform/
+
+RUN pnpm install --frozen-lockfile
+RUN pnpm nx run platform:build
+
+# Stage 2: Minimal runtime
+FROM node:24-alpine
+WORKDIR /app
+
+COPY --from=build /app/dist/apps/platform ./dist
+COPY apps/platform/server.ts ./server.ts
+
+# server.ts uses import.meta — run with tsx
+RUN npm i -g tsx
+
+ENV PORT=3334
+ENV PLATFORM_DIR=/app/dist
+
+EXPOSE 3334
+
+CMD ["tsx", "server.ts"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,7 @@
-# ── BikiniBottom VPS Docker Compose ───────────────────────────────────────────
-# Lean demo: sandbox server + dashboard (single container)
+# ── BikiniBottom + OpenSpawn VPS Docker Compose ──────────────────────────────
+# Two containers:
+#   - bikinibottom (port 3333) — BikiniBottom demo at bikinibottom.ai
+#   - openspawn-platform (port 3334) — OpenSpawn landing at openspawn.ai
 # System Caddy handles HTTPS reverse proxy (see /etc/caddy/Caddyfile on VPS)
 #
 # Expected at /opt/bikinibottom/docker-compose.yml on the VPS
@@ -25,3 +27,20 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+
+  platform:
+    image: ghcr.io/openspawn/openspawn-platform:latest
+    container_name: openspawn-platform
+    restart: unless-stopped
+    environment:
+      - PORT=3334
+      - PLATFORM_DIR=/app/dist
+      - NODE_ENV=production
+    ports:
+      - "3334:3334"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3334/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s


### PR DESCRIPTION
Adds full deploy infrastructure for the OpenSpawn platform site (openspawn.ai):

- **Dockerfile.platform** — 2-stage build (Nx build → node:24-alpine + tsx)
- **docker-compose.yml** — added `platform` service on port 3334 alongside BikiniBottom on 3333
- **deploy-platform.yml** — manual dispatch GH Actions workflow: GHCR push → VPS deploy → Cloudflare cache purge

Uses new per-domain secrets:
- `CLOUDFLARE_ZONE_ID_OPENSPAWN_DOT_AI`
- `CLOUDFLARE_PURGE_CACHE_API_TOKEN_OPENSPAWN_DOT_AI`

**Note:** VPS Caddy config needs updating to route `openspawn.ai` → `localhost:3334`.