### PR TITLE
docs: update agent-first docs with start and status commands

### DIFF
--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -3,27 +3,40 @@ purpose: Get an AI agent from zero to a running multi-agent organization
 audience: AI agents (LLMs) that need to coordinate other agents
 prerequisites: Node.js 18+, npm
 time_estimate: 10 minutes
-commands_used: [openspawn init, openspawn validate, openspawn preview]
+commands_used: [openspawn init, openspawn start, openspawn status, openspawn validate, openspawn preview]
 ---
 
 # Agent Quickstart
 
 You are an AI agent that needs to coordinate other agents. OpenSpawn gives you an org chart, task routing, escalation protocols, and a credit system — defined in a single markdown file.
 
-## One command to a running org
+## Three commands to a running org
 
 ```bash
-npx openspawn init my-org --template=assistant-team --non-interactive && cd my-org && npx openspawn preview
+openspawn init my-org --template=assistant-team --yes
+cd my-org
+openspawn start
+openspawn status
 ```
 
-That's it. You now have a running org with a chief of staff, research analyst, content team, engineer, security auditor, and quality mentor — all coordinated through a hierarchy.
+That's it. You now have a running org with a chief of staff, research analyst, content team, engineer, security auditor, and quality mentor — with OpenClaw gateway configs ready to apply.
 
 > **Q: Do I need API keys?**
 > - No. Demo/simulation mode works out of the box with zero configuration.
 
 > **Q: What just happened?**
-> - `init` created `ORG.md` (your org definition) and `openspawn.config.json` (server config)
-> - `preview` launched the sandbox server with a dashboard at http://localhost:3333
+> - `init` created `ORG.md` (your org definition) and `openclaw-agents.json`
+> - `start` read the agents config and generated `openclaw-patch.json` with OpenClaw gateway entries
+> - `status` displayed a table of all agents with their name, level, model, workspace, and reports-to
+
+> **Q: What is openclaw-patch.json?**
+> - A ready-to-apply patch for your OpenClaw gateway's `agents.list`
+> - Each entry has: `id`, `model` (opus for L7+, sonnet for L6-), `workspace`, `tools.profile: "full"`
+> - Manager agents (L7+ with direct reports) also get `subagents.allowAgents`
+> - The highest-level agent gets `default: true`
+
+> **Q: How do I apply the patch to my gateway?**
+> - Copy the entries from `openclaw-patch.json` into your OpenClaw `agents.list` configuration, then restart the gateway.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -144,7 +144,39 @@ Expected output:
 
 ---
 
-## Step 4 — Preview
+## Step 4 — Generate OpenClaw configs
+
+```bash
+openspawn start
+```
+
+This reads your org and generates `openclaw-patch.json` — ready-to-apply OpenClaw gateway configuration.
+
+```bash
+openspawn status
+```
+
+Displays a table of all agents:
+
+```
+Name       Level  Model   Workspace              Reports To
+Oscar      L10    opus    workspace-oscar         Human Principal
+Radar      L7     opus    workspace-radar         Oscar
+Forge      L7     opus    workspace-forge         Oscar
+Ink        L4     sonnet  workspace-ink           Muse
+```
+
+> **Q: What happens after init?**
+> - Run `openspawn start` to generate OpenClaw configs, then apply the patch to your gateway. The `openclaw-patch.json` file contains `agents.list` entries with id, model, workspace, and subagents config.
+
+> **Q: Can I output status as JSON?**
+> ```bash
+> openspawn status --json
+> ```
+
+---
+
+## Step 5 — Preview
 
 ```bash
 npx openspawn preview
@@ -168,7 +200,7 @@ Opens the dashboard at http://localhost:3333. You'll see:
 
 ---
 
-## Step 5 — Customize
+## Step 6 — Customize
 
 ### Change the culture preset
 
@@ -224,7 +256,7 @@ Crunches numbers, builds dashboards, surfaces insights.
 
 ---
 
-## Step 6 — Connect real models (optional)
+## Step 7 — Connect real models (optional)
 
 Edit `openspawn.config.json`:
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -71,6 +71,44 @@ Checks: valid markdown structure, required sections (Structure minimum), agent r
 ### `openspawn version`
 Print the CLI version.
 
+### `openspawn start [--dir <path>] [--json]`
+Read `openclaw-agents.json` and generate `openclaw-patch.json` with OpenClaw gateway configuration.
+
+| Flag | Description |
+|------|-------------|
+| `--dir <path>` | Project directory (default: current directory) |
+| `--json` | Output result as JSON |
+
+```bash
+openspawn start
+openspawn start --dir ./my-org
+openspawn start --json
+```
+
+What it does:
+- Reads `openclaw-agents.json` from the project directory
+- Generates `openclaw-patch.json` with `agents.list` entries for your OpenClaw gateway
+- Agent ID = lowercase hyphenated name from ORG.md
+- L7+ agents get `opus` model, L6 and below get `sonnet`
+- L7+ agents with direct reports get `subagents.allowAgents`
+- Highest-level agent gets `default: true`
+- All agents get `tools.profile: "full"`
+
+### `openspawn status [--dir <path>] [--json]`
+Display a formatted table of agents in your organization.
+
+| Flag | Description |
+|------|-------------|
+| `--dir <path>` | Project directory (default: current directory) |
+| `--json` | Output as JSON instead of table |
+
+```bash
+openspawn status
+openspawn status --json
+```
+
+Output columns: name, level, model, workspace, reports-to.
+
 ### `openspawn preview`
 Preview your org in the dashboard locally (simulation mode, no API keys).
 
@@ -223,6 +261,12 @@ A: Yes. L7+ agents can use `sessions_spawn` to create temporary workers. Costs c
 
 **Q: What happens when an agent is blocked?**
 A: It escalates to its direct manager (never skips the chain). Manager has 2 cycles to respond. If unresolved after 2 levels, alerts the owner → human principal.
+
+**Q: How do I connect to my OpenClaw gateway?**
+A: Run `openspawn start` to generate `openclaw-patch.json`, then apply it to your gateway config. The patch contains ready-to-use `agents.list` entries.
+
+**Q: What does openclaw-patch.json contain?**
+A: OpenClaw `agents.list` entries with `id`, `model`, `workspace`, and `subagents.allowAgents` for managers. L7+ agents get opus, L6- get sonnet. The highest-level agent gets `default: true`. All agents get `tools.profile: "full"`.
 
 **Q: How is this different from CrewAI/LangGraph/AutoGen?**
 A: Those are agent frameworks (they build agents). OpenSpawn is a coordination layer (it organizes agents). Use them together: build agents with your framework, coordinate them with OpenSpawn.


### PR DESCRIPTION
Updates llms.txt, agent-quickstart, and getting-started to document `openspawn start` and `openspawn status` commands (merged in #416).

Per Adam's directive: every feature ships with docs.