### PR TITLE
chore: add sandbox run scripts for all simulation modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,14 @@
     "dev:dashboard": "nx serve dashboard",
     "dev:sandbox": "nx run sandbox:dev",
     "dev:sandbox:full": "nx run sandbox:dev:full",
-    "dev:sandbox:cofounder": "nx run sandbox:dev:cofounder"
+    "dev:sandbox:cofounder": "nx run sandbox:dev:cofounder",
+    "dev:sandbox:hybrid": "nx run sandbox:dev:hybrid",
+    "dev:sandbox:record": "nx run sandbox:dev:record",
+    "dev:sandbox:replay": "nx run sandbox:dev:replay",
+    "sandbox": "nx run sandbox:serve",
+    "sandbox:hybrid": "nx run sandbox:serve:hybrid",
+    "sandbox:record": "nx run sandbox:serve:record",
+    "sandbox:replay": "nx run sandbox:serve:replay"
   },
   "dependencies": {
     "@apollo/server": "^5.4.0",

--- a/tools/sandbox/project.json
+++ b/tools/sandbox/project.json
@@ -17,6 +17,15 @@
         },
         "cofounder": {
           "command": "COFOUNDER=1 npx tsx tools/sandbox/src/index.ts"
+        },
+        "hybrid": {
+          "command": "SIMULATION_MODE=hybrid LLM_MODEL=qwen2.5:7b-instruct LLM_BASE_URL=http://localhost:11434 SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts"
+        },
+        "record": {
+          "command": "SIMULATION_MODE=record LLM_MODEL=qwen2.5:7b-instruct LLM_BASE_URL=http://localhost:11434 SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts"
+        },
+        "replay": {
+          "command": "SIMULATION_MODE=replay SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts"
         }
       }
     },
@@ -24,7 +33,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "CLEAN=1 npx tsx tools/sandbox/src/index.ts",
+          "CLEAN=1 SERVE_DASHBOARD=1 npx tsx tools/sandbox/src/index.ts",
           "VITE_SANDBOX_MODE=true nx serve dashboard"
         ],
         "cwd": "{workspaceRoot}",
@@ -33,14 +42,37 @@
       "configurations": {
         "full": {
           "commands": [
-            "npx tsx tools/sandbox/src/index.ts",
+            "SERVE_DASHBOARD=1 npx tsx tools/sandbox/src/index.ts",
             "VITE_SANDBOX_MODE=true nx serve dashboard"
           ]
         },
         "cofounder": {
           "commands": [
-            "COFOUNDER=1 npx tsx tools/sandbox/src/index.ts",
+            "COFOUNDER=1 SERVE_DASHBOARD=1 npx tsx tools/sandbox/src/index.ts",
             "VITE_SANDBOX_MODE=true nx serve dashboard"
+          ]
+        },
+        "hybrid": {
+          "commands": [
+            "SERVE_DASHBOARD=1 SIMULATION_MODE=hybrid LLM_MODEL=qwen2.5:7b-instruct LLM_BASE_URL=http://localhost:11434 SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts",
+            "VITE_SANDBOX_MODE=true nx serve dashboard"
+          ]
+        },
+        "record": {
+          "commands": [
+            "SERVE_DASHBOARD=1 SIMULATION_MODE=record LLM_MODEL=qwen2.5:7b-instruct LLM_BASE_URL=http://localhost:11434 SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts",
+            "VITE_SANDBOX_MODE=true nx serve dashboard"
+          ]
+        },
+        "replay": {
+          "commands": [
+            "SERVE_DASHBOARD=1 SIMULATION_MODE=replay SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts",
+            "VITE_SANDBOX_MODE=true nx serve dashboard"
+          ]
+        },
+        "prod": {
+          "commands": [
+            "SERVE_DASHBOARD=1 SIMULATION_MODE=replay SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts"
           ]
         }
       }


### PR DESCRIPTION
Adds Nx target configurations and root package.json shortcuts for running the sandbox in different modes.

## Commands

| Command | Mode | Dashboard |
|---|---|---|
| `pnpm sandbox` | deterministic | ❌ |
| `pnpm sandbox:hybrid` | LLM hybrid (Ollama) | ❌ |
| `pnpm sandbox:record` | record LLM decisions | ❌ |
| `pnpm sandbox:replay` | scripted replay | ❌ |
| `pnpm dev:sandbox` | deterministic | ✅ |
| `pnpm dev:sandbox:hybrid` | LLM hybrid + dashboard | ✅ |
| `pnpm dev:sandbox:record` | record + dashboard | ✅ |
| `pnpm dev:sandbox:replay` | replay + dashboard | ✅ |

The `dev:*` variants run the dashboard dev server in parallel (hot reload). The non-dev variants are headless (terminal only) or serve the pre-built dashboard via `SERVE_DASHBOARD=1`.

Defaults: `qwen2.5:7b-instruct` via Ollama at `localhost:11434`, `krabby-patties` scenario.