### PR TITLE
copy: tagline — 'A team needs structure' + introduce ORG.md

### DIFF
--- a/apps/platform/app/landing-page.tsx
+++ b/apps/platform/app/landing-page.tsx
@@ -172,10 +172,13 @@ export function LandingPage() {
               <span className="gradient-text">OpenSpawn</span>
             </h1>
             <p className="animate-fade-in-up animate-delay-200 mx-auto mb-4 max-w-xl text-lg text-slate-300 md:text-xl">
-              One agent needs a prompt. A team needs an org.
+              One agent needs a prompt. A team needs structure.
             </p>
-            <p className="animate-fade-in-up animate-delay-200 mx-auto mb-8 max-w-lg text-base text-slate-500">
-              The open-source coordination layer for AI agent teams. Define structure, hierarchy, and policies in markdown. Your agents do the rest.
+            <p className="animate-fade-in-up animate-delay-200 mx-auto mb-2 max-w-lg text-base text-cyan-400 font-medium">
+              Introducing ORG.md — the org chart your AI agents actually read.
+            </p>
+            <p className="animate-fade-in-up animate-delay-200 mx-auto mb-8 max-w-lg text-sm text-slate-500">
+              Open-source coordination layer. Define teams, hierarchy, and policies in markdown.
             </p>
             <div className="animate-fade-in-up animate-delay-300 mb-10 flex flex-wrap items-center justify-center gap-4">
               <a href="#how-it-works" className="glow-cyan rounded-xl bg-cyan-500 px-8 py-3 text-base font-semibold text-navy-950 transition hover:bg-cyan-400">

--- a/apps/platform/index.html
+++ b/apps/platform/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenSpawn — The org chart for AI agents</title>
-    <meta name="description" content="One agent needs a prompt. A team needs an org. Open-source coordination layer for AI agent teams. Define structure in markdown." />
+    <meta name="description" content="One agent needs a prompt. A team needs structure. Introducing ORG.md — the org chart your AI agents actually read. Open-source coordination layer." />
     <meta property="og:title" content="OpenSpawn — The org chart for AI agents" />
-    <meta property="og:description" content="One agent needs a prompt. A team needs an org. Open-source coordination for AI agent teams." />
+    <meta property="og:description" content="One agent needs a prompt. A team needs structure. Introducing ORG.md — the org chart your AI agents actually read." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://openspawn.ai" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪸</text></svg>" />

--- a/apps/website/app/routes/index.tsx
+++ b/apps/website/app/routes/index.tsx
@@ -89,10 +89,13 @@ export function LandingPage() {
       <span className="gradient-text">BikiniBottom</span>
      </h1>
      <p className="animate-fade-in-up animate-delay-200 mx-auto mb-4 max-w-xl text-lg text-slate-300 md:text-xl">
-      One agent needs a prompt. A team needs an org.
+      One agent needs a prompt. A team needs structure.
      </p>
-     <p className="animate-fade-in-up animate-delay-200 mx-auto mb-8 max-w-lg text-base text-slate-500">
-      The org chart for AI agents. Define teams, hierarchy, and policies in markdown.
+     <p className="animate-fade-in-up animate-delay-200 mx-auto mb-2 max-w-lg text-base text-cyan-400 font-medium">
+      Introducing ORG.md — the org chart your AI agents actually read.
+     </p>
+     <p className="animate-fade-in-up animate-delay-200 mx-auto mb-8 max-w-lg text-sm text-slate-500">
+      Define teams, hierarchy, and policies in markdown. Open source.
      </p>
      <div className="animate-fade-in-up animate-delay-300 mb-10 flex flex-wrap items-center justify-center gap-4">
       <a href="/app/" className="glow-cyan rounded-xl bg-cyan-500 px-8 py-3 text-base font-semibold text-navy-950 transition hover:bg-cyan-400">Launch Live Demo →</a>

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BikiniBottom — The org chart for AI agents</title>
-    <meta name="description" content="One agent needs a prompt. A team needs an org. The org chart for AI agents — define teams, hierarchy, and policies in markdown. Open source." />
+    <meta name="description" content="One agent needs a prompt. A team needs structure. Introducing ORG.md — the org chart your AI agents actually read. Open source." />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="canonical" href="https://bikinibottom.ai/" />
 
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://bikinibottom.ai/" />
     <meta property="og:title" content="BikiniBottom — The org chart for AI agents" />
-    <meta property="og:description" content="One agent needs a prompt. A team needs an org. Define teams, hierarchy, and policies in markdown. Open source, A2A + MCP native." />
+    <meta property="og:description" content="One agent needs a prompt. A team needs structure. Introducing ORG.md — the org chart your AI agents actually read. Open source." />
     <meta property="og:image" content="https://bikinibottom.ai/og-image.jpg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -21,7 +21,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="BikiniBottom — The control plane your AI agents deserve" />
-    <meta name="twitter:description" content="One agent needs a prompt. A team needs an org. Define teams, hierarchy, and policies in markdown. Open source, A2A + MCP native." />
+    <meta name="twitter:description" content="One agent needs a prompt. A team needs structure. Introducing ORG.md — the org chart your AI agents actually read. Open source." />
     <meta name="twitter:image" content="https://bikinibottom.ai/og-image.jpg" />
   </head>
   <body>


### PR DESCRIPTION
Updates hero tagline across both sites:

**Before:** "One agent needs a prompt. A team needs an org."
**After:** "One agent needs a prompt. A team needs structure."

Plus new ORG.md intro line:
> Introducing ORG.md — the org chart your AI agents actually read.

**Changes:**
- `apps/platform/` — landing page hero + index.html meta tags
- `apps/website/` — landing page hero + index.html meta/OG/Twitter tags
- 7 locations total, zero instances of old copy remain

The word 'org' was insider jargon — nobody outside the project knows what it means. 'Structure' lands immediately.