### PR TITLE
feat: merge hybrid+record, REPLAY_FILE selection, recording stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
     "dev:sandbox:full": "nx run sandbox:dev:full",
     "dev:sandbox:cofounder": "nx run sandbox:dev:cofounder",
     "dev:sandbox:hybrid": "nx run sandbox:dev:hybrid",
-    "dev:sandbox:record": "nx run sandbox:dev:record",
     "dev:sandbox:replay": "nx run sandbox:dev:replay",
     "sandbox": "nx run sandbox:serve",
     "sandbox:hybrid": "nx run sandbox:serve:hybrid",
-    "sandbox:record": "nx run sandbox:serve:record",
-    "sandbox:replay": "nx run sandbox:serve:replay"
+    "sandbox:replay": "nx run sandbox:serve:replay",
+    "sandbox:recordings": "nx run sandbox:recordings"
   },
   "dependencies": {
     "@apollo/server": "^5.4.0",

--- a/tools/sandbox/project.json
+++ b/tools/sandbox/project.json
@@ -21,9 +21,6 @@
         "hybrid": {
           "command": "SIMULATION_MODE=hybrid LLM_MODEL=qwen2.5:7b-instruct LLM_BASE_URL=http://localhost:11434 SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts"
         },
-        "record": {
-          "command": "SIMULATION_MODE=record LLM_MODEL=qwen2.5:7b-instruct LLM_BASE_URL=http://localhost:11434 SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts"
-        },
         "replay": {
           "command": "SIMULATION_MODE=replay SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts"
         }
@@ -58,12 +55,6 @@
             "VITE_SANDBOX_MODE=true nx serve dashboard"
           ]
         },
-        "record": {
-          "commands": [
-            "SERVE_DASHBOARD=1 SIMULATION_MODE=record LLM_MODEL=qwen2.5:7b-instruct LLM_BASE_URL=http://localhost:11434 SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts",
-            "VITE_SANDBOX_MODE=true nx serve dashboard"
-          ]
-        },
         "replay": {
           "commands": [
             "SERVE_DASHBOARD=1 SIMULATION_MODE=replay SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts",
@@ -75,6 +66,13 @@
             "SERVE_DASHBOARD=1 SIMULATION_MODE=replay SCENARIO=krabby-patties npx tsx tools/sandbox/src/index.ts"
           ]
         }
+      }
+    },
+    "recordings": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx tsx tools/sandbox/src/list-recordings.ts",
+        "cwd": "{workspaceRoot}"
       }
     }
   }

--- a/tools/sandbox/src/list-recordings.ts
+++ b/tools/sandbox/src/list-recordings.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// ── List Recorded Simulations ───────────────────────────────────────────────
+// Shows all recorded simulation runs with their stats for comparison.
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const recordedDir = resolve(__dirname, '..', 'scenarios', 'recorded');
+
+if (!existsSync(recordedDir)) {
+  console.log('No recordings found. Run a simulation with SIMULATION_MODE=hybrid to create one.');
+  process.exit(0);
+}
+
+const files = readdirSync(recordedDir)
+  .filter(f => f.endsWith('.md'))
+  .sort()
+  .reverse(); // newest first
+
+if (files.length === 0) {
+  console.log('No recordings found. Run a simulation with SIMULATION_MODE=hybrid to create one.');
+  process.exit(0);
+}
+
+console.log(`\n📼 Recorded Simulations (${files.length} total)\n`);
+console.log('─'.repeat(100));
+console.log(
+  '#'.padEnd(4) +
+  'Date'.padEnd(22) +
+  'Model'.padEnd(28) +
+  'Ticks'.padEnd(7) +
+  'Decisions'.padEnd(11) +
+  'Tasks'.padEnd(14) +
+  'Rate'.padEnd(7) +
+  'File'
+);
+console.log('─'.repeat(100));
+
+for (let i = 0; i < files.length; i++) {
+  const file = files[i];
+  const content = readFileSync(join(recordedDir, file), 'utf8');
+
+  // Parse frontmatter
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) continue;
+
+  const fm = fmMatch[1];
+  const get = (key: string): string => {
+    const m = fm.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+    return m?.[1]?.trim() ?? '';
+  };
+
+  const recorded = get('recorded');
+  const model = get('model') || 'unknown';
+  const ticks = get('ticks') || '?';
+  const decisions = get('decisions') || '?';
+  const tasksTotal = get('tasks_total');
+  const tasksDone = get('tasks_done');
+  const completionRate = get('completion_rate');
+  const actions = get('actions');
+
+  const date = recorded
+    ? new Date(recorded).toLocaleString('en-CA', { dateStyle: 'short', timeStyle: 'short' })
+    : '?';
+
+  const tasksStr = tasksTotal ? `${tasksDone}/${tasksTotal}` : '—';
+  const rateStr = completionRate ? `${completionRate}%` : '—';
+
+  console.log(
+    `${String(i + 1).padEnd(4)}` +
+    `${date.padEnd(22)}` +
+    `${model.slice(0, 26).padEnd(28)}` +
+    `${String(ticks).padEnd(7)}` +
+    `${String(decisions).padEnd(11)}` +
+    `${tasksStr.padEnd(14)}` +
+    `${rateStr.padEnd(7)}` +
+    file
+  );
+
+  // Show action distribution if available
+  if (actions) {
+    console.log(`     └─ ${actions}`);
+  }
+}
+
+console.log('─'.repeat(100));
+console.log(`\nTo replay a specific recording:`);
+console.log(`  REPLAY_FILE=tools/sandbox/scenarios/recorded/<filename> pnpm sandbox:replay`);
+console.log(`  # or with dashboard:`);
+console.log(`  REPLAY_FILE=tools/sandbox/scenarios/recorded/<filename> pnpm dev:sandbox:replay`);
+console.log('');

--- a/tools/sandbox/src/replay-engine.ts
+++ b/tools/sandbox/src/replay-engine.ts
@@ -209,15 +209,36 @@ export class ReplaySimulation extends DeterministicSimulation {
     config: SandboxConfig,
     skipSeedTasks = false,
     parsedOrg?: ParsedOrg,
+    replayFile?: string,
   ) {
     super(agents, config, skipSeedTasks, parsedOrg);
 
-    const scenariosDir = resolve(__dirname, '..', 'scenarios');
-    this.scenarios = loadScenarios(scenariosDir);
-    console.log(`\n🔁 Replay Simulation`);
-    console.log(`   Loaded ${this.scenarios.length} scenario(s) from ${scenariosDir}`);
-    for (const s of this.scenarios) {
-      console.log(`   • "${s.name}" (${s.decisions.length} decisions, ${s.metadata.ticks} ticks)`);
+    if (replayFile) {
+      // Load a specific recording file
+      const filePath = resolve(replayFile);
+      if (!existsSync(filePath)) {
+        console.log(`\n❌ Replay file not found: ${filePath}`);
+        this.scenarios = [];
+      } else {
+        const content = readFileSync(filePath, 'utf8');
+        const scenario = parseScenarioFile(content);
+        this.scenarios = scenario ? [scenario] : [];
+        console.log(`\n🔁 Replay Simulation (specific file)`);
+        console.log(`   📄 ${filePath}`);
+        if (scenario) {
+          console.log(`   • "${scenario.name}" (${scenario.decisions.length} decisions, ${scenario.metadata.ticks} ticks, model: ${scenario.metadata.model})`);
+        } else {
+          console.log(`   ⚠️ Failed to parse recording file`);
+        }
+      }
+    } else {
+      const scenariosDir = resolve(__dirname, '..', 'scenarios');
+      this.scenarios = loadScenarios(scenariosDir);
+      console.log(`\n🔁 Replay Simulation`);
+      console.log(`   Loaded ${this.scenarios.length} scenario(s) from ${scenariosDir}`);
+      for (const s of this.scenarios) {
+        console.log(`   • "${s.name}" (${s.decisions.length} decisions, ${s.metadata.ticks} ticks)`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Simplifies simulation modes and adds recording comparison tools.

## Changes

### Merged hybrid + record modes
- `hybrid` now always records — no reason not to (timestamps prevent overwrites)
- Removed `record` as a separate mode
- Simplified scripts: `pnpm sandbox:hybrid` and `pnpm dev:sandbox:hybrid`

### REPLAY_FILE selection
- `REPLAY_FILE=path/to/recording.md pnpm sandbox:replay` — replay a specific recording
- Without REPLAY_FILE, replay still fuzzy-matches all recordings (existing behavior)

### Recording stats
Each recording now includes summary stats in both frontmatter and body:
- Action distribution (delegate: 40%, work: 30%, message: 20%, etc.)
- Task completion rate (12/26 = 46%)
- Average LLM latency per call
- Total duration
- Per-decision latency annotations

### list-recordings command
`pnpm sandbox:recordings` — table view of all recordings with stats for comparison:
```
#   Date                  Model                       Ticks  Decisions  Tasks         Rate   File
1   2026-02-16, 4:30 PM   qwen2.5:7b-instruct         20     47         12/26         46%    2026-02-16T16-30-00-*.md
```

### Auto-save on exit
- SIGINT/SIGTERM handler saves recording before exit (Ctrl+C safe)
- Recording also saved when `run()` finishes naturally (MAX_TICKS reached)

## Commands

| Command | What it does |
|---|---|
| `pnpm dev:sandbox:hybrid` | LLM agents + dashboard + auto-record |
| `pnpm sandbox:hybrid` | LLM agents terminal only + auto-record |
| `pnpm sandbox:recordings` | List all recordings with stats |
| `REPLAY_FILE=<path> pnpm dev:sandbox:replay` | Replay specific recording + dashboard |
