### PR TITLE
fix(api): add declaration + composite to tsconfig.app.json

### DIFF
--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -4,6 +4,8 @@
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["node"],
+    "declaration": true,
+    "composite": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "target": "es2021",


### PR DESCRIPTION
The typecheck target runs `tsc --build --emitDeclarationOnly`, which requires either `declaration` or `composite` to be set. All other projects (shared-types, database, dashboard) already had both. The API was the only outlier, causing `pnpm typecheck` to fail.

One-line fix: added `declaration: true` and `composite: true` to `apps/api/tsconfig.app.json`.