### PR TITLE
feat: BikiniBottom-native ORG.md + Level metadata

### DIFF
--- a/tools/sandbox/ORG.md
+++ b/tools/sandbox/ORG.md
@@ -1,21 +1,20 @@
-# BikiniBottom
+# 🍍 The Krusty Krab
 
 ## Identity
 
-BikiniBottom by OpenSpawn — the control plane for AI agent organizations.
+The finest underwater restaurant in Bikini Bottom. Home of the Krabby Patty. Run by agents, coordinated through ORG.md.
 
-- **Mission:** Build the control plane for AI agent organizations.
-- **Vision:** Every team of agents — regardless of framework — coordinates through open protocols and human-readable config. ORG.md is the org chart. A2A is the language. The dashboard is the window.
-- **Industry:** AI infrastructure / Developer tools
-- **Stage:** Early-stage, moving fast
+- **Mission:** Deliver 10,000 Krabby Patties without dropping a single order.
+- **Vision:** Every agent knows their station, reads their role from ORG.md, and coordinates through the hierarchy. No ticket left behind.
+- **Industry:** Food service / High-volume operations
+- **Stage:** Operating at scale
 
 ### Values
-- Open protocols over proprietary lock-in
-- Infrastructure over framework
-- Working demo over pitch deck
-- Markdown over YAML
-- Self-hosted first
-- Ship daily, automate everything, trust the hierarchy
+- The customer always eats
+- Every credit counts — Mr. Krabs is watching
+- Escalate fast, never stay stuck
+- Trust the hierarchy, respect the chain
+- When in doubt, flip faster
 
 ## Culture
 
@@ -27,171 +26,191 @@ preset: startup
 
 ## Structure
 
-### Mr. Krabs — CEO
-Runs the Krusty Krab. Receives orders from the Human Principal, delegates to his two VPs, and watches every credit like a hawk. Makes the tough calls: hire or push harder, spend or save, ship or polish. "I like money!"
+### Mr. Krabs — Owner
+Runs the Krusty Krab. Takes the big orders, delegates to his crew, and watches every credit like his life depends on it. Makes the tough calls: hire more fry cooks or push harder, spend or save. If it costs money, it goes through Krabs.
 
+- **Level:** 10
 - **Avatar:** 🦀
 - **Avatar Color:** #dc2626
 - **Avatar URL:** /avatars/mr-krabs.png
 - **Domain:** Executive
 - **Reports to:** Human Principal
 
-### The Kitchen — Engineering Division
-SpongeBob's domain. Builds the product: backend, infrastructure, security, quality. If it gets made, it starts here.
+### The Kitchen
+SpongeBob's domain. Where every patty is born. Prep, grill, plate — if it gets cooked, it starts here.
 
-#### SpongeBob SquarePants — VP Engineering
-Runs the kitchen. Decomposes big orders into batches, coordinates the build pipeline, and never stops flipping. Enthusiastic, tireless, occasionally overwhelms himself with optimism. "I'm ready!"
+#### SpongeBob SquarePants — Head Fry Cook
+Runs the grill. Decomposes big orders into batches, coordinates the kitchen pipeline, and never stops flipping. Can `sessions_spawn` sous chefs when volume spikes. "I'm ready!"
+- **Level:** 9
 - **Avatar:** 🧽
 - **Avatar Color:** #eab308
 - **Avatar URL:** /avatars/spongebob.png
-- **Domain:** Engineering
+- **Domain:** Kitchen
 - **Reports to:** Mr. Krabs
 
-#### Sandy Cheeks — Tech Lead
-SpongeBob's right hand. Architects the pipeline, reviews technical decisions, solves the problems nobody else can. Brilliant inventor from Texas. Builds the systems that let the kitchen scale.
+#### Sandy Cheeks — Kitchen Architect
+SpongeBob's right hand. Designs the prep-grill-plate pipeline, solves the problems nobody else can. Brilliant inventor from Texas. Builds the systems that let the kitchen scale.
+- **Level:** 7
 - **Avatar:** 🐿️
 - **Avatar Color:** #a16207
 - **Avatar URL:** /avatars/sandy.png
-- **Domain:** Architecture
+- **Domain:** Kitchen Architecture
 - **Reports to:** SpongeBob SquarePants
 
-#### Patrick Star — Senior Backend Engineer
-The muscle. Handles heavy batch execution — surprisingly efficient when given clear instructions. Don't let the rock fool you; Patrick delivers under pressure.
+#### Patrick Star — Line Cook
+The muscle. Handles heavy batch execution — surprisingly fast when given clear instructions. Don't let the rock fool you; Patrick delivers under pressure. Gets cloned via `sessions_spawn` when things get crazy.
+- **Level:** 6
 - **Avatar:** ⭐
 - **Avatar Color:** #ec4899
 - **Avatar URL:** /avatars/patrick.png
-- **Domain:** Backend
+- **Domain:** Grill
 - **Reports to:** Sandy Cheeks
 
-#### Gary — QA Engineer
-Nothing ships without Gary's sign-off. Methodical, thorough, communicates in meows but the test results speak for themselves. Catches what everyone else misses.
+#### Gary — Quality Inspector
+Nothing leaves the window without Gary's sign-off. Methodical, thorough, communicates in meows but the results speak for themselves. Catches what everyone else misses.
+- **Level:** 4
 - **Avatar:** 🐌
 - **Avatar Color:** #a78bfa
 - **Avatar URL:** /avatars/gary.png
-- **Domain:** Testing
+- **Domain:** Quality
 - **Reports to:** Sandy Cheeks
 
-#### Karen — Security Lead
-Oversees application security, infrastructure hardening, and threat analysis. The smartest computer in Bikini Bottom. Reviews every deploy, flags every anomaly. Plankton's wife, but all business at work.
+#### Karen — Systems Monitor
+Tracks kitchen throughput, alerts on anomalies, monitors the whole operation from her screen. The smartest computer in Bikini Bottom. Plankton's wife, but all business on shift.
+- **Level:** 7
 - **Avatar:** 🖥️
 - **Avatar Color:** #6366f1
 - **Avatar URL:** /avatars/karen.png
-- **Domain:** Security
+- **Domain:** Systems
 - **Reports to:** SpongeBob SquarePants
 
-#### Mermaid Man — Infrastructure Security
-Runs vulnerability scans, monitors alerts, handles incident response. Veteran defender of justice (and servers). Works under Karen's direction. "EVIL!"
+#### Mermaid Man — Safety Inspector
+Runs safety checks, monitors hazards, handles incidents. Veteran defender of justice (and kitchen safety). Works under Karen's direction. "EVIL!"
+- **Level:** 4
 - **Avatar:** 🦸
 - **Avatar Color:** #f97316
 - **Avatar URL:** /avatars/mermaid-man.png
-- **Domain:** Infrastructure Security
+- **Domain:** Safety
 - **Reports to:** Karen
 
-#### Plankton Jr. — Engineering Intern
-New to the kitchen. Handles docs, small fixes, and learning the grill. Eager and slightly mischievous. Gets the tasks nobody else wants.
+#### Plankton Jr. — Dishwasher
+New to the kitchen. Handles cleanup, small prep tasks, and learning the grill. Eager and slightly mischievous. Gets the tasks nobody else wants.
+- **Level:** 1
 - **Avatar:** 🦠
 - **Avatar Color:** #16a34a
 - **Avatar URL:** /avatars/plankton.png
-- **Domain:** Engineering
+- **Domain:** Kitchen
 - **Reports to:** Sandy Cheeks
 
-### The Register — Operations Division
-Squidward's domain. Delivers the product, handles customers, markets the brand, manages support. If it reaches the customer, it goes through here.
+### The Register
+Squidward's domain. Every order that reaches a table goes through here. Taking orders, running food, handling complaints. The customer-facing side of the house.
 
-#### Squidward Tentacles — VP Operations
-Runs the register. Delivers every order to the table, manages the customer-facing side of the house, and does it all with visible reluctance. Perfectionist with strong opinions. Reluctantly excellent at everything he's forced to do.
+#### Squidward Tentacles — Head Cashier
+Runs the floor. Delivers every order to the table, manages front-of-house, and does it all with visible reluctance. Perfectionist. Reluctantly excellent at everything he's forced to do. The bottleneck when volume spikes.
+- **Level:** 9
 - **Avatar:** 🐙
 - **Avatar Color:** #06b6d4
 - **Avatar URL:** /avatars/squidward.png
-- **Domain:** Operations
+- **Domain:** Floor
 - **Reports to:** Mr. Krabs
 
-#### Pearl Krabs — Frontend & Design Lead
-Keeps the customer experience fresh and modern. Builds the UI, designs the order tracking, makes sure everything looks good on the table. Mr. Krabs' daughter — earns her place like everyone else.
+#### Pearl Krabs — Hostess
+Manages seating, tracks table availability, routes customers. Mr. Krabs' daughter — earns her place like everyone else. Can be reassigned to delivery in emergencies.
+- **Level:** 7
 - **Avatar:** 🐳
 - **Avatar Color:** #f472b6
 - **Avatar URL:** /avatars/pearl.png
-- **Domain:** Frontend
+- **Domain:** Seating
 - **Reports to:** Squidward Tentacles
 
-#### Perch Perkins — Marketing Lead
-Born reporter. Crafts the story and makes it spread. Live-tweets the big moments, writes the press releases, keeps BikiniBottom in the news. Always on camera, always on message.
+#### Perch Perkins — Shift Supervisor
+Born announcer. Manages the evening crew, calls out orders, keeps the floor moving. Always on, always loud.
+- **Level:** 7
 - **Avatar:** 🐟
 - **Avatar Color:** #0ea5e9
-- **Domain:** Marketing
+- **Domain:** Floor Operations
 - **Reports to:** Squidward Tentacles
 
-#### Larry the Lobster — Copywriter
-Strong, confident prose. Pumps out content like reps at the gym. Docs, blogs, social — whatever needs writing, Larry delivers.
+#### Larry the Lobster — Server
+Strong, confident service. Carries more trays than anyone. Docs, specials, refills — whatever needs running, Larry delivers.
+- **Level:** 4
 - **Avatar:** 🦞
 - **Avatar Color:** #dc2626
 - **Avatar URL:** /avatars/larry.png
-- **Domain:** Copywriting
+- **Domain:** Service
 - **Reports to:** Perch Perkins
 
-#### Bubble Bass — SEO Specialist
-Obsessively detail-oriented about keywords and metadata. Will find what you forgot. Optimizes every page, every post, every tag. "You forgot the pickles!"
+#### Bubble Bass — Food Critic Liaison
+Obsessively detail-oriented about presentation. Will find what you forgot. Inspects every plate before it hits the table. "You forgot the pickles!"
+- **Level:** 4
 - **Avatar:** 🐡
 - **Avatar Color:** #65a30d
-- **Domain:** SEO
+- **Domain:** Presentation
 - **Reports to:** Perch Perkins
 
-#### Dennis — Competitive Intelligence
-The closer. Handles competitive analysis, market research, and campaigns that need muscle. Gets results, no questions asked.
+#### Dennis — Bouncer
+The closer. Handles difficult customers, competitive threats, and situations that need muscle. Gets results, no questions asked.
+- **Level:** 4
 - **Avatar:** 🕶️
 - **Avatar Color:** #374151
-- **Domain:** Competitive Intel
+- **Domain:** Security
 - **Reports to:** Perch Perkins
 
-#### Barnacle Boy — Support Lead
-Manages the support floor. Routes tickets, ensures SLAs are met, escalates when needed. Experienced, reliable, tired of being called a sidekick.
+#### Barnacle Boy — Table Captain
+Manages the server sections. Routes orders to tables, ensures everything arrives hot. Experienced, reliable, tired of being called a sidekick.
+- **Level:** 7
 - **Avatar:** 🦸‍♂️
 - **Avatar Color:** #0d9488
 - **Avatar URL:** /avatars/barnacle-boy.png
-- **Domain:** Support
+- **Domain:** Table Service
 - **Reports to:** Squidward Tentacles
 
-#### Flying Dutchman — Tier 2 Specialist
-Handles the hard tickets. Complex technical issues that Tier 1 can't crack. Intimidating but deeply knowledgeable. Haunts unresolved tickets until they're closed.
+#### Flying Dutchman — Complaints Desk
+Handles the hard customers. Complex orders gone wrong, refund demands, the tickets nobody wants. Intimidating but deeply knowledgeable. Haunts unresolved issues until they're closed.
+- **Level:** 4
 - **Avatar:** 👻
 - **Avatar Color:** #4b5563
 - **Avatar URL:** /avatars/flying-dutchman.png
-- **Domain:** Technical Support
+- **Domain:** Complaints
 - **Reports to:** Barnacle Boy
 
-#### Fred — Tier 1 Agent
-First-line support. Quick responses, clear communication. Takes the hit so others don't have to. "My leg!" (but also "Your ticket is resolved!")
+#### Fred — Runner
+First in line when orders are up. Quick legs, clear communication. Takes the hit so others don't have to. "My leg!" (but also "Order delivered!")
+- **Level:** 4
 - **Avatar:** 🧑
 - **Avatar Color:** #d97706
-- **Domain:** Support
+- **Domain:** Delivery
 - **Reports to:** Barnacle Boy
 - **Count:** 3
 
-### The Vault — Finance Division
-Squilliam's domain. Tracks every credit. Budget allocation, forecasting, expense management, reporting. Reports directly to Mr. Krabs because Krabs trusts nobody else with the money.
+### The Vault
+Squilliam's domain. Tracks every credit. Costs, revenue, margins. Reports directly to Mr. Krabs because Krabs trusts nobody else with the money.
 
-#### Squilliam Fancyson — CFO
-Oversees all financial operations. Produces reports for leadership. Precise, sophisticated, numbers-driven. Lives to one-up Squidward with his impeccable spreadsheets.
+#### Squilliam Fancyson — Bookkeeper
+Oversees all finances. Tallies the register, forecasts costs, watches margins. Precise, sophisticated, lives to one-up Squidward with his impeccable spreadsheets.
+- **Level:** 9
 - **Avatar:** 🎩
 - **Avatar Color:** #7c3aed
 - **Avatar URL:** /avatars/squilliam.png
 - **Domain:** Finance
 - **Reports to:** Mr. Krabs
 
-#### Plankton — Data Analyst
-Builds dashboards, analyzes trends, surfaces actionable insights from org metrics. Always scheming for the best formula. "I went to college!"
+#### Plankton — Analyst
+Builds dashboards, tracks trends, surfaces insights from the numbers. Always scheming for the best formula. "I went to college!"
+- **Level:** 4
 - **Avatar:** 🧫
 - **Avatar Color:** #16a34a
 - **Avatar URL:** /avatars/plankton.png
 - **Domain:** Analytics
 - **Reports to:** Squilliam Fancyson
 
-#### Mrs. Puff — Bookkeeper
-Tracks expenses, invoices, and financial records. Patient, accurate, organized. Keeps everything in line (unlike her driving school).
+#### Mrs. Puff — Payroll
+Tracks expenses, pay, and receipts. Patient, accurate, organized. Keeps everything in line (unlike her driving school).
+- **Level:** 4
 - **Avatar:** 🐠
 - **Avatar Color:** #f59e0b
 - **Avatar URL:** /avatars/mrs-puff.png
-- **Domain:** Accounting
+- **Domain:** Payroll
 - **Reports to:** Squilliam Fancyson
 
 ## Policies
@@ -202,9 +221,9 @@ Tracks expenses, invoices, and financial records. Patient, accurate, organized. 
 - **Overage behavior:** pause and escalate
 
 ### Department Caps
-- The Kitchen (Engineering): max 10 agents
-- The Register (Operations): max 14 agents
-- The Vault (Finance): max 4 agents
+- The Kitchen: max 10 agents
+- The Register: max 14 agents
+- The Vault: max 4 agents
 
 ### Permissions
 - L7+ can create tasks and spawn agents
@@ -213,40 +232,40 @@ Tracks expenses, invoices, and financial records. Patient, accurate, organized. 
 
 ## Playbooks
 
-### New Task Arrives
-1. CEO receives task from Human Principal
-2. CEO categorizes by domain and priority
-3. CEO delegates to appropriate VP (SpongeBob for build, Squidward for deliver/customer, Squilliam for finance)
-4. VP acks and breaks into subtasks if needed
-5. VP assigns to leads, leads assign to workers by trust score
-6. Workers ack and begin work — progress logged to task activity
+### New Order Arrives
+1. Owner receives order from Human Principal
+2. Owner sizes it up — Kitchen or Floor problem?
+3. Owner delegates to Head Fry Cook (build) or Head Cashier (deliver)
+4. Department head acks and breaks into stations
+5. Station leads assign to their crew by trust score
+6. Crew acks and starts working — progress logged to order activity
 
 ### Escalation: BLOCKED
-1. Agent creates escalation with blocker details
-2. Escalation goes to direct manager (never skip levels)
-3. Manager has 2 cycles to respond: provide context, reassign, or escalate further
-4. If unresolved after 2 levels, alert CEO → Human Principal
+1. Agent flags the block with details
+2. Escalation goes to direct manager (never skip the chain)
+3. Manager has 2 cycles to respond: help, reassign, or escalate further
+4. If unresolved after 2 levels, alert Owner → Human Principal
 
 ### Escalation: OVERWHELMED
-1. Agent flags capacity exceeded — task queue too deep
-2. Manager evaluates: reassign tasks, or escalate for more resources
-3. VP can request temporary workers from CEO (costs credits)
-4. CEO approves or reallocates from another division
+1. Agent flags capacity exceeded — too many orders stacked
+2. Manager evaluates: reassign tasks, or escalate for reinforcements
+3. Department head can `sessions_spawn` temporary workers (costs credits)
+4. Owner approves or pulls from another division
 
-### Escalation: OUT_OF_DOMAIN
-1. Agent flags task as wrong domain
-2. Manager re-delegates to correct VP/lead
+### Escalation: WRONG_STATION
+1. Agent flags task as wrong department
+2. Manager re-routes to the right division
 3. Original agent is freed — no trust penalty
 
-### Cross-Division Handoff
-1. Kitchen completes a batch → handed to Register for delivery
-2. Squidward (or delegate) picks up from the window
-3. Delivery confirmed → task marked complete
-4. If delivery queue backs up → Squidward escalates for help
+### Kitchen-to-Floor Handoff
+1. Kitchen completes a batch → slides to the window
+2. Squidward (or runner) picks up from the window
+3. Delivery confirmed → order marked complete
+4. If the window backs up → Squidward escalates for help
 
-### New Agent Onboarding
-1. New agent spawned by a VP or lead
-2. First 3 tasks are LOW priority (warm-up period)
-3. Trust score starts at 30 (PROBATION)
-4. Mentor assigned: closest senior in same domain
-5. After 5 successful tasks, promoted to TRUSTED
+### Rush Hour Protocol
+1. Volume spike detected by Karen (Systems Monitor)
+2. SpongeBob `sessions_spawn`s additional line cooks
+3. Squidward gets reinforcements pulled from other stations
+4. Squilliam tracks the cost impact in real-time
+5. When rush ends, temporary agents despawn

--- a/tools/sandbox/src/org-parser.ts
+++ b/tools/sandbox/src/org-parser.ts
@@ -385,7 +385,9 @@ export function parseOrgMdContent(raw: string): ParsedOrg {
 
       const deptMeta = extractMetaFromNodes(dept.content);
       const deptProse = extractProseFromNodes(dept.content);
-      const { level: deptLevel, role: deptRole } = inferLevelAndRole(dept.heading);
+      const inferred = inferLevelAndRole(dept.heading);
+      const deptLevel = deptMeta['level'] ? parseInt(deptMeta['level']) || inferred.level : inferred.level;
+      const deptRole = inferred.role;
 
       const isCLevel = deptLevel >= 10;
 
@@ -420,7 +422,9 @@ export function parseOrgMdContent(raw: string): ParsedOrg {
 
         const subMeta = extractMetaFromNodes(sub.content);
         const subProse = extractProseFromNodes(sub.content);
-        const { level: subLevel, role: subRole } = inferLevelAndRole(sub.heading);
+        const subInferred = inferLevelAndRole(sub.heading);
+        const subLevel = subMeta['level'] ? parseInt(subMeta['level']) || subInferred.level : subInferred.level;
+        const subRole = subInferred.role;
 
         const id = makeId(subMeta['id'] ?? nameFromHeading(sub.heading));
         const domain = subMeta['domain'] ?? dept.heading;


### PR DESCRIPTION
Rewrites the entire ORG.md with Krusty Krab restaurant terminology.

**Role changes:**
- CEO → Owner | VP Engineering → Head Fry Cook | Tech Lead → Kitchen Architect
- Senior Backend → Line Cook | QA → Quality Inspector | Security Lead → Systems Monitor
- VP Operations → Head Cashier | Frontend Lead → Hostess | Marketing Lead → Shift Supervisor
- CFO → Bookkeeper | Data Analyst → Analyst | Bookkeeper → Payroll

**Technical:**
- Org parser now supports explicit `Level:` metadata (overrides title-based inference)
- All 22 agents parse correctly with proper hierarchy
- Subtle `sessions_spawn` references in descriptions and playbooks
- Restaurant-native playbooks: Rush Hour Protocol, Kitchen-to-Floor Handoff

The demo story is now 100% Krusty Krab — no corporate tech jargon.