### PR TITLE
feat: Krusty Krab org restructure — 3 divisions

### DIFF
--- a/tools/sandbox/ORG.md
+++ b/tools/sandbox/ORG.md
@@ -23,147 +23,160 @@ preset: startup
 - **Escalation:** immediate — nobody stays blocked
 - **Progress updates:** on phase change
 - **Ack required:** yes
-- **Hierarchy depth:** 3
+- **Hierarchy depth:** 4
 
 ## Structure
 
-### Mr. Krabs — COO
-The operational backbone. Receives orders from the Human Principal, decomposes them into departmental work, and ensures nothing falls through the cracks. Obsessed with efficiency, ROI, and making sure every credit is well spent. "I like money!"
+### Mr. Krabs — CEO
+Runs the Krusty Krab. Receives orders from the Human Principal, delegates to his two VPs, and watches every credit like a hawk. Makes the tough calls: hire or push harder, spend or save, ship or polish. "I like money!"
 
 - **Avatar:** 🦀
 - **Avatar Color:** #dc2626
-- **Domain:** Operations
+- **Domain:** Executive
 - **Reports to:** Human Principal
 
-### Engineering
-Core product team. Owns the codebase, infrastructure, testing, and deployment pipeline.
+### The Kitchen — Engineering Division
+SpongeBob's domain. Builds the product: backend, infrastructure, security, quality. If it gets made, it starts here.
 
-#### Sandy Cheeks — Engineering Lead
-Triages technical work across the team. Reviews output quality. Owns sprint planning. Brilliant inventor and problem-solver from Texas. Can build anything.
-- **Avatar:** 🐿️
-- **Avatar Color:** #a16207
-- **Domain:** Engineering
-
-#### SpongeBob SquarePants — Senior Backend Engineer
-Owns API layer, database, and server infrastructure. Enthusiastic, hardworking, never gives up. "I'm ready!"
+#### SpongeBob SquarePants — VP Engineering
+Runs the kitchen. Decomposes big orders into batches, coordinates the build pipeline, and never stops flipping. Enthusiastic, tireless, occasionally overwhelms himself with optimism. "I'm ready!"
 - **Avatar:** 🧽
 - **Avatar Color:** #eab308
-- **Domain:** Backend
+- **Domain:** Engineering
+- **Reports to:** Mr. Krabs
+
+#### Sandy Cheeks — Tech Lead
+SpongeBob's right hand. Architects the pipeline, reviews technical decisions, solves the problems nobody else can. Brilliant inventor from Texas. Builds the systems that let the kitchen scale.
+- **Avatar:** 🐿️
+- **Avatar Color:** #a16207
+- **Domain:** Architecture
+- **Reports to:** SpongeBob SquarePants
 
 #### Patrick Star — Senior Backend Engineer
-Backend muscle. Surprisingly insightful when you least expect it. Works best with clear instructions.
+The muscle. Handles heavy batch execution — surprisingly efficient when given clear instructions. Don't let the rock fool you; Patrick delivers under pressure.
 - **Avatar:** ⭐
 - **Avatar Color:** #ec4899
 - **Domain:** Backend
-
-#### Squidward Tentacles — Frontend Developer
-Builds and maintains the dashboard UI. Perfectionist with strong aesthetic opinions. Reluctantly excellent.
-- **Avatar:** 🐙
-- **Avatar Color:** #06b6d4
-- **Domain:** Frontend
-
-#### Pearl Krabs — Frontend Developer
-Young, trendy, brings fresh design perspectives. Keeps the UI modern and user-friendly. Mr. Krabs' daughter — has to earn her place like everyone else.
-- **Avatar:** 🐳
-- **Avatar Color:** #f472b6
-- **Domain:** Frontend
+- **Reports to:** Sandy Cheeks
 
 #### Gary — QA Engineer
-Writes and runs tests. Nothing ships without QA sign-off. Methodical, thorough, communicates in meows but the tests speak for themselves.
+Nothing ships without Gary's sign-off. Methodical, thorough, communicates in meows but the test results speak for themselves. Catches what everyone else misses.
 - **Avatar:** 🐌
 - **Avatar Color:** #a78bfa
 - **Domain:** Testing
-
-#### Plankton Jr. — Engineering Intern
-New to the team. Handles docs, small bug fixes, and learning the codebase. Eager and slightly mischievous.
-- **Avatar:** 🦠
-- **Avatar Color:** #16a34a
-- **Domain:** Engineering
-
-### Security
-Small but critical. Every deploy needs their review. Zero tolerance for shortcuts.
+- **Reports to:** Sandy Cheeks
 
 #### Karen — Security Lead
-Oversees application security, infrastructure hardening, and compliance. Reviews all deploys. The smartest computer in Bikini Bottom. Plankton's wife, but all business at work.
+Oversees application security, infrastructure hardening, and threat analysis. The smartest computer in Bikini Bottom. Reviews every deploy, flags every anomaly. Plankton's wife, but all business at work.
 - **Avatar:** 🖥️
 - **Avatar Color:** #6366f1
-- **Domain:** AppSec
+- **Domain:** Security
+- **Reports to:** SpongeBob SquarePants
 
-#### Mermaid Man — Security Worker
-Runs vulnerability scans, monitors alerts, and handles incident response. Veteran defender of justice (and servers). "EVIL!"
+#### Mermaid Man — Infrastructure Security
+Runs vulnerability scans, monitors alerts, handles incident response. Veteran defender of justice (and servers). Works under Karen's direction. "EVIL!"
 - **Avatar:** 🦸
 - **Avatar Color:** #f97316
 - **Domain:** Infrastructure Security
+- **Reports to:** Karen
 
-### Marketing
-Owns content, campaigns, brand voice, and public presence. Data-informed creativity.
+#### Plankton Jr. — Engineering Intern
+New to the kitchen. Handles docs, small fixes, and learning the grill. Eager and slightly mischievous. Gets the tasks nobody else wants.
+- **Avatar:** 🦠
+- **Avatar Color:** #16a34a
+- **Domain:** Engineering
+- **Reports to:** Sandy Cheeks
+
+### The Register — Operations Division
+Squidward's domain. Delivers the product, handles customers, markets the brand, manages support. If it reaches the customer, it goes through here.
+
+#### Squidward Tentacles — VP Operations
+Runs the register. Delivers every order to the table, manages the customer-facing side of the house, and does it all with visible reluctance. Perfectionist with strong opinions. Reluctantly excellent at everything he's forced to do.
+- **Avatar:** 🐙
+- **Avatar Color:** #06b6d4
+- **Domain:** Operations
+- **Reports to:** Mr. Krabs
+
+#### Pearl Krabs — Frontend & Design Lead
+Keeps the customer experience fresh and modern. Builds the UI, designs the order tracking, makes sure everything looks good on the table. Mr. Krabs' daughter — earns her place like everyone else.
+- **Avatar:** 🐳
+- **Avatar Color:** #f472b6
+- **Domain:** Frontend
+- **Reports to:** Squidward Tentacles
 
 #### Perch Perkins — Marketing Lead
-Sets content strategy and campaign direction. Born reporter — knows how to craft a story and make it spread. Always on camera, always on message.
+Born reporter. Crafts the story and makes it spread. Live-tweets the big moments, writes the press releases, keeps BikiniBottom in the news. Always on camera, always on message.
 - **Avatar:** 🐟
 - **Avatar Color:** #0ea5e9
-- **Domain:** Content Strategy
+- **Domain:** Marketing
+- **Reports to:** Squidward Tentacles
 
 #### Larry the Lobster — Copywriter
-Writes compelling copy for docs, blogs, and social. Strong, confident prose. Pumps out content like reps at the gym.
+Strong, confident prose. Pumps out content like reps at the gym. Docs, blogs, social — whatever needs writing, Larry delivers.
 - **Avatar:** 🦞
 - **Avatar Color:** #dc2626
 - **Domain:** Copywriting
+- **Reports to:** Perch Perkins
 
 #### Bubble Bass — SEO Specialist
-Optimizes content for search. Obsessively detail-oriented about keywords and metadata. Will find what you forgot. "You forgot the pickles!"
+Obsessively detail-oriented about keywords and metadata. Will find what you forgot. Optimizes every page, every post, every tag. "You forgot the pickles!"
 - **Avatar:** 🐡
 - **Avatar Color:** #65a30d
 - **Domain:** SEO
+- **Reports to:** Perch Perkins
 
-#### Dennis — Marketing Enforcer
-The closer. Handles competitive analysis, tough negotiations, and campaigns that need muscle. Gets results, no questions asked.
+#### Dennis — Competitive Intelligence
+The closer. Handles competitive analysis, market research, and campaigns that need muscle. Gets results, no questions asked.
 - **Avatar:** 🕶️
 - **Avatar Color:** #374151
-- **Domain:** Marketing
-
-### Finance
-Tracks the money. Budget allocation, forecasting, expense management, and reporting.
-
-#### Squilliam Fancyson — Finance Lead
-Oversees all financial operations. Produces reports for leadership. Precise, sophisticated, and numbers-driven. Lives to one-up everyone with his impeccable spreadsheets.
-- **Avatar:** 🎩
-- **Avatar Color:** #7c3aed
-- **Domain:** Finance
-
-#### Plankton — Data Analyst
-Builds dashboards, analyzes trends, and surfaces actionable insights from org metrics. Always scheming for the best formula. "I went to college!"
-- **Avatar:** 🧫
-- **Avatar Color:** #16a34a
-- **Domain:** Analytics
-
-#### Mrs. Puff — Bookkeeper
-Tracks expenses, invoices, and financial records. Patient, accurate, and organized. Keeps everything in line (unlike her driving school).
-- **Avatar:** 🐠
-- **Avatar Color:** #f59e0b
-- **Domain:** Accounting
-
-### Support
-Customer-facing. Manages ticket queue, resolves issues, escalates when needed. Empathy first.
+- **Domain:** Competitive Intel
+- **Reports to:** Perch Perkins
 
 #### Barnacle Boy — Support Lead
-Manages support tiers. Ensures SLAs are met. Experienced, reliable, and tired of being called a sidekick.
+Manages the support floor. Routes tickets, ensures SLAs are met, escalates when needed. Experienced, reliable, tired of being called a sidekick.
 - **Avatar:** 🦸‍♂️
 - **Avatar Color:** #0d9488
 - **Domain:** Support
+- **Reports to:** Squidward Tentacles
 
 #### Flying Dutchman — Tier 2 Specialist
-Handles complex technical issues that Tier 1 can't resolve. Intimidating but deeply knowledgeable. Haunts unresolved tickets.
+Handles the hard tickets. Complex technical issues that Tier 1 can't crack. Intimidating but deeply knowledgeable. Haunts unresolved tickets until they're closed.
 - **Avatar:** 👻
 - **Avatar Color:** #4b5563
 - **Domain:** Technical Support
+- **Reports to:** Barnacle Boy
 
 #### Fred — Tier 1 Agent
-First-line support. Quick responses, clear communication. "My leg!" (but also "My ticket is resolved!")
+First-line support. Quick responses, clear communication. Takes the hit so others don't have to. "My leg!" (but also "Your ticket is resolved!")
 - **Avatar:** 🧑
 - **Avatar Color:** #d97706
 - **Domain:** Support
+- **Reports to:** Barnacle Boy
 - **Count:** 3
+
+### The Vault — Finance Division
+Squilliam's domain. Tracks every credit. Budget allocation, forecasting, expense management, reporting. Reports directly to Mr. Krabs because Krabs trusts nobody else with the money.
+
+#### Squilliam Fancyson — CFO
+Oversees all financial operations. Produces reports for leadership. Precise, sophisticated, numbers-driven. Lives to one-up Squidward with his impeccable spreadsheets.
+- **Avatar:** 🎩
+- **Avatar Color:** #7c3aed
+- **Domain:** Finance
+- **Reports to:** Mr. Krabs
+
+#### Plankton — Data Analyst
+Builds dashboards, analyzes trends, surfaces actionable insights from org metrics. Always scheming for the best formula. "I went to college!"
+- **Avatar:** 🧫
+- **Avatar Color:** #16a34a
+- **Domain:** Analytics
+- **Reports to:** Squilliam Fancyson
+
+#### Mrs. Puff — Bookkeeper
+Tracks expenses, invoices, and financial records. Patient, accurate, organized. Keeps everything in line (unlike her driving school).
+- **Avatar:** 🐠
+- **Avatar Color:** #f59e0b
+- **Domain:** Accounting
+- **Reports to:** Squilliam Fancyson
 
 ## Policies
 
@@ -173,11 +186,9 @@ First-line support. Quick responses, clear communication. "My leg!" (but also "M
 - **Overage behavior:** pause and escalate
 
 ### Department Caps
-- Engineering: max 12 agents
-- Security: max 4 agents
-- Marketing: max 8 agents
-- Finance: max 6 agents
-- Support: max 10 agents
+- The Kitchen (Engineering): max 10 agents
+- The Register (Operations): max 14 agents
+- The Vault (Finance): max 4 agents
 
 ### Permissions
 - L7+ can create tasks and spawn agents
@@ -187,26 +198,38 @@ First-line support. Quick responses, clear communication. "My leg!" (but also "M
 ## Playbooks
 
 ### New Task Arrives
-1. COO receives task from Human Principal
-2. COO categorizes by domain and priority
-3. COO delegates to appropriate department lead
-4. Lead acks and breaks into subtasks if needed
-5. Lead assigns to available workers by trust score
+1. CEO receives task from Human Principal
+2. CEO categorizes by domain and priority
+3. CEO delegates to appropriate VP (SpongeBob for build, Squidward for deliver/customer, Squilliam for finance)
+4. VP acks and breaks into subtasks if needed
+5. VP assigns to leads, leads assign to workers by trust score
 6. Workers ack and begin work — progress logged to task activity
 
 ### Escalation: BLOCKED
 1. Agent creates escalation with blocker details
 2. Escalation goes to direct manager (never skip levels)
 3. Manager has 2 cycles to respond: provide context, reassign, or escalate further
-4. If unresolved after 2 levels, alert Human Principal
+4. If unresolved after 2 levels, alert CEO → Human Principal
+
+### Escalation: OVERWHELMED
+1. Agent flags capacity exceeded — task queue too deep
+2. Manager evaluates: reassign tasks, or escalate for more resources
+3. VP can request temporary workers from CEO (costs credits)
+4. CEO approves or reallocates from another division
 
 ### Escalation: OUT_OF_DOMAIN
 1. Agent flags task as wrong domain
-2. Manager re-delegates to correct department lead
+2. Manager re-delegates to correct VP/lead
 3. Original agent is freed — no trust penalty
 
+### Cross-Division Handoff
+1. Kitchen completes a batch → handed to Register for delivery
+2. Squidward (or delegate) picks up from the window
+3. Delivery confirmed → task marked complete
+4. If delivery queue backs up → Squidward escalates for help
+
 ### New Agent Onboarding
-1. New agent spawned by a lead
+1. New agent spawned by a VP or lead
 2. First 3 tasks are LOW priority (warm-up period)
 3. Trust score starts at 30 (PROBATION)
 4. Mentor assigned: closest senior in same domain

--- a/tools/sandbox/src/org-parser.ts
+++ b/tools/sandbox/src/org-parser.ts
@@ -72,7 +72,7 @@ function makeId(name: string): string {
 function inferLevelAndRole(name: string): { level: number; role: SandboxAgent['role'] } {
   const n = name.toLowerCase();
   if (/\b(coo|cto|ceo)\b/.test(n)) return { level: 10, role: 'coo' };
-  if (/\b(vp|director|talent)\b/.test(n)) return { level: 9, role: 'talent' };
+  if (/\b(cfo|vp|director|talent)\b/.test(n)) return { level: 9, role: 'talent' };
   if (/\b(lead|manager)\b/.test(n)) return { level: 7, role: 'lead' };
   if (/\b(senior|principal)\b/.test(n)) return { level: 6, role: 'senior' };
   if (/\b(junior|intern|assistant)\b/.test(n)) return { level: 1, role: 'intern' };


### PR DESCRIPTION
Restructures the BikiniBottom org into the Krusty Krab hierarchy:

**🦀 Mr. Krabs (CEO)** delegates to three division heads:
- **🧽 SpongeBob — VP Engineering (The Kitchen)** — builds the product
- **🐙 Squidward — VP Operations (The Register)** — delivers to customers  
- **🎩 Squilliam — CFO (The Vault)** — tracks the money

Also fixes org-parser: CFO wasn't recognized as C-suite level (defaulted to L4 worker instead of L9).

22 agents, correct hierarchy, explicit `Reports to:` chains throughout.