### PR TITLE
feat: CLI install pipeline (goreleaser + GitHub Action + install script)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,33 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - "packages/cli/v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+          workdir: packages/cli
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/packages/cli/.goreleaser.yml
+++ b/packages/cli/.goreleaser.yml
@@ -1,0 +1,52 @@
+version: 2
+
+project_name: openspawn
+
+builds:
+  - id: openspawn
+    main: .
+    binary: openspawn
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/openspawn/openspawn/packages/cli/cmd.version={{.Version}}
+
+archives:
+  - id: default
+    format: tar.gz
+    name_template: "openspawn_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+brews:
+  - name: openspawn
+    repository:
+      owner: openspawn
+      name: homebrew-tap
+    directory: Formula
+    homepage: "https://openspawn.ai"
+    description: "Organization as Code for AI agent teams"
+    license: "MIT"
+    test: |
+      system "#{bin}/openspawn", "version"
+    install: |
+      bin.install "openspawn"

--- a/packages/cli/cmd/init.go
+++ b/packages/cli/cmd/init.go
@@ -8,8 +8,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
-	"github.com/openspawn/openspawn/cli/internal/templates"
-	"github.com/openspawn/openspawn/cli/internal/wizard"
+	"github.com/openspawn/openspawn/packages/cli/internal/templates"
+	"github.com/openspawn/openspawn/packages/cli/internal/wizard"
 )
 
 var (

--- a/packages/cli/cmd/validate.go
+++ b/packages/cli/cmd/validate.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openspawn/openspawn/cli/internal/orgparser"
+	"github.com/openspawn/openspawn/packages/cli/internal/orgparser"
 )
 
 var validateCmd = &cobra.Command{

--- a/packages/cli/go.mod
+++ b/packages/cli/go.mod
@@ -1,4 +1,4 @@
-module github.com/openspawn/openspawn/cli
+module github.com/openspawn/openspawn/packages/cli
 
 go 1.24.2
 

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# OpenSpawn CLI installer
+# Usage: curl -fsSL https://raw.githubusercontent.com/openspawn/openspawn/main/packages/cli/install.sh | sh
+
+set -e
+
+REPO="openspawn/openspawn"
+BINARY="openspawn"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# Detect OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+case "$OS" in
+  linux|darwin) ;;
+  *) echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+# Get latest release tag for the CLI
+LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" | \
+  grep '"tag_name"' | grep 'packages/cli/' | head -1 | \
+  sed 's/.*"tag_name": "packages\/cli\/\(.*\)".*/\1/')
+
+if [ -z "$LATEST" ]; then
+  echo "Could not determine latest version. Check https://github.com/${REPO}/releases"
+  exit 1
+fi
+
+VERSION="${LATEST#v}"
+FILENAME="${BINARY}_${VERSION}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/packages%2Fcli%2Fv${VERSION}/${FILENAME}"
+
+echo "Installing ${BINARY} v${VERSION} (${OS}/${ARCH})..."
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+curl -fsSL "$URL" -o "${TMP}/${FILENAME}"
+tar -xzf "${TMP}/${FILENAME}" -C "$TMP"
+
+if [ -w "$INSTALL_DIR" ]; then
+  mv "${TMP}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+else
+  echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+  sudo mv "${TMP}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+fi
+
+chmod +x "${INSTALL_DIR}/${BINARY}"
+
+echo ""
+echo "✅ ${BINARY} v${VERSION} installed to ${INSTALL_DIR}/${BINARY}"
+echo ""
+echo "Get started:"
+echo "  openspawn init my-team"
+echo ""

--- a/packages/cli/main.go
+++ b/packages/cli/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/openspawn/openspawn/cli/cmd"
+	"github.com/openspawn/openspawn/packages/cli/cmd"
 )
 
 func main() {

--- a/packages/cli/main_test.go
+++ b/packages/cli/main_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
-	"github.com/openspawn/openspawn/cli/internal/orgparser"
-	"github.com/openspawn/openspawn/cli/internal/templates"
+	"github.com/openspawn/openspawn/packages/cli/internal/orgparser"
+	"github.com/openspawn/openspawn/packages/cli/internal/templates"
 )
 
 func TestTemplatesAvailable(t *testing.T) {


### PR DESCRIPTION
Enables 3 install methods for the Go CLI:

1. **`go install`** — fixed module path to match directory structure
2. **GitHub Releases** — goreleaser cross-compiles for linux/mac/windows (amd64 + arm64), triggered by `packages/cli/v*` tags
3. **curl install** — `curl -fsSL .../install.sh | sh` detects OS/arch and downloads the right binary

Homebrew tap config included in goreleaser — needs `openspawn/homebrew-tap` repo created.

### To release:
```bash
git tag packages/cli/v0.1.0
git push origin packages/cli/v0.1.0
```

GH Action runs goreleaser → binaries on GitHub Releases → Homebrew formula updated.