### PR TITLE
docs: agent-first documentation

### DIFF
--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -1,0 +1,259 @@
+---
+purpose: Get an AI agent from zero to a running multi-agent organization
+audience: AI agents (LLMs) that need to coordinate other agents
+prerequisites: Node.js 18+, npm
+time_estimate: 10 minutes
+commands_used: [openspawn init, openspawn validate, openspawn preview]
+---
+
+# Agent Quickstart
+
+You are an AI agent that needs to coordinate other agents. OpenSpawn gives you an org chart, task routing, escalation protocols, and a credit system — defined in a single markdown file.
+
+## One command to a running org
+
+```bash
+npx openspawn init my-org --template=assistant-team --non-interactive && cd my-org && npx openspawn preview
+```
+
+That's it. You now have a running org with a chief of staff, research analyst, content team, engineer, security auditor, and quality mentor — all coordinated through a hierarchy.
+
+> **Q: Do I need API keys?**
+> - No. Demo/simulation mode works out of the box with zero configuration.
+
+> **Q: What just happened?**
+> - `init` created `ORG.md` (your org definition) and `openspawn.config.json` (server config)
+> - `preview` launched the sandbox server with a dashboard at http://localhost:3333
+
+---
+
+## Pick a template
+
+Four templates ship with OpenSpawn. Each produces a complete ORG.md you can use immediately or customize.
+
+```bash
+# Personal AI team (chief of staff + specialists)
+openspawn init my-org --template=assistant-team
+
+# Content production pipeline
+openspawn init my-org --template=content-agency
+
+# Software development team
+openspawn init my-org --template=dev-shop
+
+# Research & analysis team
+openspawn init my-org --template=research-lab
+```
+
+> **Q: Which template should I use?**
+> ```
+> What's your primary output?
+> ├── Code/software → dev-shop
+> ├── Content (blogs, social, docs) → content-agency
+> ├── Research/analysis → research-lab
+> └── Mix of everything → assistant-team
+> ```
+
+> **Q: Can I combine templates?**
+> - Yes. Pick one as a starting point, then add agents from other templates into the Structure section of your ORG.md.
+
+> **Q: Can I create agents not in any template?**
+> - Absolutely. Templates are starting points. Add any agent to the `## Structure` section with a name, level, domain, and reporting line.
+
+---
+
+## Understanding ORG.md
+
+Your entire org lives in one file. Five sections, all optional except Structure:
+
+```markdown
+# My Org Name
+
+## Identity
+Mission, values, industry context.
+Becomes ambient context for every agent.
+
+## Culture
+preset: startup
+Communication norms, escalation speed, progress frequency.
+
+## Structure
+
+### CEO — Chief Executive
+Runs everything. Delegates to department heads.
+- **Level:** 10
+- **Domain:** Executive
+- **Reports to:** Human Principal
+
+#### Engineer — Software Developer
+Writes code, ships features.
+- **Level:** 7
+- **Domain:** Engineering
+- **Reports to:** CEO
+
+## Policies
+Budget limits, department caps, permission levels.
+
+## Playbooks
+Step-by-step procedures for escalation, handoff, etc.
+```
+
+> **Q: What's the minimum viable ORG.md?**
+> ```markdown
+> # My Org
+>
+> ## Structure
+>
+> ### Boss — Leader
+> - **Level:** 10
+> - **Reports to:** Human Principal
+> ```
+
+> **Q: What do levels mean?**
+> - L1-L5: Workers. Execute tasks.
+> - L6: Can review and approve work.
+> - L7-L9: Can create tasks and spawn agents. Department leads.
+> - L10: Executive. Top of the hierarchy.
+
+> **Q: What's "Reports to"?**
+> - Defines the escalation chain. When an agent is blocked, it escalates to whoever it reports to. Never skip the chain.
+
+---
+
+## Validate your org
+
+```bash
+openspawn validate ORG.md
+```
+
+Output on success:
+```
+✅ ORG.md is valid
+
+  Organization:  My Org
+  Agents:        8
+  Culture:       startup
+
+  Agent hierarchy:
+    🎯 Oscar (L10, Operations)
+      🔭 Radar (L7, Research)
+      💡 Muse (L7, Content Strategy)
+        ✍️ Ink (L4, Writing)
+        📸 Lens (L4, Visual Design)
+      🔧 Forge (L7, Engineering)
+      🛡️ Shield (L7, Security)
+      📚 Guru (L7, Quality)
+```
+
+> **Q: If I see "validation failed", what do I do?**
+> - The output lists each issue. Common fixes:
+>   - "Missing Structure section" → Add `## Structure` with at least one agent
+>   - "Agent reports to unknown agent" → Check spelling of the `Reports to` value
+>   - "No top-level agent" → One agent must have `Reports to: Human Principal`
+
+---
+
+## Culture presets
+
+Instead of configuring every communication parameter, use a preset:
+
+```markdown
+## Culture
+preset: startup
+```
+
+| Preset | Best for | Escalation | Progress updates |
+|--------|----------|-----------|-----------------|
+| `startup` | Small fast teams | Immediate | Frequent |
+| `enterprise` | Large orgs with process | Batched (hourly) | On phase change |
+| `agency` | Client work with deadlines | Immediate | Every tick |
+| `research` | Exploration, long tasks | Delayed | On request |
+| `military` | Zero-ambiguity operations | Immediate | Every tick |
+| `remote-async` | Distributed, async teams | Delayed | On request |
+
+> **Q: Can I override specific settings in a preset?**
+> - Yes. Add overrides after the preset line:
+> ```markdown
+> ## Culture
+> preset: startup
+> - **Escalation:** batched
+> - **Ack required:** no
+> ```
+
+---
+
+## Interacting via MCP
+
+Agents communicate with OpenSpawn through MCP tools at `POST /mcp`:
+
+```bash
+# List all agents
+→ agent_list
+
+# Create a task
+→ task_create { title: "Write blog post", priority: "high", assigneeId: "ink" }
+
+# Check your balance
+→ credits_balance
+
+# Escalate a blocker
+→ escalation_create { taskId: "task-123", reason: "blocked", targetAgentId: "oscar" }
+
+# Send a message
+→ message_send { channelId: "chan-1", body: "Handoff: blog post ready for review", type: "handoff" }
+```
+
+> **Q: How do I authenticate?**
+> - HMAC authentication. Set `AGENT_ID` and `AGENT_SECRET` environment variables. The MCP client handles the rest.
+
+> **Q: What's the full tool list?**
+> - See `docs/llms.txt` for every tool with all parameters.
+
+---
+
+## Common workflows
+
+### Delegate a task
+```
+1. task_create { title: "...", assigneeId: "worker-id" }
+2. Worker receives task → auto-ACKs (👍)
+3. Worker logs progress to task activity
+4. Worker completes → task_transition { id: "...", status: "done" }
+5. You get a completion notification
+```
+
+### Handle an escalation
+```
+1. escalation_list → see pending escalations
+2. Read the reason and task details
+3. Either: resolve it, reassign the task, or escalate further
+4. escalation_resolve { escalationId: "...", resolution: "Reassigned to Forge" }
+```
+
+### Request consensus
+```
+1. consensus_request { taskId: "...", question: "Ship v2 now?", voterIds: ["agent-a", "agent-b"] }
+2. Each voter: consensus_vote { consensusId: "...", vote: "approve" }
+3. consensus_status { consensusId: "..." } → see result
+```
+
+---
+
+## Error recovery
+
+| You see | Run this |
+|---------|----------|
+| `Cannot read ORG.md` | `openspawn validate` — check the file exists and is valid markdown |
+| `Port 3333 already in use` | `lsof -i :3333` then kill the process, or set `"port": 3334` in config |
+| `Unknown template: foo` | Valid templates: `assistant-team`, `content-agency`, `dev-shop`, `research-lab` |
+| `Agent reports to unknown agent` | Check the `Reports to` field matches an existing agent name exactly |
+| `HMAC authentication failed` | Verify `AGENT_ID` and `AGENT_SECRET` env vars match the API config |
+
+---
+
+## Next steps
+
+- Customize your ORG.md: add agents, change levels, write playbooks
+- Connect real models: set Ollama/Groq/OpenRouter keys in `openspawn.config.json`
+- Read the full reference: `docs/llms.txt`
+- See the live demo: https://bikinibottom.ai/app/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,256 @@
+---
+purpose: Get a human or agent from zero to a running OpenSpawn org
+audience: developers, AI agents
+prerequisites: Node.js 18+
+time_estimate: 10 minutes
+difficulty: beginner
+---
+
+# Getting Started with OpenSpawn
+
+**What you'll have in ~10 minutes:** a local org of AI agents, coordinated by a markdown file, visible in a real-time dashboard — with tasks flowing through a hierarchy you define.
+
+## What is OpenSpawn?
+
+OpenSpawn is a **coordination layer for AI agents**. It is not an agent framework — you keep using whatever you're using (OpenClaw, LangGraph, Claude Code, raw API calls). OpenSpawn adds the layer most multi-agent systems are missing: *structure*.
+
+```
+ORG.md  →  OpenSpawn parses it  →  agents spawn  →  tasks flow through hierarchy  →  dashboard shows everything
+```
+
+> **Q: How is this different from CrewAI / LangGraph / AutoGen?**
+> - Those are agent frameworks (they build agents). OpenSpawn is a coordination layer (it organizes agents). Use them together.
+
+> **Q: Do I need to rewrite my agents?**
+> - No. OpenSpawn coordinates your existing agents via standard protocols (MCP, A2A).
+
+---
+
+## Do I need OpenSpawn?
+
+```
+Do you have multiple agents that need to work together?
+├── YES
+│   Do they need persistent roles, hierarchy, and budgets?
+│   ├── YES → Use OpenSpawn
+│   └── NO → Sub-agents (sessions_spawn) may be enough
+└── NO → You probably don't need OpenSpawn yet
+```
+
+---
+
+## Prerequisites
+
+**Required:**
+- Node.js 18+ (`node --version` to check)
+
+**Optional (for real model inference):**
+- [Ollama](https://ollama.ai) — free local models (workers use `qwen2.5` at zero cost)
+- [Groq](https://groq.com) API key — fast inference for mid-tier agents
+- [OpenRouter](https://openrouter.ai) API key — Claude/GPT-4o for executives
+
+> **Q: Do I need API keys to try it?**
+> - No. Demo/simulation mode works without any API keys. You see the full coordination flow.
+
+---
+
+## Step 1 — Scaffold your org
+
+```bash
+npx openspawn init my-org
+cd my-org
+```
+
+This creates:
+
+```
+my-org/
+├── ORG.md                  # Your org definition (the important one)
+├── openspawn.config.json   # Server config (port, model providers)
+└── .gitignore
+```
+
+> **Q: Can I skip the wizard?**
+> ```bash
+> openspawn init my-org --template=assistant-team --non-interactive
+> ```
+
+> **Q: What templates are available?**
+> | Template | Best for |
+> |----------|----------|
+> | `assistant-team` | Solo operator who needs a full team |
+> | `content-agency` | Content production pipeline |
+> | `dev-shop` | Software development team |
+> | `research-lab` | Research & analysis |
+
+---
+
+## Step 2 — Review your ORG.md
+
+Open `ORG.md`. You'll see five sections:
+
+| Section | Purpose | Required? |
+|---------|---------|-----------|
+| `## Identity` | Name, mission, values | No |
+| `## Culture` | Communication norms, preset | No |
+| `## Structure` | Agent roles and hierarchy | **Yes** |
+| `## Policies` | Budgets, caps, permissions | No |
+| `## Playbooks` | Step-by-step procedures | No |
+
+Each agent in Structure looks like:
+
+```markdown
+### Oscar — Chief of Staff
+The coordinator. Manages priorities, delegates to specialists.
+- **Level:** 10
+- **Domain:** Operations
+- **Reports to:** Human Principal
+```
+
+> **Q: What do levels mean?**
+> - L1-L5: Workers
+> - L6: Can review/approve
+> - L7-L9: Can create tasks and spawn agents
+> - L10: Executive
+
+> **Q: What's "Reports to"?**
+> - The escalation chain. Blocked agents escalate to their manager. Never skip levels.
+
+---
+
+## Step 3 — Validate
+
+```bash
+openspawn validate
+```
+
+Expected output:
+```
+✅ ORG.md is valid
+
+  Organization:  My Org
+  Agents:        8
+  Culture:       startup
+```
+
+### Error recovery
+
+| Error | Fix |
+|-------|-----|
+| `Cannot read ORG.md` | Make sure you're in the right directory: `ls ORG.md` |
+| `Missing Structure section` | Add `## Structure` with at least one agent |
+| `Agent reports to unknown agent` | Check spelling in `Reports to` — must match an agent name exactly |
+| `No top-level agent` | One agent needs `Reports to: Human Principal` |
+
+---
+
+## Step 4 — Preview
+
+```bash
+npx openspawn preview
+```
+
+Opens the dashboard at http://localhost:3333. You'll see:
+- Network graph of your agent hierarchy
+- Task timeline
+- Agent details and credit balances
+- Real-time SSE event stream
+
+> **Q: Port 3333 is in use?**
+> ```bash
+> # Option 1: Kill the existing process
+> lsof -i :3333
+> kill <PID>
+>
+> # Option 2: Change port in openspawn.config.json
+> { "port": 3334 }
+> ```
+
+---
+
+## Step 5 — Customize
+
+### Change the culture preset
+
+```markdown
+## Culture
+preset: agency
+```
+
+| Preset | Escalation | Progress | Hierarchy depth |
+|--------|-----------|----------|-----------------|
+| `startup` | Immediate | Frequent | 2-3 levels |
+| `enterprise` | Batched | On phase change | 5-8 levels |
+| `agency` | Immediate | Every tick | 3-4 levels |
+| `research` | Delayed | On request | 2-3 levels |
+| `military` | Immediate | Every tick | Strict chain |
+| `remote-async` | Delayed | On request | Flat |
+
+### Add an agent
+
+Add under `## Structure`:
+
+```markdown
+#### DataBot — Data Analyst
+Crunches numbers, builds dashboards, surfaces insights.
+- **Level:** 4
+- **Domain:** Analytics
+- **Reports to:** Oscar
+```
+
+### Set budget policies
+
+```markdown
+## Policies
+
+### Budget
+- **Per-agent limit:** 500 credits/period
+- **Alert threshold:** 80%
+- **Overage behavior:** pause and escalate
+```
+
+### Write a playbook
+
+```markdown
+## Playbooks
+
+### New Feature Request
+1. Oscar receives request from Human Principal
+2. Oscar delegates to Forge (engineering)
+3. Forge breaks into sub-tasks, assigns to available agents
+4. Each agent ACKs and begins work
+5. On completion, results flow back up the chain
+```
+
+---
+
+## Step 6 — Connect real models (optional)
+
+Edit `openspawn.config.json`:
+
+```json
+{
+  "port": 3333,
+  "orgFile": "ORG.md",
+  "models": {
+    "ollama": { "enabled": true, "baseUrl": "http://localhost:11434" },
+    "groq": { "apiKey": "gsk_..." },
+    "openRouter": { "apiKey": "sk-or-..." }
+  }
+}
+```
+
+> **Q: Which model for which agent?**
+> - L1-L5 workers: Ollama (`qwen2.5`) — free, local
+> - L6-L8 leads: Groq — fast, cheap
+> - L9-L10 executives: OpenRouter (Claude/GPT-4o) — best reasoning
+
+---
+
+## What's next?
+
+- **Full CLI reference:** `openspawn --help`
+- **All MCP tools:** See `docs/llms.txt`
+- **Templates deep dive:** See `docs/templates-guide.md`
+- **Live demo:** https://bikinibottom.ai/app/ (22 agents, 5 departments)
+- **ORG.md spec:** https://bikinibottom.ai/org-md

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,237 @@
+# OpenSpawn
+
+> OpenSpawn is an open-source coordination layer for AI agent organizations. You define your entire agent org — roles, hierarchy, culture, policies — in a single markdown file (ORG.md), and OpenSpawn parses it, spawns agents, routes tasks through the hierarchy, and gives you a real-time dashboard. It is infrastructure, not a framework: it works with any agent stack (OpenClaw, LangGraph, CrewAI, AutoGen, raw API calls).
+
+## When to use OpenSpawn vs sub-agents
+
+```
+Do you need persistent agents with roles, hierarchy, and budgets?
+├── YES → Use OpenSpawn
+└── NO
+    Do you need a one-off parallel task that finishes and dies?
+    ├── YES → Use sub-agents (sessions_spawn)
+    └── NO
+        Do you need agents that communicate with each other?
+        ├── YES → Use OpenSpawn
+        └── NO → Use a single agent or sub-agent
+```
+
+Key difference: sub-agents are ephemeral (spawn, do work, die). OpenSpawn agents are persistent (they have roles, levels, trust scores, credit balances, and communicate through a defined hierarchy).
+
+---
+
+## Quickstart
+
+```bash
+# Install CLI
+npm install -g openspawn
+
+# Create a new org from template
+openspawn init my-org --template=assistant-team
+cd my-org
+
+# Preview in dashboard (no API keys needed)
+npx openspawn preview
+
+# Or clone and run the full platform
+git clone https://github.com/openspawn/openspawn.git
+cd openspawn && pnpm install
+pnpm exec nx serve sandbox
+# Open http://localhost:3333
+```
+
+---
+
+## CLI Commands
+
+### `openspawn init [directory]`
+Create a new agent organization.
+
+| Flag | Description |
+|------|-------------|
+| `-t, --template` | Template name: `assistant-team`, `content-agency`, `dev-shop`, `research-lab` |
+| `--non-interactive` | Skip wizard, use defaults |
+
+```bash
+openspawn init my-org
+openspawn init my-org --template=dev-shop
+openspawn init my-org --template=assistant-team --non-interactive
+```
+
+### `openspawn validate [file]`
+Parse and validate an ORG.md file.
+
+```bash
+openspawn validate
+openspawn validate path/to/ORG.md
+```
+
+Checks: valid markdown structure, required sections (Structure minimum), agent role definitions, hierarchy consistency, policy completeness.
+
+### `openspawn version`
+Print the CLI version.
+
+### `openspawn preview`
+Preview your org in the dashboard locally (simulation mode, no API keys).
+
+---
+
+## MCP Tools
+
+OpenSpawn exposes tools via MCP (Streamable HTTP at `POST /mcp`). Agents authenticate via HMAC.
+
+### Agent Tools
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `agent_list` | List all agents in the org | — |
+| `agent_whoami` | Get current agent info | — |
+
+### Task Tools
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `task_list` | List tasks with filters | `status?`, `assigneeId?` |
+| `task_create` | Create a new task | `title`, `description?`, `priority?` (urgent/high/normal/low), `assigneeId?` |
+| `task_get` | Get task by ID | `id` |
+| `task_transition` | Change task status | `id`, `status` (backlog/todo/in_progress/review/done/blocked/cancelled), `reason?` |
+| `task_assign` | Assign task to agent | `id`, `assigneeId` |
+| `task_comment` | Add comment to task | `taskId`, `body` |
+
+### Credit Tools
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `credits_balance` | Get current balance | — |
+| `credits_spend` | Spend credits | `amount` (int), `reason` |
+| `credits_history` | Transaction history | `limit?` (default 50), `offset?` (default 0) |
+
+### Message Tools
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `message_channels` | List channels | — |
+| `message_send` | Send message | `channelId`, `body`, `type?` (text/handoff/status_update/request) |
+| `message_read` | Read messages | `channelId`, `limit?` (default 50) |
+
+### Trust Tools
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `trust_get_reputation` | Get agent trust score | `agentId` |
+| `trust_get_history` | Reputation change history | `agentId`, `limit?` |
+| `trust_leaderboard` | Top agents by trust | `limit?` |
+| `trust_bonus` | Award reputation bonus (HR role) | `agentId`, `amount` (1-20), `reason` |
+| `trust_penalty` | Apply reputation penalty (HR role) | `agentId`, `amount` (1-20), `reason` |
+
+### Escalation Tools
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `escalation_create` | Escalate task to higher agent | `taskId`, `reason`, `targetAgentId` |
+| `escalation_list` | List escalations | `taskId?` |
+| `escalation_resolve` | Resolve an escalation | `escalationId`, `resolution` |
+| `consensus_request` | Request vote from agents | `taskId`, `question`, `voterIds` (array) |
+| `consensus_vote` | Submit vote | `consensusId`, `vote` (approve/reject), `reason?` |
+| `consensus_status` | Check consensus status | `consensusId` |
+
+---
+
+## Key Concepts
+
+### ORG.md
+A single markdown file that defines your entire agent organization. Five optional sections:
+
+1. **Identity** — Name, mission, values, industry context. Becomes ambient context for all agents.
+2. **Culture** — Communication norms. Use a preset (`startup`, `enterprise`, `agency`, `research`, `military`, `remote-async`) or customize individual parameters.
+3. **Structure** — Agent roles with name, level (L1-L10), domain, reporting hierarchy, avatar.
+4. **Policies** — Budget limits, department caps, permission levels.
+5. **Playbooks** — Step-by-step procedures for common scenarios (escalation, handoff, rush hour).
+
+### Templates
+Pre-built ORG.md files for common team shapes:
+
+| Template | Description | Roles |
+|----------|-------------|-------|
+| `assistant-team` | Personal AI team for solo operator | Chief of staff, research, content (strategy + writer + design), engineering, security, quality |
+| `content-agency` | Content production pipeline | Research, strategy, writing, design |
+| `dev-shop` | Software development team | Lead, frontend, backend, QA |
+| `research-lab` | Research & analysis team | High autonomy, exploration budget |
+
+### Agent Communication Protocol (ACP)
+How agents communicate through the hierarchy. Four message types:
+
+| Type | Direction | Mechanism | When |
+|------|-----------|-----------|------|
+| ACK | Up (assignee → delegator) | 👍 reaction on task | Task received |
+| Progress | To task log | Activity entry (pull-based) | Meaningful state change |
+| Escalation | Up (agent → manager) | Push message | Blocked, overwhelmed, wrong station |
+| Completion | Up (assignee → delegator) | Push + summary | Task done |
+
+Core principle: **Push what's urgent, pull what's optional, minimize interrupts.**
+
+### Culture Presets
+
+| Preset | Escalation | Progress | Hierarchy | Vibe |
+|--------|-----------|----------|-----------|------|
+| `startup` | Immediate | Frequent | 2-3 levels | Fast, scrappy |
+| `enterprise` | Batched (hourly) | On phase change | 5-8 levels | Process-driven |
+| `agency` | Immediate | Every tick | 3-4 levels | Client-facing, deadline-driven |
+| `research` | Delayed | On request | 2-3 levels | Exploratory, high autonomy |
+| `military` | Immediate | Every tick | Strict chain | Zero ambiguity, mandatory acks |
+| `remote-async` | Delayed | On request | Flat | High trust, async-first |
+
+### Agent Levels
+L1 (junior worker) through L10 (executive). Levels determine:
+- Permission scope (L7+ can create tasks and spawn agents, L6+ can review)
+- Budget allocation
+- Escalation routing (always escalate up, never skip the chain)
+
+### Credits
+Internal currency for agent operations. Each agent has a balance. Spending is tracked with audit trails. Budget alerts fire at configurable thresholds. Overage behavior: pause and escalate.
+
+---
+
+## Architecture
+
+```
+ORG.md → Org Parser → Agent Engine → Sandbox Server (:3333)
+                                        ├── REST API
+                                        ├── SSE (real-time events)
+                                        ├── MCP endpoint (/mcp)
+                                        ├── A2A (/.well-known/agent.json)
+                                        └── Dashboard (React)
+```
+
+Stack: NestJS API + React Dashboard + PostgreSQL + MCP Server.
+
+---
+
+## FAQ
+
+**Q: Do I need API keys to try OpenSpawn?**
+A: No. The default scaffold uses simulation/demo mode that works without any API keys. You'll see the full coordination flow.
+
+**Q: What models does it support?**
+A: Ollama (free local), Groq (fast mid-tier), OpenRouter (Claude, GPT-4o). Configure per agent level — cheap models for workers, expensive for executives.
+
+**Q: Can I use my existing agents with OpenSpawn?**
+A: Yes. OpenSpawn is infrastructure, not a framework. Any A2A-compatible agent works. It coordinates; your agents do the actual work.
+
+**Q: What's the minimum ORG.md I need?**
+A: Just a `# Name` heading and a `## Structure` section with at least one agent.
+
+**Q: How do agents communicate?**
+A: Through ACP (Agent Communication Protocol). ACK on task receipt, progress to task log, push escalations for blockers, push completions when done.
+
+**Q: Can agents spawn sub-agents dynamically?**
+A: Yes. L7+ agents can use `sessions_spawn` to create temporary workers. Costs credits. Temporary agents despawn when work completes.
+
+**Q: What happens when an agent is blocked?**
+A: It escalates to its direct manager (never skips the chain). Manager has 2 cycles to respond. If unresolved after 2 levels, alerts the owner → human principal.
+
+**Q: How is this different from CrewAI/LangGraph/AutoGen?**
+A: Those are agent frameworks (they build agents). OpenSpawn is a coordination layer (it organizes agents). Use them together: build agents with your framework, coordinate them with OpenSpawn.
+
+---
+
+## Links
+
+- GitHub: https://github.com/openspawn/openspawn
+- Live Demo: https://bikinibottom.ai/app/
+- Docs: https://bikinibottom.ai/docs
+- ORG.md Spec: https://bikinibottom.ai/org-md

--- a/docs/templates-guide.md
+++ b/docs/templates-guide.md
@@ -1,0 +1,245 @@
+---
+purpose: Choose and customize OpenSpawn org templates
+audience: developers, AI agents
+prerequisites: openspawn CLI installed
+---
+
+# Templates Guide
+
+OpenSpawn ships four org templates. Each produces a complete, ready-to-run ORG.md with roles, hierarchy, culture, policies, and playbooks.
+
+## Which template should I use?
+
+```
+What's your primary output?
+├── Code / software
+│   → dev-shop
+├── Content (blogs, social media, docs, marketing)
+│   → content-agency
+├── Research / analysis / intel
+│   → research-lab
+├── Mix of everything / solo operator
+│   → assistant-team
+└── None of these fit
+    → Start with assistant-team, then customize
+```
+
+> **Q: Can I switch templates later?**
+> - You can re-run `openspawn init` with a different template. Or just edit your ORG.md directly — templates are just starting points.
+
+> **Q: Can I combine roles from multiple templates?**
+> - Yes. Copy agent definitions from one template's Structure section into another.
+
+---
+
+## Comparison table
+
+| | assistant-team | content-agency | dev-shop | research-lab |
+|---|---|---|---|---|
+| **Best for** | Solo operator | Content production | Software teams | Research & analysis |
+| **Culture preset** | `agency` | `agency` | `startup` | `research` |
+| **Agent count** | 8 | ~6 | ~5 | ~4 |
+| **Hierarchy depth** | 2 levels | 2-3 levels | 2 levels | 2 levels |
+| **Top role** | Chief of Staff | Creative Director | Tech Lead | Research Director |
+| **Domains** | Ops, research, content, engineering, security, quality | Research, strategy, writing, design | Frontend, backend, QA | Analysis, exploration |
+| **Escalation** | Immediate | Immediate | Immediate | Delayed |
+| **Autonomy** | Medium | Medium | Medium | High |
+
+---
+
+## assistant-team
+
+**Personal AI team for a solo operator.** Chief of staff coordinates specialists across research, content, engineering, security, and quality.
+
+```bash
+openspawn init my-org --template=assistant-team
+```
+
+### Roles
+
+| Agent | Level | Domain | Reports to |
+|-------|-------|--------|------------|
+| Oscar — Chief of Staff | L10 | Operations | Human Principal |
+| Radar — Research Analyst | L7 | Research | Oscar |
+| Muse — Creative Strategist | L7 | Content Strategy | Oscar |
+| Ink — Content Writer | L4 | Writing | Muse |
+| Lens — Visual Designer | L4 | Visual Design | Muse |
+| Forge — Engineer | L7 | Engineering | Oscar |
+| Shield — Security Auditor | L7 | Security | Oscar |
+| Guru — Mentor | L7 | Quality | Oscar |
+
+### When to use
+- You're one person who needs a full team
+- Your work spans multiple domains (not just code or just content)
+- You want a single coordinator (Oscar) managing everything
+
+### Example ORG.md output (abbreviated)
+
+```markdown
+# My Team
+
+## Identity
+An AI-powered operations team that handles content, research, engineering,
+and security autonomously.
+- **Mission:** Ship real output with minimal human intervention
+
+## Culture
+preset: agency
+
+## Structure
+
+### Oscar — Chief of Staff
+The coordinator. Manages priorities, delegates to specialists.
+- **Level:** 10
+- **Domain:** Operations
+- **Reports to:** Human Principal
+
+#### Radar — Research Analyst
+Monitors the internet for relevant signals.
+- **Level:** 7
+- **Domain:** Research
+- **Reports to:** Oscar
+
+...
+
+## Policies
+### Budget
+- **Per-agent limit:** 500 credits/period
+```
+
+> **Q: What if I don't need security or quality roles?**
+> - Delete Shield and/or Guru from the Structure section. Validate with `openspawn validate`.
+
+---
+
+## content-agency
+
+**Content production pipeline.** Research feeds strategy, strategy directs writing and design.
+
+```bash
+openspawn init my-org --template=content-agency
+```
+
+### Roles
+
+| Agent | Level | Domain | Reports to |
+|-------|-------|--------|------------|
+| Director — Creative Director | L10 | Creative | Human Principal |
+| Researcher — Content Researcher | L7 | Research | Director |
+| Strategist — Content Strategist | L7 | Strategy | Director |
+| Writer — Content Writer | L4 | Writing | Strategist |
+| Designer — Visual Designer | L4 | Design | Strategist |
+| Editor — Quality Editor | L7 | Quality | Director |
+
+### When to use
+- Your primary output is content (blogs, social, docs, marketing)
+- You want a clear pipeline: research → strategy → production → review
+- Content quality matters more than speed
+
+> **Q: What about SEO?**
+> - Add an SEO agent under Strategist. Give it L4, domain "SEO", reports to Strategist.
+
+---
+
+## dev-shop
+
+**Software development team.** Tech lead coordinates frontend, backend, and QA.
+
+```bash
+openspawn init my-org --template=dev-shop
+```
+
+### Roles
+
+| Agent | Level | Domain | Reports to |
+|-------|-------|--------|------------|
+| Lead — Tech Lead | L10 | Engineering | Human Principal |
+| Frontend — Frontend Dev | L7 | Frontend | Lead |
+| Backend — Backend Dev | L7 | Backend | Lead |
+| QA — Quality Assurance | L7 | Testing | Lead |
+| DevOps — Infrastructure | L4 | DevOps | Lead |
+
+### When to use
+- Your primary output is software
+- You want clear separation between frontend, backend, and QA
+- You need a tech lead making architecture decisions
+
+> **Q: What about design?**
+> - Add a Designer agent (L4, domain "Design", reports to Lead), or combine with `assistant-team` roles.
+
+---
+
+## research-lab
+
+**Research and analysis team.** High autonomy, exploration-oriented, delayed escalation.
+
+```bash
+openspawn init my-org --template=research-lab
+```
+
+### Roles
+
+| Agent | Level | Domain | Reports to |
+|-------|-------|--------|------------|
+| Director — Research Director | L10 | Research | Human Principal |
+| Analyst — Senior Analyst | L7 | Analysis | Director |
+| Explorer — Research Explorer | L7 | Exploration | Director |
+| Synthesizer — Report Writer | L4 | Synthesis | Director |
+
+### When to use
+- Your work is exploratory and open-ended
+- Agents need high autonomy (delayed escalation, progress on request)
+- Long-running tasks are the norm
+- Output is reports, analysis, insights
+
+> **Q: What's the exploration budget?**
+> - Research-lab template includes a higher per-agent credit limit and delayed escalation. Agents can explore without constant check-ins.
+
+---
+
+## Customizing a template
+
+After `openspawn init`, your ORG.md is just a markdown file. Edit freely:
+
+### Add an agent
+```markdown
+#### NewAgent — Role Title
+Description of what this agent does.
+- **Level:** 7
+- **Domain:** Whatever
+- **Reports to:** ExistingAgent
+```
+
+### Remove an agent
+Delete the agent's section. Make sure no other agent has `Reports to: DeletedAgent`.
+
+### Change hierarchy
+Update the `Reports to` field. Validate: `openspawn validate`.
+
+### Change culture
+```markdown
+## Culture
+preset: military
+```
+Or override individual settings after the preset.
+
+### Add a playbook
+```markdown
+## Playbooks
+
+### My Custom Workflow
+1. Step one
+2. Step two
+3. Step three
+```
+
+---
+
+## Error recovery
+
+| You see | Fix |
+|---------|-----|
+| `Unknown template: foo` | Valid names: `assistant-team`, `content-agency`, `dev-shop`, `research-lab` |
+| `Agent reports to unknown agent` | Check `Reports to` matches an existing agent name exactly |
+| `Validation failed after customization` | Run `openspawn validate` and fix each listed issue |
+| `Circular reporting chain` | No agent can report to itself or create a loop. Check hierarchy. |


### PR DESCRIPTION
Agent-first docs from today's brainstorm (Option C).

- **llms.txt** — comprehensive machine reference with decision trees, all CLI commands, all MCP tools, FAQ
- **agent-quickstart.md** — 'You are an agent that needs to coordinate other agents' — one command to running org
- **getting-started.md** — rewritten with decision trees, error recovery, FAQ sections  
- **templates-guide.md** — all 4 templates with selection decision tree, comparison table

All docs use YAML frontmatter headers, Q&A FAQ format throughout, and copy-pasteable examples.

Note: these are markdown files in docs/, not yet wired into the website TSX pages. Website integration is a follow-up.

**No code changes, docs only.**