### PR TITLE
feat(dashboard): Demo UX P1 — typewriter intro, narrative annotations, zoom choreography

### DIFF
--- a/apps/dashboard/src/components/live/intro-card.tsx
+++ b/apps/dashboard/src/components/live/intro-card.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useRef } from 'react';
 import { motion } from 'motion/react';
 
 interface IntroCardProps {
@@ -34,13 +35,11 @@ const ORG_LINES = [
 ];
 
 function renderLine(line: string) {
-  // Headers
   if (line.startsWith('#### ')) return <span className="text-cyan-400 font-bold">{line.slice(5)}</span>;
   if (line.startsWith('### ')) return <span className="text-cyan-400 font-bold text-[15px]">{line.slice(4)}</span>;
   if (line.startsWith('## ')) return <span className="text-cyan-400 font-bold text-base">{line.slice(3)}</span>;
   if (line.startsWith('# ')) return <span className="text-cyan-400 font-bold text-lg">{line.slice(2)}</span>;
 
-  // Metadata lines: - **Key:** Value
   const metaMatch = line.match(/^- \*\*(.+?):\*\* (.+)$/);
   if (metaMatch) {
     return (
@@ -52,7 +51,6 @@ function renderLine(line: string) {
     );
   }
 
-  // Line with sessions_spawn
   if (line.includes('sessions_spawn')) {
     const parts = line.split('sessions_spawn');
     return (
@@ -68,7 +66,85 @@ function renderLine(line: string) {
   return <span className="text-white/50">{line}</span>;
 }
 
+// ── Typewriter hook: rAF-driven character-by-character reveal ────────────────
+
+function useTypewriter(lines: string[], charDelay = 12, lineDelay = 80) {
+  const [visibleLines, setVisibleLines] = useState<string[]>([]);
+  const [done, setDone] = useState(false);
+  const rafRef = useRef<number>(0);
+  const startRef = useRef<number>(0);
+
+  useEffect(() => {
+    const flat: { lineIdx: number; charIdx: number; time: number }[] = [];
+    let t = 0;
+    for (let l = 0; l < lines.length; l++) {
+      const line = lines[l];
+      if (line.length === 0) {
+        flat.push({ lineIdx: l, charIdx: 0, time: t });
+        t += lineDelay;
+      } else {
+        for (let c = 0; c < line.length; c++) {
+          flat.push({ lineIdx: l, charIdx: c + 1, time: t });
+          t += charDelay;
+        }
+        t += lineDelay;
+      }
+    }
+
+    const totalTime = t;
+
+    const tick = (now: number) => {
+      if (!startRef.current) startRef.current = now;
+      const elapsed = now - startRef.current;
+
+      let lastIdx = -1;
+      for (let i = 0; i < flat.length; i++) {
+        if (flat[i].time <= elapsed) lastIdx = i;
+        else break;
+      }
+
+      if (lastIdx >= 0) {
+        const next = new Array(lines.length).fill('');
+        for (let i = 0; i <= lastIdx; i++) {
+          const entry = flat[i];
+          next[entry.lineIdx] = lines[entry.lineIdx].slice(0, entry.charIdx);
+        }
+        setVisibleLines([...next]);
+      }
+
+      if (elapsed < totalTime) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        setVisibleLines([...lines]);
+        setDone(true);
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      rafRef.current = requestAnimationFrame(tick);
+    }, 400);
+
+    return () => {
+      clearTimeout(timeout);
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [lines, charDelay, lineDelay]);
+
+  return { visibleLines, done };
+}
+
 export function IntroCard({ onStart }: IntroCardProps) {
+  const { visibleLines, done } = useTypewriter(ORG_LINES, 12, 60);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [visibleLines]);
+
+  const lastVisibleIdx = visibleLines.reduce((acc, l, i) => (l && l.length > 0 ? i : acc), -1);
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -78,15 +154,14 @@ export function IntroCard({ onStart }: IntroCardProps) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-[#020817]/95 backdrop-blur-sm p-4"
     >
       <div className="flex flex-col md:flex-row items-center gap-8 md:gap-12 max-w-5xl w-full">
-        {/* Left: Terminal panel */}
+        {/* Left: Terminal panel with typewriter effect */}
         <motion.div
           initial={{ opacity: 0, x: -40 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ delay: 0.2, duration: 0.6, ease: 'easeOut' }}
           className="w-full md:w-[55%] shrink-0"
         >
-          <div className="rounded-xl border border-white/10 bg-[#0d1117] shadow-[0_0_40px_rgba(34,211,238,0.08)] max-h-[40vh] md:max-h-none overflow-y-auto">
-            {/* Terminal chrome */}
+          <div className="rounded-xl border border-white/10 bg-[#0d1117] shadow-[0_0_40px_rgba(34,211,238,0.08)] max-h-[40vh] md:max-h-none overflow-hidden">
             <div className="flex items-center gap-2 px-4 py-2.5 border-b border-white/5">
               <div className="flex gap-1.5">
                 <div className="w-2.5 h-2.5 rounded-full bg-red-500/70" />
@@ -95,14 +170,24 @@ export function IntroCard({ onStart }: IntroCardProps) {
               </div>
               <span className="text-white/40 text-xs ml-2 font-mono">org.md</span>
             </div>
-            {/* Content */}
-            <div className="p-4 font-mono text-[13px] leading-relaxed">
-              {ORG_LINES.map((line, i) => (
-                <div key={i} className="flex gap-3">
-                  <span className="text-white/10 select-none w-5 text-right shrink-0 text-[11px] leading-relaxed">{i + 1}</span>
-                  <div className="min-w-0">{renderLine(line)}</div>
-                </div>
-              ))}
+            <div ref={containerRef} className="p-4 font-mono text-[13px] leading-relaxed overflow-y-auto max-h-[35vh] md:max-h-[60vh]">
+              {ORG_LINES.map((fullLine, i) => {
+                const partial = visibleLines[i];
+                if (partial === undefined || (partial === '' && fullLine !== '')) return null;
+                return (
+                  <div key={i} className="flex gap-3">
+                    <span className="text-white/10 select-none w-5 text-right shrink-0 text-[11px] leading-relaxed">
+                      {i + 1}
+                    </span>
+                    <div className="min-w-0">
+                      {renderLine(partial)}
+                      {!done && i === lastVisibleIdx && (
+                        <span className="inline-block w-[2px] h-[14px] bg-cyan-400 ml-0.5 align-middle animate-pulse" />
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </motion.div>

--- a/apps/dashboard/src/components/live/org-chart-live.tsx
+++ b/apps/dashboard/src/components/live/org-chart-live.tsx
@@ -77,11 +77,19 @@ export interface EdgeAnimation {
   timestamp: number;
 }
 
+export interface ZoomTarget {
+  x: number;
+  y: number;
+  zoom: number;
+  duration?: number;
+}
+
 interface OrgChartLiveProps {
   nodeStates: Record<string, AgentNodeState>;
   edgeAnimations: EdgeAnimation[];
   reassignedEdges: Array<{ from: string; to: string }>;
   spawnedAgents: SpawnedAgent[];
+  zoomTarget?: ZoomTarget | null;
 }
 
 // ── Custom Nodes ─────────────────────────────────────────────────────────────
@@ -375,34 +383,30 @@ function buildGraph(
 
 // ── Component ────────────────────────────────────────────────────────────────
 
-function OrgChartInner({ nodeStates, edgeAnimations, reassignedEdges, spawnedAgents }: OrgChartLiveProps) {
+function OrgChartInner({ nodeStates, edgeAnimations, reassignedEdges, spawnedAgents, zoomTarget }: OrgChartLiveProps) {
   const { nodes, edges } = useMemo(
     () => buildGraph(nodeStates, edgeAnimations, reassignedEdges, spawnedAgents),
     [nodeStates, edgeAnimations, reassignedEdges, spawnedAgents],
   );
 
   const { fitView, setCenter } = useReactFlow();
-  const prevSpawnCount = useRef(0);
-  const zoomResetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const prevZoomRef = useRef<ZoomTarget | null>(null);
 
-  // Zoom into pool node area when spawning starts, zoom back out after
+  // External zoom choreography — driven by parent via zoomTarget prop
   useEffect(() => {
-    const count = spawnedAgents.length;
-    if (count > prevSpawnCount.current && count >= 1) {
-      // Zoom to the Grill Station pool node area
-      // Pool is at x=CX-400-80=120, y=LY[3]+100=600
-      clearTimeout(zoomResetTimer.current);
-      setCenter(120, 580, { zoom: 1.4, duration: 800 });
-
-      // After 3 seconds (or when spawning stops), zoom back to full view
-      zoomResetTimer.current = setTimeout(() => {
-        fitView({ padding: 0.15, duration: 800 });
-      }, 3000);
+    if (zoomTarget && zoomTarget !== prevZoomRef.current) {
+      prevZoomRef.current = zoomTarget;
+      setCenter(zoomTarget.x, zoomTarget.y, {
+        zoom: zoomTarget.zoom,
+        duration: zoomTarget.duration ?? 800,
+      });
+    } else if (!zoomTarget && prevZoomRef.current) {
+      prevZoomRef.current = null;
+      fitView({ padding: 0.15, duration: 800 });
     }
-    prevSpawnCount.current = count;
-  }, [spawnedAgents.length, setCenter, fitView]);
+  }, [zoomTarget, setCenter, fitView]);
 
-  // On first render and when no spawns, fit the full view
+  // On first render, fit the full view
   const onInit = useCallback(() => {
     fitView({ padding: 0.15, duration: 0 });
   }, [fitView]);

--- a/apps/dashboard/src/pages/live-view.tsx
+++ b/apps/dashboard/src/pages/live-view.tsx
@@ -46,7 +46,7 @@ interface ReplayState {
   zoomTarget: ZoomTarget | null;
 }
 
-// ── Zoom choreography schedule (demo scenario) ──────────────────────────────
+// ── Zoom choreography schedule ───────────────────────────────────────────────
 const CHART_CX = 600;
 const CHART_LY = [0, 160, 330, 500];
 
@@ -248,6 +248,14 @@ function useReplay(scenario: ScenarioDef) {
     if (tick >= 0) processEvents(tick);
   }, [tick, processEvents]);
 
+  // Zoom choreography
+  const zoomTarget = useMemo(() => {
+    for (const [start, end, zt] of ZOOM_SCHEDULE) {
+      if (tick >= start && tick < end) return zt;
+    }
+    return null;
+  }, [tick]);
+
   return {
     tick,
     running,
@@ -262,6 +270,7 @@ function useReplay(scenario: ScenarioDef) {
     messages: messagesRef.current,
     pattiesDelivered: statsRef.current.pattiesDelivered,
     actBanner,
+    zoomTarget,
   };
 }
 
@@ -386,7 +395,10 @@ export function LiveViewPage() {
               edgeAnimations={replay.edgeAnimations}
               reassignedEdges={replay.reassignedEdges}
               spawnedAgents={replay.spawnedAgents}
+              zoomTarget={replay.zoomTarget}
             />
+            {/* Narrative annotations */}
+            <NarrativeAnnotations tick={replay.tick} />
             {/* Act banner overlay */}
             <AnimatePresence>
               {replay.actBanner && (


### PR DESCRIPTION
## Demo UX P1 Improvements

### 1. Typewriter effect on ORG.md intro
- rAF-driven character-by-character reveal with blinking cyan cursor
- `useTypewriter` hook with configurable char/line delays
- Auto-scrolls terminal panel as lines appear

### 2. Narrative annotations (16 overlays)
- Contextual banners timed to replay events across all 5 acts
- Positioned at corners or center with framer-motion enter/exit animations
- Examples: "⚡ Sous-chefs spawning", "🚨 ESCALATION: Squidward → Mr. Krabs"

### 3. Zoom choreography (9 beats)
- Camera follows the action: zooms into Mr. Krabs for orders, kitchen during spawning, Squidward during bottleneck
- Smooth transitions via ReactFlow `setCenter` with configurable duration
- Auto-resets to fitView between choreography segments

**Files changed:** 4 (229 additions, 34 deletions)
- `intro-card.tsx` — typewriter hook + cursor
- `narrative-annotations.tsx` — new component
- `org-chart-live.tsx` — `ZoomTarget` prop replaces hardcoded spawn zoom
- `live-view.tsx` — zoom schedule + wiring