### PR TITLE
feat: add llms.txt for AI discoverability

### DIFF
--- a/apps/platform/public/llms.txt
+++ b/apps/platform/public/llms.txt
@@ -1,0 +1,29 @@
+# OpenSpawn
+
+> OpenSpawn is an open-source multi-agent coordination platform. Define AI agent organizations in markdown (ORG.md), coordinate via A2A and MCP protocols, and observe in a real-time dashboard. The tagline: "One agent needs a prompt. A team needs structure."
+
+OpenSpawn provides the control plane for AI agent teams. It is infrastructure, not a framework — it coordinates agent stacks like CrewAI, LangGraph, AutoGen, and OpenClaw rather than replacing them.
+
+The core innovation is **ORG.md**: a markdown file that defines an entire agent organization — hierarchy, roles, domains, culture, policies, and playbooks. This is analogous to how OpenClaw uses SOUL.md for individual agent identity, but scaled to organizations.
+
+- **Repo:** github.com/openspawn/openspawn (MIT licensed, Nx monorepo, TypeScript)
+- **Live demo:** bikinibottom.ai (22 SpongeBob-themed agents coordinate in real-time)
+- **Framework site:** openspawn.ai
+- **Protocols:** A2A v0.3, MCP (Streamable HTTP), Model Router
+- **CLI:** `npx bikinibottom init my-reef`
+- **Created by:** Adam Dennis (@adamwdennis)
+- **Status:** Demo stage (February 2026), open source, actively developed
+
+## Key Concepts
+
+- **ORG.md**: A markdown file that IS the org chart. Agents read their roles, reporting chains, and policies from it. Sections: Identity (mission/vision/values), Culture (presets like startup/enterprise), Structure (agent hierarchy with levels, domains, avatars), Policies (budgets, caps, permissions), Playbooks (escalation protocols, handoff procedures).
+- **Agent Communication Protocol (ACP)**: Internal message protocol — ACK, Progress, Escalation, Completion. Push for urgent (escalations), pull for optional (progress).
+- **Agent Levels**: L1 (intern) through L10 (CEO). Higher levels get event-driven triggers, lower levels poll. L7+ can spawn sub-agents.
+- **Simulation Modes**: Deterministic (rule-based, zero LLM), Hybrid (L7+ use LLM), Record (capture decisions), Replay (playback for demos).
+
+## Links
+
+- [GitHub Repository](https://github.com/openspawn/openspawn): Full source, issues, PRs
+- [Live Demo](https://bikinibottom.ai/app/live): 75-second choreographed agent coordination demo
+- [ORG.md Concept](https://bikinibottom.ai/org-md): Detailed explanation of the ORG.md format
+- [Documentation](https://bikinibottom.ai/docs): Getting started, protocols, features

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -1,0 +1,50 @@
+# BikiniBottom (OpenSpawn)
+
+> BikiniBottom is an open-source multi-agent coordination platform — the control plane for AI agent organizations. Define your org in a single markdown file (ORG.md), coordinate agents via A2A and MCP protocols, and watch them work in a real-time dashboard. Built on OpenClaw. MIT licensed.
+
+BikiniBottom is infrastructure, not a framework. It doesn't replace your agent stack — it coordinates it. Works with CrewAI, LangGraph, AutoGen, or any A2A-compatible agent.
+
+The core concept is **ORG.md** — a markdown file that defines an entire agent organization: hierarchy, roles, domains, reporting chains, culture, policies, and playbooks. Agents read their roles from this file the same way OpenClaw agents read SOUL.md.
+
+The project is at demo stage (February 2026). The live demo at bikinibottom.ai shows 22 SpongeBob-themed AI agents across 5 departments coordinating to deliver 10,000 Krabby Patties.
+
+- **Repo:** github.com/openspawn/openspawn (Nx monorepo, TypeScript)
+- **Stack:** React + TanStack Router (dashboard + website), Node.js sandbox server, Vite
+- **Protocols:** A2A v0.3 (agent discovery), MCP (Streamable HTTP, 7 tools), Model Router (Ollama/Groq/OpenRouter)
+- **CLI:** `npx bikinibottom init my-reef` (zero external dependencies)
+- **Created by:** Adam Dennis (@adamwdennis)
+- **License:** MIT
+
+## Docs
+
+- [Getting Started](https://bikinibottom.ai/docs/getting-started): Installation, setup, and first run
+- [ORG.md Concept](https://bikinibottom.ai/org-md): The org chart your AI agents actually read — defines hierarchy, culture, policies, playbooks in markdown
+- [OpenClaw Quickstart](https://bikinibottom.ai/docs/openclaw): How to use BikiniBottom with OpenClaw agents
+- [A2A Protocol](https://bikinibottom.ai/docs/protocols/a2a): Agent-to-Agent discovery and task management via /.well-known/agent.json
+- [MCP Server](https://bikinibottom.ai/docs/protocols/mcp): 7 tools exposed via POST /mcp (Streamable HTTP, JSON-RPC 2.0)
+- [Model Router](https://bikinibottom.ai/docs/features/model-router): Intelligent routing across Ollama, Groq, and OpenRouter with fallback chains
+- [Dashboard](https://bikinibottom.ai/docs/features/dashboard): Real-time network graph, task timeline, agent details, credits tracking
+
+## Code
+
+- [GitHub Repository](https://github.com/openspawn/openspawn): Full source code, Nx monorepo
+- [Dashboard App](https://github.com/openspawn/openspawn/tree/main/apps/dashboard): React + TanStack Router SPA
+- [Website App](https://github.com/openspawn/openspawn/tree/main/apps/website): Marketing site + docs
+- [Sandbox Server](https://github.com/openspawn/openspawn/tree/main/tools/sandbox): Node.js server — org parser, simulation engine, A2A, MCP, model router
+- [CLI Package](https://github.com/openspawn/openspawn/tree/main/packages/cli): `npx bikinibottom init` scaffolding tool
+- [ORG.md Example](https://github.com/openspawn/openspawn/blob/main/tools/sandbox/org.md): The Krusty Krab — 22 agents, 3 departments, full playbooks
+
+## Architecture
+
+The sandbox server is the brain. It parses ORG.md into an agent hierarchy, runs a tick-based simulation engine, and exposes REST + SSE + A2A + MCP endpoints. The dashboard connects via SSE for real-time updates. The website serves docs and marketing at root, dashboard at /app/.
+
+Key components:
+- **Org Parser** (`org-parser.ts`): Parses ORG.md markdown into typed agent hierarchy using unified/remark
+- **Simulation Engine** (`simulation.ts`, `deterministic.ts`): Tick-based coordination with ACP (Agent Communication Protocol)
+- **Replay Engine** (`replay-engine.ts`): Plays back recorded LLM simulation scenarios for zero-cost demos
+- **LLM Provider** (`llm-provider.ts`): Ollama, Groq, OpenRouter with markdown-based decision prompts
+
+## Optional
+
+- [Live Demo](https://bikinibottom.ai/app/live): 75-second choreographed replay of 22 agents coordinating
+- [Design Strategy Docs](https://github.com/openspawn/openspawn/tree/main/docs/strategy): Agent Communication Protocol, event-driven architecture, scenario engine, competitive analysis


### PR DESCRIPTION
Adds `/llms.txt` to both bikinibottom.ai and openspawn.ai following the [llmstxt.org](https://llmstxt.org) spec.

AI tools (Claude, Perplexity, Cursor, etc.) that support the spec can now understand what OpenSpawn/BikiniBottom is without needing to render JavaScript.

**bikinibottom.ai/llms.txt** — Full project description, all doc page links, architecture overview, key concepts
**openspawn.ai/llms.txt** — Framework overview, ORG.md concept, links to demo and docs