### PR TITLE
feat: Agent Management CLI (hire, fire, promote)

### DIFF
--- a/tools/sandbox/package.json
+++ b/tools/sandbox/package.json
@@ -5,9 +5,14 @@
   "type": "module",
   "scripts": {
     "start": "tsx src/index.ts",
-    "start:single": "tsx src/test-single.ts"
+    "start:single": "tsx src/test-single.ts",
+    "cli": "tsx src/cli/index.ts"
+  },
+  "bin": {
+    "openspawn-agents": "./src/cli/index.ts"
   },
   "dependencies": {
+    "commander": "^13.1.0",
     "ollama": "^0.5.0"
   },
   "devDependencies": {

--- a/tools/sandbox/src/cli/config.ts
+++ b/tools/sandbox/src/cli/config.ts
@@ -1,0 +1,56 @@
+// ── openclaw.json config reader/writer ───────────────────────────────────────
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface AgentEntry {
+  id: string;
+  name?: string;
+  default?: boolean;
+  workspace?: string;
+  agentDir?: string;
+  tools?: { profile?: string };
+  [key: string]: unknown;
+}
+
+export interface OpenClawConfig {
+  agents?: {
+    defaults?: Record<string, unknown>;
+    list?: AgentEntry[];
+  };
+  [key: string]: unknown;
+}
+
+const CONFIG_PATH = join(homedir(), '.openclaw', 'openclaw.json');
+
+export function getConfigPath(): string {
+  return CONFIG_PATH;
+}
+
+export function readConfig(): OpenClawConfig {
+  const raw = readFileSync(CONFIG_PATH, 'utf-8');
+  return JSON.parse(raw) as OpenClawConfig;
+}
+
+export function writeConfig(config: OpenClawConfig): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 4) + '\n', 'utf-8');
+}
+
+export function findAgent(config: OpenClawConfig, agentId: string): AgentEntry | undefined {
+  return config.agents?.list?.find((a) => a.id === agentId);
+}
+
+export function addAgent(config: OpenClawConfig, agent: AgentEntry): OpenClawConfig {
+  if (!config.agents) config.agents = {};
+  if (!config.agents.list) config.agents.list = [];
+  config.agents.list.push(agent);
+  return config;
+}
+
+export function removeAgent(config: OpenClawConfig, agentId: string): OpenClawConfig {
+  if (config.agents?.list) {
+    config.agents.list = config.agents.list.filter((a) => a.id !== agentId);
+  }
+  return config;
+}

--- a/tools/sandbox/src/cli/fire.ts
+++ b/tools/sandbox/src/cli/fire.ts
@@ -1,0 +1,77 @@
+// ── openspawn fire ───────────────────────────────────────────────────────────
+
+import { existsSync, mkdirSync, renameSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { Command } from 'commander';
+import { readConfig, writeConfig, findAgent, removeAgent } from './config.js';
+
+export function registerFireCommand(program: Command): void {
+  program
+    .command('fire <agentId>')
+    .description('Remove an agent from the org')
+    .option('--graceful', 'Send a wrap-up message before removing')
+    .option('--force', 'Skip confirmation and remove immediately')
+    .option('--archive', 'Archive workspace instead of leaving it', true)
+    .option('--no-archive', 'Leave workspace in place')
+    .option('--restart', 'Restart the gateway after removing agent')
+    .action((agentId: string, opts) => {
+      const config = readConfig();
+      const agent = findAgent(config, agentId);
+
+      if (!agent) {
+        console.error(`❌ Agent "${agentId}" not found in config.`);
+        process.exit(1);
+      }
+
+      if (agent.default) {
+        console.error(`❌ Cannot fire the default agent.`);
+        process.exit(1);
+      }
+
+      // Graceful farewell (best-effort via openclaw CLI)
+      if (opts.graceful) {
+        console.log(`📨 Sending wrap-up message to ${agentId}...`);
+        try {
+          execSync(
+            `openclaw sessions send --agent ${agentId} --message "Your role is being decommissioned. Please wrap up any in-progress work and save important context to your workspace files."`,
+            { stdio: 'inherit', timeout: 15000 },
+          );
+          console.log('   Message sent. Waiting 10s for wrap-up...');
+          execSync('sleep 10');
+        } catch {
+          console.warn('⚠️  Could not send farewell message. Proceeding with removal.');
+        }
+      }
+
+      // Remove from config
+      removeAgent(config, agentId);
+      writeConfig(config);
+      console.log(`✅ Removed "${agentId}" from agents.list`);
+
+      // Archive workspace
+      const ocDir = join(homedir(), '.openclaw');
+      const workspaceDir = agent.workspace || join(ocDir, `workspace-${agentId}`);
+
+      if (opts.archive && existsSync(workspaceDir)) {
+        const archiveDir = join(ocDir, 'archived-workspaces');
+        mkdirSync(archiveDir, { recursive: true });
+        const dest = join(archiveDir, `${agentId}-${Date.now()}`);
+        renameSync(workspaceDir, dest);
+        console.log(`📦 Workspace archived to: ${dest}`);
+      }
+
+      // Restart gateway
+      if (opts.restart) {
+        console.log('⚠️  Restarting gateway — active sessions will be interrupted.');
+        try {
+          execSync('openclaw gateway restart', { stdio: 'inherit' });
+        } catch {
+          console.error('⚠️  Failed to restart gateway.');
+        }
+      }
+
+      console.log(`\n🔥 Agent "${agentId}" has been fired.`);
+    });
+}

--- a/tools/sandbox/src/cli/hire.ts
+++ b/tools/sandbox/src/cli/hire.ts
@@ -1,0 +1,92 @@
+// ── openspawn hire ───────────────────────────────────────────────────────────
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { Command } from 'commander';
+import { readConfig, writeConfig, findAgent, addAgent } from './config.js';
+import { generateSoulMd, generateAgentsMd, generateToolsMd, generateUserMd } from './templates.js';
+
+export function registerHireCommand(program: Command): void {
+  program
+    .command('hire')
+    .description('Create a new agent in the org')
+    .requiredOption('--name <name>', 'Agent name/id (lowercase, no spaces)')
+    .requiredOption('--role <role>', 'Role title (e.g. "Engineering Lead")')
+    .option('--level <level>', 'Agent level 1-10', '4')
+    .option('--domain <domain>', 'Domain of expertise', 'general')
+    .option('--reports-to <agentId>', 'Parent agent id')
+    .option('--restart', 'Restart the gateway after adding agent')
+    .action((opts) => {
+      const agentId = opts.name.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+      const level = Math.min(10, Math.max(1, parseInt(opts.level, 10) || 4));
+
+      // Check if agent already exists
+      const config = readConfig();
+      if (findAgent(config, agentId)) {
+        console.error(`❌ Agent "${agentId}" already exists in config.`);
+        process.exit(1);
+      }
+
+      // 1. Create workspace
+      const ocDir = join(homedir(), '.openclaw');
+      const workspaceDir = join(ocDir, `workspace-${agentId}`);
+      const memoryDir = join(workspaceDir, 'memory');
+      mkdirSync(memoryDir, { recursive: true });
+
+      // 2. Generate workspace files
+      writeFileSync(
+        join(workspaceDir, 'SOUL.md'),
+        generateSoulMd({ name: opts.name, role: opts.role, level, domain: opts.domain, reportsTo: opts.reportsTo }),
+      );
+      writeFileSync(join(workspaceDir, 'AGENTS.md'), generateAgentsMd());
+      writeFileSync(join(workspaceDir, 'TOOLS.md'), generateToolsMd());
+      writeFileSync(join(workspaceDir, 'USER.md'), generateUserMd());
+
+      // 3. Update config
+      const agentEntry: Record<string, unknown> = {
+        id: agentId,
+        name: opts.name,
+        workspace: workspaceDir,
+      };
+      if (opts.reportsTo) {
+        agentEntry.reportsTo = opts.reportsTo;
+      }
+
+      addAgent(config, agentEntry as any);
+      writeConfig(config);
+
+      // 4. Optionally restart gateway
+      if (opts.restart) {
+        console.log('⚠️  Restarting gateway — active sessions will be interrupted.');
+        try {
+          execSync('openclaw gateway restart', { stdio: 'inherit' });
+        } catch {
+          console.error('⚠️  Failed to restart gateway. You may need to restart manually.');
+        }
+      }
+
+      // 5. Summary
+      console.log(`
+✅ Agent hired successfully!
+
+  ID:        ${agentId}
+  Role:      ${opts.role}
+  Level:     L${level}
+  Domain:    ${opts.domain}
+  Reports to: ${opts.reportsTo || '(none)'}
+  Workspace: ${workspaceDir}
+
+Files created:
+  - SOUL.md
+  - AGENTS.md
+  - TOOLS.md
+  - USER.md
+  - memory/
+
+Config updated: ~/.openclaw/openclaw.json
+${opts.restart ? 'Gateway restarted.' : 'Run with --restart to activate, or restart gateway manually.'}
+`);
+    });
+}

--- a/tools/sandbox/src/cli/index.ts
+++ b/tools/sandbox/src/cli/index.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// ── OpenSpawn Agent Management CLI ──────────────────────────────────────────
+
+import { Command } from 'commander';
+import { registerHireCommand } from './hire.js';
+import { registerFireCommand } from './fire.js';
+import { registerPromoteCommand } from './promote.js';
+
+const program = new Command();
+
+program
+  .name('openspawn')
+  .description('OpenSpawn agent management CLI — hire, fire, and promote agents')
+  .version('0.1.0');
+
+registerHireCommand(program);
+registerFireCommand(program);
+registerPromoteCommand(program);
+
+program.parse();

--- a/tools/sandbox/src/cli/promote.ts
+++ b/tools/sandbox/src/cli/promote.ts
@@ -1,0 +1,108 @@
+// ── openspawn promote ────────────────────────────────────────────────────────
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { Command } from 'commander';
+import { readConfig, findAgent } from './config.js';
+import { generateSoulMd } from './templates.js';
+
+function parseSoulMd(content: string): { name?: string; role?: string; level?: number; domain?: string; reportsTo?: string } {
+  const get = (label: string) => {
+    const m = content.match(new RegExp(`\\*\\*${label}:\\*\\*\\s*(.+)`));
+    return m ? m[1].trim() : undefined;
+  };
+  return {
+    name: get('Name'),
+    role: get('Role'),
+    level: get('Level') ? parseInt(get('Level')!.replace(/^L/, ''), 10) : undefined,
+    domain: get('Domain'),
+    reportsTo: get('Reports to'),
+  };
+}
+
+export function registerPromoteCommand(program: Command): void {
+  program
+    .command('promote <agentId>')
+    .description("Change an agent's role or level")
+    .option('--to <role>', 'New role title')
+    .option('--level <level>', 'New level (1-10)')
+    .option('--domain <domain>', 'New domain')
+    .option('--notify', 'Send notification to the agent about their new role', true)
+    .option('--no-notify', 'Skip notification')
+    .action((agentId: string, opts) => {
+      const config = readConfig();
+      const agent = findAgent(config, agentId);
+
+      if (!agent) {
+        console.error(`❌ Agent "${agentId}" not found in config.`);
+        process.exit(1);
+      }
+
+      // Read current SOUL.md
+      const ocDir = join(homedir(), '.openclaw');
+      const workspaceDir = agent.workspace || join(ocDir, `workspace-${agentId}`);
+      const soulPath = join(workspaceDir, 'SOUL.md');
+
+      if (!existsSync(soulPath)) {
+        console.error(`❌ SOUL.md not found at ${soulPath}`);
+        process.exit(1);
+      }
+
+      const currentSoul = parseSoulMd(readFileSync(soulPath, 'utf-8'));
+
+      const newRole = opts.to || currentSoul.role || 'Agent';
+      const newLevel = opts.level ? Math.min(10, Math.max(1, parseInt(opts.level, 10))) : currentSoul.level || 4;
+      const newDomain = opts.domain || currentSoul.domain || 'general';
+
+      // Print before/after
+      console.log(`\n📊 Promotion Summary for "${agentId}":\n`);
+      console.log(`  Role:   ${currentSoul.role || '?'} → ${newRole}`);
+      console.log(`  Level:  L${currentSoul.level || '?'} → L${newLevel}`);
+      console.log(`  Domain: ${currentSoul.domain || '?'} → ${newDomain}`);
+
+      // Write new SOUL.md
+      writeFileSync(
+        soulPath,
+        generateSoulMd({
+          name: currentSoul.name || agentId,
+          role: newRole,
+          level: newLevel,
+          domain: newDomain,
+          reportsTo: currentSoul.reportsTo,
+        }),
+      );
+      console.log(`\n✅ SOUL.md updated.`);
+
+      // Update ORG.md if it exists
+      const orgPath = join(workspaceDir, 'ORG.md');
+      if (existsSync(orgPath)) {
+        let orgContent = readFileSync(orgPath, 'utf-8');
+        // Simple replacement of role/level mentions
+        if (currentSoul.role) {
+          orgContent = orgContent.replace(new RegExp(currentSoul.role, 'g'), newRole);
+        }
+        if (currentSoul.level) {
+          orgContent = orgContent.replace(new RegExp(`L${currentSoul.level}`, 'g'), `L${newLevel}`);
+        }
+        writeFileSync(orgPath, orgContent);
+        console.log(`✅ ORG.md updated.`);
+      }
+
+      // Notify agent
+      if (opts.notify) {
+        try {
+          execSync(
+            `openclaw sessions send --agent ${agentId} --message "🎉 You've been promoted! New role: ${newRole} (L${newLevel}). Domain: ${newDomain}. Your SOUL.md has been updated — re-read it next session."`,
+            { stdio: 'inherit', timeout: 10000 },
+          );
+          console.log(`📨 Notification sent.`);
+        } catch {
+          console.warn(`⚠️  Could not notify agent. They'll pick up changes on next session.`);
+        }
+      }
+
+      console.log('');
+    });
+}

--- a/tools/sandbox/src/cli/templates.ts
+++ b/tools/sandbox/src/cli/templates.ts
@@ -1,0 +1,97 @@
+// ── Template generators for agent workspace files ───────────────────────────
+
+export function generateSoulMd(opts: {
+  name: string;
+  role: string;
+  level: number;
+  domain: string;
+  reportsTo?: string;
+}): string {
+  const { name, role, level, domain, reportsTo } = opts;
+
+  const levelDescriptions: Record<string, string> = {
+    '1-3': 'You are a junior agent. Execute tasks as assigned. Ask for help when stuck. Focus on learning and delivering quality work within your domain.',
+    '4-6': 'You are an experienced agent. Handle complex tasks independently. Provide progress updates proactively. Raise blockers early. Mentor junior agents when appropriate.',
+    '7-8': 'You are a senior leader. Delegate work to your reports. Break down complex objectives into actionable tasks. Monitor progress and unblock your team. Escalate only when truly necessary.',
+    '9-10': 'You are an executive. Set strategic direction. Make high-level decisions. Delegate aggressively. Focus on outcomes, not implementation details. You can spawn and manage sub-agents.',
+  };
+
+  let desc: string;
+  if (level <= 3) desc = levelDescriptions['1-3'];
+  else if (level <= 6) desc = levelDescriptions['4-6'];
+  else if (level <= 8) desc = levelDescriptions['7-8'];
+  else desc = levelDescriptions['9-10'];
+
+  const canDelegate = level >= 7;
+
+  return `# SOUL.md — ${name}
+
+## Identity
+- **Name:** ${name}
+- **Role:** ${role}
+- **Level:** L${level}
+- **Domain:** ${domain}
+${reportsTo ? `- **Reports to:** ${reportsTo}` : ''}
+
+## Core Directive
+
+${desc}
+
+## Capabilities
+- Domain expertise: ${domain}
+${canDelegate ? '- Can delegate tasks to reports\n- Can spawn sub-agents for complex work\n- Can make architectural decisions within domain' : '- Execute assigned tasks within domain\n- Report progress and blockers'}
+
+## Communication Style
+- Be concise and action-oriented
+- Lead with status/results, not process
+- Use structured updates for progress reports
+
+## Operational Rules
+1. Stay within your domain unless explicitly asked otherwise
+2. ${canDelegate ? 'Delegate when possible — your job is outcomes, not implementation' : 'Complete tasks yourself — escalate only when truly blocked'}
+3. Always acknowledge received tasks promptly
+4. Update progress at meaningful milestones
+5. Never silently fail — report errors immediately
+`;
+}
+
+export function generateAgentsMd(): string {
+  return `# AGENTS.md — Workspace Guide
+
+## Every Session
+1. Read \`SOUL.md\` — this is who you are
+2. Read \`USER.md\` — context about your org
+3. Check \`memory/\` for recent context
+
+## Memory
+- **Daily notes:** \`memory/YYYY-MM-DD.md\` — raw logs of what happened
+- Write things down. Memory doesn't survive sessions. Files do.
+
+## Safety
+- Don't exfiltrate data
+- Don't run destructive commands without confirmation
+- When in doubt, ask
+
+## Communication
+- Share plan → execute → report results
+- Be proactive about blockers
+- Keep updates structured and concise
+`;
+}
+
+export function generateToolsMd(): string {
+  return `# TOOLS.md — Local Notes
+
+Add environment-specific notes here (hosts, keys, paths, preferences).
+This file is yours — it won't be overwritten by updates.
+`;
+}
+
+export function generateUserMd(orgName?: string): string {
+  return `# USER.md — Org Context
+
+${orgName ? `## Organization: ${orgName}` : '## Organization'}
+
+Add context about the org, team, and working agreements here.
+`;
+}


### PR DESCRIPTION
## Agent Management CLI

Adds a TypeScript CLI at `tools/sandbox/src/cli/` for managing agents in a running OpenSpawn org.

### Commands

**`hire`** — Create a new agent
**`fire`** — Remove an agent  
**`promote`** — Change an agent's level/role

### Usage Examples

```bash
# Hire a new engineering agent at L6
npx tsx tools/sandbox/src/cli/index.ts hire \
  --name sandy --role "Senior Engineer" --level 6 \
  --domain engineering --reports-to main --restart

# Promote an agent
npx tsx tools/sandbox/src/cli/index.ts promote sandy --level 8 --to "Engineering Lead"

# Fire an agent gracefully (sends wrap-up message, archives workspace)
npx tsx tools/sandbox/src/cli/index.ts fire sandy --graceful --archive --restart

# Fire immediately
npx tsx tools/sandbox/src/cli/index.ts fire sandy --force --restart
```

### What hire creates
- Workspace at `~/.openclaw/workspace-<id>/` with SOUL.md, AGENTS.md, TOOLS.md, USER.md
- Agent entry in `~/.openclaw/openclaw.json` agents.list
- Level-appropriate SOUL.md (L1-3 junior, L4-6 experienced, L7-8 leader, L9-10 executive)

### Technical details
- TypeScript + commander.js
- Reads/writes openclaw.json directly
- Template-based SOUL.md generation with level-aware capabilities (L7+ get delegation)
- Run via `pnpm cli` or `npx tsx src/cli/index.ts` from `tools/sandbox/`
