### PR TITLE
fix: resolve server.ts typecheck error

### DIFF
--- a/tools/sandbox/src/server.ts
+++ b/tools/sandbox/src/server.ts
@@ -655,7 +655,7 @@ export function startServer(sim: Simulation): void {
             parentId = domainLead?.id ?? coo?.id;
           }
 
-          const agent = makeAgentPublic(id, name, role, level ?? 4, domain ?? 'Engineering', parentId, undefined);
+          const agent = makeAgentPublic(id, name, role, level ?? 4, domain ?? 'Engineering', parentId ?? '', '');
           agent.avatar = avatar;
           agent.avatarColor = avatarColor;
           agent.status = 'active';


### PR DESCRIPTION
Fixes pre-existing TS2345 in spawn endpoint — `parentId` (`string | undefined`) and `personality` (`undefined`) passed to `makeAgentPublic()` which expects `string`. Sandbox typecheck now clean (0 errors).