### PR TITLE
redesign(bb): value prop intro + contextual annotations + mobile tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ __pycache__/
 
 # Production secrets
 .env.production
+node_modules

--- a/apps/dashboard/src/components/live/OpenSpawnBadge.tsx
+++ b/apps/dashboard/src/components/live/OpenSpawnBadge.tsx
@@ -5,7 +5,7 @@ interface OpenSpawnBadgeProps {
   spawnedAgents: SpawnedAgent[];
   pattiesDelivered: number;
   finished: boolean;
-  /** 'desktop' renders as absolute-positioned corner badge; 'mobile' renders as full-width strip */
+  /** 'desktop' renders as sticky top banner; 'mobile' renders as full-width strip */
   variant: 'desktop' | 'mobile';
 }
 
@@ -13,93 +13,55 @@ export function OpenSpawnBadge({ spawnedAgents, pattiesDelivered, finished, vari
   const baseAgentCount = 22;
   const totalAgents = baseAgentCount + spawnedAgents.length;
 
-  // Dynamic subtitle text
-  const subtitle = finished
-    ? `${pattiesDelivered.toLocaleString()} patties · ${totalAgents} agents · 0 humans 🎉`
-    : spawnedAgents.length > 0
-      ? `${baseAgentCount} + ${spawnedAgents.length} agents · 5 depts · 0 humans`
-      : `${totalAgents} agents · 5 departments · 0 humans`;
+  const agentText = spawnedAgents.length > 0
+    ? `${baseAgentCount} + ${spawnedAgents.length} agents`
+    : `${totalAgents} agents`;
 
-  if (variant === 'desktop') {
-    return (
-      <a
-        href="https://openspawn.ai"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="openspawn-badge-desktop group flex items-center gap-2 px-3 py-2 rounded-xl"
-        style={{
-          position: 'absolute',
-          bottom: 12,
-          left: 12,
-          zIndex: 20,
-          background: 'rgba(6, 42, 69, 0.85)',
-          border: '1px solid rgba(74, 174, 217, 0.25)',
-          backdropFilter: 'blur(8px)',
-          textDecoration: 'none',
-          transition: 'border-color 0.3s, background 0.3s',
-        }}
-      >
-        <span className="text-base">🪸</span>
-        <div className="flex flex-col">
-          <span
-            className="text-[11px] font-bold uppercase tracking-wider"
-            style={{ color: '#4AAED9', fontFamily: 'Nunito, sans-serif' }}
-          >
-            Orchestrated by OpenSpawn
-          </span>
-          <span
-            className="text-[10px]"
-            style={{ color: 'rgba(184,228,247,0.5)', fontFamily: 'Nunito, sans-serif' }}
-          >
-            {subtitle}
-          </span>
-        </div>
-        <ExternalLink
-          className="w-3 h-3 openspawn-badge-icon"
-          style={{ color: '#4AAED9', opacity: 0.3, transition: 'opacity 0.3s' }}
-        />
-        <style>{`
-          .openspawn-badge-desktop:hover {
-            border-color: rgba(74, 174, 217, 0.6) !important;
-            background: rgba(6, 50, 82, 0.9) !important;
-          }
-          .openspawn-badge-desktop:hover .openspawn-badge-icon {
-            opacity: 0.8 !important;
-          }
-        `}</style>
-      </a>
-    );
-  }
+  const suffix = finished
+    ? `${pattiesDelivered.toLocaleString()} patties delivered 🎉`
+    : `${agentText} · 5 departments · 0 humans`;
 
-  // Mobile: full-width strip
+  // Both variants now render as full-width sticky banner
   return (
     <a
       href="https://openspawn.ai"
       target="_blank"
       rel="noopener noreferrer"
-      className="shrink-0 px-4 py-2 flex items-center justify-between"
+      className="openspawn-banner shrink-0 flex items-center justify-center gap-3 px-4"
       style={{
-        background: 'rgba(6,42,69,0.9)',
-        borderBottom: '1px solid rgba(74,174,217,0.12)',
+        background: 'rgba(6,42,69,0.95)',
+        borderBottom: '1px solid rgba(74,174,217,0.15)',
         textDecoration: 'none',
+        height: variant === 'desktop' ? 40 : 36,
+        backdropFilter: 'blur(8px)',
+        zIndex: 20,
       }}
     >
-      <div className="flex items-center gap-2">
-        <span>🪸</span>
-        <span
-          className="text-xs font-bold"
-          style={{ color: '#4AAED9', fontFamily: 'Nunito, sans-serif' }}
-        >
-          Orchestrated by OpenSpawn
-        </span>
-        <span
-          className="text-[10px]"
-          style={{ color: 'rgba(184,228,247,0.4)', fontFamily: 'Nunito, sans-serif' }}
-        >
-          · {subtitle}
-        </span>
-      </div>
-      <ExternalLink className="w-3 h-3" style={{ color: 'rgba(74,174,217,0.4)' }} />
+      <span className="text-sm">🪸</span>
+      <span
+        className="text-xs font-bold"
+        style={{ color: '#4AAED9', fontFamily: 'Nunito, sans-serif' }}
+      >
+        {suffix}
+      </span>
+      <span
+        className="text-[10px]"
+        style={{ color: 'rgba(184,228,247,0.35)', fontFamily: 'Nunito, sans-serif' }}
+      >
+        · Powered by OpenSpawn
+      </span>
+      <ExternalLink
+        className="w-3 h-3 openspawn-banner-icon"
+        style={{ color: 'rgba(74,174,217,0.3)', transition: 'color 0.3s' }}
+      />
+      <style>{`
+        .openspawn-banner:hover {
+          background: rgba(6, 50, 82, 0.95) !important;
+        }
+        .openspawn-banner:hover .openspawn-banner-icon {
+          color: rgba(74,174,217,0.8) !important;
+        }
+      `}</style>
     </a>
   );
 }

--- a/apps/dashboard/src/components/live/intro-card.tsx
+++ b/apps/dashboard/src/components/live/intro-card.tsx
@@ -1,6 +1,5 @@
 /**
- * IntroCard — Full-screen intro overlay before the live dashboard.
- * POLISH PASS: Replaced motion/react with CSS-only animations.
+ * IntroCard — Full-screen intro overlay that communicates OpenSpawn's value prop.
  * CSS animations only. prefers-reduced-motion: respected via media query.
  */
 
@@ -10,29 +9,22 @@ interface IntroCardProps {
   onStart: () => void;
 }
 
-// CSS animations injected once
 const INTRO_STYLES = `
   @keyframes intro-overlay-in {
     from { opacity: 0; }
     to   { opacity: 1; }
   }
-  @keyframes intro-terminal-in {
-    from { opacity: 0; transform: translateX(-32px); }
-    to   { opacity: 1; transform: translateX(0); }
+  @keyframes intro-hero-in {
+    from { opacity: 0; transform: translateY(24px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
-  @keyframes intro-copy-in {
+  @keyframes intro-sub-in {
     from { opacity: 0; transform: translateY(16px); }
     to   { opacity: 1; transform: translateY(0); }
   }
-  @keyframes intro-burger-bounce {
-    0%   { transform: scale(0.5) rotate(-12deg); opacity: 0; }
-    60%  { transform: scale(1.12) rotate(3deg); opacity: 1; }
-    80%  { transform: scale(0.96) rotate(-1deg); }
-    100% { transform: scale(1) rotate(0deg); opacity: 1; }
-  }
-  @keyframes intro-title-in {
-    from { opacity: 0; transform: translateY(10px); letter-spacing: 0.1em; }
-    to   { opacity: 1; transform: translateY(0); letter-spacing: -0.01em; }
+  @keyframes intro-compare-in {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
   @keyframes intro-btn-in {
     0%   { opacity: 0; transform: scale(0.85); }
@@ -40,33 +32,42 @@ const INTRO_STYLES = `
     100% { transform: scale(1); opacity: 1; }
   }
   @keyframes intro-cta-glow {
-    0%, 100% { box-shadow: 0 0 20px rgba(244,197,66,0.5), 0 0 40px rgba(244,197,66,0.2); }
-    50%       { box-shadow: 0 0 32px rgba(244,197,66,0.75), 0 0 60px rgba(244,197,66,0.35); }
+    0%, 100% { box-shadow: 0 0 20px rgba(74,174,217,0.4), 0 0 40px rgba(74,174,217,0.15); }
+    50%       { box-shadow: 0 0 32px rgba(74,174,217,0.6), 0 0 60px rgba(74,174,217,0.25); }
+  }
+  @keyframes intro-line-expand {
+    from { width: 0; opacity: 0; }
+    to   { width: 120px; opacity: 1; }
+  }
+  @keyframes intro-badge-in {
+    from { opacity: 0; transform: scale(0.9); }
+    to   { opacity: 1; transform: scale(1); }
   }
 
   .intro-overlay   { animation: intro-overlay-in  0.5s ease forwards; }
-  .intro-terminal  { animation: intro-terminal-in 0.6s 0.2s cubic-bezier(0.16,1,0.3,1) forwards; opacity: 0; }
-  .intro-copy      { animation: intro-copy-in     0.5s 0.4s ease forwards; opacity: 0; }
-  .intro-burger    { animation: intro-burger-bounce 0.6s 0.5s cubic-bezier(0.34,1.56,0.64,1) forwards; opacity: 0; }
-  .intro-title     { animation: intro-title-in    0.5s 0.65s cubic-bezier(0.16,1,0.3,1) forwards; opacity: 0; }
+  .intro-hero      { animation: intro-hero-in     0.6s 0.2s cubic-bezier(0.16,1,0.3,1) forwards; opacity: 0; }
+  .intro-sub       { animation: intro-sub-in      0.5s 0.5s ease forwards; opacity: 0; }
+  .intro-compare   { animation: intro-compare-in  0.5s 0.7s ease forwards; opacity: 0; }
   .intro-btn       {
     animation:
-      intro-btn-in   0.5s 0.8s cubic-bezier(0.34,1.56,0.64,1) forwards,
-      intro-cta-glow 2.5s 1.4s ease-in-out infinite;
+      intro-btn-in   0.5s 1.0s cubic-bezier(0.34,1.56,0.64,1) forwards,
+      intro-cta-glow 2.5s 1.6s ease-in-out infinite;
     opacity: 0;
   }
   .intro-btn:hover {
     animation-play-state: paused;
     transform: scale(1.05) translateY(-2px);
-    box-shadow: 0 0 40px rgba(244,197,66,0.8), 0 0 80px rgba(244,197,66,0.4) !important;
+    box-shadow: 0 0 40px rgba(74,174,217,0.7), 0 0 80px rgba(74,174,217,0.3) !important;
   }
   .intro-btn:active {
     transform: scale(0.97);
   }
+  .intro-line { animation: intro-line-expand 0.6s 0.4s ease forwards; width: 0; opacity: 0; }
+  .intro-badge { animation: intro-badge-in 0.5s 0.9s ease forwards; opacity: 0; }
 
   @media (prefers-reduced-motion: reduce) {
-    .intro-overlay, .intro-terminal, .intro-copy, .intro-burger,
-    .intro-title, .intro-btn {
+    .intro-overlay, .intro-hero, .intro-sub, .intro-compare,
+    .intro-btn, .intro-line, .intro-badge {
       animation: none !important;
       opacity: 1 !important;
       transform: none !important;
@@ -74,189 +75,147 @@ const INTRO_STYLES = `
   }
 `;
 
-const ORG_LINES = [
-  '# 🍍 The Krusty Krab',
-  '',
-  '## Structure',
-  '',
-  '### 🦀 Mr. Krabs — Owner',
-  'Makes the tough calls. Watches every credit.',
-  '- **Level:** 10',
-  '- **Domain:** Executive',
-  '',
-  '#### 🧽 SpongeBob — Head Fry Cook',
-  'Runs the grill. Can sessions_spawn sous chefs.',
-  '- **Level:** 9',
-  '- **Domain:** Kitchen',
-  '- **Reports to:** Mr. Krabs',
-  '',
-  '#### 🐙 Squidward — Head Cashier',
-  'Delivers every order. The bottleneck.',
-  '- **Level:** 9',
-  '- **Domain:** Floor',
-  '- **Reports to:** Mr. Krabs',
-  '',
-  '#### 🎩 Squilliam — Bookkeeper',
-  'Tracks every credit.',
-  '- **Level:** 9',
-  '- **Domain:** Finance',
-  '- **Reports to:** Mr. Krabs',
-];
-
-function renderLine(line: string) {
-  if (line.startsWith('#### '))
-    return <span style={{ color: '#F4C542', fontWeight: 'bold' }}>{line.slice(5)}</span>;
-  if (line.startsWith('### '))
-    return <span style={{ color: '#F4C542', fontWeight: 'bold', fontSize: '15px' }}>{line.slice(4)}</span>;
-  if (line.startsWith('## '))
-    return <span style={{ color: '#4AAED9', fontWeight: 'bold' }}>{line.slice(3)}</span>;
-  if (line.startsWith('# '))
-    return <span style={{ color: '#4AAED9', fontWeight: 'bold', fontSize: '1.125rem' }}>{line.slice(2)}</span>;
-
-  const metaMatch = line.match(/^- \*\*(.+?):\*\* (.+)$/);
-  if (metaMatch) {
-    return (
-      <span>
-        <span style={{ color: '#4AAED9' }}>- </span>
-        <span style={{ color: '#B8E4F7', fontWeight: '600' }}>{metaMatch[1]}:</span>
-        <span style={{ color: 'rgba(184,228,247,0.6)' }}> {metaMatch[2]}</span>
-      </span>
-    );
-  }
-
-  if (line.includes('sessions_spawn')) {
-    const parts = line.split('sessions_spawn');
-    return (
-      <span style={{ color: 'rgba(184,228,247,0.5)' }}>
-        {parts[0]}
-        <code
-          className="px-1.5 py-0.5 rounded text-[11px]"
-          style={{ background: 'rgba(244,197,66,0.1)', color: '#F4C542' }}
-        >
-          sessions_spawn
-        </code>
-        {parts[1]}
-      </span>
-    );
-  }
-
-  if (line === '') return <span>&nbsp;</span>;
-  return <span style={{ color: 'rgba(184,228,247,0.45)' }}>{line}</span>;
-}
-
 export function IntroCard({ onStart }: IntroCardProps) {
   return (
     <div
-      className="intro-overlay fixed inset-0 z-50 flex items-center justify-center p-4"
+      className="intro-overlay fixed inset-0 z-50 flex items-center justify-center p-6"
       style={{
-        background: 'rgba(3,14,26,0.96)',
-        backdropFilter: 'blur(8px)',
+        background: 'rgba(3,14,26,0.97)',
+        backdropFilter: 'blur(12px)',
       }}
     >
       <style>{INTRO_STYLES}</style>
 
-      <div className="flex flex-col md:flex-row items-center gap-8 md:gap-12 max-w-5xl w-full">
-        {/* Left: ORG.md terminal */}
-        <div className="intro-terminal w-full md:w-[55%] shrink-0">
-          <div
-            className="rounded-2xl max-h-[40vh] md:max-h-none overflow-y-auto scrollbar-none"
-            style={{
-              background: '#0B3D60',
-              border: '1px solid rgba(74,174,217,0.2)',
-              boxShadow: '0 0 40px rgba(74,174,217,0.08)',
-            }}
-          >
-            {/* Terminal chrome */}
-            <div
-              className="flex items-center gap-2 px-4 py-2.5"
-              style={{ borderBottom: '1px solid rgba(74,174,217,0.1)' }}
-            >
-              <div className="flex gap-1.5">
-                <div className="w-2.5 h-2.5 rounded-full" style={{ background: '#FF4757' }} />
-                <div className="w-2.5 h-2.5 rounded-full" style={{ background: '#F4C542' }} />
-                <div className="w-2.5 h-2.5 rounded-full" style={{ background: '#4AE88A' }} />
-              </div>
-              <span
-                className="ml-2"
-                style={{ color: 'rgba(184,228,247,0.4)', fontSize: '0.75rem', fontFamily: '"JetBrains Mono", monospace' }}
+      <div className="flex flex-col items-center text-center max-w-2xl w-full">
+        {/* Hero headline */}
+        <h1
+          className="intro-hero font-black mb-4 leading-tight"
+          style={{
+            fontFamily: '"Baloo 2", cursive',
+            fontSize: 'clamp(1.75rem, 5vw, 3rem)',
+            color: '#F4C542',
+            textShadow: '0 0 40px rgba(244,197,66,0.3)',
+          }}
+        >
+          Watch 42 agents run a restaurant.
+          <br />
+          No humans. One command.
+        </h1>
+
+        {/* Divider line */}
+        <div
+          className="intro-line h-px mb-6"
+          style={{ background: 'linear-gradient(90deg, transparent, rgba(74,174,217,0.5), transparent)' }}
+        />
+
+        {/* Subtext */}
+        <p
+          className="intro-sub text-lg mb-8 max-w-md"
+          style={{
+            color: 'rgba(184,228,247,0.7)',
+            fontFamily: 'Nunito, sans-serif',
+            lineHeight: 1.6,
+          }}
+        >
+          Built with{' '}
+          <span style={{ color: '#4AAED9', fontWeight: 700 }}>OpenSpawn</span>
+          {' '}— the platform agents use when sub-agents aren't enough.
+        </p>
+
+        {/* Comparison card */}
+        <div
+          className="intro-compare w-full max-w-lg rounded-2xl p-5 mb-8"
+          style={{
+            background: 'rgba(6,42,69,0.6)',
+            border: '1px solid rgba(74,174,217,0.2)',
+          }}
+        >
+          <div className="grid grid-cols-2 gap-4 text-left">
+            {/* Sub-agents column */}
+            <div>
+              <div
+                className="text-xs font-bold uppercase tracking-wider mb-3"
+                style={{ color: 'rgba(184,228,247,0.4)', fontFamily: 'Nunito, sans-serif' }}
               >
-                org.md
-              </span>
+                Sub-agents
+              </div>
+              <ul className="space-y-2 text-sm" style={{ color: 'rgba(184,228,247,0.45)', fontFamily: 'Nunito, sans-serif' }}>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: '#FF4757' }}>✗</span> No persistence
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: '#FF4757' }}>✗</span> No hierarchy
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: '#FF4757' }}>✗</span> No peer communication
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: '#FF4757' }}>✗</span> No org structure
+                </li>
+              </ul>
             </div>
-            {/* Content */}
-            <div
-              className="p-4 text-[13px] leading-relaxed"
-              style={{ fontFamily: '"JetBrains Mono", monospace' }}
-            >
-              {ORG_LINES.map((line, i) => (
-                <div key={i} className="flex gap-3">
-                  <span
-                    className="select-none w-5 text-right shrink-0 text-[11px] leading-relaxed"
-                    style={{ color: 'rgba(74,174,217,0.2)' }}
-                  >
-                    {i + 1}
-                  </span>
-                  <div className="min-w-0">{renderLine(line)}</div>
-                </div>
-              ))}
+
+            {/* OpenSpawn column */}
+            <div>
+              <div
+                className="text-xs font-bold uppercase tracking-wider mb-3"
+                style={{ color: '#4AAED9', fontFamily: 'Nunito, sans-serif' }}
+              >
+                🪸 OpenSpawn
+              </div>
+              <ul className="space-y-2 text-sm" style={{ color: 'rgba(184,228,247,0.7)', fontFamily: 'Nunito, sans-serif' }}>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: '#4AE88A' }}>✓</span> Persistent agents
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: '#4AE88A' }}>✓</span> Org hierarchy
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: '#4AE88A' }}>✓</span> Agent-to-agent comms
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: '#4AE88A' }}>✓</span> Escalation & delegation
+                </li>
+              </ul>
             </div>
           </div>
         </div>
 
-        {/* Right: Intro copy */}
-        <div className="intro-copy flex flex-col items-center md:items-start text-center md:text-left">
-          <div className="intro-burger text-7xl mb-4">🍔</div>
-
-          <div
-            className="text-xs uppercase tracking-widest mb-1"
-            style={{ color: 'rgba(184,228,247,0.4)', fontFamily: 'Nunito, sans-serif' }}
-          >
-            Operation:
-          </div>
-          <h1
-            className="intro-title font-black mb-6"
-            style={{
-              fontFamily: '"Baloo 2", cursive',
-              fontSize: '1.875rem',
-              color: '#F4C542',
-              textShadow: '0 0 30px rgba(244,197,66,0.3)',
-            }}
-          >
-            10,000 KRABBY PATTIES
-          </h1>
-          <p
-            className="text-lg mb-1"
-            style={{ color: 'rgba(184,228,247,0.6)', fontFamily: 'Nunito, sans-serif' }}
-          >
-            22 agents. One massive order.
-          </p>
-          <p
-            className="text-lg mb-8"
-            style={{ color: 'rgba(184,228,247,0.6)', fontFamily: 'Nunito, sans-serif' }}
-          >
-            Watch them coordinate — or collapse.
-          </p>
-
-          <button
-            onClick={onStart}
-            className="intro-btn flex items-center gap-3 px-8 py-3.5 rounded-2xl font-black text-lg cursor-pointer border-none"
-            style={{
-              background: 'linear-gradient(135deg, #F4C542 0%, #EAB308 100%)',
-              color: '#062A45',
-              fontFamily: '"Baloo 2", cursive',
-            }}
-          >
-            <Play className="w-5 h-5" />
-            Watch the Story →
-          </button>
-
-          <p
-            className="text-xs mt-3"
-            style={{ color: 'rgba(184,228,247,0.25)', fontFamily: 'Nunito, sans-serif' }}
-          >
-            Defined in one markdown file.
-          </p>
+        {/* OpenSpawn badge */}
+        <div
+          className="intro-badge flex items-center gap-2 mb-8 px-4 py-2 rounded-xl"
+          style={{
+            background: 'rgba(74,174,217,0.08)',
+            border: '1px solid rgba(74,174,217,0.2)',
+          }}
+        >
+          <span>🪸</span>
+          <span className="text-xs" style={{ color: 'rgba(184,228,247,0.5)', fontFamily: 'Nunito, sans-serif' }}>
+            42 agents · 5 departments · 0 humans · Powered by OpenSpawn
+          </span>
         </div>
+
+        {/* CTA */}
+        <button
+          onClick={onStart}
+          className="intro-btn flex items-center gap-3 px-10 py-4 rounded-2xl font-black text-lg cursor-pointer border-none"
+          style={{
+            background: 'linear-gradient(135deg, #4AAED9 0%, #1A7DB5 100%)',
+            color: '#fff',
+            fontFamily: '"Baloo 2", cursive',
+            letterSpacing: '0.02em',
+          }}
+        >
+          <Play className="w-5 h-5" />
+          Watch the Demo →
+        </button>
+
+        <p
+          className="text-xs mt-4"
+          style={{ color: 'rgba(184,228,247,0.2)', fontFamily: 'Nunito, sans-serif' }}
+        >
+          ~75 seconds · Defined in one markdown file
+        </p>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/live/live-view-annotations.ts
+++ b/apps/dashboard/src/components/live/live-view-annotations.ts
@@ -1,0 +1,73 @@
+/**
+ * Contextual annotations that appear during key demo moments.
+ * Each annotation is triggered by a tick range and displayed as a floating bubble.
+ */
+
+export interface Annotation {
+  id: string;
+  triggerTick: number;
+  durationTicks: number;
+  text: string;
+  icon: string;
+  color: string; // CSS color for border/icon
+}
+
+export const ANNOTATIONS: Annotation[] = [
+  {
+    id: 'escalation-spongebob',
+    triggerTick: 13,
+    durationTicks: 6,
+    text: '↑ Automatic escalation — agent detected it can\'t handle 10K alone, OpenSpawn routed it up the hierarchy',
+    icon: '⬆️',
+    color: '#FF4757',
+  },
+  {
+    id: 'spawn-burst',
+    triggerTick: 19,
+    durationTicks: 10,
+    text: '🔥 Dynamic scaling — SpongeBob spawns 20 sous-chefs via sessions_spawn. No human approval needed.',
+    icon: '⚡',
+    color: '#F4C542',
+  },
+  {
+    id: 'cross-dept',
+    triggerTick: 52,
+    durationTicks: 8,
+    text: '← Cross-department communication via ACP — Support sees Kitchen\'s queue backup in real-time',
+    icon: '🔗',
+    color: '#4AAED9',
+  },
+  {
+    id: 'escalation-squidward',
+    triggerTick: 70,
+    durationTicks: 8,
+    text: '↑ Automatic escalation — Squidward detected overload, OpenSpawn routed it up the hierarchy',
+    icon: '🚨',
+    color: '#FF4757',
+  },
+  {
+    id: 'reorg',
+    triggerTick: 95,
+    durationTicks: 10,
+    text: '🔀 Live reorganization — Mr. Krabs reassigns agents across departments. Org chart updates in real-time.',
+    icon: '🔀',
+    color: '#F4C542',
+  },
+  {
+    id: 'autonomous-milestone',
+    triggerTick: 135,
+    durationTicks: 10,
+    text: 'This org ran autonomously for ~75 seconds. No human touched it.',
+    icon: '🏆',
+    color: '#4AE88A',
+  },
+];
+
+export function getActiveAnnotation(tick: number): Annotation | null {
+  for (const a of ANNOTATIONS) {
+    if (tick >= a.triggerTick && tick < a.triggerTick + a.durationTicks) {
+      return a;
+    }
+  }
+  return null;
+}

--- a/apps/dashboard/src/pages/live-view.tsx
+++ b/apps/dashboard/src/pages/live-view.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Link } from '@tanstack/react-router';
-import { ArrowRight, ExternalLink } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
 import { IntroCard } from '../components/live/intro-card';
 import { OrgChartLive, type AgentNodeState, type EdgeAnimation } from '../components/live/org-chart-live';
 import { MobileOrgChart } from '../components/live/MobileOrgChart';
@@ -8,52 +7,28 @@ import { LiveFeed, type FeedMessage } from '../components/live/live-feed';
 import { StatsBar } from '../components/live/stats-bar';
 import { OpenSpawnBadge } from '../components/live/OpenSpawnBadge';
 import { TIMELINE, ACTS, type Stats, type ReplayEvent, type SpawnedAgent } from '../components/live/replay-data';
+import { getActiveAnnotation, type Annotation } from '../components/live/live-view-annotations';
 
 // ── Variable tick timing ──────────────────────────────────────────────────────
-//
-// Dramatic pauses fire BEFORE the specified tick (pre-event delay).
-// Act timings:
-//   Act I   (0–10):   400ms — brisk
-//   Act II  (11–40):  500ms — steady; spawn burst (19–26) = 300ms
-//   Act III (41–90):  rising 450 → crisis 350 → dead-stop 600
-//   Act IV  (91–120): 600ms — breathing room
-//   Act V   (121–150):500ms
 
 const PRE_PAUSE_TICKS: Record<number, number> = {
-  1:   1000,   // Before Plankton's mega-order
-  13:  900,    // Before SpongeBob's first escalation
-  56:  800,    // Before Squidward overwhelmed
-  70:  800,    // Before escalation to Mr. Krabs 🚨
-  92:  900,    // Before Mr. Krabs's decision
-  138: 1500,   // Before final completion
+  1:   1000,
+  13:  900,
+  56:  800,
+  70:  800,
+  92:  900,
+  138: 1500,
 };
 
 function getTickDelay(nextTick: number): number {
-  // Dramatic pre-event pauses override everything
   if (PRE_PAUSE_TICKS[nextTick] !== undefined) return PRE_PAUSE_TICKS[nextTick];
-
-  // Act I: brisk setup (0–10)
   if (nextTick <= 10) return 400;
-
-  // Spawn burst: rapid-fire (19–26)
   if (nextTick >= 19 && nextTick <= 26) return 300;
-
-  // Act II: steady cooking (11–40)
   if (nextTick <= 40) return 500;
-
-  // Act III rising tension (41–55)
   if (nextTick <= 55) return 450;
-
-  // Act III crisis peak (56–75): frantic
   if (nextTick <= 75) return 350;
-
-  // Act III dead stop (76–90): uncomfortable silence
   if (nextTick <= 90) return 600;
-
-  // Act IV resolution (91–120): breathing room
   if (nextTick <= 120) return 600;
-
-  // Act V victory (121–150)
   return 500;
 }
 
@@ -95,7 +70,6 @@ function useReplay() {
     setFinished(false);
   }, []);
 
-  // Process events for a given tick
   const processEvents = useCallback((currentTick: number) => {
     const events = TIMELINE.filter((e: ReplayEvent) => e.tick === currentTick);
     let changed = false;
@@ -179,7 +153,6 @@ function useReplay() {
             },
           ];
 
-          // Edge animations for delegation/escalation/reassign
           if ((event.type === 'delegation' || event.type === 'reassign') && d.from && d.to) {
             edgeAnimsRef.current = [
               ...edgeAnimsRef.current,
@@ -202,7 +175,6 @@ function useReplay() {
         }
       }
 
-      // Update Squidward's queue badge
       if (statsRef.current.queueSize > 0) {
         nodeStatesRef.current = {
           ...nodeStatesRef.current,
@@ -214,7 +186,6 @@ function useReplay() {
       }
     }
 
-    // Clean up old edge animations (>2s old)
     const now = Date.now();
     const before = edgeAnimsRef.current.length;
     edgeAnimsRef.current = edgeAnimsRef.current.filter(a => now - a.timestamp < 2000);
@@ -223,36 +194,26 @@ function useReplay() {
     if (changed) forceUpdate(n => n + 1);
   }, []);
 
-  // Variable-speed tick engine using setTimeout (instead of flat setInterval)
   useEffect(() => {
     if (!running) return;
     if (tick < 0) return;
-
     const nextTick = tick + 1;
     if (nextTick > 150) {
       setRunning(false);
       setFinished(true);
       return;
     }
-
     const delay = getTickDelay(nextTick);
-    const timer = setTimeout(() => {
-      setTick(nextTick);
-    }, delay);
-
+    const timer = setTimeout(() => setTick(nextTick), delay);
     return () => clearTimeout(timer);
   }, [tick, running]);
 
-  // Process events when tick changes
   useEffect(() => {
     if (tick >= 0) processEvents(tick);
   }, [tick, processEvents]);
 
   return {
-    tick,
-    running,
-    finished,
-    start,
+    tick, running, finished, start,
     act: ACTS[actRef.current] || ACTS[0],
     stats: statsRef.current,
     nodeStates: nodeStatesRef.current,
@@ -267,9 +228,8 @@ function useReplay() {
 
 // ── Progress Bar ─────────────────────────────────────────────────────────────
 
-function ProgressHeader({ act, tick, pattiesDelivered }: { act: typeof ACTS[0]; tick: number; pattiesDelivered: number }) {
+function ProgressHeader({ act, pattiesDelivered }: { act: typeof ACTS[0]; pattiesDelivered: number }) {
   const pct = Math.min(100, (pattiesDelivered / 10000) * 100);
-
   return (
     <div className="shrink-0 space-y-2 px-4 py-3 border-b" style={{ background: 'rgba(6,42,69,0.9)', borderColor: 'rgba(74,174,217,0.2)', backdropFilter: 'blur(8px)' }}>
       <div className="flex items-center justify-between">
@@ -297,7 +257,7 @@ function ProgressHeader({ act, tick, pattiesDelivered }: { act: typeof ACTS[0]; 
   );
 }
 
-// ── Act Banner CSS animations ─────────────────────────────────────────────────
+// ── Act Banner CSS ───────────────────────────────────────────────────────────
 const ACT_BANNER_STYLES = `
   @keyframes act-overlay-in {
     from { opacity: 0; backdrop-filter: blur(0px); }
@@ -308,10 +268,10 @@ const ACT_BANNER_STYLES = `
     to   { opacity: 1; transform: translateY(0); letter-spacing: 0.3em; }
   }
   @keyframes act-title-stamp {
-    0%   { opacity: 0; transform: scale(1.18) translateY(-6px); letter-spacing: 0.05em; filter: blur(6px); }
-    60%  { opacity: 1; transform: scale(0.98) translateY(1px); letter-spacing: -0.03em; filter: blur(0); }
+    0%   { opacity: 0; transform: scale(1.18) translateY(-6px); filter: blur(6px); }
+    60%  { opacity: 1; transform: scale(0.98) translateY(1px); filter: blur(0); }
     80%  { transform: scale(1.01); }
-    100% { opacity: 1; transform: scale(1); letter-spacing: -0.01em; }
+    100% { opacity: 1; transform: scale(1); }
   }
   @keyframes act-narrative-in {
     from { opacity: 0; transform: translateY(10px); }
@@ -321,13 +281,12 @@ const ACT_BANNER_STYLES = `
     from { width: 0; opacity: 0; }
     to   { width: 80px; opacity: 1; }
   }
-  @keyframes act-overlay-out {
-    from { opacity: 1; }
-    to   { opacity: 0; }
+  @keyframes annotation-slide-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
-
   @media (prefers-reduced-motion: reduce) {
-    .act-overlay, .act-label, .act-title, .act-narrative, .act-line {
+    .act-overlay, .act-label, .act-title, .act-narrative, .act-line, .annotation-bubble {
       animation: none !important;
       opacity: 1 !important;
       transform: none !important;
@@ -336,12 +295,9 @@ const ACT_BANNER_STYLES = `
   }
 `;
 
-// ── Act Banner (CSS-only, no motion/react) ───────────────────────────────────
-
 function ActBanner({ banner }: { banner: { num: number; name: string; narrative: string } | null }) {
   const [visible, setVisible] = useState(false);
   const [content, setContent] = useState<typeof banner>(null);
-  // Key increments each time a new banner appears → forces re-mount → re-triggers animations
   const [animKey, setAnimKey] = useState(0);
 
   useEffect(() => {
@@ -369,79 +325,79 @@ function ActBanner({ banner }: { banner: { num: number; name: string; narrative:
           animation: visible ? 'act-overlay-in 0.4s ease forwards' : undefined,
         }}
       >
-        {/* Decorative top line */}
         <div
           key={`line-top-${animKey}`}
           className="act-line h-px mb-6"
-          style={{
-            background: 'linear-gradient(90deg, transparent, rgba(244,197,66,0.6), transparent)',
-            animation: 'act-line-expand 0.5s 0.1s ease forwards',
-            width: 0,
-            opacity: 0,
-          }}
+          style={{ background: 'linear-gradient(90deg, transparent, rgba(244,197,66,0.6), transparent)', animation: 'act-line-expand 0.5s 0.1s ease forwards', width: 0, opacity: 0 }}
         />
-
-        {/* Act number label */}
         <div
           key={`label-${animKey}`}
           className="act-label text-xs font-bold uppercase mb-2"
-          style={{
-            color: 'rgba(244,197,66,0.7)',
-            fontFamily: 'Nunito, sans-serif',
-            animation: 'act-label-rise 0.4s 0.05s cubic-bezier(0.16,1,0.3,1) forwards',
-            opacity: 0,
-            letterSpacing: '0.3em',
-          }}
+          style={{ color: 'rgba(244,197,66,0.7)', fontFamily: 'Nunito, sans-serif', animation: 'act-label-rise 0.4s 0.05s cubic-bezier(0.16,1,0.3,1) forwards', opacity: 0, letterSpacing: '0.3em' }}
         >
           ── Act {content.num} ──
         </div>
-
-        {/* Title — cinematic stamp */}
         <div
           key={`title-${animKey}`}
           className="act-title text-2xl md:text-4xl font-black tracking-tight mb-3"
-          style={{
-            color: '#F4C542',
-            fontFamily: '"Baloo 2", cursive',
-            textShadow: '0 0 40px rgba(244,197,66,0.5), 0 0 80px rgba(244,197,66,0.2)',
-            animation: 'act-title-stamp 0.55s 0.12s cubic-bezier(0.34,1.56,0.64,1) forwards',
-            opacity: 0,
-          }}
+          style={{ color: '#F4C542', fontFamily: '"Baloo 2", cursive', textShadow: '0 0 40px rgba(244,197,66,0.5)', animation: 'act-title-stamp 0.55s 0.12s cubic-bezier(0.34,1.56,0.64,1) forwards', opacity: 0 }}
         >
           {content.name.replace(/^Act \w+: /, '')}
         </div>
-
-        {/* Narrative */}
         <div
           key={`narrative-${animKey}`}
           className="act-narrative text-sm max-w-sm text-center px-6"
-          style={{
-            color: 'rgba(184,228,247,0.55)',
-            fontFamily: 'Nunito, sans-serif',
-            animation: 'act-narrative-in 0.5s 0.3s ease forwards',
-            opacity: 0,
-          }}
+          style={{ color: 'rgba(184,228,247,0.55)', fontFamily: 'Nunito, sans-serif', animation: 'act-narrative-in 0.5s 0.3s ease forwards', opacity: 0 }}
         >
           {content.narrative}
         </div>
-
-        {/* Decorative bottom line */}
         <div
           key={`line-bot-${animKey}`}
           className="act-line h-px mt-6"
-          style={{
-            background: 'linear-gradient(90deg, transparent, rgba(244,197,66,0.4), transparent)',
-            animation: 'act-line-expand 0.5s 0.2s ease forwards',
-            width: 0,
-            opacity: 0,
-          }}
+          style={{ background: 'linear-gradient(90deg, transparent, rgba(244,197,66,0.4), transparent)', animation: 'act-line-expand 0.5s 0.2s ease forwards', width: 0, opacity: 0 }}
         />
       </div>
     </>
   );
 }
 
-// ── Completion Overlay (CSS-only) ────────────────────────────────────────────
+// ── Annotation Bubble ────────────────────────────────────────────────────────
+
+function AnnotationBubble({ annotation }: { annotation: Annotation | null }) {
+  if (!annotation) return null;
+  return (
+    <div
+      key={annotation.id}
+      className="annotation-bubble absolute bottom-4 left-4 right-4 md:left-auto md:right-4 md:max-w-sm z-20 rounded-xl px-4 py-3"
+      style={{
+        background: 'rgba(6,42,69,0.95)',
+        border: `1px solid ${annotation.color}40`,
+        boxShadow: `0 0 20px ${annotation.color}20`,
+        backdropFilter: 'blur(8px)',
+        animation: 'annotation-slide-in 0.3s ease forwards',
+      }}
+    >
+      <div className="flex items-start gap-2">
+        <span className="text-lg shrink-0">{annotation.icon}</span>
+        <p
+          className="text-xs leading-relaxed"
+          style={{ color: 'rgba(184,228,247,0.8)', fontFamily: 'Nunito, sans-serif' }}
+        >
+          {annotation.text}
+        </p>
+      </div>
+      <div
+        className="mt-2 flex items-center gap-1.5"
+      >
+        <span className="text-[10px]" style={{ color: 'rgba(74,174,217,0.4)', fontFamily: 'Nunito, sans-serif' }}>
+          🪸 OpenSpawn feature
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ── Completion Overlay ───────────────────────────────────────────────────────
 
 const COMPLETION_STYLES = `
   @keyframes completion-stamp {
@@ -454,142 +410,240 @@ const COMPLETION_STYLES = `
     from { opacity: 0; transform: translateY(16px); }
     to   { opacity: 1; transform: translateY(0); }
   }
-  @keyframes completion-fade {
-    from { opacity: 0; }
-    to   { opacity: 1; }
-  }
   @keyframes completion-glow-pulse {
     0%, 100% { text-shadow: 0 0 40px rgba(244,197,66,0.5), 0 0 80px rgba(244,197,66,0.2); }
     50%       { text-shadow: 0 0 60px rgba(244,197,66,0.8), 0 0 120px rgba(244,197,66,0.35); }
   }
+  @keyframes completion-stat-in {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
   @media (prefers-reduced-motion: reduce) {
-    .completion-stamp, .completion-subtitle, .completion-glow { animation: none !important; opacity: 1 !important; transform: none !important; filter: none !important; }
+    .completion-stamp, .completion-subtitle, .completion-glow, .completion-stat {
+      animation: none !important; opacity: 1 !important; transform: none !important; filter: none !important;
+    }
   }
 `;
 
-function CompletionOverlay({ finished, onReplay }: { finished: boolean; onReplay: () => void }) {
+interface CompletionProps {
+  finished: boolean;
+  onReplay: () => void;
+  stats: Stats;
+  messageCount: number;
+  spawnedCount: number;
+}
+
+function CompletionOverlay({ finished, onReplay, stats, messageCount, spawnedCount }: CompletionProps) {
+  // Count escalations from messages
+  const escalationCount = 2; // known from timeline: tick 13 & tick 70
+
   return (
     <>
       <style>{COMPLETION_STYLES}</style>
       <div
-        className="absolute inset-0 z-30 flex items-center justify-center backdrop-blur-sm"
+        className="absolute inset-0 z-30 flex items-center justify-center backdrop-blur-sm overflow-y-auto"
         style={{
-          background: 'rgba(3,14,26,0.92)',
+          background: 'rgba(3,14,26,0.94)',
           opacity: finished ? 1 : 0,
           pointerEvents: finished ? 'auto' : 'none',
           transition: 'opacity 0.5s ease',
         }}
       >
-      <div className="text-center max-w-lg px-8">
-        {/* Stamp entrance for the big number */}
-        <div
-          className="completion-stamp text-6xl md:text-7xl font-black mb-2"
-          style={{
-            fontFamily: '"Baloo 2", cursive',
-            color: '#F4C542',
-            animation: finished ? 'completion-stamp 0.7s cubic-bezier(0.34,1.56,0.64,1) forwards, completion-glow-pulse 3s 1s ease-in-out infinite' : 'none',
-            opacity: finished ? undefined : 0,
-          }}
-        >
-          🍔 10,000
-        </div>
-        <div
-          className="completion-subtitle text-lg font-semibold mb-6"
-          style={{
-            color: '#4AE88A',
-            fontFamily: '"Baloo 2", cursive',
-            animation: finished ? 'completion-subtitle 0.6s 0.35s ease forwards' : 'none',
-            opacity: finished ? undefined : 0,
-          }}
-        >
-          🎉 PATTIES DELIVERED! 🎉
-        </div>
-        <p className="text-lg mb-8" style={{ color: 'rgba(184,228,247,0.6)', fontFamily: 'Nunito, sans-serif' }}>
-          22 agents. 5 departments. One{' '}
-          <code
-            className="px-1.5 py-0.5 rounded text-sm"
-            style={{ color: '#F4C542', background: 'rgba(244,197,66,0.1)' }}
-          >
-            ORG.md
-          </code>
-          .
-        </p>
-
-        {/* Navigation buttons */}
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mb-8">
-          <Link
-            to="/"
-            className="flex items-center gap-2 px-6 py-3 rounded-xl font-semibold transition-all"
+        <div className="text-center max-w-lg px-6 py-8">
+          {/* Big number */}
+          <div
+            className="completion-stamp text-5xl md:text-7xl font-black mb-2"
             style={{
-              background: 'rgba(244,197,66,0.15)',
-              border: '1px solid rgba(244,197,66,0.4)',
+              fontFamily: '"Baloo 2", cursive',
               color: '#F4C542',
-              fontFamily: 'Nunito, sans-serif',
+              animation: finished ? 'completion-stamp 0.7s cubic-bezier(0.34,1.56,0.64,1) forwards, completion-glow-pulse 3s 1s ease-in-out infinite' : 'none',
+              opacity: finished ? undefined : 0,
             }}
           >
-            Explore the Dashboard <ArrowRight className="w-4 h-4" />
-          </Link>
-          <a
-            href="/org-md"
-            target="_blank"
-            rel="noopener"
-            className="px-6 py-3 rounded-xl font-medium transition-all"
+            🍔 10,000
+          </div>
+          <div
+            className="completion-subtitle text-lg font-semibold mb-8"
             style={{
-              background: 'rgba(255,255,255,0.05)',
-              border: '1px solid rgba(255,255,255,0.1)',
-              color: 'rgba(184,228,247,0.6)',
-              fontFamily: 'Nunito, sans-serif',
+              color: '#4AE88A',
+              fontFamily: '"Baloo 2", cursive',
+              animation: finished ? 'completion-subtitle 0.6s 0.35s ease forwards' : 'none',
+              opacity: finished ? undefined : 0,
             }}
           >
-            See the ORG.md →
-          </a>
+            🎉 PATTIES DELIVERED! 🎉
+          </div>
+
+          {/* Summary stats grid */}
+          <div
+            className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8 completion-stat"
+            style={{
+              animation: finished ? 'completion-stat-in 0.5s 0.6s ease forwards' : 'none',
+              opacity: finished ? undefined : 0,
+            }}
+          >
+            {[
+              { label: 'Agents Used', value: `${22 + spawnedCount}`, icon: '🤖' },
+              { label: 'Messages', value: `${messageCount}`, icon: '💬' },
+              { label: 'Escalations', value: `${escalationCount}`, icon: '🚨' },
+              { label: 'Revenue', value: `${stats.revenue.toLocaleString()} cr`, icon: '💰' },
+            ].map(s => (
+              <div
+                key={s.label}
+                className="rounded-xl p-3"
+                style={{
+                  background: 'rgba(6,42,69,0.7)',
+                  border: '1px solid rgba(74,174,217,0.15)',
+                }}
+              >
+                <div className="text-lg mb-1">{s.icon}</div>
+                <div className="text-lg font-bold" style={{ color: '#F4C542', fontFamily: '"Baloo 2", cursive' }}>
+                  {s.value}
+                </div>
+                <div className="text-[10px]" style={{ color: 'rgba(184,228,247,0.4)', fontFamily: 'Nunito, sans-serif' }}>
+                  {s.label}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Value proposition */}
+          <div
+            className="completion-stat rounded-2xl p-6 mb-6 text-center"
+            style={{
+              background: 'rgba(6,42,69,0.8)',
+              border: '1px solid rgba(74,174,217,0.3)',
+              animation: finished ? 'completion-stat-in 0.5s 0.8s ease forwards' : 'none',
+              opacity: finished ? undefined : 0,
+            }}
+          >
+            <div className="flex items-center justify-center gap-2 mb-3">
+              <span className="text-2xl">🪸</span>
+              <span className="text-lg font-black" style={{ color: '#4AAED9', fontFamily: '"Baloo 2", cursive' }}>
+                OpenSpawn
+              </span>
+            </div>
+            <p className="text-base font-semibold mb-2" style={{ color: '#B8E4F7', fontFamily: 'Nunito, sans-serif' }}>
+              This is what OpenSpawn does.
+            </p>
+            <p className="text-sm mb-1" style={{ color: 'rgba(184,228,247,0.55)', fontFamily: 'Nunito, sans-serif' }}>
+              Graduate from sub-agents.
+            </p>
+            <p className="text-sm mb-5" style={{ color: 'rgba(184,228,247,0.4)', fontFamily: 'Nunito, sans-serif' }}>
+              Persistent agents · Org hierarchy · Cross-department comms · Auto-escalation
+            </p>
+            <a
+              href="https://openspawn.ai"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold text-sm"
+              style={{
+                background: 'linear-gradient(135deg, #4AAED9 0%, #1A7DB5 100%)',
+                color: '#fff',
+                fontFamily: 'Nunito, sans-serif',
+                textDecoration: 'none',
+              }}
+            >
+              Try it → npx openspawn start <ExternalLink className="w-3.5 h-3.5" />
+            </a>
+          </div>
+
+          {/* Replay */}
           <button
             onClick={onReplay}
-            className="px-6 py-3 font-medium transition-all cursor-pointer"
+            className="px-6 py-3 font-medium cursor-pointer"
             style={{ color: 'rgba(184,228,247,0.3)', fontFamily: 'Nunito, sans-serif', background: 'none', border: 'none' }}
           >
             Replay ↻
           </button>
         </div>
+      </div>
+    </>
+  );
+}
 
-        {/* OpenSpawn CTA block — upgraded from tiny footnote */}
-        <div
-          className="rounded-2xl p-6 text-left"
+// ── Mobile Tab Bar ───────────────────────────────────────────────────────────
+
+type MobileTab = 'org' | 'feed' | 'stats';
+
+function MobileTabBar({ active, onChange }: { active: MobileTab; onChange: (t: MobileTab) => void }) {
+  const tabs: { id: MobileTab; label: string; icon: string }[] = [
+    { id: 'org', label: 'Org Chart', icon: '🏢' },
+    { id: 'feed', label: 'Live Feed', icon: '💬' },
+    { id: 'stats', label: 'Stats', icon: '📊' },
+  ];
+
+  return (
+    <div
+      className="flex md:hidden shrink-0"
+      style={{
+        background: 'rgba(6,42,69,0.95)',
+        borderBottom: '1px solid rgba(74,174,217,0.15)',
+      }}
+    >
+      {tabs.map(tab => (
+        <button
+          key={tab.id}
+          onClick={() => onChange(tab.id)}
+          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-semibold border-none cursor-pointer"
           style={{
-            background: 'rgba(6,42,69,0.8)',
-            border: '1px solid rgba(74,174,217,0.3)',
+            background: active === tab.id ? 'rgba(74,174,217,0.1)' : 'transparent',
+            borderBottom: active === tab.id ? '2px solid #4AAED9' : '2px solid transparent',
+            color: active === tab.id ? '#4AAED9' : 'rgba(184,228,247,0.4)',
+            fontFamily: 'Nunito, sans-serif',
+            transition: 'color 0.2s, background 0.2s',
           }}
         >
-          <div className="flex items-center gap-2 mb-3">
-            <span className="text-2xl">🪸</span>
-            <span className="text-lg font-black" style={{ color: '#4AAED9', fontFamily: '"Baloo 2", cursive' }}>
-              OpenSpawn
-            </span>
-          </div>
-          <p className="text-sm mb-1" style={{ color: '#B8E4F7', fontFamily: 'Nunito, sans-serif' }}>
-            This entire operation ran on OpenSpawn.
-          </p>
-          <p className="text-sm mb-4" style={{ color: 'rgba(184,228,247,0.6)', fontFamily: 'Nunito, sans-serif' }}>
-            22 AI agents. 5 departments. One ORG.md file. No engineers babysitting the process.
-          </p>
-          <a
-            href="https://openspawn.ai"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl font-bold text-sm transition-all"
+          <span>{tab.icon}</span>
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ── Mobile Stats Panel (full-screen view) ────────────────────────────────────
+
+function MobileStatsPanel({ stats }: { stats: Stats }) {
+  const items = [
+    { icon: '🔥', label: 'Kitchen Rate', value: `${stats.kitchenRate}/tick`, color: '#F4C542' },
+    { icon: '📦', label: 'Queue', value: stats.queueSize.toLocaleString(), color: stats.queueSize > 2000 ? '#FF4757' : stats.queueSize > 1000 ? '#F4C542' : '#4AE88A' },
+    { icon: '🚚', label: 'Delivery Rate', value: `${stats.deliveryRate}/tick`, color: '#4AE88A' },
+    { icon: '💰', label: 'Revenue', value: `${stats.revenue.toLocaleString()} cr`, color: '#F4C542' },
+    { icon: '📊', label: 'Margin', value: `${stats.margin.toFixed(1)}%`, color: '#B8E4F7' },
+    { icon: '🦀', label: 'Budget Used', value: `${stats.budgetUsed}%`, color: stats.budgetUsed > 85 ? '#FF4757' : stats.budgetUsed > 65 ? '#F4C542' : '#4AE88A' },
+    { icon: '🍔', label: 'Produced', value: stats.pattiesProduced.toLocaleString(), color: '#F4C542' },
+    { icon: '✅', label: 'Delivered', value: stats.pattiesDelivered.toLocaleString(), color: '#4AE88A' },
+  ];
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 space-y-3" style={{ background: 'linear-gradient(180deg, #062A45 0%, #030E1A 100%)' }}>
+      <div className="grid grid-cols-2 gap-3">
+        {items.map(item => (
+          <div
+            key={item.label}
+            className="rounded-xl p-3"
             style={{
-              background: 'rgba(74,174,217,0.2)',
-              border: '1px solid rgba(74,174,217,0.5)',
-              color: '#4AAED9',
-              fontFamily: 'Nunito, sans-serif',
+              background: 'rgba(6,42,69,0.85)',
+              border: '1px solid rgba(74,174,217,0.12)',
             }}
           >
-            Build your own org → <ExternalLink className="w-3.5 h-3.5" />
-          </a>
-        </div>
+            <div className="flex items-center gap-2 mb-2">
+              <span className="text-lg">{item.icon}</span>
+              <span className="text-[11px]" style={{ color: 'rgba(184,228,247,0.4)', fontFamily: 'Nunito, sans-serif' }}>
+                {item.label}
+              </span>
+            </div>
+            <div
+              className="text-xl font-bold"
+              style={{ color: item.color, fontFamily: '"Baloo 2", cursive' }}
+            >
+              {item.value}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
-    </>
   );
 }
 
@@ -599,8 +653,17 @@ export function LiveViewPage() {
   const [showIntro, setShowIntro] = useState(() => {
     return !localStorage.getItem('live-intro-seen');
   });
+  const [mobileTab, setMobileTab] = useState<MobileTab>('org');
 
   const replay = useReplay();
+  const annotation = getActiveAnnotation(replay.tick);
+
+  // Auto-switch mobile tab to feed during key moments
+  useEffect(() => {
+    if (replay.tick === 13 || replay.tick === 70) {
+      setMobileTab('feed');
+    }
+  }, [replay.tick]);
 
   const handleStart = useCallback(() => {
     localStorage.setItem('live-intro-seen', '1');
@@ -612,7 +675,6 @@ export function LiveViewPage() {
     replay.start();
   }, [replay.start]);
 
-  // Auto-start if intro already seen
   useEffect(() => {
     if (!showIntro && !replay.running && !replay.finished && replay.tick < 0) {
       replay.start();
@@ -621,10 +683,10 @@ export function LiveViewPage() {
 
   return (
     <div className="relative h-screen w-full text-white flex flex-col overflow-hidden" style={{ background: 'linear-gradient(180deg, #062A45 0%, #030E1A 100%)' }}>
-      {/* BikiniBottom ocean background */}
+      {/* Ocean background */}
       <div className="absolute inset-0" style={{ background: 'radial-gradient(ellipse at 20% 80%, rgba(11,94,138,0.3) 0%, transparent 50%), radial-gradient(ellipse at 80% 20%, rgba(26,125,181,0.2) 0%, transparent 50%)' }} />
 
-      {/* Ambient caustic light effects — subtle underwater atmosphere */}
+      {/* Ambient caustics */}
       <div className="absolute inset-0 pointer-events-none overflow-hidden" aria-hidden="true">
         <div style={{
           position: 'absolute', borderRadius: '50%',
@@ -633,28 +695,6 @@ export function LiveViewPage() {
           opacity: 0.04,
           animation: 'bb-caustic 18s ease-in-out infinite',
         }} />
-        <div style={{
-          position: 'absolute', borderRadius: '50%',
-          width: '40vw', height: '30vh', bottom: '10%', right: '-8vw',
-          background: 'radial-gradient(ellipse, rgba(46,204,113,1) 0%, transparent 70%)',
-          opacity: 0.025,
-          animation: 'bb-caustic 13s 6s ease-in-out infinite',
-          '--bb-caustic-rotate': '-3deg' as string,
-          '--bb-caustic-drift': '20px' as string,
-          '--bb-caustic-min': '0.02' as string,
-          '--bb-caustic-max': '0.05' as string,
-        } as React.CSSProperties} />
-        <div style={{
-          position: 'absolute', borderRadius: '50%',
-          width: '35vw', height: '25vh', top: '40%', left: '30%',
-          background: 'radial-gradient(ellipse, rgba(26,125,181,1) 0%, transparent 70%)',
-          opacity: 0.03,
-          animation: 'bb-caustic 22s 3s ease-in-out infinite',
-          '--bb-caustic-rotate': '5deg' as string,
-          '--bb-caustic-drift': '0px' as string,
-          '--bb-caustic-min': '0.02' as string,
-          '--bb-caustic-max': '0.04' as string,
-        } as React.CSSProperties} />
       </div>
 
       {/* Intro overlay */}
@@ -662,18 +702,19 @@ export function LiveViewPage() {
 
       {/* Main content */}
       <div className="relative z-10 flex flex-col h-full">
-        {/* Top: Progress header */}
-        <ProgressHeader act={replay.act} tick={replay.tick} pattiesDelivered={replay.pattiesDelivered} />
+        {/* Persistent OpenSpawn banner — always visible at top */}
+        <OpenSpawnBadge
+          variant="desktop"
+          spawnedAgents={replay.spawnedAgents}
+          pattiesDelivered={replay.pattiesDelivered}
+          finished={replay.finished}
+        />
 
-        {/* Mobile: OpenSpawn badge strip (below header, above org chart) */}
-        <div className="flex md:hidden">
-          <OpenSpawnBadge
-            variant="mobile"
-            spawnedAgents={replay.spawnedAgents}
-            pattiesDelivered={replay.pattiesDelivered}
-            finished={replay.finished}
-          />
-        </div>
+        {/* Progress header */}
+        <ProgressHeader act={replay.act} pattiesDelivered={replay.pattiesDelivered} />
+
+        {/* Mobile tab bar */}
+        <MobileTabBar active={mobileTab} onChange={setMobileTab} />
 
         {/* Middle: Org Chart + Feed */}
         <div className="flex-1 min-h-0 flex flex-col md:flex-row">
@@ -685,41 +726,54 @@ export function LiveViewPage() {
               reassignedEdges={replay.reassignedEdges}
               spawnedAgents={replay.spawnedAgents}
             />
-
-            {/* Desktop OpenSpawn badge — bottom-left of org chart panel */}
-            <OpenSpawnBadge
-              variant="desktop"
-              spawnedAgents={replay.spawnedAgents}
-              pattiesDelivered={replay.pattiesDelivered}
-              finished={replay.finished}
-            />
-
-            {/* Act banner overlay */}
             <ActBanner banner={replay.actBanner} />
+            <AnnotationBubble annotation={annotation} />
           </div>
 
-          {/* Mobile Org Chart (<md) — compact department cards */}
-          <div className="flex md:hidden w-full overflow-y-auto" style={{ maxHeight: '45vh' }}>
-            <MobileOrgChart
-              nodeStates={replay.nodeStates}
-              spawnedAgents={replay.spawnedAgents}
-            />
+          {/* Mobile: one panel at a time */}
+          <div className="flex md:hidden flex-1 min-h-0 relative">
+            {mobileTab === 'org' && (
+              <div className="w-full h-full overflow-y-auto">
+                <MobileOrgChart
+                  nodeStates={replay.nodeStates}
+                  spawnedAgents={replay.spawnedAgents}
+                />
+              </div>
+            )}
+            {mobileTab === 'feed' && (
+              <div className="w-full h-full">
+                <LiveFeed messages={replay.messages} />
+              </div>
+            )}
+            {mobileTab === 'stats' && (
+              <MobileStatsPanel stats={replay.stats} />
+            )}
+            {/* Mobile annotation */}
+            <AnnotationBubble annotation={annotation} />
           </div>
 
-          {/* Live Feed - 40% */}
+          {/* Desktop Live Feed - 40% */}
           <div
-            className="flex-[2] min-h-0"
+            className="hidden md:flex flex-[2] min-h-0"
             style={{ borderLeft: '1px solid rgba(74,174,217,0.1)' }}
           >
             <LiveFeed messages={replay.messages} />
           </div>
         </div>
 
-        {/* Bottom: Stats bar */}
-        <StatsBar stats={replay.stats} />
+        {/* Desktop stats bar */}
+        <div className="hidden md:flex">
+          <StatsBar stats={replay.stats} />
+        </div>
 
         {/* Finished overlay */}
-        <CompletionOverlay finished={replay.finished} onReplay={handleReplay} />
+        <CompletionOverlay
+          finished={replay.finished}
+          onReplay={handleReplay}
+          stats={replay.stats}
+          messageCount={replay.messages.length}
+          spawnedCount={replay.spawnedAgents.length}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
Addresses Adam's feedback: demo needs to communicate WHY OpenSpawn matters.

- **Intro screen:** 'Watch 42 agents run a restaurant. No humans. One command.' + sub-agents vs OpenSpawn comparison
- **Mobile:** Tab bar (Org Chart | Live Feed | Stats) — one panel at a time
- **6 contextual annotations** at key moments explaining what OpenSpawn does
- **Sticky value banner** with agent/dept/human counts
- **End screen:** summary stats + 'Graduate from sub-agents' CTA

CSS-only animations, prefers-reduced-motion supported, build clean, tests passing.