### PR TITLE
fix: website SPA fallback was swallowing /api/* routes

### DIFF
--- a/tools/sandbox/src/server.ts
+++ b/tools/sandbox/src/server.ts
@@ -1031,7 +1031,8 @@ export function startServer(sim: Simulation): void {
       }
 
       // Website: /* routes — serve from website-dist (SPA with fallback to index.html)
-      if (existsSync(websiteDir)) {
+      // Skip API and protocol routes — those must reach handlers below
+      if (existsSync(websiteDir) && !path.startsWith('/api/') && !path.startsWith('/graphql') && !path.startsWith('/sse') && !path.startsWith('/mcp') && !path.startsWith('/.well-known/')) {
         const subPath = path === '/' ? 'index.html' : path.slice(1);
         let filePath = join(websiteDir, subPath);
 


### PR DESCRIPTION
The website catch-all SPA fallback was serving `index.html` for `/api/*` routes before they could reach their handlers. This caused CORS errors in dev mode since the HTML response had no CORS headers.

Now excludes `/api/*`, `/graphql`, `/sse`, `/mcp`, and `/.well-known/` from the SPA fallback.