### PR TITLE
feat(sandbox): seedable PRNG + shared ACP helpers

### DIFF
--- a/tools/sandbox/src/acp.ts
+++ b/tools/sandbox/src/acp.ts
@@ -1,0 +1,45 @@
+// ── Shared ACP Helpers ───────────────────────────────────────────────────────
+// Extracted from deterministic.ts and decision-executor.ts to eliminate duplication.
+// Used by all simulation engines for creating and routing ACP messages.
+
+import type { SandboxAgent, ACPMessage } from './types.js';
+
+let acpCounter = 0;
+
+/** Generate a unique ACP message ID (deterministic counter, no Math.random) */
+export function acpId(): string {
+  return `acp-${++acpCounter}`;
+}
+
+/** Reset the ACP counter (for tests) */
+export function resetAcpCounter(): void {
+  acpCounter = 0;
+}
+
+/** Create an ACP message */
+export function createACPMessage(
+  type: ACPMessage['type'],
+  from: string,
+  to: string,
+  taskId: string,
+  extra?: Partial<ACPMessage>,
+): ACPMessage {
+  return { id: acpId(), type, from, to, taskId, timestamp: Date.now(), ...extra };
+}
+
+/** Route a message to sender/receiver recentMessages and event-driven inboxes */
+export function pushMessage(agents: SandboxAgent[], msg: ACPMessage): void {
+  for (const agent of agents) {
+    if (agent.id === msg.from || agent.id === msg.to) {
+      agent.recentMessages.push(msg);
+      if (agent.recentMessages.length > 10) {
+        agent.recentMessages = agent.recentMessages.slice(-10);
+      }
+    }
+    if (agent.id === msg.to && agent.trigger === 'event-driven') {
+      if (!agent.triggerOn || agent.triggerOn.includes(msg.type)) {
+        agent.inbox.push(msg);
+      }
+    }
+  }
+}

--- a/tools/sandbox/src/decision-executor.ts
+++ b/tools/sandbox/src/decision-executor.ts
@@ -3,43 +3,14 @@
 
 import { resolveAgentId, type AgentDecision } from './markdown-decision.js';
 import { makeAgentPublic } from './agents.js';
-import type { SandboxAgent, SandboxTask, ACPMessage } from './types.js';
+import { createACPMessage, pushMessage } from './acp.js';
+import type { SandboxAgent, SandboxTask } from './types.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 let executorTaskCounter = 20000;
 function nextExecutorTaskId(): string {
   return `TASK-${String(++executorTaskCounter).padStart(4, '0')}`;
-}
-
-function acpId(): string {
-  return `acp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
-function createACPMessage(
-  type: ACPMessage['type'],
-  from: string,
-  to: string,
-  taskId: string,
-  extra?: Partial<ACPMessage>,
-): ACPMessage {
-  return { id: acpId(), type, from, to, taskId, timestamp: Date.now(), ...extra };
-}
-
-function pushMessage(agents: SandboxAgent[], msg: ACPMessage): void {
-  for (const agent of agents) {
-    if (agent.id === msg.from || agent.id === msg.to) {
-      agent.recentMessages.push(msg);
-      if (agent.recentMessages.length > 10) {
-        agent.recentMessages = agent.recentMessages.slice(-10);
-      }
-    }
-    if (agent.id === msg.to && agent.trigger === 'event-driven') {
-      if (!agent.triggerOn || agent.triggerOn.includes(msg.type)) {
-        agent.inbox.push(msg);
-      }
-    }
-  }
 }
 
 // ── Context for execution ───────────────────────────────────────────────────

--- a/tools/sandbox/src/deterministic.ts
+++ b/tools/sandbox/src/deterministic.ts
@@ -11,6 +11,8 @@
 import type { SandboxAgent, SandboxTask, SandboxEvent, SandboxConfig, ACPMessage } from './types.js';
 import type { ParsedOrg } from './org-parser.js';
 import { makeAgentPublic } from './agents.js';
+import { createACPMessage, pushMessage } from './acp.js';
+import { createPRNG, type PRNG } from './prng.js';
 import type { ScenarioEngine } from './scenario-engine.js';
 import type { ModelRouter, RouteRequest } from './model-router.js';
 
@@ -19,36 +21,6 @@ import type { ModelRouter, RouteRequest } from './model-router.js';
 let taskCounter = 0;
 function nextTaskId(): string {
   return `TASK-${String(++taskCounter).padStart(4, '0')}`;
-}
-
-function acpId(): string {
-  return `acp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
-function createACPMessage(
-  type: ACPMessage['type'],
-  from: string,
-  to: string,
-  taskId: string,
-  extra?: Partial<ACPMessage>,
-): ACPMessage {
-  return { id: acpId(), type, from, to, taskId, timestamp: Date.now(), ...extra };
-}
-
-function pushMessage(agents: SandboxAgent[], msg: ACPMessage): void {
-  for (const agent of agents) {
-    if (agent.id === msg.from || agent.id === msg.to) {
-      agent.recentMessages.push(msg);
-      if (agent.recentMessages.length > 10) {
-        agent.recentMessages = agent.recentMessages.slice(-10);
-      }
-    }
-    if (agent.id === msg.to && agent.trigger === 'event-driven') {
-      if (!agent.triggerOn || agent.triggerOn.includes(msg.type)) {
-        agent.inbox.push(msg);
-      }
-    }
-  }
 }
 
 // ── Domain matching ─────────────────────────────────────────────────────────
@@ -132,7 +104,7 @@ function parseOrderIntoTasks(order: string): Array<{ title: string; domain: stri
 // ── Work simulation ─────────────────────────────────────────────────────────
 
 /** Tick-based work progress. Returns true if task advanced a stage. */
-function advanceWork(task: SandboxTask, agent: SandboxAgent): { advanced: boolean; done: boolean; status: string } {
+function advanceWork(task: SandboxTask, agent: SandboxAgent, rng: PRNG): { advanced: boolean; done: boolean; status: string } {
   // Work progresses through stages: assigned → in_progress → review → done
   // Each stage takes 2-4 ticks based on priority
   const ticksPerStage = task.priority === 'critical' ? 2 : task.priority === 'high' ? 3 : 4;
@@ -152,9 +124,9 @@ function advanceWork(task: SandboxTask, agent: SandboxAgent): { advanced: boolea
   }
   if (task.status === 'in_progress') {
     // 10% chance of getting blocked (adds drama)
-    if (Math.random() < 0.10) {
+    if (rng.chance(0.10)) {
       task.status = 'blocked';
-      task.blockedReason = pickRandom(['Missing requirements', 'Dependency not ready', 'Need clarification', 'Waiting on external service']);
+      task.blockedReason = rng.pick(['Missing requirements', 'Dependency not ready', 'Need clarification', 'Waiting on external service']);
       return { advanced: true, done: false, status: 'blocked' };
     }
     task.status = 'review';
@@ -171,9 +143,7 @@ function advanceWork(task: SandboxTask, agent: SandboxAgent): { advanced: boolea
   return { advanced: false, done: false, status: task.status };
 }
 
-function pickRandom<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
-}
+// pickRandom removed — use this.rng.pick() instead
 
 // ── Flavor messages ─────────────────────────────────────────────────────────
 
@@ -225,6 +195,8 @@ export class DeterministicSimulation {
   }> = [];
   parsedOrg?: ParsedOrg;
   scenarioEngine?: ScenarioEngine;
+  /** Seedable PRNG — same seed = identical simulation run */
+  rng: PRNG;
 
   /** Agent IDs to skip in the deterministic tick loop (e.g. already handled by LLM) */
   protected skipAgentIds = new Set<string>();
@@ -235,7 +207,8 @@ export class DeterministicSimulation {
   /** Pending task assignments: tasks waiting for a lead in matching domain */
   private pendingTaskDefs: Array<{ title: string; domain: string; priority: SandboxTask['priority'] }> = [];
 
-  constructor(agents: SandboxAgent[], config: SandboxConfig, skipSeedTasks = false, parsedOrg?: ParsedOrg) {
+  constructor(agents: SandboxAgent[], config: SandboxConfig, skipSeedTasks = false, parsedOrg?: ParsedOrg, seed?: number) {
+    this.rng = createPRNG(seed);
     this.tasks = [];
     this.config = config;
     this.parsedOrg = parsedOrg;
@@ -336,7 +309,7 @@ export class DeterministicSimulation {
 
       // ACP hire message
       const msg = createACPMessage('delegation', manager.id, candidate.id, '', {
-        body: pickRandom(HIRE_FLAVORS)(candidate.name, domain),
+        body: this.rng.pick(HIRE_FLAVORS)(candidate.name, domain),
       });
       pushMessage(this.agents, msg);
       manager.stats.messagessSent++;
@@ -434,7 +407,7 @@ export class DeterministicSimulation {
         lead.taskIds.push(task.id);
 
         const delegationMsg = createACPMessage('delegation', coo.id, lead.id, task.id, {
-          body: pickRandom(DELEGATION_FLAVORS)(task.title, lead.name),
+          body: this.rng.pick(DELEGATION_FLAVORS)(task.title, lead.name),
         });
         pushMessage(this.agents, delegationMsg);
         task.activityLog.push(delegationMsg);
@@ -481,7 +454,7 @@ export class DeterministicSimulation {
         lead.taskIds.push(task.id);
 
         const delegationMsg = createACPMessage('delegation', coo.id, lead.id, task.id, {
-          body: pickRandom(DELEGATION_FLAVORS)(task.title, lead.name),
+          body: this.rng.pick(DELEGATION_FLAVORS)(task.title, lead.name),
         });
         pushMessage(this.agents, delegationMsg);
         task.activityLog.push(delegationMsg);
@@ -525,7 +498,7 @@ export class DeterministicSimulation {
         availableWorker.taskIds.push(task.id);
 
         const msg = createACPMessage('delegation', lead.id, availableWorker.id, task.id, {
-          body: pickRandom(DELEGATION_FLAVORS)(task.title, availableWorker.name),
+          body: this.rng.pick(DELEGATION_FLAVORS)(task.title, availableWorker.name),
         });
         pushMessage(this.agents, msg);
         task.activityLog.push(msg);
@@ -552,7 +525,7 @@ export class DeterministicSimulation {
     );
 
     for (const task of myTasks) {
-      const result = advanceWork(task, worker);
+      const result = advanceWork(task, worker, this.rng);
 
       if (result.advanced) {
         if (result.done) {
@@ -560,7 +533,7 @@ export class DeterministicSimulation {
           const parent = this.agents.find(a => a.id === worker.parentId);
           if (parent) {
             const completionMsg = createACPMessage('completion', worker.id, parent.id, task.id, {
-              summary: pickRandom(COMPLETION_FLAVORS)(task.title),
+              summary: this.rng.pick(COMPLETION_FLAVORS)(task.title),
               body: `Completed: "${task.title}"`,
             });
             pushMessage(this.agents, completionMsg);
@@ -574,7 +547,7 @@ export class DeterministicSimulation {
           if (parent) {
             const escMsg = createACPMessage('escalation', worker.id, parent.id, task.id, {
               reason: 'BLOCKED',
-              body: pickRandom(ESCALATION_FLAVORS)(task.title, task.blockedReason || 'Unknown'),
+              body: this.rng.pick(ESCALATION_FLAVORS)(task.title, task.blockedReason || 'Unknown'),
             });
             pushMessage(this.agents, escMsg);
             task.activityLog.push(escMsg);
@@ -586,7 +559,7 @@ export class DeterministicSimulation {
           const parent = this.agents.find(a => a.id === worker.parentId);
           if (parent) {
             const progressMsg = createACPMessage('progress', worker.id, parent.id, task.id, {
-              body: pickRandom(PROGRESS_FLAVORS)(task.title),
+              body: this.rng.pick(PROGRESS_FLAVORS)(task.title),
               pct: 30,
             });
             pushMessage(this.agents, progressMsg);
@@ -686,7 +659,7 @@ export class DeterministicSimulation {
       const toRoute = workingAgents.slice(0, Math.min(3, workingAgents.length));
       for (const agent of toRoute) {
         const taskTypes: Array<RouteRequest['taskType']> = ['delegation', 'coding', 'analysis', 'simple'];
-        const taskType = agent.role === 'coo' ? 'delegation' : agent.role === 'lead' ? 'analysis' : pickRandom(taskTypes);
+        const taskType = agent.role === 'coo' ? 'delegation' : agent.role === 'lead' ? 'analysis' : this.rng.pick(taskTypes);
         const decision = modelRouter.route({
           agentId: agent.id,
           agentLevel: agent.level,

--- a/tools/sandbox/src/prng.spec.ts
+++ b/tools/sandbox/src/prng.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { createPRNG } from './prng.js';
+
+describe('PRNG', () => {
+  it('produces the same sequence for the same seed', () => {
+    const a = createPRNG(42);
+    const b = createPRNG(42);
+    for (let i = 0; i < 100; i++) {
+      expect(a.random()).toBe(b.random());
+    }
+  });
+
+  it('produces different sequences for different seeds', () => {
+    const a = createPRNG(42);
+    const b = createPRNG(99);
+    const aVals = Array.from({ length: 10 }, () => a.random());
+    const bVals = Array.from({ length: 10 }, () => b.random());
+    expect(aVals).not.toEqual(bVals);
+  });
+
+  it('random() returns values in [0, 1)', () => {
+    const rng = createPRNG(42);
+    for (let i = 0; i < 1000; i++) {
+      const v = rng.random();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it('int() returns integers in [min, max]', () => {
+    const rng = createPRNG(42);
+    for (let i = 0; i < 100; i++) {
+      const v = rng.int(3, 7);
+      expect(v).toBeGreaterThanOrEqual(3);
+      expect(v).toBeLessThanOrEqual(7);
+      expect(Number.isInteger(v)).toBe(true);
+    }
+  });
+
+  it('pick() returns elements from the array', () => {
+    const rng = createPRNG(42);
+    const arr = ['a', 'b', 'c'];
+    for (let i = 0; i < 50; i++) {
+      expect(arr).toContain(rng.pick(arr));
+    }
+  });
+
+  it('pick() is deterministic', () => {
+    const a = createPRNG(42);
+    const b = createPRNG(42);
+    const arr = ['x', 'y', 'z'];
+    for (let i = 0; i < 20; i++) {
+      expect(a.pick(arr)).toBe(b.pick(arr));
+    }
+  });
+
+  it('chance() respects probability', () => {
+    const rng = createPRNG(42);
+    let hits = 0;
+    const n = 10000;
+    for (let i = 0; i < n; i++) {
+      if (rng.chance(0.3)) hits++;
+    }
+    // Should be roughly 30% (allow ±5%)
+    expect(hits / n).toBeGreaterThan(0.25);
+    expect(hits / n).toBeLessThan(0.35);
+  });
+
+  it('shuffle() is deterministic', () => {
+    const a = createPRNG(42);
+    const b = createPRNG(42);
+    const arr1 = [1, 2, 3, 4, 5, 6, 7, 8];
+    const arr2 = [1, 2, 3, 4, 5, 6, 7, 8];
+    a.shuffle(arr1);
+    b.shuffle(arr2);
+    expect(arr1).toEqual(arr2);
+  });
+
+  it('shuffle() actually shuffles', () => {
+    const rng = createPRNG(42);
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const original = [...arr];
+    rng.shuffle(arr);
+    // Extremely unlikely to remain identical
+    expect(arr).not.toEqual(original);
+    // Same elements
+    expect([...arr].sort((a, b) => a - b)).toEqual(original);
+  });
+
+  it('exposes the seed', () => {
+    const rng = createPRNG(12345);
+    expect(rng.seed).toBe(12345);
+  });
+});

--- a/tools/sandbox/src/prng.ts
+++ b/tools/sandbox/src/prng.ts
@@ -1,0 +1,62 @@
+// ── Seedable PRNG ────────────────────────────────────────────────────────────
+// Mulberry32: a simple, fast, seedable 32-bit PRNG.
+// Used by the deterministic simulation engine so that:
+//   1. Tests are fully reproducible (fixed seed → identical run)
+//   2. Demo replays produce consistent "drama" moments
+//   3. The name "DeterministicSimulation" actually means something
+//
+// Default seed is Date.now() so production still feels random.
+
+export interface PRNG {
+  /** Returns a float in [0, 1), like Math.random() */
+  random(): number;
+  /** Returns an integer in [min, max] inclusive */
+  int(min: number, max: number): number;
+  /** Pick a random element from an array */
+  pick<T>(arr: T[]): T;
+  /** Returns true with the given probability (0-1) */
+  chance(probability: number): boolean;
+  /** Shuffle an array in place (Fisher-Yates) */
+  shuffle<T>(arr: T[]): T[];
+  /** The seed used to initialize this PRNG */
+  readonly seed: number;
+}
+
+/**
+ * Create a seedable PRNG using the Mulberry32 algorithm.
+ * Same seed always produces the same sequence.
+ */
+export function createPRNG(seed: number = Date.now()): PRNG {
+  let state = seed | 0;
+
+  function random(): number {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  return {
+    random,
+    int(min: number, max: number): number {
+      return Math.floor(random() * (max - min + 1)) + min;
+    },
+    pick<T>(arr: T[]): T {
+      return arr[Math.floor(random() * arr.length)];
+    },
+    chance(probability: number): boolean {
+      return random() < probability;
+    },
+    shuffle<T>(arr: T[]): T[] {
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      return arr;
+    },
+    get seed() {
+      return seed;
+    },
+  };
+}


### PR DESCRIPTION
The `DeterministicSimulation` was using `Math.random()` — making the 'deterministic' engine non-deterministic. This fixes that.

### Seedable PRNG
- Mulberry32 algorithm (`prng.ts`), 62 lines
- Constructor accepts optional `seed` parameter (defaults to `Date.now()`)
- Same seed → identical sequence of blocking events, flavor text, and routing
- Clean API: `rng.random()`, `rng.pick()`, `rng.chance()`, `rng.int()`, `rng.shuffle()`

### Shared ACP Helpers
- Extracted `createACPMessage`, `pushMessage`, `acpId` into `acp.ts`
- Was duplicated identically in `deterministic.ts` and `decision-executor.ts`
- ID generation now uses a counter instead of `Math.random()`

### Tests
- 10 new tests for PRNG: determinism, distribution, bounds, shuffle

TypeScript compiles clean. No behavioral change with default (unseeded) usage.