### PR TITLE
chore: lint cleanup — remove unused imports and fix unused vars (150→86)

### DIFF
--- a/apps/api/src/auth/api-key.guard.ts
+++ b/apps/api/src/auth/api-key.guard.ts
@@ -88,7 +88,7 @@ export class JwtOrApiKeyGuard implements CanActivate {
       throw new UnauthorizedException("Missing authorization header");
     }
 
-    const [scheme, token] = authHeader.split(" ");
+    const [_scheme, token] = authHeader.split(" ");
     if (!token) {
       throw new UnauthorizedException("Invalid authorization format");
     }

--- a/apps/api/src/auth/api-keys.service.ts
+++ b/apps/api/src/auth/api-keys.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, ForbiddenException } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, IsNull } from "typeorm";
 import { randomBytes, createHash } from "node:crypto";

--- a/apps/api/src/auth/types.ts
+++ b/apps/api/src/auth/types.ts
@@ -22,4 +22,4 @@ declare global {
   }
 }
 
-export {};
+

--- a/apps/api/src/credits/credit-analytics.service.ts
+++ b/apps/api/src/credits/credit-analytics.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository, Between, MoreThanOrEqual } from "typeorm";
+import { Repository } from "typeorm";
 
 import { Agent, CreditTransaction } from "@openspawn/database";
 import { CreditType, AgentStatus } from "@openspawn/shared-types";

--- a/apps/api/src/github/github.service.ts
+++ b/apps/api/src/github/github.service.ts
@@ -2,8 +2,7 @@ import {
   Injectable,
   Logger,
   NotFoundException,
-  BadRequestException,
-} from "@nestjs/common";
+  } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { OnEvent } from "@nestjs/event-emitter";
 import { Repository } from "typeorm";

--- a/apps/api/src/inbound-webhooks/inbound-webhook-receiver.controller.spec.ts
+++ b/apps/api/src/inbound-webhooks/inbound-webhook-receiver.controller.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { NotFoundException, UnauthorizedException, BadRequestException } from "@nestjs/common";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
 
 import { InboundWebhookKey, Task } from "@openspawn/database";
 import { TaskPriority, TaskStatus } from "@openspawn/shared-types";

--- a/apps/api/src/linear/linear.service.ts
+++ b/apps/api/src/linear/linear.service.ts
@@ -87,13 +87,13 @@ export class LinearService implements IntegrationProvider {
     catch { return false; }
   }
 
-  async handleWebhookEvent(orgId: string, event: string, payload: unknown): Promise<void> {
-    this.logger.log(`Processing Linear event: \${event} for org \${orgId}`);
+  async handleWebhookEvent(_orgId: string, _event: string, _payload: unknown): Promise<void> {
+    this.logger.log(`Processing Linear webhook event`);
     // Webhook processing implementation
   }
 
-  async syncOutbound(orgId: string, event: string, data: Record<string, unknown>): Promise<void> {
-    this.logger.log(`Outbound sync: \${event} for org \${orgId}`);
+  async syncOutbound(_orgId: string, _event: string, _data: Record<string, unknown>): Promise<void> {
+    this.logger.log(`Outbound sync`);
   }
 
   async testConnection(connectionId: string): Promise<{ ok: boolean; message: string }> {

--- a/apps/api/src/tasks/escalations.controller.ts
+++ b/apps/api/src/tasks/escalations.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from "@nestjs/common";
+import { Controller, Get, Param, Post } from "@nestjs/common";
 
 import { EscalationReason } from "@openspawn/shared-types";
 

--- a/apps/api/src/tasks/task-routing.service.ts
+++ b/apps/api/src/tasks/task-routing.service.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Injectable,
   NotFoundException,
 } from "@nestjs/common";

--- a/apps/api/src/tasks/task-templates.service.ts
+++ b/apps/api/src/tasks/task-templates.service.ts
@@ -1,6 +1,5 @@
 import {
   ConflictException,
-  ForbiddenException,
   Injectable,
   NotFoundException,
 } from "@nestjs/common";

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -11,7 +11,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 
 import { Task, TaskComment, TaskDependency, TaskTag } from "@openspawn/database";
-import { TaskPriority, TaskStatus } from "@openspawn/shared-types";
+import { TaskStatus } from "@openspawn/shared-types";
 
 import { TrustService } from "../agents";
 import { EventsService } from "../events";

--- a/apps/dashboard/src/components/agent-detail-panel.tsx
+++ b/apps/dashboard/src/components/agent-detail-panel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { motion, AnimatePresence } from "motion/react";
 import { X, TrendingUp, TrendingDown, Calendar, Zap, MessageSquare, Settings, Activity, Award, Coins, Clock, Terminal } from "lucide-react";
@@ -13,7 +13,7 @@ import { Progress } from "./ui/progress";
 import { useAgents } from "../hooks/use-agents";
 import { useTasks } from "../hooks/use-tasks";
 import { useCredits } from "../hooks/use-credits";
-import { AgentRole, AgentStatus, TaskStatus } from "../graphql/generated/graphql";
+import { AgentRole, TaskStatus } from "../graphql/generated/graphql";
 import type { AgentFieldsFragment } from "../graphql/generated/graphql";
 // recharts v3 has infinite-loop bug — using custom bars instead
 import { useContainerSize } from "../hooks/use-container-size";

--- a/apps/dashboard/src/components/agent-mode-selector.tsx
+++ b/apps/dashboard/src/components/agent-mode-selector.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { Briefcase, Eye, Network, Check, ChevronDown, Info } from "lucide-react";
+import { Briefcase, Eye, Network, Check, ChevronDown } from "lucide-react";
 import { cn } from "../lib/utils";
 import {
   DropdownMenu,

--- a/apps/dashboard/src/components/agent-onboarding.tsx
+++ b/apps/dashboard/src/components/agent-onboarding.tsx
@@ -7,8 +7,7 @@ import {
   Clock,
   Users,
   Loader2,
-  ChevronRight,
-} from "lucide-react";
+  } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";

--- a/apps/dashboard/src/components/live-notifications.tsx
+++ b/apps/dashboard/src/components/live-notifications.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, createContext, useContext, useCallback, useRef } from 'react';
+import { useState, useEffect, createContext, useContext, useCallback } from 'react';
 import type { ReactNode } from 'react';
 import { isSandboxMode } from '../graphql/fetcher';
 import { useSandboxSSE, type SandboxSSEEvent } from '../hooks/use-sandbox-sse';

--- a/apps/dashboard/src/components/onboarding/onboarding-provider.tsx
+++ b/apps/dashboard/src/components/onboarding/onboarding-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
 
 const STORAGE_KEY = 'bb-onboarding-complete';
 const TOTAL_STEPS = 5;

--- a/apps/dashboard/src/components/org-chart.tsx
+++ b/apps/dashboard/src/components/org-chart.tsx
@@ -2,7 +2,7 @@
  * Org Chart — ReactFlow tree layout showing teams → sub-teams → agents.
  * Features: animated edge pulses, click-to-detail, presence glow on active agents.
  */
-import { useEffect, useState, useMemo, useCallback, useRef, memo } from 'react';
+import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { useDemo } from '../demo/DemoProvider';
 import {
   ReactFlow,

--- a/apps/dashboard/src/components/settings/api-key-settings.tsx
+++ b/apps/dashboard/src/components/settings/api-key-settings.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Key, Plus, Trash2, Copy, Eye, EyeOff, Loader2, Check } from "lucide-react";
+import { Key, Plus, Trash2, Copy, Loader2, Check } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";

--- a/apps/dashboard/src/components/settings/github-settings.tsx
+++ b/apps/dashboard/src/components/settings/github-settings.tsx
@@ -7,12 +7,10 @@ import {
   Copy,
   Check,
   ExternalLink,
-  RefreshCw,
   Link2,
   GitPullRequest,
   AlertCircle,
-  CheckCircle2,
-} from "lucide-react";
+  } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";

--- a/apps/dashboard/src/components/settings/inbound-webhooks-settings.tsx
+++ b/apps/dashboard/src/components/settings/inbound-webhooks-settings.tsx
@@ -3,15 +3,13 @@ import {
   Webhook,
   Plus,
   Trash2,
-  Loader2,
   Copy,
   Check,
   RefreshCw,
   Eye,
   EyeOff,
   ExternalLink,
-  Code,
-} from "lucide-react";
+  } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";

--- a/apps/dashboard/src/components/task-timeline.tsx
+++ b/apps/dashboard/src/components/task-timeline.tsx
@@ -18,15 +18,15 @@ import {
   ChevronRight,
   ArrowRight,
 } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Card, CardTitle } from './ui/card';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { AgentAvatar } from './agent-avatar';
 import { cn } from '../lib/utils';
-import { useAgents, useTasks, useMessages, useEvents } from '../hooks';
+import { useAgents, useTasks, useMessages } from '../hooks';
 import type { Task } from '../hooks/use-tasks';
 import type { Message } from '../hooks/use-messages';
-import { getStatusVariant, getTaskStatusVariant } from '../lib/status-colors';
+import { getTaskStatusVariant } from '../lib/status-colors';
 import { TaskStatus } from '../graphql/generated/graphql';
 
 // ── Timeline event types ────────────────────────────────────────────────────

--- a/apps/dashboard/src/components/team-detail-panel.tsx
+++ b/apps/dashboard/src/components/team-detail-panel.tsx
@@ -33,7 +33,7 @@ import { Badge } from './ui/badge';
 import { AgentAvatar } from './agent-avatar';
 import { AgentModeBadge } from './agent-mode-selector';
 import { Progress } from './ui/progress';
-import { getStatusVariant, getLevelColor } from '../lib/status-colors';
+import { getStatusVariant } from '../lib/status-colors';
 import {
   type Team,
   getTeamById,

--- a/apps/dashboard/src/components/team-view.tsx
+++ b/apps/dashboard/src/components/team-view.tsx
@@ -34,18 +34,16 @@ import { AgentModeBadge } from './agent-mode-selector';
 import { getStatusVariant } from '../lib/status-colors';
 import { cn } from '../lib/utils';
 import {
-  teams,
   type Team,
   getParentTeams,
   getSubTeams,
   getTeamColor,
-  TEAM_COLOR_MAP,
-} from '../demo/teams';
+  } from '../demo/teams';
 import { useAgents } from '../hooks/use-agents';
 import { useTeamStats } from '../hooks/use-teams';
 import { usePresence } from '../hooks/use-presence';
 import { useAgentHealth } from '../hooks/use-agent-health';
-import { AgentMode, AgentStatus } from '../graphql/generated/graphql';
+import { AgentMode } from '../graphql/generated/graphql';
 import type { AgentFieldsFragment } from '../graphql/generated/graphql';
 
 type Agent = AgentFieldsFragment;

--- a/apps/dashboard/src/components/thread-view.tsx
+++ b/apps/dashboard/src/components/thread-view.tsx
@@ -3,7 +3,7 @@
  * with a visual timeline showing message flow direction.
  */
 import { useMemo } from 'react';
-import { motion, AnimatePresence } from 'motion/react';
+import { motion } from 'motion/react';
 import { X, MessageSquare } from 'lucide-react';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';

--- a/apps/dashboard/src/demo/DemoProvider.tsx
+++ b/apps/dashboard/src/demo/DemoProvider.tsx
@@ -13,7 +13,7 @@ import {
   type DemoScenario,
 } from '@openspawn/demo-data';
 import { setDemoEngine } from './mock-fetcher';
-import { celebrate, celebrateLevelUp, celebrateSparkle, celebrateElite } from '../lib/confetti';
+import { celebrateLevelUp, celebrateElite } from '../lib/confetti';
 import { debug } from '../lib/debug';
 
 export type ScenarioName = 'acmetech' | 'fresh' | 'startup' | 'growth' | 'enterprise' | 'sandbox';

--- a/apps/dashboard/src/hooks/use-sandbox-sse.ts
+++ b/apps/dashboard/src/hooks/use-sandbox-sse.ts
@@ -2,7 +2,7 @@
  * Shared hook for connecting to the sandbox SSE stream.
  * Only connects when isSandboxMode is true.
  */
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { isSandboxMode } from '../graphql/fetcher';
 import { SANDBOX_URL } from '../lib/sandbox-url';
 

--- a/apps/dashboard/src/lib/__tests__/sandbox-url.spec.ts
+++ b/apps/dashboard/src/lib/__tests__/sandbox-url.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
 // We need to re-import each test because getSandboxUrl reads window at import time
 describe('getSandboxUrl', () => {

--- a/apps/dashboard/src/pages/live-view.tsx
+++ b/apps/dashboard/src/pages/live-view.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Link } from '@tanstack/react-router';
 import { motion, AnimatePresence } from 'motion/react';
 import { ArrowRight } from 'lucide-react';

--- a/apps/dashboard/src/pages/mobile-status.tsx
+++ b/apps/dashboard/src/pages/mobile-status.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useMemo, useCallback } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { RefreshCw, ChevronDown, Coins, Zap, Clock, Activity, CheckCircle, AlertTriangle, Bot } from "lucide-react";
+import { RefreshCw, ChevronDown, Coins, Zap, Clock, Activity, CheckCircle, Bot } from "lucide-react";
 import { cn } from "../lib/utils";
 import { useAgents, usePresence, useAgentHealth, useTasks } from "../hooks";
 import type { PresenceStatus } from "../hooks";

--- a/apps/sandbox-cli/src/commands/agents.ts
+++ b/apps/sandbox-cli/src/commands/agents.ts
@@ -2,7 +2,6 @@ import { Command } from "commander";
 import pc from "picocolors";
 import { createClient, unwrap } from "../lib/api.js";
 import {
-  output,
   outputError,
   outputSuccess,
   outputTable,

--- a/apps/sandbox-cli/src/commands/auth.ts
+++ b/apps/sandbox-cli/src/commands/auth.ts
@@ -7,8 +7,7 @@ import {
   formatStatus,
   formatKeyValue,
   icons,
-  colors,
-} from "../lib/output.js";
+  } from "../lib/output.js";
 import { withSpinner } from "../lib/spinner.js";
 import { OpenSpawnClient } from "../lib/api.js";
 

--- a/apps/sandbox-cli/src/commands/credits.ts
+++ b/apps/sandbox-cli/src/commands/credits.ts
@@ -2,11 +2,8 @@ import { Command } from "commander";
 import pc from "picocolors";
 import { createClient, unwrap } from "../lib/api.js";
 import {
-  output,
   outputError,
-  outputSuccess,
   outputTable,
-  formatCredits,
   formatEmpty,
   icons,
   colors,

--- a/apps/sandbox-cli/src/commands/messages.ts
+++ b/apps/sandbox-cli/src/commands/messages.ts
@@ -2,14 +2,11 @@ import { Command } from "commander";
 import pc from "picocolors";
 import { createClient, unwrap } from "../lib/api.js";
 import {
-  output,
   outputError,
-  outputSuccess,
   outputTable,
   formatEmpty,
   icons,
-  colors,
-} from "../lib/output.js";
+  } from "../lib/output.js";
 import { withSpinner } from "../lib/spinner.js";
 
 interface Message {

--- a/apps/sandbox-cli/src/commands/tasks.ts
+++ b/apps/sandbox-cli/src/commands/tasks.ts
@@ -2,15 +2,13 @@ import { Command } from "commander";
 import pc from "picocolors";
 import { createClient, unwrap } from "../lib/api.js";
 import {
-  output,
   outputError,
   outputSuccess,
   outputTable,
   formatTask,
   formatEmpty,
   icons,
-  colors,
-} from "../lib/output.js";
+  } from "../lib/output.js";
 import { withSpinner } from "../lib/spinner.js";
 
 interface Task {

--- a/e2e/legacy/demo-mobile.spec.ts
+++ b/e2e/legacy/demo-mobile.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 
 test.use({ 
   baseURL: 'http://localhost:4200',

--- a/e2e/legacy/trust-reputation.spec.ts
+++ b/e2e/legacy/trust-reputation.spec.ts
@@ -70,7 +70,7 @@ test.describe('Trust Leaderboard', () => {
     
     if (await leaderboardSection.isVisible({ timeout: 2000 }).catch(() => false)) {
       // Should have numbered rankings or medal icons
-      const rankings = leaderboardSection.locator('[class*="rank"], .medal, span:has-text(/[1-9]\./)');
+      const rankings = leaderboardSection.locator('[class*="rank"], .medal, span:has-text(/[1-9]./)');
       const count = await rankings.count();
       console.log('Rankings found:', count);
     }

--- a/libs/demo-data/src/scenarios/startup.ts
+++ b/libs/demo-data/src/scenarios/startup.ts
@@ -1,6 +1,6 @@
 import type { DemoScenario } from '../types';
-import { agents, AGENT_IDS, generateRandomAgent } from '../fixtures/agents';
-import { tasks, generateRandomTask } from '../fixtures/tasks';
+import { agents, AGENT_IDS } from '../fixtures/agents';
+import { tasks } from '../fixtures/tasks';
 import { creditTransactions } from '../fixtures/credits';
 import { events } from '../fixtures/events';
 import { generateInitialMessages } from '../fixtures/messages';

--- a/tools/sandbox/src/index.ts
+++ b/tools/sandbox/src/index.ts
@@ -26,9 +26,9 @@ if (existsSync(envPath)) {
 } else {
   console.log(`  ⚠ No .env file found at ${envPath}`);
 }
-import { createAgents, createCOO } from './agents.js';
+import { createAgents } from './agents.js';
 import { parseOrgMd, type ParsedOrg } from './org-parser.js';
-import { initLLM, getProvider, getProviderInfo } from './llm.js';
+import { initLLM } from './llm.js';
 import { Simulation } from './simulation.js';
 import { DeterministicSimulation } from './deterministic.js';
 import { startServer } from './server.js';

--- a/tools/sandbox/src/markdown-decision.ts
+++ b/tools/sandbox/src/markdown-decision.ts
@@ -4,7 +4,7 @@
 
 import type { SandboxAgent, SandboxTask, ACPMessage } from './types.js';
 import { loadAgentConfig, buildSystemPrompt } from './config-loader.js';
-import { resolve, dirname, join } from 'node:path';
+import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Reduced lint warnings from 150 to 86 (43% reduction).

### Changes:
- Removed unused imports across 35+ files
- Prefixed unused function parameters with `_`  
- Removed empty `export {}` statement
- Fixed useless escape in e2e test

### Remaining (86 warnings):
- Complex multiline import patterns needing manual review
- Unused variables in destructuring (some intentional for API compliance)
- Type-only imports that oxlint flags but TypeScript needs

All existing tests pass. Dashboard and libs typecheck clean.