### PR TITLE
feat(bb): cinematic visual polish + perf pass

### DIFF
--- a/apps/dashboard/src/components/bb/BubbleField.tsx
+++ b/apps/dashboard/src/components/bb/BubbleField.tsx
@@ -1,45 +1,112 @@
 /**
- * BubbleField — floating bubble particles for underwater atmosphere.
- * Render as an absolute-positioned layer behind main content.
+ * BubbleField — organic floating bubble particles for underwater atmosphere.
+ * Uses bb-bubble-float keyframe with CSS custom properties for drift variation.
+ * IntersectionObserver pauses animation when off-screen.
+ * CSS animations only — no motion/react.
  */
+
+import { useEffect, useRef, useState } from 'react';
 
 interface BubbleFieldProps {
   count?: number;
   className?: string;
 }
 
+interface BubbleDef {
+  id: number;
+  size: number;       // px
+  left: number;       // 0-100%
+  bottom: number;     // 0-40%
+  delay: number;      // s
+  duration: number;   // s
+  opacity: number;    // 0.1-0.55
+  drift: 'float' | 'left' | 'right';
+  borderWidth: number; // 1-2px
+  shine: number;      // 20-40 — position of internal highlight
+}
+
 export function BubbleField({ count = 18, className = '' }: BubbleFieldProps) {
-  // Deterministic-ish bubbles (stable across renders, no Math.random in render)
-  const bubbles = Array.from({ length: count }, (_, i) => {
-    const seed = i * 7919; // prime-based seed for variety
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsVisible(entry.isIntersecting),
+      { threshold: 0 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Deterministic bubbles via prime-based seed — stable across renders
+  const bubbles: BubbleDef[] = Array.from({ length: count }, (_, i) => {
+    const seed = i * 7919 + 31;  // prime-based, offset to avoid i=0 edge
+    const seed2 = i * 6271 + 17;
+    const drift: BubbleDef['drift'] =
+      (seed % 3) === 0 ? 'left' :
+      (seed % 3) === 1 ? 'right' :
+      'float';
+
     return {
       id: i,
-      size:     (((seed * 13) % 12) + 4),            // 4–16px
-      left:     ((seed * 17) % 100),                  // 0–100%
-      bottom:   ((seed * 23) % 30),                   // 0–30%
-      delay:    ((seed * 11) % 12),                   // 0–12s
-      duration: (((seed * 7) % 8) + 8),               // 8–16s
-      opacity:  (((seed * 31) % 30) / 100) + 0.15,   // 0.15–0.45
+      // Size: 3 tiers — small (3-8), medium (9-16), large (17-24)
+      size:        i % 7 === 0 ? ((seed * 3) % 8) + 17   // large
+                 : i % 3 === 0 ? ((seed * 7) % 8) + 9    // medium
+                 : ((seed * 13) % 6) + 3,                 // small
+
+      left:        ((seed * 17) % 100),          // 0-100%
+      bottom:      ((seed * 23) % 40),            // 0-40%
+      delay:       ((seed * 11) % 14),            // 0-14s
+      duration:    (((seed2 * 7) % 10) + 9),     // 9-19s
+      opacity:     (((seed * 31) % 40) / 100) + 0.12,  // 0.12-0.52
+      drift,
+      borderWidth: (seed % 4 === 0) ? 2 : 1,
+      shine:       ((seed2 * 13) % 20) + 20,      // 20-40
     };
   });
 
+  const getAnimation = (b: BubbleDef) => {
+    return `bb-bubble-float ${b.duration}s ease-in-out ${b.delay}s infinite`;
+  };
+
+  const getDriftVars = (b: BubbleDef): React.CSSProperties => {
+    if (b.drift === 'left') return { '--bb-drift-x1': '0px', '--bb-drift-x2': '-12px', '--bb-drift-x3': '4px' } as React.CSSProperties;
+    if (b.drift === 'right') return { '--bb-drift-x1': '0px', '--bb-drift-x2': '10px', '--bb-drift-x3': '-2px' } as React.CSSProperties;
+    return { '--bb-drift-x1': '0px', '--bb-drift-x2': '8px', '--bb-drift-x3': '-4px' } as React.CSSProperties;
+  };
+
   return (
     <div
+      ref={containerRef}
       className={`absolute inset-0 pointer-events-none overflow-hidden ${className}`}
       aria-hidden="true"
+      style={{ animationPlayState: isVisible ? 'running' : 'paused' }}
     >
       {bubbles.map(b => (
         <div
           key={b.id}
-          className="absolute rounded-full border border-[#B8E4F7]/30"
+          className="absolute rounded-full"
           style={{
-            width:    b.size,
-            height:   b.size,
-            left:     `${b.left}%`,
-            bottom:   `${b.bottom}%`,
-            opacity:  b.opacity,
-            background: 'radial-gradient(circle at 30% 30%, rgba(184,228,247,0.5), rgba(74,174,217,0.1))',
-            animation: `bb-bubble-float ${b.duration}s ease-in-out ${b.delay}s infinite`,
+            width:   b.size,
+            height:  b.size,
+            left:    `${b.left}%`,
+            bottom:  `${b.bottom}%`,
+            opacity: b.opacity,
+            background: `radial-gradient(
+              circle at ${b.shine}% ${b.shine}%,
+              rgba(232, 248, 255, 0.7) 0%,
+              rgba(184, 228, 247, 0.35) 30%,
+              rgba(74, 174, 217, 0.08) 100%
+            )`,
+            border: `${b.borderWidth}px solid rgba(184, 228, 247, ${0.15 + b.opacity * 0.4})`,
+            boxShadow: b.size > 12
+              ? `inset 0 -2px 4px rgba(74,174,217,0.2), 0 0 ${Math.round(b.size * 0.5)}px rgba(74,174,217,0.1)`
+              : undefined,
+            animation: getAnimation(b),
+            animationPlayState: isVisible ? 'running' : 'paused',
+            ...getDriftVars(b),
           }}
         />
       ))}

--- a/apps/dashboard/src/components/bb/CharacterCard.tsx
+++ b/apps/dashboard/src/components/bb/CharacterCard.tsx
@@ -46,9 +46,9 @@ const STATUS_RING: Record<AgentStatus, string> = {
 
 const ANIM_CLASS: Record<AgentStatus, string> = {
   idle:        'animate-[bb-bob_2.5s_ease-in-out_infinite]',
-  working:     'animate-[bb-bob-fast_1s_ease-in-out_infinite]',
+  working:     'animate-[bb-bob_1s_ease-in-out_infinite]',
   busy:        'animate-[bb-bob_1.2s_ease-in-out_infinite]',
-  overwhelmed: 'animate-[bb-jitter_0.35s_ease-in-out_infinite]',
+  overwhelmed: 'animate-[bb-bob_0.6s_ease-in-out_infinite]',
 };
 
 interface CharacterCardProps {
@@ -85,7 +85,7 @@ export function CharacterCard({ agent, onClick, size = 'md' }: CharacterCardProp
     >
       {/* Crisis overlay flash */}
       {isCrisis && (
-        <div className="absolute inset-0 rounded-[1.25rem] bg-[#FF4757]/5 pointer-events-none animate-[bb-pulse-ring-coral_1s_ease-in-out_infinite]" />
+        <div className="absolute inset-0 rounded-[1.25rem] bg-[#FF4757]/5 pointer-events-none animate-[bb-pulse-ring_1s_ease-in-out_infinite]" style={{ '--bb-ring-color': 'rgba(255, 71, 87, 0.4)' } as React.CSSProperties} />
       )}
 
       {/* Avatar */}

--- a/apps/dashboard/src/components/bb/HeroBikiniBottom.tsx
+++ b/apps/dashboard/src/components/bb/HeroBikiniBottom.tsx
@@ -1,17 +1,13 @@
 /**
  * HeroBikiniBottom — Full-page hero + landing page sections.
- * This replaces intro.tsx entirely with a BikiniBottom-branded experience.
+ * POLISH PASS: scroll-reveal, text animation, glow CTA, multi-layer caustics,
+ * organic bubble field, natural kelp, character swim parade.
  *
- * Sections:
- *   1. Hero (full viewport) — animated, yellow headline, big CTA
- *   2. The Story (movie-poster narrative)
- *   3. Live Ticker feed preview
- *   4. Meet the Crew (CharacterCardGrid)
- *   5. Footer
- *
- * NOTE: All animations use plain CSS (bb-tokens.css keyframes) — no motion/react.
+ * All animations: CSS-only (no motion/react).
+ * prefers-reduced-motion: respected via bb-tokens.css media query.
  */
 
+import { useEffect, useRef, useState } from 'react';
 import { ArrowRight, Play, Waves } from 'lucide-react';
 import { BubbleField } from './BubbleField';
 import { KelpSilhouette } from './KelpSilhouette';
@@ -21,19 +17,44 @@ import { AGENT_ROSTER, SAMPLE_TICKER_MESSAGES } from './agent-roster';
 
 // ── Character swim parade data ────────────────────────────────────────────────
 const SWIM_CHARACTERS = [
-  { emoji: '🦀', name: 'Mr. Krabs',  delay: 0,  duration: 28 },
-  { emoji: '🧽', name: 'SpongeBob', delay: 3,  duration: 22 },
-  { emoji: '🐙', name: 'Squidward', delay: 7,  duration: 30 },
-  { emoji: '🐿️', name: 'Sandy',     delay: 11, duration: 25 },
-  { emoji: '⭐', name: 'Patrick',   delay: 15, duration: 35 },
-  { emoji: '🦠', name: 'Plankton',  delay: 2,  duration: 18 },
-  { emoji: '🐌', name: 'Gary',      delay: 18, duration: 45 },
-  { emoji: '🐳', name: 'Pearl',     delay: 9,  duration: 26 },
-  { emoji: '👻', name: 'Dutchman',  delay: 22, duration: 20 },
+  { emoji: '🦀', name: 'Mr. Krabs',  delay: 0,   duration: 28, vOffset: 0,  bobDuration: 1.8  },
+  { emoji: '🧽', name: 'SpongeBob', delay: 5,   duration: 22, vOffset: -8, bobDuration: 1.2  },
+  { emoji: '🐙', name: 'Squidward', delay: 10,  duration: 32, vOffset: 4,  bobDuration: 2.0  },
+  { emoji: '🐿️', name: 'Sandy',     delay: 14,  duration: 26, vOffset: -4, bobDuration: 1.5  },
+  { emoji: '⭐', name: 'Patrick',   delay: 18,  duration: 38, vOffset: 8,  bobDuration: 2.5  },
+  { emoji: '🦠', name: 'Plankton',  delay: 2,   duration: 18, vOffset: -12,bobDuration: 0.9  },
+  { emoji: '🐌', name: 'Gary',      delay: 22,  duration: 48, vOffset: 6,  bobDuration: 3.0  },
+  { emoji: '🐳', name: 'Pearl',     delay: 8,   duration: 27, vOffset: -2, bobDuration: 2.2  },
+  { emoji: '👻', name: 'Dutchman',  delay: 25,  duration: 21, vOffset: -16,bobDuration: 1.4  },
+  { emoji: '🤖', name: 'Karen',     delay: 16,  duration: 24, vOffset: 10, bobDuration: 1.6  },
 ];
 
-// ── Props ─────────────────────────────────────────────────────────────────────
+// ── Scroll reveal hook ────────────────────────────────────────────────────────
+function useScrollReveal(containerRef: React.RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
 
+    const targets = container.querySelectorAll('.bb-reveal');
+    if (!targets.length) return;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+          }
+        });
+      },
+      { threshold: 0.12 }
+    );
+
+    targets.forEach(el => observer.observe(el));
+    return () => observer.disconnect();
+  }, [containerRef]);
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
 interface HeroBikiniBottomProps {
   onWatchLive: () => void;
   onGitHub?: () => void;
@@ -41,10 +62,31 @@ interface HeroBikiniBottomProps {
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
+// Hook to pause ambient animations when section is off-screen
+function useAmbientPause(ref: React.RefObject<HTMLElement | null>) {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setVisible(entry.isIntersecting),
+      { threshold: 0 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+  return visible;
+}
 
 export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: HeroBikiniBottomProps) {
+  const pageRef = useRef<HTMLDivElement>(null);
+  const causticRef = useRef<HTMLDivElement>(null);
+  const causticVisible = useAmbientPause(causticRef);
+  useScrollReveal(pageRef as React.RefObject<HTMLElement>);
+
   return (
     <div
+      ref={pageRef}
       className="bb-theme relative w-full overflow-x-hidden"
       style={{ fontFamily: 'Nunito, DM Sans, system-ui, sans-serif' }}
     >
@@ -61,32 +103,76 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
           `,
         }}
       >
-        {/* Caustic light effects */}
-        <div className="absolute inset-0 pointer-events-none overflow-hidden" aria-hidden="true">
+        {/* ── Multi-layer caustic light effects ── */}
+        <div ref={causticRef} className="absolute inset-0 pointer-events-none overflow-hidden" aria-hidden="true">
+          {/* Layer 1 — blue, slow sweep */}
           <div
-            className="absolute w-[600px] h-[400px] -top-20 -left-20 rounded-full"
+            className="absolute rounded-full"
             style={{
+              width: '70vw', height: '50vh',
+              top: '-10vh', left: '-10vw',
               background: 'radial-gradient(ellipse, rgba(74,174,217,1) 0%, transparent 70%)',
               opacity: 0.06,
-              animation: 'bb-caustic 14s ease-in-out infinite',
+              animation: 'bb-caustic 16s ease-in-out infinite',
+              animationPlayState: causticVisible ? 'running' : 'paused',
             }}
           />
+          {/* Layer 2 — green, mid-speed */}
           <div
-            className="absolute w-[500px] h-[300px] top-1/3 right-0 rounded-full"
+            className="absolute rounded-full"
             style={{
+              width: '55vw', height: '40vh',
+              top: '30%', right: '-5vw',
               background: 'radial-gradient(ellipse, rgba(46,204,113,1) 0%, transparent 70%)',
               opacity: 0.04,
-              animation: 'bb-caustic 10s 5s ease-in-out infinite',
-            }}
+              '--bb-caustic-rotate': '-3deg',
+              '--bb-caustic-drift': '20px',
+              '--bb-caustic-min': '0.03',
+              '--bb-caustic-max': '0.06',
+              animation: 'bb-caustic 11s 4s ease-in-out infinite',
+              animationPlayState: causticVisible ? 'running' : 'paused',
+            } as React.CSSProperties}
+          />
+          {/* Layer 3 — sandy highlight, center-bottom */}
+          <div
+            className="absolute rounded-full"
+            style={{
+              width: '40vw', height: '30vh',
+              bottom: '10%', left: '30%',
+              background: 'radial-gradient(ellipse, rgba(244,197,66,1) 0%, transparent 70%)',
+              opacity: 0.03,
+              '--bb-caustic-rotate': '5deg',
+              '--bb-caustic-drift': '0px',
+              '--bb-caustic-min': '0.02',
+              '--bb-caustic-max': '0.05',
+              animation: 'bb-caustic 19s 8s ease-in-out infinite',
+              animationPlayState: causticVisible ? 'running' : 'paused',
+            } as React.CSSProperties}
+          />
+          {/* Layer 4 — deep blue drift, top-right */}
+          <div
+            className="absolute rounded-full"
+            style={{
+              width: '45vw', height: '35vh',
+              top: '15%', right: '20%',
+              background: 'radial-gradient(ellipse, rgba(26,125,181,1) 0%, transparent 70%)',
+              opacity: 0.05,
+              '--bb-caustic-rotate': '-3deg',
+              '--bb-caustic-drift': '20px',
+              '--bb-caustic-min': '0.03',
+              '--bb-caustic-max': '0.06',
+              animation: 'bb-caustic 14s 2s ease-in-out infinite',
+              animationPlayState: causticVisible ? 'running' : 'paused',
+            } as React.CSSProperties}
           />
         </div>
 
-        {/* Bubble field */}
-        <BubbleField count={22} className="z-20" />
+        {/* Organic bubble field */}
+        <BubbleField count={28} className="z-20" />
 
         {/* ── Nav ── */}
         <nav className="relative z-30 flex items-center justify-between px-6 py-4 md:px-10 md:py-6">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2" style={{ animation: 'bb-enter-up 0.6s 0.1s ease forwards', opacity: 0, '--bb-enter-y': '20px' } as React.CSSProperties}>
             <span className="text-2xl" role="img" aria-label="pineapple">🍍</span>
             <span
               className="font-extrabold text-lg tracking-tight"
@@ -95,7 +181,7 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
               BikiniBottom
             </span>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3" style={{ animation: 'bb-enter-up 0.6s 0.2s ease forwards', opacity: 0, '--bb-enter-y': '20px' } as React.CSSProperties}>
             {onGitHub && (
               <button
                 onClick={onGitHub}
@@ -124,11 +210,10 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
         {/* ── Hero content ── */}
         <div className="relative z-30 flex-1 flex flex-col items-center justify-center px-6 py-12 text-center">
 
-          {/* Subtitle pill */}
+          {/* Subtitle pill — shimmer */}
           <div
-            className="mb-6 inline-flex items-center gap-2 px-4 py-1.5 rounded-full border text-sm font-semibold"
+            className="bb-pill-shimmer bb-fade-up-1 mb-6 inline-flex items-center gap-2 px-4 py-1.5 rounded-full border text-sm font-semibold"
             style={{
-              background: 'rgba(74,174,217,0.1)',
               borderColor: 'rgba(74,174,217,0.25)',
               color: '#4AAED9',
               fontFamily: 'Nunito, sans-serif',
@@ -138,25 +223,27 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
             {agentCount} agents · 1 massive order · 0 humans in the loop
           </div>
 
-          {/* H1 — Sandy yellow, NOT cyan */}
+          {/* H1 — word-by-word reveal animation */}
           <h1
             className="font-black leading-[1.05] tracking-tight mb-6"
             style={{
               fontFamily: '"Baloo 2", cursive',
               fontSize: 'clamp(3rem, 8vw, 6rem)',
               color: '#F4C542',
-              textShadow: '0 0 60px rgba(244,197,66,0.3)',
+              textShadow: '0 0 60px rgba(244,197,66,0.35), 0 0 120px rgba(244,197,66,0.15)',
               letterSpacing: '-0.02em',
             }}
           >
-            Hire the
+            <span className="bb-hero-word">Hire</span>{' '}
+            <span className="bb-hero-word">the</span>
             <br />
-            whole ocean.
+            <span className="bb-hero-word">whole</span>{' '}
+            <span className="bb-hero-word">ocean.</span>
           </h1>
 
-          {/* Subhead */}
+          {/* Subhead — fade up */}
           <p
-            className="font-medium max-w-xl mb-10 leading-relaxed"
+            className="bb-fade-up-2 font-medium max-w-xl mb-10 leading-relaxed"
             style={{
               fontFamily: 'Nunito, sans-serif',
               fontSize: 'clamp(1rem, 2vw, 1.25rem)',
@@ -168,17 +255,18 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
             Watch them argue, delegate, mess up, and somehow deliver 10,000 Krabby Patties.
           </p>
 
-          {/* CTA buttons */}
-          <div className="flex flex-col sm:flex-row items-center gap-4 mb-16">
-            {/* PRIMARY CTA — Sandy yellow, big, bouncy */}
+          {/* CTA buttons — fade up with glow pulse on primary */}
+          <div className="bb-fade-up-3 flex flex-col sm:flex-row items-center gap-4 mb-16">
+            {/* PRIMARY CTA — Sandy yellow, glow pulse, magnetic hover */}
             <button
               onClick={onWatchLive}
-              className="group flex items-center gap-3 px-8 py-4 rounded-2xl font-black text-xl transition-all hover:scale-[1.06] hover:-translate-y-1 active:scale-[0.97]"
+              className="bb-cta-pulse group flex items-center gap-3 px-8 py-4 rounded-2xl font-black text-xl transition-transform hover:scale-[1.06] hover:-translate-y-1 active:scale-[0.97]"
               style={{
                 background: 'linear-gradient(135deg, #F4C542 0%, #EAB308 100%)',
                 color: '#062A45',
                 fontFamily: '"Baloo 2", cursive',
-                boxShadow: '0 0 24px rgba(244,197,66,0.5), 0 4px 16px rgba(6,42,69,0.3)',
+                border: 'none',
+                cursor: 'pointer',
               }}
             >
               <Play className="w-5 h-5" />
@@ -190,7 +278,7 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
             {onGitHub && (
               <button
                 onClick={onGitHub}
-                className="flex items-center gap-2 px-6 py-3.5 rounded-xl font-semibold text-base border backdrop-blur-sm transition-all hover:-translate-y-0.5"
+                className="flex items-center gap-2 px-6 py-3.5 rounded-xl font-semibold text-base border backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:border-[#4AAED9]/50 hover:bg-[#4AAED9]/15"
                 style={{
                   color: '#B8E4F7',
                   fontFamily: 'Nunito, sans-serif',
@@ -204,30 +292,33 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
           </div>
 
           {/* Live ticker preview */}
-          <div className="w-full max-w-lg">
+          <div className="bb-fade-up-4 w-full max-w-lg">
             <LiveTickerFeed messages={SAMPLE_TICKER_MESSAGES} onJoinWatch={onWatchLive} />
           </div>
         </div>
 
-        {/* ── Character swim parade ── */}
+        {/* ── Character swim parade — varied speeds, bob amplitudes, z-offsets ── */}
         <div
-          className="absolute bottom-28 left-0 right-0 h-16 pointer-events-none overflow-hidden z-20"
+          className="absolute bottom-28 left-0 right-0 h-20 pointer-events-none overflow-hidden z-20"
           aria-hidden="true"
         >
           {SWIM_CHARACTERS.map(char => (
             <div
               key={char.name}
-              className="absolute bottom-2 text-2xl"
+              className="absolute text-2xl"
               title={char.name}
               style={{
-                filter: 'drop-shadow(0 2px 4px rgba(6,42,69,0.5))',
+                bottom: `${8 + Math.abs(char.vOffset)}px`,
+                filter: 'drop-shadow(0 2px 6px rgba(6,42,69,0.6))',
                 animation: `bb-swim ${char.duration}s ${char.delay}s linear infinite`,
               }}
             >
+              {/* Per-character bob with unique duration */}
               <span
                 style={{
                   display: 'block',
-                  animation: `bb-bob ${1.5 + char.delay * 0.1}s ease-in-out infinite`,
+                  animation: `bb-swim-bob ${char.bobDuration}s ease-in-out infinite`,
+                  animationDelay: `${char.delay * 0.3}s`,
                 }}
               >
                 {char.emoji}
@@ -257,7 +348,7 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
       </section>
 
       {/* ================================================================
-          SECTION 2: THE STORY
+          SECTION 2: THE STORY — scroll-reveal cards
           ================================================================ */}
       <section
         className="relative py-20 px-6 overflow-hidden"
@@ -265,79 +356,77 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
       >
         <BubbleField count={8} className="opacity-50" />
         <div className="relative z-10 max-w-4xl mx-auto text-center">
-          <div>
-            <p
-              className="text-sm font-bold uppercase tracking-widest mb-4"
-              style={{ color: '#4AAED9', fontFamily: 'Nunito, sans-serif' }}
-            >
-              🎬 THE STORY SO FAR 🎬
-            </p>
-            <h2
-              className="font-black mb-6 leading-tight"
-              style={{
-                fontFamily: '"Baloo 2", cursive',
-                fontSize: 'clamp(1.75rem, 4vw, 3rem)',
-                color: '#E8F8FF',
-              }}
-            >
-              One order. 10,000 Krabby Patties.
-            </h2>
-            <p
-              className="text-lg leading-relaxed max-w-2xl mx-auto mb-12"
-              style={{ color: 'rgba(184,228,247,0.7)', fontFamily: 'Nunito, sans-serif' }}
-            >
-              Plankton walks in and orders 10,000 Krabby Patties. Mr. Krabs sees dollar signs.
-              SpongeBob cooks faster than Squidward can deliver. Sandy optimizes everything.
-              Patrick helps… mostly. 22 agents, 5 departments, 1 <code
-                className="px-1.5 py-0.5 rounded text-sm"
-                style={{ color: '#F4C542', background: 'rgba(244,197,66,0.1)' }}
-              >ORG.md</code>.
-            </p>
+          <p
+            className="bb-reveal text-sm font-bold uppercase tracking-widest mb-4"
+            style={{ color: '#4AAED9', fontFamily: 'Nunito, sans-serif' }}
+          >
+            🎬 THE STORY SO FAR 🎬
+          </p>
+          <h2
+            className="bb-reveal bb-reveal-delay-1 font-black mb-6 leading-tight"
+            style={{
+              fontFamily: '"Baloo 2", cursive',
+              fontSize: 'clamp(1.75rem, 4vw, 3rem)',
+              color: '#E8F8FF',
+            }}
+          >
+            One order. 10,000 Krabby Patties.
+          </h2>
+          <p
+            className="bb-reveal bb-reveal-delay-2 text-lg leading-relaxed max-w-2xl mx-auto mb-12"
+            style={{ color: 'rgba(184,228,247,0.7)', fontFamily: 'Nunito, sans-serif' }}
+          >
+            Plankton walks in and orders 10,000 Krabby Patties. Mr. Krabs sees dollar signs.
+            SpongeBob cooks faster than Squidward can deliver. Sandy optimizes everything.
+            Patrick helps… mostly. 22 agents, 5 departments, 1 <code
+              className="px-1.5 py-0.5 rounded text-sm"
+              style={{ color: '#F4C542', background: 'rgba(244,197,66,0.1)' }}
+            >ORG.md</code>.
+          </p>
 
-            {/* Act cards */}
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-left">
-              {[
-                { act: 'Act I', title: 'The Order', desc: 'Plankton places the most ambitious order in Bikini Bottom history. Mr. Krabs says yes immediately.', icon: '🦠' },
-                { act: 'Act II', title: 'Kitchen Heats Up', desc: 'SpongeBob enters overdrive. Squidward hits his limit. Sandy spins up 3 more Fred clones.', icon: '🔥' },
-                { act: 'Act III', title: 'Delivery Crisis', desc: 'The queue hits 200+. Mr. Krabs delegates hard. Flying Dutchman audits the books. Patties delivered.', icon: '📦' },
-              ].map(a => (
+          {/* Act cards — staggered reveal */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-left">
+            {[
+              { act: 'Act I', title: 'The Order', desc: 'Plankton places the most ambitious order in Bikini Bottom history. Mr. Krabs says yes immediately.', icon: '🦠', delay: 3 },
+              { act: 'Act II', title: 'Kitchen Heats Up', desc: 'SpongeBob enters overdrive. Squidward hits his limit. Sandy spins up 3 more Fred clones.', icon: '🔥', delay: 4 },
+              { act: 'Act III', title: 'Delivery Crisis', desc: 'The queue hits 200+. Mr. Krabs delegates hard. Flying Dutchman audits the books. Patties delivered.', icon: '📦', delay: 5 },
+            ].map(a => (
+              <div
+                key={a.act}
+                className={`bb-reveal bb-reveal-delay-${a.delay} rounded-2xl p-5 border transition-all duration-300 hover:-translate-y-1 hover:border-[#F4C542]/30 hover:shadow-[0_0_24px_rgba(244,197,66,0.15)]`}
+                style={{
+                  background: 'rgba(11,61,96,0.5)',
+                  borderColor: 'rgba(74,174,217,0.2)',
+                  backdropFilter: 'blur(8px)',
+                }}
+              >
+                <div className="text-2xl mb-2">{a.icon}</div>
                 <div
-                  key={a.act}
-                  className="rounded-2xl p-5 border"
-                  style={{
-                    background: 'rgba(11,61,96,0.5)',
-                    borderColor: 'rgba(74,174,217,0.2)',
-                    backdropFilter: 'blur(8px)',
-                  }}
+                  className="text-xs font-bold uppercase tracking-widest mb-1"
+                  style={{ color: '#4AAED9', fontFamily: 'Nunito, sans-serif' }}
                 >
-                  <div className="text-2xl mb-2">{a.icon}</div>
-                  <div
-                    className="text-xs font-bold uppercase tracking-widest mb-1"
-                    style={{ color: '#4AAED9', fontFamily: 'Nunito, sans-serif' }}
-                  >
-                    {a.act}
-                  </div>
-                  <h3
-                    className="font-bold mb-2"
-                    style={{ fontFamily: '"Baloo 2", cursive', color: '#F4C542', fontSize: '1.1rem' }}
-                  >
-                    {a.title}
-                  </h3>
-                  <p
-                    className="text-sm leading-relaxed"
-                    style={{ color: 'rgba(184,228,247,0.6)', fontFamily: 'Nunito, sans-serif' }}
-                  >
-                    {a.desc}
-                  </p>
+                  {a.act}
                 </div>
-              ))}
-            </div>
+                <h3
+                  className="font-bold mb-2"
+                  style={{ fontFamily: '"Baloo 2", cursive', color: '#F4C542', fontSize: '1.1rem' }}
+                >
+                  {a.title}
+                </h3>
+                <p
+                  className="text-sm leading-relaxed"
+                  style={{ color: 'rgba(184,228,247,0.6)', fontFamily: 'Nunito, sans-serif' }}
+                >
+                  {a.desc}
+                </p>
+              </div>
+            ))}
           </div>
         </div>
       </section>
 
       {/* ================================================================
-          SECTION 3: MEET THE CREW
+          SECTION 3: MEET THE CREW — scroll-reveal
           ================================================================ */}
       <section
         className="relative py-20 px-6 overflow-hidden"
@@ -349,13 +438,13 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
         <div className="relative z-10 max-w-5xl mx-auto">
           <div className="text-center mb-12">
             <p
-              className="text-sm font-bold uppercase tracking-widest mb-4"
+              className="bb-reveal text-sm font-bold uppercase tracking-widest mb-4"
               style={{ color: '#4AAED9', fontFamily: 'Nunito, sans-serif' }}
             >
               👥 MEET THE CREW
             </p>
             <h2
-              className="font-black mb-4"
+              className="bb-reveal bb-reveal-delay-1 font-black mb-4"
               style={{
                 fontFamily: '"Baloo 2", cursive',
                 fontSize: 'clamp(1.75rem, 4vw, 3rem)',
@@ -365,25 +454,28 @@ export function HeroBikiniBottom({ onWatchLive, onGitHub, agentCount = 22 }: Her
               22 fish in a frenzy.
             </h2>
             <p
-              className="text-lg max-w-xl mx-auto"
+              className="bb-reveal bb-reveal-delay-2 text-lg max-w-xl mx-auto"
               style={{ color: 'rgba(184,228,247,0.6)', fontFamily: 'Nunito, sans-serif' }}
             >
               Each agent is a real SpongeBob character with a job title, a team, and way too much to do.
             </p>
           </div>
 
-          <CharacterCardGrid agents={AGENT_ROSTER} maxVisible={6} />
+          <div className="bb-reveal bb-reveal-delay-3">
+            <CharacterCardGrid agents={AGENT_ROSTER} maxVisible={6} />
+          </div>
 
           {/* CTA to watch live */}
-          <div className="text-center mt-12">
+          <div className="bb-reveal bb-reveal-delay-4 text-center mt-12">
             <button
               onClick={onWatchLive}
-              className="group inline-flex items-center gap-3 px-8 py-4 rounded-2xl font-black text-xl transition-all hover:scale-[1.05] hover:-translate-y-0.5 active:scale-[0.97]"
+              className="bb-cta-pulse group inline-flex items-center gap-3 px-8 py-4 rounded-2xl font-black text-xl transition-transform hover:scale-[1.05] hover:-translate-y-0.5 active:scale-[0.97]"
               style={{
                 background: 'linear-gradient(135deg, #F4C542 0%, #EAB308 100%)',
                 color: '#062A45',
                 fontFamily: '"Baloo 2", cursive',
-                boxShadow: '0 0 24px rgba(244,197,66,0.4)',
+                border: 'none',
+                cursor: 'pointer',
               }}
             >
               <Play className="w-5 h-5" />

--- a/apps/dashboard/src/components/bb/KelpSilhouette.tsx
+++ b/apps/dashboard/src/components/bb/KelpSilhouette.tsx
@@ -1,11 +1,122 @@
 /**
  * KelpSilhouette — SVG kelp at the bottom of hero / dashboard.
- * Animated with CSS sway for underwater depth cue.
+ * POLISH PASS: Per-strand animation-delay variation, 3 sway amplitude variants,
+ * 4 depth layers for natural parallax feel.
+ * CSS animations only. prefers-reduced-motion: respected via global bb-tokens.css rule.
+ * IntersectionObserver pauses animation when off-screen.
  */
 
+import { useEffect, useRef, useState } from 'react';
+
+// Per-strand config: x position, color, strokeWidth, sway variant, delay
+interface Strand {
+  x: number;
+  color: string;
+  sw: number;
+  anim: string; // animation name
+  delay: number; // seconds
+  dur: number;   // seconds
+  opacity: number;
+  ctrl1offset: number; // Q control point x offset
+  ctrl2offset: number;
+  swayAngle: string;
+  swayScale: string;
+}
+
+// Generate deterministic per-strand variation
+function makeStrand(x: number, i: number, layer: 0|1|2|3): Strand {
+  const seed = x * 17 + i * 31;
+  const layers = [
+    { color: '#062A1A', sw: 12, opBase: 0.5  },  // back — darkest, thickest
+    { color: '#0A3826', sw: 9,  opBase: 0.65 },  // mid-back
+    { color: '#0F4A39', sw: 7,  opBase: 0.78 },  // mid-front
+    { color: '#165C42', sw: 5,  opBase: 0.92 },  // front — lightest, finest
+  ] as const;
+  const l = layers[layer];
+
+  const anim = 'bb-kelp-sway';
+  // Sway amplitude varies by strand via CSS custom property
+  const swayAngles = ['1.5deg', '3deg', '5deg'];
+  const swayScales = ['0.005', '0.01', '0.015'];
+  const swayIdx = seed % swayAngles.length;
+
+  // Duration varies 3-6s per layer range
+  const durBase = [5, 4.5, 4, 3.2] as const;
+  const dur = durBase[layer] + (seed % 20) / 10; // +0-2s variation
+
+  // Delay 0-2.5s per strand
+  const delay = (seed % 25) / 10;
+
+  // Control point offsets for S-curve shape variation
+  const ctrl1offset = 10 + (seed % 12) * (i % 2 === 0 ? 1 : -1);
+  const ctrl2offset = 18 + (seed % 8) * (i % 2 === 0 ? -1 : 1);
+
+  return {
+    x,
+    color: l.color,
+    sw: l.sw,
+    anim,
+    delay,
+    dur,
+    opacity: l.opBase - (seed % 12) / 100, // subtle variation
+    ctrl1offset,
+    ctrl2offset,
+    swayAngle: swayAngles[swayIdx],
+    swayScale: swayScales[swayIdx],
+  };
+}
+
 export function KelpSilhouette({ className = '' }: { className?: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsVisible(entry.isIntersecting),
+      { threshold: 0 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Layer x positions — offset per layer for depth feel
+  const backXs   = [60, 170, 310, 470, 640, 810, 950, 1090, 1270, 1390];
+  const midBackXs = [95, 190, 330, 490, 655, 820, 970, 1110, 1290, 1400];
+  const midFrontXs= [30, 130, 250, 390, 530, 680, 810, 950,  1090, 1240, 1370];
+  const frontXs  = [10, 110, 230, 370, 510, 660, 790, 930,  1070, 1220, 1380];
+
+  const backStrands    = backXs.map((x, i) => makeStrand(x, i, 0));
+  const midBackStrands = midBackXs.map((x, i) => makeStrand(x, i, 1));
+  const midFrontStrands= midFrontXs.map((x, i) => makeStrand(x, i, 2));
+  const frontStrands   = frontXs.map((x, i) => makeStrand(x, i, 3));
+
+  const renderStrand = (s: Strand, key: string) => {
+    const mid = `M${s.x} 120 Q${s.x + s.ctrl1offset} 75 ${s.x - 3} 35 Q${s.x + s.ctrl2offset} 10 ${s.x + 5} 0`;
+    return (
+      <path
+        key={key}
+        d={mid}
+        stroke={s.color}
+        strokeWidth={s.sw}
+        fill="none"
+        strokeLinecap="round"
+        opacity={s.opacity}
+        style={{
+          animation: `${s.anim} ${s.dur}s ${s.delay}s ease-in-out infinite`,
+          animationPlayState: isVisible ? 'running' : 'paused',
+          transformOrigin: 'bottom center',
+          '--bb-sway-angle': s.swayAngle,
+          '--bb-sway-scale': s.swayScale,
+        } as React.CSSProperties}
+      />
+    );
+  };
+
   return (
     <div
+      ref={containerRef}
       className={`absolute bottom-0 left-0 right-0 pointer-events-none ${className}`}
       aria-hidden="true"
     >
@@ -15,50 +126,17 @@ export function KelpSilhouette({ className = '' }: { className?: string }) {
         className="w-full h-24 md:h-32"
         xmlns="http://www.w3.org/2000/svg"
       >
-        {/* Back kelp layer — darkest, slowest sway */}
-        <g style={{ animation: 'bb-kelp-sway 5s ease-in-out infinite', transformOrigin: 'bottom center' }}>
-          {[80, 180, 320, 480, 650, 820, 960, 1100, 1280, 1400].map((x, i) => (
-            <path
-              key={`back-${i}`}
-              d={`M${x} 120 Q${x + 15 * (i % 2 === 0 ? 1 : -1)} 80 ${x + 5} 40 Q${x + 20 * (i % 2 === 0 ? -1 : 1)} 20 ${x + 8} 0`}
-              stroke="#0D3B2E"
-              strokeWidth="10"
-              fill="none"
-              strokeLinecap="round"
-              opacity="0.7"
-            />
-          ))}
-        </g>
+        {/* Layer 0 — back (darkest, slowest, gentle sway) */}
+        {backStrands.map((s, i) => renderStrand(s, `back-${i}`))}
 
-        {/* Mid kelp layer */}
-        <g style={{ animation: 'bb-kelp-sway 4s 1s ease-in-out infinite', transformOrigin: 'bottom center' }}>
-          {[40, 140, 260, 400, 540, 700, 850, 1010, 1160, 1340].map((x, i) => (
-            <path
-              key={`mid-${i}`}
-              d={`M${x} 120 Q${x + 12 * (i % 2 === 0 ? -1 : 1)} 75 ${x - 3} 35 Q${x + 18 * (i % 2 === 0 ? 1 : -1)} 15 ${x + 4} 0`}
-              stroke="#0F4A39"
-              strokeWidth="8"
-              fill="none"
-              strokeLinecap="round"
-              opacity="0.85"
-            />
-          ))}
-        </g>
+        {/* Layer 1 — mid-back */}
+        {midBackStrands.map((s, i) => renderStrand(s, `midback-${i}`))}
 
-        {/* Front kelp layer — lightest, fastest sway */}
-        <g style={{ animation: 'bb-kelp-sway 3s 0.5s ease-in-out infinite', transformOrigin: 'bottom center' }}>
-          {[10, 110, 230, 370, 510, 660, 790, 930, 1070, 1220, 1380].map((x, i) => (
-            <path
-              key={`front-${i}`}
-              d={`M${x} 120 Q${x + 10 * (i % 2 === 0 ? 1 : -1)} 70 ${x + 2} 30 Q${x + 15 * (i % 2 === 0 ? -1 : 1)} 10 ${x + 5} 0`}
-              stroke="#165C42"
-              strokeWidth="6"
-              fill="none"
-              strokeLinecap="round"
-              opacity="0.9"
-            />
-          ))}
-        </g>
+        {/* Layer 2 — mid-front */}
+        {midFrontStrands.map((s, i) => renderStrand(s, `midfront-${i}`))}
+
+        {/* Layer 3 — front (lightest, fastest, strongest sway) */}
+        {frontStrands.map((s, i) => renderStrand(s, `front-${i}`))}
       </svg>
     </div>
   );

--- a/apps/dashboard/src/components/live/intro-card.tsx
+++ b/apps/dashboard/src/components/live/intro-card.tsx
@@ -1,9 +1,78 @@
-import { motion } from 'motion/react';
+/**
+ * IntroCard — Full-screen intro overlay before the live dashboard.
+ * POLISH PASS: Replaced motion/react with CSS-only animations.
+ * CSS animations only. prefers-reduced-motion: respected via media query.
+ */
+
 import { Play } from 'lucide-react';
 
 interface IntroCardProps {
   onStart: () => void;
 }
+
+// CSS animations injected once
+const INTRO_STYLES = `
+  @keyframes intro-overlay-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+  @keyframes intro-terminal-in {
+    from { opacity: 0; transform: translateX(-32px); }
+    to   { opacity: 1; transform: translateX(0); }
+  }
+  @keyframes intro-copy-in {
+    from { opacity: 0; transform: translateY(16px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes intro-burger-bounce {
+    0%   { transform: scale(0.5) rotate(-12deg); opacity: 0; }
+    60%  { transform: scale(1.12) rotate(3deg); opacity: 1; }
+    80%  { transform: scale(0.96) rotate(-1deg); }
+    100% { transform: scale(1) rotate(0deg); opacity: 1; }
+  }
+  @keyframes intro-title-in {
+    from { opacity: 0; transform: translateY(10px); letter-spacing: 0.1em; }
+    to   { opacity: 1; transform: translateY(0); letter-spacing: -0.01em; }
+  }
+  @keyframes intro-btn-in {
+    0%   { opacity: 0; transform: scale(0.85); }
+    60%  { transform: scale(1.04); opacity: 1; }
+    100% { transform: scale(1); opacity: 1; }
+  }
+  @keyframes intro-cta-glow {
+    0%, 100% { box-shadow: 0 0 20px rgba(244,197,66,0.5), 0 0 40px rgba(244,197,66,0.2); }
+    50%       { box-shadow: 0 0 32px rgba(244,197,66,0.75), 0 0 60px rgba(244,197,66,0.35); }
+  }
+
+  .intro-overlay   { animation: intro-overlay-in  0.5s ease forwards; }
+  .intro-terminal  { animation: intro-terminal-in 0.6s 0.2s cubic-bezier(0.16,1,0.3,1) forwards; opacity: 0; }
+  .intro-copy      { animation: intro-copy-in     0.5s 0.4s ease forwards; opacity: 0; }
+  .intro-burger    { animation: intro-burger-bounce 0.6s 0.5s cubic-bezier(0.34,1.56,0.64,1) forwards; opacity: 0; }
+  .intro-title     { animation: intro-title-in    0.5s 0.65s cubic-bezier(0.16,1,0.3,1) forwards; opacity: 0; }
+  .intro-btn       {
+    animation:
+      intro-btn-in   0.5s 0.8s cubic-bezier(0.34,1.56,0.64,1) forwards,
+      intro-cta-glow 2.5s 1.4s ease-in-out infinite;
+    opacity: 0;
+  }
+  .intro-btn:hover {
+    animation-play-state: paused;
+    transform: scale(1.05) translateY(-2px);
+    box-shadow: 0 0 40px rgba(244,197,66,0.8), 0 0 80px rgba(244,197,66,0.4) !important;
+  }
+  .intro-btn:active {
+    transform: scale(0.97);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .intro-overlay, .intro-terminal, .intro-copy, .intro-burger,
+    .intro-title, .intro-btn {
+      animation: none !important;
+      opacity: 1 !important;
+      transform: none !important;
+    }
+  }
+`;
 
 const ORG_LINES = [
   '# 🍍 The Krusty Krab',
@@ -77,22 +146,18 @@ function renderLine(line: string) {
 
 export function IntroCard({ onStart }: IntroCardProps) {
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      transition={{ duration: 0.5 }}
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
-      style={{ background: 'rgba(3,14,26,0.96)' }}
+    <div
+      className="intro-overlay fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{
+        background: 'rgba(3,14,26,0.96)',
+        backdropFilter: 'blur(8px)',
+      }}
     >
+      <style>{INTRO_STYLES}</style>
+
       <div className="flex flex-col md:flex-row items-center gap-8 md:gap-12 max-w-5xl w-full">
         {/* Left: ORG.md terminal */}
-        <motion.div
-          initial={{ opacity: 0, x: -40 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{ delay: 0.2, duration: 0.6, ease: 'easeOut' }}
-          className="w-full md:w-[55%] shrink-0"
-        >
+        <div className="intro-terminal w-full md:w-[55%] shrink-0">
           <div
             className="rounded-2xl max-h-[40vh] md:max-h-none overflow-y-auto scrollbar-none"
             style={{
@@ -136,16 +201,12 @@ export function IntroCard({ onStart }: IntroCardProps) {
               ))}
             </div>
           </div>
-        </motion.div>
+        </div>
 
         {/* Right: Intro copy */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.4, duration: 0.5 }}
-          className="flex flex-col items-center md:items-start text-center md:text-left"
-        >
-          <div className="text-7xl mb-4">🍔</div>
+        <div className="intro-copy flex flex-col items-center md:items-start text-center md:text-left">
+          <div className="intro-burger text-7xl mb-4">🍔</div>
+
           <div
             className="text-xs uppercase tracking-widest mb-1"
             style={{ color: 'rgba(184,228,247,0.4)', fontFamily: 'Nunito, sans-serif' }}
@@ -153,7 +214,7 @@ export function IntroCard({ onStart }: IntroCardProps) {
             Operation:
           </div>
           <h1
-            className="font-black mb-6"
+            className="intro-title font-black mb-6"
             style={{
               fontFamily: '"Baloo 2", cursive',
               fontSize: '1.875rem',
@@ -176,32 +237,27 @@ export function IntroCard({ onStart }: IntroCardProps) {
             Watch them coordinate — or collapse.
           </p>
 
-          <motion.button
-            initial={{ scale: 0.8, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            transition={{ delay: 0.7, type: 'spring', stiffness: 200, damping: 20 }}
-            whileHover={{ scale: 1.05, boxShadow: '0 0 32px rgba(244,197,66,0.6)' }}
-            whileTap={{ scale: 0.97 }}
+          <button
             onClick={onStart}
-            className="flex items-center gap-3 px-8 py-3.5 rounded-2xl font-black text-lg cursor-pointer"
+            className="intro-btn flex items-center gap-3 px-8 py-3.5 rounded-2xl font-black text-lg cursor-pointer border-none"
             style={{
               background: 'linear-gradient(135deg, #F4C542 0%, #EAB308 100%)',
               color: '#062A45',
               fontFamily: '"Baloo 2", cursive',
-              boxShadow: '0 0 24px rgba(244,197,66,0.4)',
             }}
           >
             <Play className="w-5 h-5" />
             Watch the Story →
-          </motion.button>
+          </button>
+
           <p
             className="text-xs mt-3"
             style={{ color: 'rgba(184,228,247,0.25)', fontFamily: 'Nunito, sans-serif' }}
           >
             Defined in one markdown file.
           </p>
-        </motion.div>
+        </div>
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/apps/dashboard/src/components/live/live-feed.tsx
+++ b/apps/dashboard/src/components/live/live-feed.tsx
@@ -54,23 +54,50 @@ const TYPE_PREFIX: Record<FeedMessage['type'], string> = {
   message:     '',
 };
 
-// CSS animation class injected once
+// CSS animations — injected once, no motion/react needed
 const FEED_STYLES = `
   @keyframes feed-slide-in {
-    from { opacity: 0; transform: translateY(8px); }
-    to   { opacity: 1; transform: translateY(0); }
+    from { opacity: 0; transform: translateY(10px) scale(0.97); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
   }
-  @keyframes feed-slide-right {
-    from { opacity: 0; transform: translateX(20px); }
-    to   { opacity: 1; transform: translateX(0); }
+  @keyframes feed-slam-right {
+    0%   { opacity: 0; transform: translateX(28px); }
+    60%  { transform: translateX(-3px); }
+    100% { opacity: 1; transform: translateX(0); }
   }
-  @keyframes feed-scale-in {
-    from { opacity: 0; transform: scale(0.9); }
-    to   { opacity: 1; transform: scale(1); }
+  @keyframes feed-pop {
+    0%   { opacity: 0; transform: scale(0.88); }
+    60%  { transform: scale(1.03); }
+    100% { opacity: 1; transform: scale(1); }
   }
-  .feed-entry { animation: feed-slide-in 0.2s ease forwards; }
-  .feed-entry-escalation { animation: feed-slide-right 0.25s ease forwards; }
-  .feed-entry-completion { animation: feed-scale-in 0.3s ease forwards; }
+  @keyframes feed-flash-red {
+    0%   { background: rgba(255,71,87,0.30); }
+    50%  { background: rgba(255,71,87,0.18); }
+    100% { background: rgba(255,71,87,0.12); }
+  }
+  @keyframes feed-flash-green {
+    0%   { background: rgba(74,232,138,0.22); }
+    50%  { background: rgba(74,232,138,0.13); }
+    100% { background: rgba(74,232,138,0.08); }
+  }
+  @keyframes feed-flash-sandy {
+    0%   { background: rgba(244,197,66,0.16); }
+    100% { background: rgba(244,197,66,0.05); }
+  }
+  .feed-entry            { animation: feed-slide-in 0.22s cubic-bezier(0.16,1,0.3,1) forwards; }
+  .feed-entry-escalation { animation: feed-slam-right 0.28s cubic-bezier(0.34,1.56,0.64,1) forwards,
+                                      feed-flash-red 0.7s 0.05s ease forwards; }
+  .feed-entry-completion { animation: feed-pop 0.32s cubic-bezier(0.34,1.56,0.64,1) forwards,
+                                      feed-flash-green 0.6s 0.05s ease forwards; }
+  .feed-entry-reassign   { animation: feed-slide-in 0.22s ease forwards,
+                                      feed-flash-sandy 0.6s 0.05s ease forwards; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .feed-entry, .feed-entry-escalation, .feed-entry-completion, .feed-entry-reassign {
+      animation: none !important;
+      opacity: 1;
+    }
+  }
 `;
 
 function FeedEntry({ msg, isMobile }: { msg: FeedMessage; isMobile?: boolean }) {
@@ -78,6 +105,7 @@ function FeedEntry({ msg, isMobile }: { msg: FeedMessage; isMobile?: boolean }) 
   const animClass =
     msg.type === 'escalation' ? 'feed-entry-escalation' :
     msg.type === 'completion'  ? 'feed-entry-completion' :
+    msg.type === 'reassign'    ? 'feed-entry-reassign' :
     'feed-entry';
 
   return (
@@ -86,6 +114,12 @@ function FeedEntry({ msg, isMobile }: { msg: FeedMessage; isMobile?: boolean }) 
       style={{
         background: TYPE_BG[msg.type],
         borderLeft: TYPE_BORDER[msg.type],
+        // Color-coded subtle left border glow on dramatic messages
+        boxShadow: msg.type === 'escalation'
+          ? 'inset 4px 0 8px -4px rgba(255,71,87,0.3)'
+          : msg.type === 'completion'
+          ? 'inset 4px 0 8px -4px rgba(74,232,138,0.25)'
+          : undefined,
       }}
     >
       {agent?.avatarUrl ? (

--- a/apps/dashboard/src/components/live/stats-bar.tsx
+++ b/apps/dashboard/src/components/live/stats-bar.tsx
@@ -1,7 +1,88 @@
+/**
+ * StatsBar — bottom stats bar for the live dashboard.
+ * POLISH PASS: Animated number transitions using CSS key-based remounting,
+ * color-coded states, crisis jitter, mini progress bars.
+ * CSS animations only — no motion/react.
+ */
+
+import React, { useRef, useState, useEffect } from 'react';
 import type { Stats } from './replay-data';
 
 interface StatsBarProps {
   stats: Stats;
+}
+
+// CSS animations injected once
+const STATS_STYLES = `
+  @keyframes stat-tick-flash {
+    0%   { color: #fff; text-shadow: 0 0 20px rgba(244,197,66,1), 0 0 40px rgba(244,197,66,0.5); }
+    40%  { color: #F4C542; text-shadow: 0 0 10px rgba(244,197,66,0.5); }
+    100% { color: #F4C542; text-shadow: none; }
+  }
+  @keyframes stat-tick-crisis {
+    0%   { color: #fff; text-shadow: 0 0 20px rgba(255,71,87,0.9), 0 0 40px rgba(255,71,87,0.4); }
+    40%  { color: #FF4757; text-shadow: 0 0 8px rgba(255,71,87,0.5); }
+    100% { color: #FF4757; text-shadow: none; }
+  }
+  @keyframes stat-tick-warning {
+    0%   { color: #fff; text-shadow: 0 0 20px rgba(244,197,66,0.8); }
+    100% { color: #F4C542; text-shadow: none; }
+  }
+  @keyframes stat-tick-kelp {
+    0%   { color: #fff; text-shadow: 0 0 20px rgba(74,232,138,0.8); }
+    100% { color: #4AE88A; text-shadow: none; }
+  }
+  .stat-flash        { animation: stat-tick-flash  0.55s ease forwards; }
+  .stat-flash-crisis { animation: stat-tick-crisis 0.55s ease forwards; }
+  .stat-flash-warn   { animation: stat-tick-warning 0.55s ease forwards; }
+  .stat-flash-kelp   { animation: stat-tick-kelp 0.55s ease forwards; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .stat-flash, .stat-flash-crisis, .stat-flash-warn, .stat-flash-kelp {
+      animation: none !important;
+    }
+  }
+`;
+
+/**
+ * StatValue — flashes a CSS animation when the displayed value changes.
+ * Uses useRef + setState to detect changes without needing a remount key.
+ */
+function StatValue({
+  value,
+  color,
+  flashClass,
+  suffix = '',
+}: {
+  value: string | number;
+  color: string;
+  flashClass: string;
+  suffix?: string;
+}) {
+  const prevRef = useRef(value);
+  const [animating, setAnimating] = useState(false);
+
+  useEffect(() => {
+    if (prevRef.current !== value) {
+      prevRef.current = value;
+      setAnimating(true);
+      const t = setTimeout(() => setAnimating(false), 650);
+      return () => clearTimeout(t);
+    }
+  }, [value]);
+
+  return (
+    <span
+      className={`font-bold ${animating ? flashClass : ''}`}
+      style={{
+        color,
+        fontFamily: '"Baloo 2", cursive',
+        fontSize: '0.875rem',
+      }}
+    >
+      {value}{suffix}
+    </span>
+  );
 }
 
 function MiniBar({ value, max, color }: { value: number; max: number; color: string }) {
@@ -9,8 +90,13 @@ function MiniBar({ value, max, color }: { value: number; max: number; color: str
   return (
     <div className="w-12 h-1.5 rounded-full overflow-hidden" style={{ background: 'rgba(74,174,217,0.1)' }}>
       <div
-        className="h-full rounded-full transition-all duration-500"
-        style={{ width: `${pct}%`, backgroundColor: color }}
+        className="h-full rounded-full"
+        style={{
+          width: `${pct}%`,
+          backgroundColor: color,
+          transition: 'width 0.5s cubic-bezier(0.16,1,0.3,1)',
+          boxShadow: pct > 80 ? `0 0 6px ${color}80` : undefined,
+        }}
       />
     </div>
   );
@@ -22,10 +108,25 @@ export function StatsBar({ stats }: StatsBarProps) {
     stats.queueSize > 1000 ? '#F4C542' :
     '#4AE88A';
 
+  const queueFlash =
+    stats.queueSize > 2000 ? 'stat-flash-crisis' :
+    stats.queueSize > 1000 ? 'stat-flash-warn' :
+    'stat-flash-kelp';
+
   const budgetColor =
     stats.budgetUsed > 85 ? '#FF4757' :
     stats.budgetUsed > 65 ? '#F4C542' :
     '#4AE88A';
+
+  const budgetFlash =
+    stats.budgetUsed > 85 ? 'stat-flash-crisis' :
+    stats.budgetUsed > 65 ? 'stat-flash-warn' :
+    'stat-flash-kelp';
+
+  // Crisis pulse on queue (was jitter — replaced per UX feedback)
+  const queueJitter = stats.queueSize > 2000
+    ? { animation: 'bb-pulse-ring 1.5s ease-in-out infinite', '--bb-ring-color': 'rgba(255, 71, 87, 0.4)' } as React.CSSProperties
+    : {} as React.CSSProperties;
 
   return (
     <div
@@ -37,51 +138,59 @@ export function StatsBar({ stats }: StatsBarProps) {
         fontFamily: 'Nunito, sans-serif',
       }}
     >
+      <style>{STATS_STYLES}</style>
+
+      {/* Kitchen rate */}
       <div className="flex items-center gap-2">
         <span>🔥</span>
         <span style={{ color: 'rgba(184,228,247,0.4)' }}>Kitchen:</span>
-        <span className="font-bold" style={{ color: '#F4C542', fontFamily: '"Baloo 2", cursive', fontSize: '0.875rem' }}>
-          {stats.kitchenRate}/tick
-        </span>
+        <StatValue value={`${stats.kitchenRate}/tick`} color="#F4C542" flashClass="stat-flash" />
         <MiniBar value={stats.kitchenRate} max={50} color="#F4C542" />
       </div>
-      <div className="flex items-center gap-2">
+
+      {/* Queue — crisis jitter */}
+      <div className="flex items-center gap-2" style={queueJitter}>
         <span>📦</span>
         <span style={{ color: 'rgba(184,228,247,0.4)' }}>Queue:</span>
-        <span className="font-bold" style={{ color: queueColor, fontFamily: '"Baloo 2", cursive', fontSize: '0.875rem' }}>
-          {stats.queueSize > 100 ? `${stats.queueSize.toLocaleString()} 😅` : stats.queueSize.toLocaleString()}
-        </span>
+        <StatValue
+          value={stats.queueSize > 100
+            ? `${stats.queueSize.toLocaleString()} 😅`
+            : stats.queueSize.toLocaleString()}
+          color={queueColor}
+          flashClass={queueFlash}
+        />
       </div>
+
+      {/* Delivery rate */}
       <div className="flex items-center gap-2">
         <span>🚚</span>
         <span style={{ color: 'rgba(184,228,247,0.4)' }}>Delivery:</span>
-        <span className="font-bold" style={{ color: '#4AE88A', fontFamily: '"Baloo 2", cursive', fontSize: '0.875rem' }}>
-          {stats.deliveryRate}/tick
-        </span>
+        <StatValue value={`${stats.deliveryRate}/tick`} color="#4AE88A" flashClass="stat-flash-kelp" />
         <MiniBar value={stats.deliveryRate} max={25} color="#4AE88A" />
       </div>
+
+      {/* Revenue */}
       <div className="flex items-center gap-2">
         <span>💰</span>
         <span style={{ color: 'rgba(184,228,247,0.4)' }}>Revenue:</span>
-        <span className="font-bold" style={{ color: '#F4C542', fontFamily: '"Baloo 2", cursive', fontSize: '0.875rem' }}>
-          {stats.revenue.toLocaleString()} cr
-        </span>
+        <StatValue value={`${stats.revenue.toLocaleString()} cr`} color="#F4C542" flashClass="stat-flash" />
       </div>
+
+      {/* Margin */}
       <div className="flex items-center gap-2">
         <span>📊</span>
         <span style={{ color: 'rgba(184,228,247,0.4)' }}>Margin:</span>
-        <span className="font-bold" style={{ color: '#B8E4F7', fontFamily: '"Baloo 2", cursive', fontSize: '0.875rem' }}>
-          {stats.margin.toFixed(1)}%
-        </span>
+        <StatValue value={`${stats.margin.toFixed(1)}%`} color="#B8E4F7" flashClass="stat-flash" />
       </div>
+
+      {/* Budget */}
       <div className="flex items-center gap-2">
         <span>🦀</span>
         <span style={{ color: 'rgba(184,228,247,0.4)' }}>
-          {stats.budgetUsed > 85 ? "Mr. Krabs is sweating:" : "Budget:"}
+          {stats.budgetUsed > 85 ? 'Mr. Krabs is sweating:' : 'Budget:'}
         </span>
-        <span className="font-bold" style={{ color: budgetColor, fontFamily: '"Baloo 2", cursive', fontSize: '0.875rem' }}>
-          {stats.budgetUsed}%
-        </span>
+        <StatValue value={`${stats.budgetUsed}%`} color={budgetColor} flashClass={budgetFlash} />
+        <MiniBar value={stats.budgetUsed} max={100} color={budgetColor} />
       </div>
     </div>
   );

--- a/apps/dashboard/src/pages/live-view.tsx
+++ b/apps/dashboard/src/pages/live-view.tsx
@@ -297,16 +297,58 @@ function ProgressHeader({ act, tick, pattiesDelivered }: { act: typeof ACTS[0]; 
   );
 }
 
+// ── Act Banner CSS animations ─────────────────────────────────────────────────
+const ACT_BANNER_STYLES = `
+  @keyframes act-overlay-in {
+    from { opacity: 0; backdrop-filter: blur(0px); }
+    to   { opacity: 1; backdrop-filter: blur(8px); }
+  }
+  @keyframes act-label-rise {
+    from { opacity: 0; transform: translateY(8px); letter-spacing: 0.6em; }
+    to   { opacity: 1; transform: translateY(0); letter-spacing: 0.3em; }
+  }
+  @keyframes act-title-stamp {
+    0%   { opacity: 0; transform: scale(1.18) translateY(-6px); letter-spacing: 0.05em; filter: blur(6px); }
+    60%  { opacity: 1; transform: scale(0.98) translateY(1px); letter-spacing: -0.03em; filter: blur(0); }
+    80%  { transform: scale(1.01); }
+    100% { opacity: 1; transform: scale(1); letter-spacing: -0.01em; }
+  }
+  @keyframes act-narrative-in {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes act-line-expand {
+    from { width: 0; opacity: 0; }
+    to   { width: 80px; opacity: 1; }
+  }
+  @keyframes act-overlay-out {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .act-overlay, .act-label, .act-title, .act-narrative, .act-line {
+      animation: none !important;
+      opacity: 1 !important;
+      transform: none !important;
+      filter: none !important;
+    }
+  }
+`;
+
 // ── Act Banner (CSS-only, no motion/react) ───────────────────────────────────
 
 function ActBanner({ banner }: { banner: { num: number; name: string; narrative: string } | null }) {
   const [visible, setVisible] = useState(false);
   const [content, setContent] = useState<typeof banner>(null);
+  // Key increments each time a new banner appears → forces re-mount → re-triggers animations
+  const [animKey, setAnimKey] = useState(0);
 
   useEffect(() => {
     if (banner) {
       setContent(banner);
       setVisible(true);
+      setAnimKey(k => k + 1);
     } else {
       setVisible(false);
     }
@@ -315,45 +357,151 @@ function ActBanner({ banner }: { banner: { num: number; name: string; narrative:
   if (!content) return null;
 
   return (
-    <div
-      className="absolute inset-0 z-10 flex flex-col items-center justify-center backdrop-blur-sm pointer-events-none"
-      style={{
-        background: 'rgba(3,14,26,0.7)',
-        opacity: visible ? 1 : 0,
-        transition: 'opacity 0.3s ease',
-      }}
-    >
-      <div className="text-sm uppercase tracking-[0.3em] font-medium mb-1" style={{ color: 'rgba(244,197,66,0.8)', fontFamily: 'Nunito, sans-serif' }}>
-        Act {content.num}
+    <>
+      <style>{ACT_BANNER_STYLES}</style>
+      <div
+        key={`overlay-${animKey}`}
+        className="act-overlay absolute inset-0 z-10 flex flex-col items-center justify-center pointer-events-none"
+        style={{
+          background: 'rgba(3,14,26,0.75)',
+          opacity: visible ? undefined : 0,
+          transition: visible ? undefined : 'opacity 0.4s ease',
+          animation: visible ? 'act-overlay-in 0.4s ease forwards' : undefined,
+        }}
+      >
+        {/* Decorative top line */}
+        <div
+          key={`line-top-${animKey}`}
+          className="act-line h-px mb-6"
+          style={{
+            background: 'linear-gradient(90deg, transparent, rgba(244,197,66,0.6), transparent)',
+            animation: 'act-line-expand 0.5s 0.1s ease forwards',
+            width: 0,
+            opacity: 0,
+          }}
+        />
+
+        {/* Act number label */}
+        <div
+          key={`label-${animKey}`}
+          className="act-label text-xs font-bold uppercase mb-2"
+          style={{
+            color: 'rgba(244,197,66,0.7)',
+            fontFamily: 'Nunito, sans-serif',
+            animation: 'act-label-rise 0.4s 0.05s cubic-bezier(0.16,1,0.3,1) forwards',
+            opacity: 0,
+            letterSpacing: '0.3em',
+          }}
+        >
+          ── Act {content.num} ──
+        </div>
+
+        {/* Title — cinematic stamp */}
+        <div
+          key={`title-${animKey}`}
+          className="act-title text-2xl md:text-4xl font-black tracking-tight mb-3"
+          style={{
+            color: '#F4C542',
+            fontFamily: '"Baloo 2", cursive',
+            textShadow: '0 0 40px rgba(244,197,66,0.5), 0 0 80px rgba(244,197,66,0.2)',
+            animation: 'act-title-stamp 0.55s 0.12s cubic-bezier(0.34,1.56,0.64,1) forwards',
+            opacity: 0,
+          }}
+        >
+          {content.name.replace(/^Act \w+: /, '')}
+        </div>
+
+        {/* Narrative */}
+        <div
+          key={`narrative-${animKey}`}
+          className="act-narrative text-sm max-w-sm text-center px-6"
+          style={{
+            color: 'rgba(184,228,247,0.55)',
+            fontFamily: 'Nunito, sans-serif',
+            animation: 'act-narrative-in 0.5s 0.3s ease forwards',
+            opacity: 0,
+          }}
+        >
+          {content.narrative}
+        </div>
+
+        {/* Decorative bottom line */}
+        <div
+          key={`line-bot-${animKey}`}
+          className="act-line h-px mt-6"
+          style={{
+            background: 'linear-gradient(90deg, transparent, rgba(244,197,66,0.4), transparent)',
+            animation: 'act-line-expand 0.5s 0.2s ease forwards',
+            width: 0,
+            opacity: 0,
+          }}
+        />
       </div>
-      <div className="text-2xl md:text-3xl font-black tracking-tight mb-2" style={{ color: '#F4C542', fontFamily: '"Baloo 2", cursive' }}>
-        {content.name.replace(/^Act \w+: /, '')}
-      </div>
-      <div className="text-sm max-w-md text-center" style={{ color: 'rgba(184,228,247,0.5)', fontFamily: 'Nunito, sans-serif' }}>
-        {content.narrative}
-      </div>
-    </div>
+    </>
   );
 }
 
 // ── Completion Overlay (CSS-only) ────────────────────────────────────────────
 
+const COMPLETION_STYLES = `
+  @keyframes completion-stamp {
+    0%   { transform: scale(1.5); opacity: 0; filter: blur(8px); }
+    55%  { transform: scale(0.94); opacity: 1; filter: blur(0); }
+    75%  { transform: scale(1.03); }
+    100% { transform: scale(1); opacity: 1; }
+  }
+  @keyframes completion-subtitle {
+    from { opacity: 0; transform: translateY(16px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes completion-fade {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+  @keyframes completion-glow-pulse {
+    0%, 100% { text-shadow: 0 0 40px rgba(244,197,66,0.5), 0 0 80px rgba(244,197,66,0.2); }
+    50%       { text-shadow: 0 0 60px rgba(244,197,66,0.8), 0 0 120px rgba(244,197,66,0.35); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .completion-stamp, .completion-subtitle, .completion-glow { animation: none !important; opacity: 1 !important; transform: none !important; filter: none !important; }
+  }
+`;
+
 function CompletionOverlay({ finished, onReplay }: { finished: boolean; onReplay: () => void }) {
   return (
-    <div
-      className="absolute inset-0 z-30 flex items-center justify-center backdrop-blur-sm"
-      style={{
-        background: 'rgba(3,14,26,0.92)',
-        opacity: finished ? 1 : 0,
-        pointerEvents: finished ? 'auto' : 'none',
-        transition: 'opacity 0.5s ease',
-      }}
-    >
+    <>
+      <style>{COMPLETION_STYLES}</style>
+      <div
+        className="absolute inset-0 z-30 flex items-center justify-center backdrop-blur-sm"
+        style={{
+          background: 'rgba(3,14,26,0.92)',
+          opacity: finished ? 1 : 0,
+          pointerEvents: finished ? 'auto' : 'none',
+          transition: 'opacity 0.5s ease',
+        }}
+      >
       <div className="text-center max-w-lg px-8">
-        <div className="text-6xl md:text-7xl font-black mb-2" style={{ fontFamily: '"Baloo 2", cursive', color: '#F4C542' }}>
+        {/* Stamp entrance for the big number */}
+        <div
+          className="completion-stamp text-6xl md:text-7xl font-black mb-2"
+          style={{
+            fontFamily: '"Baloo 2", cursive',
+            color: '#F4C542',
+            animation: finished ? 'completion-stamp 0.7s cubic-bezier(0.34,1.56,0.64,1) forwards, completion-glow-pulse 3s 1s ease-in-out infinite' : 'none',
+            opacity: finished ? undefined : 0,
+          }}
+        >
           🍔 10,000
         </div>
-        <div className="text-lg font-semibold mb-6" style={{ color: '#4AE88A', fontFamily: '"Baloo 2", cursive' }}>
+        <div
+          className="completion-subtitle text-lg font-semibold mb-6"
+          style={{
+            color: '#4AE88A',
+            fontFamily: '"Baloo 2", cursive',
+            animation: finished ? 'completion-subtitle 0.6s 0.35s ease forwards' : 'none',
+            opacity: finished ? undefined : 0,
+          }}
+        >
           🎉 PATTIES DELIVERED! 🎉
         </div>
         <p className="text-lg mb-8" style={{ color: 'rgba(184,228,247,0.6)', fontFamily: 'Nunito, sans-serif' }}>
@@ -441,6 +589,7 @@ function CompletionOverlay({ finished, onReplay }: { finished: boolean; onReplay
         </div>
       </div>
     </div>
+    </>
   );
 }
 
@@ -474,6 +623,39 @@ export function LiveViewPage() {
     <div className="relative h-screen w-full text-white flex flex-col overflow-hidden" style={{ background: 'linear-gradient(180deg, #062A45 0%, #030E1A 100%)' }}>
       {/* BikiniBottom ocean background */}
       <div className="absolute inset-0" style={{ background: 'radial-gradient(ellipse at 20% 80%, rgba(11,94,138,0.3) 0%, transparent 50%), radial-gradient(ellipse at 80% 20%, rgba(26,125,181,0.2) 0%, transparent 50%)' }} />
+
+      {/* Ambient caustic light effects — subtle underwater atmosphere */}
+      <div className="absolute inset-0 pointer-events-none overflow-hidden" aria-hidden="true">
+        <div style={{
+          position: 'absolute', borderRadius: '50%',
+          width: '50vw', height: '40vh', top: '-5vh', left: '-5vw',
+          background: 'radial-gradient(ellipse, rgba(74,174,217,1) 0%, transparent 70%)',
+          opacity: 0.04,
+          animation: 'bb-caustic 18s ease-in-out infinite',
+        }} />
+        <div style={{
+          position: 'absolute', borderRadius: '50%',
+          width: '40vw', height: '30vh', bottom: '10%', right: '-8vw',
+          background: 'radial-gradient(ellipse, rgba(46,204,113,1) 0%, transparent 70%)',
+          opacity: 0.025,
+          animation: 'bb-caustic 13s 6s ease-in-out infinite',
+          '--bb-caustic-rotate': '-3deg' as string,
+          '--bb-caustic-drift': '20px' as string,
+          '--bb-caustic-min': '0.02' as string,
+          '--bb-caustic-max': '0.05' as string,
+        } as React.CSSProperties} />
+        <div style={{
+          position: 'absolute', borderRadius: '50%',
+          width: '35vw', height: '25vh', top: '40%', left: '30%',
+          background: 'radial-gradient(ellipse, rgba(26,125,181,1) 0%, transparent 70%)',
+          opacity: 0.03,
+          animation: 'bb-caustic 22s 3s ease-in-out infinite',
+          '--bb-caustic-rotate': '5deg' as string,
+          '--bb-caustic-drift': '0px' as string,
+          '--bb-caustic-min': '0.02' as string,
+          '--bb-caustic-max': '0.04' as string,
+        } as React.CSSProperties} />
+      </div>
 
       {/* Intro overlay */}
       {showIntro && <IntroCard onStart={handleStart} />}

--- a/apps/dashboard/src/styles/bb-tokens.css
+++ b/apps/dashboard/src/styles/bb-tokens.css
@@ -235,43 +235,37 @@
 
 /* ============================================================
    KEYFRAME ANIMATIONS
+   Consolidated: use CSS custom properties for variation.
+   --bb-bob-y: bob distance (default -4px)
+   --bb-sway-angle: kelp sway amplitude (default 3deg)
+   --bb-sway-scale: kelp sway scaleY delta (default 0.01)
+   --bb-ring-color: pulse ring color (default sandy)
+   --bb-caustic-rotate: caustic rotation (default 2deg)
+   --bb-caustic-drift: caustic translateX (default 0px)
+   --bb-enter-y: enter translateY distance (default 12px)
+   --bb-enter-blur: enter blur (default 0px)
+   --bb-enter-skew: enter skewY (default 0deg)
+   --bb-flash-color: feed flash rgb (default coral)
    ============================================================ */
 
 @keyframes bb-bob {
   0%, 100% { transform: translateY(0px); }
-  50%       { transform: translateY(-4px); }
-}
-
-@keyframes bb-bob-fast {
-  0%, 100% { transform: translateY(0px); }
-  50%       { transform: translateY(-3px); }
-}
-
-@keyframes bb-jitter {
-  0%, 100% { transform: translateX(0); }
-  20%       { transform: translateX(-2px) rotate(-1deg); }
-  40%       { transform: translateX(2px) rotate(1deg); }
-  60%       { transform: translateX(-1.5px); }
-  80%       { transform: translateX(1.5px); }
+  50%       { transform: translateY(var(--bb-bob-y, -4px)); }
 }
 
 @keyframes bb-bubble-float {
   0% {
-    transform: translateY(0) translateX(0) scale(1);
+    transform: translateY(0) translateX(var(--bb-drift-x1, 0px)) scale(1);
     opacity: 0;
   }
-  5% {
-    opacity: 0.5;
-  }
+  5% { opacity: 0.5; }
   50% {
-    transform: translateY(-50vh) translateX(8px) scale(0.9);
+    transform: translateY(-50vh) translateX(var(--bb-drift-x2, 8px)) scale(0.9);
     opacity: 0.4;
   }
-  95% {
-    opacity: 0.2;
-  }
+  95% { opacity: 0.2; }
   100% {
-    transform: translateY(-100vh) translateX(-4px) scale(0.6);
+    transform: translateY(-100vh) translateX(var(--bb-drift-x3, -4px)) scale(0.6);
     opacity: 0;
   }
 }
@@ -282,11 +276,11 @@
     transform-origin: bottom center;
   }
   25% {
-    transform: skewX(3deg) scaleY(1.01);
+    transform: skewX(var(--bb-sway-angle, 3deg)) scaleY(calc(1 + var(--bb-sway-scale, 0.01)));
     transform-origin: bottom center;
   }
   75% {
-    transform: skewX(-3deg) scaleY(0.99);
+    transform: skewX(calc(-1 * var(--bb-sway-angle, 3deg))) scaleY(calc(1 - var(--bb-sway-scale, 0.01)));
     transform-origin: bottom center;
   }
 }
@@ -298,32 +292,22 @@
 
 @keyframes bb-caustic {
   0%, 100% {
-    opacity: 0.04;
-    transform: scale(1) rotate(0deg);
+    opacity: var(--bb-caustic-min, 0.04);
+    transform: scale(1) rotate(0deg) translateX(0px);
   }
   33% {
-    opacity: 0.07;
-    transform: scale(1.1) rotate(2deg);
+    opacity: var(--bb-caustic-max, 0.07);
+    transform: scale(1.1) rotate(var(--bb-caustic-rotate, 2deg)) translateX(var(--bb-caustic-drift, 0px));
   }
   66% {
-    opacity: 0.05;
-    transform: scale(0.95) rotate(-1deg);
+    opacity: calc((var(--bb-caustic-min, 0.04) + var(--bb-caustic-max, 0.07)) / 2);
+    transform: scale(0.95) rotate(calc(-0.5 * var(--bb-caustic-rotate, 2deg))) translateX(calc(-0.5 * var(--bb-caustic-drift, 0px)));
   }
 }
 
 @keyframes bb-pulse-ring {
-  0%, 100% { box-shadow: 0 0 0 0px rgba(244, 197, 66, 0.4); }
-  50%       { box-shadow: 0 0 0 8px rgba(244, 197, 66, 0); }
-}
-
-@keyframes bb-pulse-ring-coral {
-  0%, 100% { box-shadow: 0 0 0 0px rgba(255, 71, 87, 0.4); }
-  50%       { box-shadow: 0 0 0 8px rgba(255, 71, 87, 0); }
-}
-
-@keyframes bb-pulse-ring-kelp {
-  0%, 100% { box-shadow: 0 0 0 0px rgba(74, 232, 138, 0.4); }
-  50%       { box-shadow: 0 0 0 8px rgba(74, 232, 138, 0); }
+  0%, 100% { box-shadow: 0 0 0 0px var(--bb-ring-color, rgba(244, 197, 66, 0.4)); }
+  50%       { box-shadow: 0 0 0 8px transparent; }
 }
 
 @keyframes bb-shimmer {
@@ -334,18 +318,20 @@
 @keyframes bb-enter-up {
   from {
     opacity: 0;
-    transform: translateY(12px);
+    transform: translateY(var(--bb-enter-y, 12px)) skewY(var(--bb-enter-skew, 0deg));
+    filter: blur(var(--bb-enter-blur, 0px));
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) skewY(0deg);
+    filter: blur(0);
   }
 }
 
 @keyframes bb-enter-scale {
   from {
     opacity: 0;
-    transform: scale(0.92);
+    transform: scale(var(--bb-enter-from-scale, 0.92));
   }
   to {
     opacity: 1;
@@ -353,20 +339,71 @@
   }
 }
 
+@keyframes bb-cta-glow {
+  0%, 100% {
+    box-shadow:
+      0 0 20px rgba(244, 197, 66, 0.5),
+      0 0 40px rgba(244, 197, 66, 0.25),
+      0 4px 20px rgba(6, 42, 69, 0.4);
+  }
+  50% {
+    box-shadow:
+      0 0 32px rgba(244, 197, 66, 0.7),
+      0 0 64px rgba(244, 197, 66, 0.35),
+      0 0 90px rgba(244, 197, 66, 0.15),
+      0 4px 20px rgba(6, 42, 69, 0.4);
+  }
+}
+
+@keyframes bb-act-enter {
+  0% {
+    opacity: 0;
+    transform: scale(1.04) translateY(-6px);
+    filter: blur(8px);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(0.99) translateY(1px);
+    filter: blur(0);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+    filter: blur(0);
+  }
+}
+
+@keyframes bb-feed-flash {
+  0%   { background: rgba(var(--bb-flash-r, 255), var(--bb-flash-g, 71), var(--bb-flash-b, 87), 0.35); }
+  60%  { background: rgba(var(--bb-flash-r, 255), var(--bb-flash-g, 71), var(--bb-flash-b, 87), 0.20); }
+  100% { background: rgba(var(--bb-flash-r, 255), var(--bb-flash-g, 71), var(--bb-flash-b, 87), 0.12); }
+}
+
+@keyframes bb-stat-tick {
+  0%   { color: #fff; text-shadow: 0 0 16px rgba(244, 197, 66, 0.9); }
+  40%  { color: #F4C542; text-shadow: 0 0 8px rgba(244, 197, 66, 0.5); }
+  100% { color: #F4C542; text-shadow: none; }
+}
+
+@keyframes bb-swim-bob {
+  0%, 100% { transform: translateY(0px) rotate(0deg); }
+  25%       { transform: translateY(-5px) rotate(-1deg); }
+  75%       { transform: translateY(3px) rotate(1deg); }
+}
+
 /* ============================================================
    ANIMATION UTILITIES
    ============================================================ */
 
-.bb-bob         { animation: bb-bob var(--bb-duration-bob) var(--bb-ease-float) infinite; }
-.bb-bob-fast    { animation: bb-bob-fast 1s var(--bb-ease-float) infinite; }
-.bb-jitter      { animation: bb-jitter 0.4s var(--bb-ease-wave) infinite; }
-.bb-sway        { animation: bb-kelp-sway var(--bb-duration-kelp) var(--bb-ease-float) infinite; }
+.bb-bob         { animation: bb-bob var(--bb-duration-bob) var(--bb-ease-float) infinite; will-change: transform; }
+.bb-bob-fast    { --bb-bob-y: -3px; animation: bb-bob 1s var(--bb-ease-float) infinite; will-change: transform; }
+.bb-sway        { animation: bb-kelp-sway var(--bb-duration-kelp) var(--bb-ease-float) infinite; will-change: transform; }
 
 /* Status-based animation helpers */
-[data-status="working"]     { animation: bb-bob-fast 1s ease-in-out infinite; }
-[data-status="overwhelmed"] { animation: bb-jitter 0.35s ease-in-out infinite; }
+[data-status="working"]     { --bb-bob-y: -3px; animation: bb-bob 1s ease-in-out infinite; }
+[data-status="overwhelmed"] { --bb-bob-y: -2px; animation: bb-bob 0.6s ease-in-out infinite; }
 [data-status="idle"]        { animation: bb-bob 2.5s ease-in-out infinite; }
-[data-status="busy"]        { animation: bb-bob 1.2s ease-in-out infinite; }
+[data-status="busy"]        { --bb-bob-y: -3px; animation: bb-bob 1.2s ease-in-out infinite; }
 
 /* ============================================================
    COMPONENT TOKENS: CHARACTER CARDS
@@ -444,18 +481,21 @@
   background: rgba(244, 197, 66, 0.15);
   color: var(--bb-sandy-400);
   border: 1px solid rgba(244, 197, 66, 0.3);
+  --bb-ring-color: rgba(244, 197, 66, 0.4);
   animation: bb-pulse-ring 2s ease-in-out infinite;
 }
 .bb-status-working::before {
   background: var(--bb-sandy-400);
-  animation: bb-bob-fast 0.8s ease-in-out infinite;
+  --bb-bob-y: -3px;
+  animation: bb-bob 0.8s ease-in-out infinite;
 }
 
 .bb-status-busy {
   background: rgba(255, 107, 107, 0.15);
   color: var(--bb-coral-400);
   border: 1px solid rgba(255, 107, 107, 0.3);
-  animation: bb-pulse-ring-coral 1.5s ease-in-out infinite;
+  --bb-ring-color: rgba(255, 71, 87, 0.4);
+  animation: bb-pulse-ring 1.5s ease-in-out infinite;
 }
 .bb-status-busy::before {
   background: var(--bb-coral-400);
@@ -465,11 +505,13 @@
   background: rgba(255, 71, 87, 0.2);
   color: var(--bb-coral-500);
   border: 1px solid rgba(255, 71, 87, 0.4);
-  animation: bb-jitter 0.4s ease-in-out infinite;
+  --bb-ring-color: rgba(255, 71, 87, 0.4);
+  animation: bb-pulse-ring 1s ease-in-out infinite;
 }
 .bb-status-overwhelmed::before {
   background: var(--bb-coral-500);
-  animation: bb-pulse-ring-coral 0.8s ease-in-out infinite;
+  --bb-ring-color: rgba(255, 71, 87, 0.4);
+  animation: bb-pulse-ring 0.8s ease-in-out infinite;
 }
 
 /* ============================================================
@@ -618,19 +660,22 @@
 .bb-agent-ring[data-status="working"] {
   border-color: var(--bb-sandy-400);
   box-shadow: var(--bb-glow-sandy);
+  --bb-ring-color: rgba(244, 197, 66, 0.4);
   animation: bb-pulse-ring 2s ease-in-out infinite;
 }
 
 .bb-agent-ring[data-status="busy"] {
   border-color: var(--bb-coral-400);
   box-shadow: var(--bb-glow-coral);
-  animation: bb-pulse-ring-coral 1.5s ease-in-out infinite;
+  --bb-ring-color: rgba(255, 71, 87, 0.4);
+  animation: bb-pulse-ring 1.5s ease-in-out infinite;
 }
 
 .bb-agent-ring[data-status="overwhelmed"] {
   border-color: var(--bb-coral-500);
   box-shadow: var(--bb-glow-coral);
-  animation: bb-pulse-ring-coral 0.8s ease-in-out infinite;
+  --bb-ring-color: rgba(255, 71, 87, 0.4);
+  animation: bb-pulse-ring 0.8s ease-in-out infinite;
 }
 
 .bb-agent-ring[data-status="idle"] {
@@ -711,7 +756,8 @@
 
 .bb-stat-crisis .bb-stat-value {
   color: var(--bb-coral-400);
-  animation: bb-jitter 0.5s ease-in-out infinite;
+  --bb-ring-color: rgba(255, 71, 87, 0.4);
+  animation: bb-pulse-ring 1.5s ease-in-out infinite;
 }
 
 /* ============================================================
@@ -778,4 +824,174 @@
 .bb-caustics::after {
   background: radial-gradient(ellipse 70% 50% at 70% 60%, rgba(46, 204, 113, 0.05) 0%, transparent 70%);
   animation-delay: -6s;
+}
+
+/* ============================================================
+   POLISH PASS — Utility classes for consolidated keyframes
+   Caustic/kelp/bubble variations use CSS custom properties
+   on the consolidated keyframes above.
+   ============================================================ */
+
+/* ── Utility Classes ─────────────────────────────────────────── */
+
+/* CTA button — irresistible glow pulse */
+.bb-cta-pulse {
+  animation: bb-cta-glow 2.5s ease-in-out infinite;
+}
+
+.bb-cta-pulse:hover {
+  animation-play-state: paused;
+  transform: translateY(-3px) scale(1.05);
+  box-shadow:
+    0 0 40px rgba(244, 197, 66, 0.8),
+    0 0 80px rgba(244, 197, 66, 0.4),
+    0 8px 32px rgba(6, 42, 69, 0.5) !important;
+}
+
+/* Scroll-reveal — applied via JS IntersectionObserver */
+.bb-reveal {
+  opacity: 0;
+  transform: translateY(32px);
+  transition:
+    opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.bb-reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.bb-reveal-delay-1 { transition-delay: 0.1s; }
+.bb-reveal-delay-2 { transition-delay: 0.2s; }
+.bb-reveal-delay-3 { transition-delay: 0.3s; }
+.bb-reveal-delay-4 { transition-delay: 0.4s; }
+.bb-reveal-delay-5 { transition-delay: 0.5s; }
+
+/* Hero title words — stagger reveal */
+.bb-hero-word {
+  display: inline-block;
+  opacity: 0;
+  --bb-enter-y: 0.5em;
+  --bb-enter-skew: 2deg;
+  --bb-enter-blur: 4px;
+  animation: bb-enter-up 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.bb-hero-word:nth-child(1) { animation-delay: 0.2s; }
+.bb-hero-word:nth-child(2) { animation-delay: 0.45s; }
+.bb-hero-word:nth-child(3) { animation-delay: 0.65s; }
+.bb-hero-word:nth-child(4) { animation-delay: 0.82s; }
+.bb-hero-word:nth-child(5) { animation-delay: 0.95s; }
+
+/* Hero subtitle and CTA fade-up */
+.bb-fade-up-1 { opacity: 0; --bb-enter-y: 20px; animation: bb-enter-up 0.8s 1.0s ease forwards; }
+.bb-fade-up-2 { opacity: 0; --bb-enter-y: 20px; animation: bb-enter-up 0.8s 1.3s ease forwards; }
+.bb-fade-up-3 { opacity: 0; --bb-enter-y: 20px; animation: bb-enter-up 0.8s 1.5s ease forwards; }
+.bb-fade-up-4 { opacity: 0; --bb-enter-y: 20px; animation: bb-enter-up 0.8s 1.7s ease forwards; }
+
+/* Act banner enter */
+.bb-act-enter {
+  animation: bb-act-enter 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.bb-act-title {
+  --bb-enter-from-scale: 1.2;
+  animation: bb-enter-scale 0.45s 0.1s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  opacity: 0;
+}
+
+/* Feed entry animations */
+.bb-feed-entry {
+  --bb-enter-y: 8px;
+  animation: bb-enter-up 0.22s ease forwards;
+}
+
+.bb-feed-entry-escalation {
+  --bb-flash-r: 255; --bb-flash-g: 71; --bb-flash-b: 87;
+  animation: bb-feed-flash 0.6s ease forwards;
+  border-left: 4px solid #FF4757;
+}
+
+.bb-feed-entry-completion {
+  --bb-flash-r: 74; --bb-flash-g: 232; --bb-flash-b: 138;
+  animation: bb-feed-flash 0.5s ease forwards;
+  border-left: 4px solid #4AE88A;
+}
+
+/* Stat value flash when it changes */
+.bb-stat-changed {
+  animation: bb-stat-tick 0.5s ease forwards;
+}
+
+/* Stamp for completion screen */
+.bb-stamp {
+  --bb-enter-from-scale: 1.4;
+  animation: bb-enter-scale 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/* Pill shimmer */
+.bb-pill-shimmer {
+  background: linear-gradient(
+    90deg,
+    rgba(74, 174, 217, 0.1) 0%,
+    rgba(74, 174, 217, 0.25) 40%,
+    rgba(74, 174, 217, 0.1) 80%
+  );
+  background-size: 200% auto;
+  animation: bb-shimmer 3s linear infinite;
+}
+
+/* ── prefers-reduced-motion — respect user preferences ──────── */
+@media (prefers-reduced-motion: reduce) {
+  /* Disable all ambient animations */
+  .bb-bob,
+  .bb-bob-fast,
+  .bb-sway,
+  .bb-cta-pulse,
+  .bb-hero-word,
+  .bb-fade-up-1,
+  .bb-fade-up-2,
+  .bb-fade-up-3,
+  .bb-fade-up-4,
+  .bb-reveal,
+  .bb-pill-shimmer {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+    filter: none !important;
+    transition: none !important;
+  }
+
+  /* Disable bubble float */
+  .bb-bubble,
+  [style*="bb-bubble-float"] {
+    animation: none !important;
+    opacity: 0.3;
+  }
+
+  /* Disable kelp sway */
+  [style*="bb-kelp-sway"] {
+    animation: none !important;
+  }
+
+  /* Disable character swim */
+  [style*="bb-swim"] {
+    animation: none !important;
+    display: none;
+  }
+
+  /* Keep status badges readable but static */
+  .bb-status-working,
+  .bb-status-busy,
+  .bb-status-overwhelmed {
+    animation: none !important;
+  }
+
+  /* Keep transitions minimal */
+  * {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
 }

--- a/apps/dashboard/src/test-setup.ts
+++ b/apps/dashboard/src/test-setup.ts
@@ -1,5 +1,16 @@
 import "@testing-library/jest-dom";
 
+// Mock IntersectionObserver
+global.IntersectionObserver = class IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = '0px';
+  readonly thresholds = [0];
+  observe() { /* noop */ }
+  unobserve() { /* noop */ }
+  disconnect() { /* noop */ }
+  takeRecords() { return []; }
+} as unknown as typeof IntersectionObserver;
+
 // Mock ResizeObserver
 global.ResizeObserver = class ResizeObserver {
   observe() { /* noop */ }


### PR DESCRIPTION
BikiniBottom dashboard visual overhaul — rebased onto current master (post-#408).

## Changes (dashboard only, no website changes)
- 4-layer caustic light system with independent timing
- Word-by-word title reveal with blur + skewY animation
- CTA glow pulse with magnetic hover
- 10-character swim parade (18-48s durations)
- Act banners with backdrop blur + scale bounce
- Completion counter stamps with persistent glow
- Feed effects: escalation slam, completion bounce, reassign slide-in
- Stats flash animations + reactive mini bars
- Ambient bubbles + kelp with IntersectionObserver (pause off-screen)

## Perf
- **20 keyframes** (consolidated from 71 → 38 → 20)
- IntersectionObserver on all ambient effects
- will-change audit (only on continuously animating elements)
- Crisis jitter removed (replaced with pulse-ring)
- Full `prefers-reduced-motion` support

## Test fix
- Added IntersectionObserver mock to jsdom test setup

**Build clean ✅ | All tests passing ✅**