### PR TITLE
feat(dashboard): Guided Product Tour during demo replay

### DIFF
--- a/apps/dashboard/src/app/app.tsx
+++ b/apps/dashboard/src/app/app.tsx
@@ -19,6 +19,7 @@ console.log(
   'color: #64748b'
 );
 import { OnboardingProvider, WelcomeScreen, FeatureTour, CompletionCelebration } from "../components/onboarding";
+import { TourProvider, TourBar, TourSpotlight } from "../components/tour";
 import { AuthProvider, SidePanelProvider } from "../contexts";
 import { router } from "../routes";
 import type { ReactNode } from "react";
@@ -74,14 +75,18 @@ export function App() {
           <NotificationProvider>
             <OnboardingProvider>
             <SidePanelProvider>
+            <TourProvider>
             <DemoWrapper>
               <OfflineIndicator />
               <CommandPalette />
               <WelcomeScreen />
               <FeatureTour />
               <CompletionCelebration />
+              <TourBar />
+              <TourSpotlight />
               <RouterProvider router={router} />
             </DemoWrapper>
+            </TourProvider>
             </SidePanelProvider>
             </OnboardingProvider>
           </NotificationProvider>

--- a/apps/dashboard/src/components/tour/index.ts
+++ b/apps/dashboard/src/components/tour/index.ts
@@ -1,0 +1,3 @@
+export { TourProvider, useTour, useTourSafe, TOUR_STEPS } from './tour-context';
+export { TourBar } from './tour-bar';
+export { TourSpotlight } from './tour-spotlight';

--- a/apps/dashboard/src/components/tour/tour-bar.tsx
+++ b/apps/dashboard/src/components/tour/tour-bar.tsx
@@ -1,0 +1,105 @@
+import { motion, AnimatePresence } from 'motion/react';
+import { useTourSafe } from './tour-context';
+import { ChevronLeft, ChevronRight, X, Timer, TimerOff } from 'lucide-react';
+
+export function TourBar() {
+  const tour = useTourSafe();
+  if (!tour || !tour.isActive) return null;
+
+  const { currentStep, steps, autoAdvance, setAutoAdvance, next, prev, exit } = tour;
+  const step = steps[currentStep];
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ y: 80, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: 80, opacity: 0 }}
+        transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+        className="fixed bottom-0 left-0 right-0 z-[9999] pointer-events-none"
+      >
+        <div className="pointer-events-auto mx-auto max-w-3xl mb-4 px-4">
+          <div className="relative bg-[#0a1628]/95 backdrop-blur-xl border border-cyan-500/20 rounded-2xl shadow-2xl shadow-cyan-500/10 px-5 py-3.5">
+            {/* Progress bar at top */}
+            <div className="absolute top-0 left-0 right-0 h-0.5 rounded-t-2xl overflow-hidden bg-white/5">
+              <motion.div
+                className="h-full bg-gradient-to-r from-cyan-500 to-emerald-400"
+                animate={{ width: `${((currentStep + 1) / steps.length) * 100}%` }}
+                transition={{ duration: 0.4, ease: 'easeOut' }}
+              />
+            </div>
+
+            <div className="flex items-center gap-4">
+              {/* Step info */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-0.5">
+                  <span className="text-[10px] font-bold text-cyan-400 uppercase tracking-widest">
+                    {currentStep + 1} of {steps.length}
+                  </span>
+                  <span className="text-white/20">·</span>
+                  <span className="text-xs font-semibold text-white/90 truncate">{step.title}</span>
+                </div>
+                <p className="text-[11px] text-white/40 truncate">{step.description}</p>
+              </div>
+
+              {/* Progress dots */}
+              <div className="hidden sm:flex items-center gap-1.5">
+                {steps.map((_, i) => (
+                  <div
+                    key={i}
+                    className={`w-1.5 h-1.5 rounded-full transition-all duration-300 ${
+                      i === currentStep
+                        ? 'bg-cyan-400 scale-125'
+                        : i < currentStep
+                          ? 'bg-cyan-400/40'
+                          : 'bg-white/10'
+                    }`}
+                  />
+                ))}
+              </div>
+
+              {/* Controls */}
+              <div className="flex items-center gap-1.5">
+                <button
+                  onClick={() => setAutoAdvance(!autoAdvance)}
+                  className={`p-1.5 rounded-lg transition-all cursor-pointer ${
+                    autoAdvance
+                      ? 'text-cyan-400 bg-cyan-500/10 hover:bg-cyan-500/20'
+                      : 'text-white/30 hover:text-white/50 hover:bg-white/5'
+                  }`}
+                  title={autoAdvance ? 'Auto-advance ON' : 'Auto-advance OFF'}
+                >
+                  {autoAdvance ? <Timer className="w-3.5 h-3.5" /> : <TimerOff className="w-3.5 h-3.5" />}
+                </button>
+
+                <button
+                  onClick={prev}
+                  disabled={currentStep === 0}
+                  className="p-1.5 rounded-lg text-white/40 hover:text-white/70 hover:bg-white/5 disabled:opacity-20 disabled:cursor-not-allowed transition-all cursor-pointer"
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                </button>
+
+                <button
+                  onClick={next}
+                  className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-cyan-500/20 border border-cyan-500/30 text-cyan-400 text-xs font-semibold hover:bg-cyan-500/30 transition-all cursor-pointer"
+                >
+                  {currentStep === steps.length - 1 ? 'Finish' : 'Next'}
+                  <ChevronRight className="w-3.5 h-3.5" />
+                </button>
+
+                <button
+                  onClick={exit}
+                  className="p-1.5 rounded-lg text-white/30 hover:text-red-400 hover:bg-red-500/10 transition-all cursor-pointer"
+                  title="Exit Tour"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/apps/dashboard/src/components/tour/tour-context.tsx
+++ b/apps/dashboard/src/components/tour/tour-context.tsx
@@ -1,0 +1,161 @@
+import { createContext, useContext, useState, useCallback, useRef, useEffect, type ReactNode } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+
+export interface TourStep {
+  id: string;
+  path: string;
+  title: string;
+  description: string;
+  /** CSS selector for the element to spotlight (optional — if omitted, no spotlight) */
+  spotlightSelector?: string;
+}
+
+export const TOUR_STEPS: TourStep[] = [
+  {
+    id: 'live-start',
+    path: '/live',
+    title: 'Live View',
+    description: 'Watch 22 agents coordinate a 10,000 order in real time',
+  },
+  {
+    id: 'agents',
+    path: '/agents',
+    title: 'Agents',
+    description: 'Every agent has a role, trust score, and real-time stats',
+    spotlightSelector: '[data-tour="agent-list"]',
+  },
+  {
+    id: 'tasks',
+    path: '/tasks',
+    title: 'Tasks',
+    description: 'Tasks flow through a pipeline: backlog → assigned → in-progress → done',
+    spotlightSelector: '[data-tour="task-list"]',
+  },
+  {
+    id: 'dashboard',
+    path: '/',
+    title: 'Dashboard',
+    description: 'Executive overview with live charts and org health',
+    spotlightSelector: '[data-tour="dashboard-charts"]',
+  },
+  {
+    id: 'router',
+    path: '/router',
+    title: 'Model Router',
+    description: 'The Model Router picks the cheapest LLM provider for each decision',
+    spotlightSelector: '[data-tour="router-cards"]',
+  },
+  {
+    id: 'network',
+    path: '/network',
+    title: 'Network',
+    description: 'Visualize the full org graph and communication flows',
+    spotlightSelector: '[data-tour="network-viz"]',
+  },
+  {
+    id: 'live-end',
+    path: '/live',
+    title: 'Live View',
+    description: 'Back to the action — watch the final delivery rush',
+  },
+];
+
+interface TourContextValue {
+  isActive: boolean;
+  currentStep: number;
+  steps: TourStep[];
+  autoAdvance: boolean;
+  setAutoAdvance: (v: boolean) => void;
+  start: () => void;
+  next: () => void;
+  prev: () => void;
+  exit: () => void;
+}
+
+const TourContext = createContext<TourContextValue | null>(null);
+
+export function useTour() {
+  const ctx = useContext(TourContext);
+  if (!ctx) throw new Error('useTour must be used within TourProvider');
+  return ctx;
+}
+
+export function useTourSafe() {
+  return useContext(TourContext);
+}
+
+export function TourProvider({ children }: { children: ReactNode }) {
+  const [isActive, setIsActive] = useState(false);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [autoAdvance, setAutoAdvance] = useState(true);
+  const navigate = useNavigate();
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+    }
+  }, []);
+
+  const navigateToStep = useCallback((stepIndex: number) => {
+    const step = TOUR_STEPS[stepIndex];
+    if (step) {
+      navigate({ to: step.path });
+    }
+  }, [navigate]);
+
+  const start = useCallback(() => {
+    setCurrentStep(0);
+    setIsActive(true);
+    navigateToStep(0);
+  }, [navigateToStep]);
+
+  const exit = useCallback(() => {
+    clearTimer();
+    setIsActive(false);
+    setCurrentStep(0);
+  }, [clearTimer]);
+
+  const next = useCallback(() => {
+    clearTimer();
+    setCurrentStep(prev => {
+      const nextStep = prev + 1;
+      if (nextStep >= TOUR_STEPS.length) {
+        setIsActive(false);
+        return 0;
+      }
+      navigateToStep(nextStep);
+      return nextStep;
+    });
+  }, [clearTimer, navigateToStep]);
+
+  const prev = useCallback(() => {
+    clearTimer();
+    setCurrentStep(prev => {
+      const prevStep = Math.max(0, prev - 1);
+      navigateToStep(prevStep);
+      return prevStep;
+    });
+  }, [clearTimer, navigateToStep]);
+
+  // Auto-advance timer
+  useEffect(() => {
+    if (!isActive || !autoAdvance) {
+      clearTimer();
+      return;
+    }
+    // First step gets 10s (let replay start), others get 8s
+    const delay = currentStep === 0 ? 10000 : 8000;
+    timerRef.current = setTimeout(() => {
+      next();
+    }, delay);
+    return clearTimer;
+  }, [isActive, autoAdvance, currentStep, next, clearTimer]);
+
+  return (
+    <TourContext.Provider value={{ isActive, currentStep, steps: TOUR_STEPS, autoAdvance, setAutoAdvance, start, next, prev, exit }}>
+      {children}
+    </TourContext.Provider>
+  );
+}

--- a/apps/dashboard/src/components/tour/tour-spotlight.tsx
+++ b/apps/dashboard/src/components/tour/tour-spotlight.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { useTourSafe, TOUR_STEPS } from './tour-context';
+import { useLocation } from '@tanstack/react-router';
+
+interface SpotlightRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export function TourSpotlight() {
+  const tour = useTourSafe();
+  const location = useLocation();
+  const [rect, setRect] = useState<SpotlightRect | null>(null);
+  const rafRef = useRef<number>(0);
+
+  const step = tour?.isActive ? TOUR_STEPS[tour.currentStep] : null;
+  const isCurrentPage = step && location.pathname.replace(/\/$/, '') === `/app${step.path}`.replace(/\/$/, '');
+  const selector = isCurrentPage ? step?.spotlightSelector : null;
+
+  useEffect(() => {
+    if (!selector) {
+      setRect(null);
+      return;
+    }
+
+    // Wait a bit for page to render
+    const timeout = setTimeout(() => {
+      const update = () => {
+        const el = document.querySelector(selector);
+        if (el) {
+          const r = el.getBoundingClientRect();
+          const pad = 12;
+          setRect({
+            top: r.top - pad,
+            left: r.left - pad,
+            width: r.width + pad * 2,
+            height: r.height + pad * 2,
+          });
+        } else {
+          setRect(null);
+        }
+        rafRef.current = requestAnimationFrame(update);
+      };
+      update();
+    }, 300);
+
+    return () => {
+      clearTimeout(timeout);
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [selector]);
+
+  if (!tour?.isActive || !isCurrentPage) return null;
+
+  return (
+    <AnimatePresence>
+      {rect && (
+        <motion.div
+          key="spotlight-overlay"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+          className="fixed inset-0 z-[9998] pointer-events-none"
+        >
+          {/* SVG overlay with cutout */}
+          <svg className="absolute inset-0 w-full h-full">
+            <defs>
+              <mask id="tour-spotlight-mask">
+                <rect x="0" y="0" width="100%" height="100%" fill="white" />
+                <rect
+                  x={rect.left}
+                  y={rect.top}
+                  width={rect.width}
+                  height={rect.height}
+                  rx="12"
+                  fill="black"
+                />
+              </mask>
+            </defs>
+            <rect
+              x="0" y="0" width="100%" height="100%"
+              fill="rgba(2, 8, 23, 0.6)"
+              mask="url(#tour-spotlight-mask)"
+            />
+            {/* Glow border around cutout */}
+            <rect
+              x={rect.left}
+              y={rect.top}
+              width={rect.width}
+              height={rect.height}
+              rx="12"
+              fill="none"
+              stroke="#22d3ee"
+              strokeWidth="2"
+              strokeOpacity="0.4"
+            />
+          </svg>
+
+          {/* Tooltip card */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2, duration: 0.3 }}
+            className="absolute pointer-events-auto"
+            style={{
+              top: rect.top + rect.height + 16,
+              left: Math.max(16, Math.min(rect.left, window.innerWidth - 320)),
+            }}
+          >
+            <div className="bg-[#0a1628]/95 backdrop-blur-xl border border-cyan-500/20 rounded-xl px-4 py-3 max-w-[280px] shadow-xl shadow-cyan-500/5">
+              <div className="flex items-center gap-2 mb-1">
+                {/* Pulsing indicator */}
+                <span className="relative flex h-2 w-2">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-cyan-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-cyan-400" />
+                </span>
+                <span className="text-xs font-bold text-cyan-400 uppercase tracking-wider">{step?.title}</span>
+              </div>
+              <p className="text-[11px] text-white/50 leading-relaxed">{step?.description}</p>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+
+      {/* Show tooltip without spotlight when no selector */}
+      {!rect && step && !step.spotlightSelector && (
+        <motion.div
+          key="spotlight-tooltip-only"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+          className="fixed top-20 left-1/2 -translate-x-1/2 z-[9998] pointer-events-none"
+        >
+          <div className="bg-[#0a1628]/95 backdrop-blur-xl border border-cyan-500/20 rounded-xl px-5 py-3 shadow-xl shadow-cyan-500/5">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="relative flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-cyan-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-cyan-400" />
+              </span>
+              <span className="text-xs font-bold text-cyan-400 uppercase tracking-wider">{step.title}</span>
+            </div>
+            <p className="text-[11px] text-white/50 leading-relaxed">{step.description}</p>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -913,7 +913,7 @@ export function AgentsPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-tour="agent-list">
       {/* Page header */}
       <PageHeader
         title="Agents"

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -350,7 +350,7 @@ export function DashboardPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-tour="dashboard-charts">
       {/* Page header */}
       <PageHeader
         title="Dashboard"

--- a/apps/dashboard/src/pages/live-view.tsx
+++ b/apps/dashboard/src/pages/live-view.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Link } from '@tanstack/react-router';
 import { motion, AnimatePresence } from 'motion/react';
-import { ArrowRight, FlaskConical, PlayCircle } from 'lucide-react';
+import { ArrowRight, FlaskConical, PlayCircle, Clapperboard } from 'lucide-react';
+import { useTourSafe } from '../components/tour';
 import { IntroCard } from '../components/live/intro-card';
 import { OrgChartLive, type AgentNodeState, type EdgeAnimation, type ZoomTarget } from '../components/live/org-chart-live';
 import { LiveFeed, type FeedMessage } from '../components/live/live-feed';
@@ -328,6 +329,28 @@ function ScenarioPicker({ current, onChange }: { current: ScenarioId; onChange: 
   );
 }
 
+// ── Tour Button ──────────────────────────────────────────────────────────────
+
+function TourButton({ onStartReplay }: { onStartReplay: () => void }) {
+  const tour = useTourSafe();
+  if (!tour) return null;
+
+  const handleClick = () => {
+    onStartReplay();
+    tour.start();
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-gradient-to-r from-cyan-500/20 to-purple-500/20 border border-cyan-500/30 text-cyan-300 hover:from-cyan-500/30 hover:to-purple-500/30 transition-all cursor-pointer"
+    >
+      <Clapperboard className="w-3 h-3" />
+      🎬 Guided Tour
+    </button>
+  );
+}
+
 // ── Main Page ────────────────────────────────────────────────────────────────
 
 export function LiveViewPage() {
@@ -381,7 +404,10 @@ export function LiveViewPage() {
       <div className="relative z-10 flex flex-col h-full">
         {/* Top: Scenario picker + Progress header */}
         <div className="shrink-0 flex items-center justify-between px-4 pt-3 pb-1 bg-white/[0.02]">
-          <ScenarioPicker current={scenarioId} onChange={handleScenarioChange} />
+          <div className="flex items-center gap-3">
+            <ScenarioPicker current={scenarioId} onChange={handleScenarioChange} />
+            <TourButton onStartReplay={handleStart} />
+          </div>
           <div className="text-[10px] text-white/20 font-mono">tick {replay.tick}/{scenario.maxTick}</div>
         </div>
         <ProgressHeader act={replay.act} pattiesDelivered={replay.pattiesDelivered} target={scenario.target} targetLabel={scenario.targetLabel} badge={scenario.badge} />

--- a/apps/dashboard/src/pages/network.tsx
+++ b/apps/dashboard/src/pages/network.tsx
@@ -53,7 +53,7 @@ export function NetworkPage() {
   }
 
   return (
-    <div className="h-[calc(100vh-theme(spacing.16))] overflow-hidden relative">
+    <div className="h-[calc(100vh-theme(spacing.16))] overflow-hidden relative" data-tour="network-viz">
       {/* Header bar with title + stats + view toggle */}
       <div className="absolute top-4 sm:top-6 left-1/2 -translate-x-1/2 z-10
         bg-card/90 backdrop-blur border border-border

--- a/apps/dashboard/src/pages/router.tsx
+++ b/apps/dashboard/src/pages/router.tsx
@@ -96,7 +96,7 @@ export function RouterPage() {
   const saved = metrics ? (metrics.cloudOnlyCostEstimate - metrics.totalCost) : 0;
 
   return (
-    <div className="space-y-6 p-4 md:p-6 max-w-7xl mx-auto">
+    <div className="space-y-6 p-4 md:p-6 max-w-7xl mx-auto" data-tour="router-cards">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Model Router</h1>

--- a/apps/dashboard/src/pages/tasks.tsx
+++ b/apps/dashboard/src/pages/tasks.tsx
@@ -723,7 +723,7 @@ export function TasksPage() {
   }
 
   return (
-    <div className="p-4 space-y-6">
+    <div className="p-4 space-y-6" data-tour="task-list">
       {/* Page header */}
       <PageHeader
         title="Tasks"


### PR DESCRIPTION
## What

Adds a page-hopping guided product tour that runs **during** the BikiniBottom demo replay. Users click '🎬 Guided Tour' on the Live View page, which starts the replay and walks them through 7 dashboard pages while data streams in via SSE.

## Tour Steps
1. **Live View** — Watch the replay start (10s)
2. **Agents** — Agent cards with roles & trust scores
3. **Tasks** — Pipeline view (backlog → done)
4. **Dashboard** — Executive charts & org health
5. **Model Router** — LLM provider selection
6. **Network** — Org graph visualization
7. **Live View** — Return for the delivery finish

## Components
- `TourProvider` — React context managing state, navigation, auto-advance timer
- `TourBar` — Fixed bottom bar with step indicator, progress dots, next/prev/exit, auto-advance toggle
- `TourSpotlight` — SVG overlay with spotlight cutout + animated tooltip (framer-motion)

## Details
- Auto-advance: toggleable, 8s per step (10s for first)
- Spotlight uses `data-tour` attributes on page containers
- Works in both standalone (Live View) and sidebar layout contexts
- Opt-in, doesn't break any existing functionality
- Ocean theme: deep navy, bioluminescent cyan