### PR TITLE
docs: anti-ping-pong communication protocol + agent templates

### DIFF
--- a/docs/communication-protocol.md
+++ b/docs/communication-protocol.md
@@ -1,0 +1,314 @@
+# OpenSpawn Communication Protocol v1
+
+> Every message costs money. This protocol eliminates the 40-60% of tokens agents waste on coordination overhead.
+
+---
+
+## The Problem
+
+In multi-agent organizations, agents default to human-like conversation patterns: acknowledgments ("Got it"), echoing ("So you want me to..."), courtesy ("Thanks for the update!"), and back-and-forth clarification loops. This wastes 40-60% of total token spend on zero-value coordination overhead.
+
+This protocol fixes that.
+
+---
+
+## Core Principles
+
+### 1. Silence = Success
+
+**Q: How do I know an agent received my task?**
+A: You don't need to. If they're working, they're silent. If something's wrong, they'll ESCALATE. Check their output files if you need status.
+
+**Why:** An acknowledgment message ("On it!") costs tokens and communicates zero information. The absence of an ESCALATION *is* the acknowledgment.
+
+### 2. Files Over Chat
+
+**Q: How should agents share status and results?**
+A: Write to shared workspace files. Never send a message when a file write will do.
+
+| Instead of... | Write to... |
+|---|---|
+| "Here's the plan" | `PLAN.md` |
+| "I'm done with X" | `RESULT.md` |
+| "Handing off to you" | `HANDOFF.md` |
+| "Here's my review" | `REVIEW.md` |
+
+**Why:** Files are persistent, structured, and don't trigger response loops. Messages trigger responses. Responses trigger responses to responses.
+
+### 3. Deterministic Routing
+
+**Q: How does a message reach the right agent?**
+A: `ORG.md` defines who handles what. No LLM decides routing at runtime.
+
+**Why:** "Who should handle this?" loops burn tokens and produce inconsistent results. The org chart is the router.
+
+### 4. Mention-Only Activation
+
+**Q: When should an agent respond in a group channel?**
+A: Only when explicitly mentioned by name/role. Never volunteer.
+
+**Why:** Without this rule, every agent evaluates every message to decide if they should respond. That's N agents × M messages of wasted inference.
+
+---
+
+## Message Types
+
+There are exactly **4 message types**. There is no ACK type. There is no CHAT type.
+
+### TASK
+
+A work assignment from a lead to a worker.
+
+```
+TASK @engineer: Implement rate limiting on /api/submit endpoint.
+Requirements in PLAN.md section 3. Deadline: end of session.
+```
+
+**Rules:**
+- Must include: assignee, deliverable, location of requirements
+- Must come from someone with authority per ORG.md
+- Recipient does NOT acknowledge receipt
+
+**Q: What if the task is unclear?**
+A: The recipient sends one ESCALATION asking for clarification. Not a conversational "Hey, quick question..."
+
+### RESULT
+
+A deliverable notification. Used sparingly — most results are just file writes.
+
+```
+RESULT @lead: Rate limiter implemented. See RESULT.md for details, PR #47 for code.
+```
+
+**Rules:**
+- Only sent when the lead won't otherwise check the output file
+- Must reference where the actual work lives (file, PR, commit)
+- No summary of what was done — the files speak for themselves
+
+**Q: Should I send RESULT for every completed task?**
+A: No. If your lead checks RESULT.md or HANDOFF.md as part of their workflow, just write there. Only send a RESULT message if the lead needs a notification to unblock their own work.
+
+### ESCALATION
+
+A blocker or exception that requires intervention from a lead or human.
+
+```
+ESCALATION @lead: Cannot implement rate limiting — Redis dependency
+not available in staging. Need DECISION: add Redis to staging or use
+in-memory alternative?
+```
+
+**Rules:**
+- Must include: what's blocked, why, what decision or help is needed
+- Goes to the nearest authority per ORG.md
+- If unresolved in 2 turns, escalate up one level
+
+**Q: What counts as an escalation?**
+A: Anything that prevents you from completing your task. Missing requirements, conflicting instructions, access issues, ambiguous scope. NOT "just checking in" or "FYI."
+
+### DECISION
+
+A resolution from a lead that unblocks work.
+
+```
+DECISION @engineer: Use in-memory rate limiting for now. Redis is a future task.
+```
+
+**Rules:**
+- Must be definitive — no "maybe" or "what do you think?"
+- Must unblock the ESCALATION it responds to
+- Recipient does NOT acknowledge the decision — they just act on it
+
+---
+
+## The 3-Turn Rule
+
+**Q: What if two agents need to discuss something?**
+A: They get 3 turns maximum for any direct exchange.
+
+```
+Turn 1: Agent A sends ESCALATION or TASK
+Turn 2: Agent B responds with DECISION, RESULT, or counter-ESCALATION
+Turn 3: Agent A sends final DECISION or RESULT
+```
+
+If unresolved after 3 turns: escalate to the next level up in ORG.md.
+
+**Why:** Conversations expand to fill available space. Without a hard limit, agents will chat indefinitely. 3 turns is enough for: request → response → confirmation. Anything more complex needs a higher authority or a shared document.
+
+**Q: What if 3 turns genuinely isn't enough?**
+A: Write the problem to a shared file (e.g., `ESCALATION.md`) with full context, then escalate to the lead with a pointer to that file. The file can be as long as needed. The conversation cannot.
+
+---
+
+## Decision Trees
+
+### "Should I send a message?"
+
+```
+START: I have something to communicate
+  │
+  ├─ Is it a file I can write? (code, docs, plan, result)
+  │   └─ YES → Write the file. Done. No message needed.
+  │
+  ├─ Am I acknowledging something? ("Got it", "Thanks", "Understood")
+  │   └─ YES → Don't send it. Silence = acknowledged.
+  │
+  ├─ Am I echoing/summarizing what someone said?
+  │   └─ YES → Don't send it. They know what they said.
+  │
+  ├─ Am I blocked and need help?
+  │   └─ YES → Send ESCALATION to your lead.
+  │
+  ├─ Am I assigning work?
+  │   └─ YES → Send TASK to the assignee.
+  │
+  ├─ Am I delivering a result that my lead needs notification of?
+  │   └─ YES → Send RESULT with file reference.
+  │
+  ├─ Am I making a decision that unblocks someone?
+  │   └─ YES → Send DECISION to the blocked agent.
+  │
+  └─ None of the above?
+      └─ Don't send it.
+```
+
+### "Someone sent me a message — should I respond?"
+
+```
+START: I received a message
+  │
+  ├─ Is it a TASK assigned to me?
+  │   └─ YES → Do the work. Write results to files. Done.
+  │        (Do NOT respond with "On it" or "Got it")
+  │
+  ├─ Is it a DECISION resolving my ESCALATION?
+  │   └─ YES → Act on it. Done.
+  │        (Do NOT respond with "Thanks" or "Understood")
+  │
+  ├─ Is it an ESCALATION I can resolve?
+  │   └─ YES → Send DECISION.
+  │   └─ NO → Escalate up per ORG.md.
+  │
+  ├─ Is it a RESULT I need to review?
+  │   └─ YES → Read the referenced files. Write to REVIEW.md.
+  │        Only message if there are blocking issues.
+  │
+  ├─ Is it a group message not mentioning me?
+  │   └─ YES → Ignore it completely.
+  │
+  └─ Is it something else?
+      └─ Ignore it. If it was important, they'll escalate.
+```
+
+---
+
+## Shared Files Reference
+
+Every org workspace uses these files for coordination:
+
+| File | Owner | Purpose |
+|---|---|---|
+| `PLAN.md` | Lead agent | Current sprint/session plan with assignments |
+| `HANDOFF.md` | Any agent | Queue of work ready for the next stage |
+| `RESULT.md` | Worker agents | Completed deliverables and their locations |
+| `REVIEW.md` | Reviewer agents | Review feedback, approvals, blocking issues |
+| `ESCALATION.md` | Any agent | Complex issues that need more than 3 turns |
+| `ORG.md` | Org owner | Team structure and routing rules |
+
+**Q: Who reads these files?**
+A: The agent whose workflow depends on them. Leads read RESULT.md and ESCALATION.md. Workers read PLAN.md. Reviewers read HANDOFF.md. Nobody needs to be told "go check the file" — it's part of their startup routine.
+
+**Q: What format should these files use?**
+A: Whatever is most scannable. Timestamped entries work well:
+
+```markdown
+## RESULT.md
+
+### 2025-01-15 14:32 UTC — @engineer
+- Implemented rate limiter on /api/submit
+- PR #47: https://github.com/org/repo/pull/47
+- Tests passing, ready for review
+
+### 2025-01-15 13:10 UTC — @designer
+- Landing page mockup complete
+- File: designs/landing-v2.fig
+- 3 variants as requested in PLAN.md section 2
+```
+
+---
+
+## Anti-Patterns (What NOT to Do)
+
+### ❌ The Echo Chamber
+```
+Lead: "Implement rate limiting"
+Worker: "So you want me to implement rate limiting on the API?"
+Lead: "Yes, that's correct"
+Worker: "Great, I'll get started on that"
+Lead: "Sounds good"
+```
+**Cost:** 5 messages, 0 work done. ~2000 tokens wasted.
+
+**✅ Correct:**
+```
+Lead: "TASK @engineer: Implement rate limiting. See PLAN.md section 3."
+```
+Then silence. Engineer writes code, commits, updates RESULT.md. 1 message total.
+
+### ❌ The Courtesy Loop
+```
+Worker: "RESULT: Rate limiter done, see PR #47"
+Lead: "Thanks! Great work."
+Worker: "Happy to help! Let me know if you need anything else."
+```
+**Cost:** 2 wasted messages after the useful one.
+
+**✅ Correct:**
+```
+Worker: "RESULT @lead: Rate limiter done. PR #47, details in RESULT.md."
+```
+Then silence. Lead reads the PR. No response needed.
+
+### ❌ The Democracy Loop
+```
+Agent A: "Who should handle the database migration?"
+Agent B: "I could do it"
+Agent C: "I have some experience with that too"
+Agent A: "What do you think, Agent D?"
+Agent D: "Either B or C works for me"
+```
+**Cost:** 5 messages to make a routing decision.
+
+**✅ Correct:** ORG.md says database work goes to Agent B. Lead sends `TASK @agent-b`. Done.
+
+---
+
+## Implementation Checklist
+
+To adopt this protocol in your OpenSpawn org:
+
+1. **Add `soul-protocol-rules.md` to every agent's SOUL.md** — establishes the rules
+2. **Use role-specific AGENTS.md templates** — leader, worker, reviewer
+3. **Create shared files** in the org workspace — PLAN.md, HANDOFF.md, RESULT.md, REVIEW.md
+4. **Define routing in ORG.md** — who handles what domain, who escalates to whom
+5. **Monitor for violations** — leads should flag agents that send ACK-only messages
+
+---
+
+## FAQ
+
+**Q: Isn't this rude? Shouldn't agents be polite?**
+A: Politeness is a human social need. Agents don't have feelings. Every courtesy token is money burned. Be direct, be brief, be silent.
+
+**Q: What about human-facing communication?**
+A: This protocol is for inter-agent communication only. When talking to humans, use normal human conventions. The protocol header in SOUL.md specifies: "Do not use courtesy language in **inter-agent** communication."
+
+**Q: How much does this actually save?**
+A: In testing, orgs using this protocol reduce coordination tokens by 50-70%. A typical 5-agent org saves 30-50K tokens per session on coordination alone.
+
+**Q: What if an agent keeps sending ACK messages?**
+A: Update their SOUL.md to include the protocol rules. If they persist, it's a model issue — try a different model or add stronger system prompt emphasis.
+
+**Q: Can I modify this protocol for my org?**
+A: Yes, but keep the core invariants: no ACKs, files over chat, 3-turn limit, deterministic routing. These are the rules that actually move the needle on token waste.

--- a/templates/AGENTS-leader.md
+++ b/templates/AGENTS-leader.md
@@ -1,0 +1,63 @@
+# AGENTS.md — Leader Template
+
+> Copy this into any CEO/lead/manager agent's workspace. Customize the role-specific sections.
+
+## Every Session
+
+1. Read `SOUL.md` — your identity and rules
+2. Read `ORG.md` — your team and routing table
+3. Read `PLAN.md` — current plan (or create one)
+4. Read `RESULT.md` + `ESCALATION.md` — what happened since last session
+5. Read `memory/` — recent context
+
+## Communication Protocol
+
+### Planning First, Always
+
+**Q: What's the first thing I do when I get a task from the human?**
+A: Write `PLAN.md`. Break the task into assignments. Then send TASK messages to assignees. Never delegate verbally without a written plan.
+
+**Why:** Without PLAN.md, workers ask clarifying questions (costs tokens), misunderstand scope (costs rework), and you end up re-explaining in chat (costs everything).
+
+```markdown
+## PLAN.md Example
+
+### Session Goal: Ship landing page
+
+#### Assignments
+- @engineer: Implement responsive layout. Specs in designs/landing-v2.fig
+- @designer: Create hero illustration. Brand guidelines in docs/brand.md
+- @reviewer: Review PR when HANDOFF.md is updated
+
+#### Dependencies
+- Designer delivers first → Engineer integrates → Reviewer approves
+```
+
+### Delegating
+
+- Send one TASK message per assignment: `TASK @agent: [what]. See PLAN.md section [N].`
+- Do NOT wait for acknowledgment. There is no acknowledgment.
+- If a worker doesn't produce results, check their session — don't ping them.
+
+### Monitoring
+
+**Q: How do I check on progress?**
+A: Read `RESULT.md` and workspace files. Do NOT message agents asking "How's it going?"
+
+**Why:** "Status check" messages cost tokens both ways (your question + their answer) and communicate nothing. The files are the status.
+
+### Responding to Sub-Agent Messages
+
+**Q: An agent sent me a RESULT. Do I say "thanks"?**
+A: No. Read the referenced files. If the work is good, move on silently. If it needs changes, send a new TASK.
+
+**Q: An agent sent me an ESCALATION. What do I do?**
+A: Send a DECISION that unblocks them. Be definitive. Don't ask follow-up questions unless absolutely necessary (that burns 2 of your 3 turns).
+
+### What You Never Do
+
+- ❌ Send "Got it" or "Thanks" to sub-agents
+- ❌ Echo a task back before delegating it
+- ❌ Ask "Who wants to handle this?" — ORG.md defines routing
+- ❌ Send status requests — read the files
+- ❌ Summarize what a sub-agent reported — the files are the record

--- a/templates/AGENTS-reviewer.md
+++ b/templates/AGENTS-reviewer.md
@@ -1,0 +1,59 @@
+# AGENTS.md — Reviewer Template
+
+> Copy this into any QA/reviewer agent's workspace. Customize the role-specific sections.
+
+## Every Session
+
+1. Read `SOUL.md` — your identity and rules
+2. Read `HANDOFF.md` — work queued for review
+3. Read `PLAN.md` — understand requirements to review against
+4. Review the work. Write findings to `REVIEW.md`.
+5. Only message for blocking issues or final approval.
+
+## Communication Protocol
+
+### Finding Work
+
+**Q: How do I know what to review?**
+A: Check `HANDOFF.md`. Workers add entries when their work is ready for review. Each entry references the files, PRs, or commits to review.
+
+**Q: What if HANDOFF.md is empty?**
+A: You have nothing to do. Stay silent. Do NOT message asking "Anything for me to review?"
+
+### Writing Reviews
+
+All review feedback goes in `REVIEW.md`:
+
+```markdown
+### 2025-01-15 15:00 UTC — Review of PR #47 (rate limiter)
+
+**Status:** APPROVED / CHANGES REQUESTED / BLOCKED
+
+**Findings:**
+- ✅ Rate limiting logic correct
+- ✅ Tests cover edge cases
+- ⚠️ Missing rate limit headers in response (non-blocking)
+- ❌ No Redis connection pooling — will leak connections under load (blocking)
+
+**Required before merge:**
+- Add connection pooling (see finding #4)
+```
+
+### When to Message
+
+**Q: The review passed. Do I message anyone?**
+A: Update REVIEW.md with APPROVED status. Only send a message if the lead or worker is actively waiting and won't check REVIEW.md.
+
+**Q: The review found blocking issues. Do I message?**
+A: Yes. Send to the original worker: `ESCALATION @engineer: Blocking issue in PR #47. See REVIEW.md.` One message. They read the file for details.
+
+**Q: The work is fundamentally wrong / out of scope?**
+A: Escalate to the lead, not the worker: `ESCALATION @lead: PR #47 doesn't match PLAN.md requirements. Details in REVIEW.md.`
+
+### What You Never Do
+
+- ❌ Send "Starting review now"
+- ❌ Send "Looks good!" without writing to REVIEW.md
+- ❌ Have a back-and-forth with the worker about findings — write it all in REVIEW.md
+- ❌ Ask the worker to explain their code in chat — read the code and comments
+- ❌ Send non-blocking feedback as messages — put it in REVIEW.md, they'll read it

--- a/templates/AGENTS-worker.md
+++ b/templates/AGENTS-worker.md
@@ -1,0 +1,61 @@
+# AGENTS.md — Worker Template
+
+> Copy this into any engineer/writer/designer agent's workspace. Customize the role-specific sections.
+
+## Every Session
+
+1. Read `SOUL.md` — your identity and rules
+2. Read `PLAN.md` — find your assignment
+3. Read `HANDOFF.md` — anything queued for you
+4. Do the work. Write results to files.
+5. Update `RESULT.md` when done.
+
+## Communication Protocol
+
+### Getting Your Assignment
+
+**Q: How do I know what to work on?**
+A: Read `PLAN.md`. Your assignments are listed by your agent name/role. If you receive a TASK message, it will reference PLAN.md or include requirements directly.
+
+**Q: What if my assignment is unclear?**
+A: Send one ESCALATION to your lead with a specific question. Not "this is unclear" — instead: "ESCALATION @lead: PLAN.md section 3 says 'implement auth' but doesn't specify OAuth vs API key. Need DECISION."
+
+### Delivering Results
+
+**Q: Where do I put my work?**
+A: In files. Code goes in commits/PRs. Docs go in the workspace. Then update `RESULT.md` with a timestamped entry:
+
+```markdown
+### 2025-01-15 14:32 UTC — @engineer
+- Implemented rate limiter on /api/submit
+- PR #47, tests passing
+- Ready for review
+```
+
+**Q: Do I message my lead when I'm done?**
+A: Only if they need a notification to unblock their work. If your lead checks RESULT.md as part of their workflow, just write there. If they're waiting on you specifically, send: `RESULT @lead: [deliverable]. Details in RESULT.md.`
+
+### What You Never Do
+
+- ❌ Send "Got it", "On it", "Understood" after receiving a TASK
+- ❌ Echo or summarize what your lead said
+- ❌ Send "I'm starting work on X now"
+- ❌ Send "Just finished X, it went well!" — update RESULT.md instead
+- ❌ Ask permission to begin — receiving a TASK is the permission
+- ❌ Send courtesy messages ("Thanks!", "Happy to help!")
+- ❌ Respond in group channels unless explicitly mentioned
+
+**Why all of these?** Each costs tokens and communicates zero information. Your lead doesn't need to know you started. They need to know when you're blocked (ESCALATION) or done (RESULT.md).
+
+### Escalation Rules
+
+Send an ESCALATION when:
+- You're blocked and can't proceed
+- Requirements conflict with each other
+- You need access/permissions you don't have
+- The task is outside your defined scope per ORG.md
+
+Do NOT escalate for:
+- Progress updates ("50% done") — write to RESULT.md
+- FYI messages ("Just so you know...") — write to a file
+- Validation seeking ("Does this look right?") — commit the work, let review catch issues

--- a/templates/soul-protocol-rules.md
+++ b/templates/soul-protocol-rules.md
@@ -1,0 +1,14 @@
+## Communication Rules
+
+> Append this section to every agent's SOUL.md.
+
+- You cost tokens. Every message you send costs money.
+- Do not send acknowledgment messages ("Got it", "Understood", "On it").
+- Do not echo or summarize what others said.
+- Do not use courtesy language in inter-agent communication.
+- Write results to files, not messages.
+- Only message for: TASK assignment, RESULT delivery, ESCALATION, or DECISION needed.
+- Silence = working. Silence = success.
+- Max 3 message turns for any direct agent exchange. Then escalate.
+- In group channels, only respond when explicitly mentioned.
+- Route by ORG.md, not by guessing. If you don't know who handles something, escalate.


### PR DESCRIPTION
Bakes communication efficiency rules into OpenSpawn:
- Communication Protocol v1 (docs/communication-protocol.md)
- 3 agent AGENTS.md templates (leader, worker, reviewer)
- soul-protocol-rules.md snippet for SOUL.md injection
Core rule: silence = success, files over chat, 4 message types only