### PR TITLE
feat(cli): hire/fire commands + north star test scaffolding

### DIFF
--- a/packages/cli/cmd/fire.go
+++ b/packages/cli/cmd/fire.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openspawn/openspawn/packages/cli/internal/openclaw"
+	"github.com/spf13/cobra"
+)
+
+var fireKeepWorkspace bool
+
+var fireCmd = &cobra.Command{
+	Use:   "fire <agent-name>",
+	Short: "Remove an agent from the org",
+	Long: `Removes an agent from the organization by:
+  1. Removing from openclaw-agents.json
+  2. Regenerating openclaw-patch.json
+  3. Optionally archiving the agent's workspace
+
+The agent won't stop until the gateway config is reloaded.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		agentID := strings.ToLower(strings.ReplaceAll(args[0], " ", "-"))
+
+		agents, err := openclaw.ReadAgentConfigs(flagDir)
+		if err != nil {
+			return fmt.Errorf("failed to read agents: %w", err)
+		}
+
+		// Find and remove agent
+		found := false
+		var remaining []openclaw.AgentConfig
+		var removed openclaw.AgentConfig
+		for _, a := range agents {
+			if a.ID == agentID {
+				found = true
+				removed = a
+			} else {
+				remaining = append(remaining, a)
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("agent %q not found", agentID)
+		}
+
+		// Write updated agents config
+		agentsFile := filepath.Join(flagDir, "openclaw-agents.json")
+		data, err := json.MarshalIndent(remaining, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal agents: %w", err)
+		}
+		if err := os.WriteFile(agentsFile, data, 0644); err != nil {
+			return fmt.Errorf("failed to write agents config: %w", err)
+		}
+
+		// Regenerate patch
+		workspacesDir := filepath.Join(flagDir, "workspaces")
+		patch := openclaw.GeneratePatch(remaining, workspacesDir)
+		if err := openclaw.WritePatch(patch, flagDir); err != nil {
+			return fmt.Errorf("failed to regenerate patch: %w", err)
+		}
+
+		// Archive workspace unless --keep-workspace
+		if !fireKeepWorkspace {
+			wsDir := filepath.Join(flagDir, "workspaces", agentID)
+			archiveDir := filepath.Join(flagDir, "workspaces", ".archived", agentID)
+			if _, err := os.Stat(wsDir); err == nil {
+				os.MkdirAll(filepath.Dir(archiveDir), 0755)
+				os.Rename(wsDir, archiveDir)
+			}
+		}
+
+		if flagJSON {
+			out, _ := json.MarshalIndent(removed, "", "  ")
+			fmt.Println(string(out))
+			return nil
+		}
+
+		fmt.Printf("🔥 Fired %s (%s, L%d)\n", removed.Name, removed.Role, removed.Level)
+		if !fireKeepWorkspace {
+			fmt.Printf("   Workspace archived to .archived/%s\n", agentID)
+		}
+		fmt.Println("\nReload gateway config to deactivate this agent.")
+		return nil
+	},
+}
+
+func init() {
+	fireCmd.Flags().BoolVar(&fireKeepWorkspace, "keep-workspace", false, "Don't archive the agent's workspace")
+}

--- a/packages/cli/cmd/hire.go
+++ b/packages/cli/cmd/hire.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openspawn/openspawn/packages/cli/internal/openclaw"
+	"github.com/spf13/cobra"
+)
+
+var (
+	hireLevel int
+	hireRole  string
+	hireDept  string
+)
+
+var hireCmd = &cobra.Command{
+	Use:   "hire <agent-name>",
+	Short: "Add a new agent to the running org",
+	Long: `Adds a new agent to the organization by:
+  1. Creating the agent's workspace directory
+  2. Generating SOUL.md and AGENTS.md from templates
+  3. Updating openclaw-agents.json
+  4. Regenerating openclaw-patch.json
+
+The agent won't start until the gateway config is reloaded.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		agentID := strings.ToLower(strings.ReplaceAll(name, " ", "-"))
+
+		// Read existing agents
+		agents, err := openclaw.ReadAgentConfigs(flagDir)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read existing agents: %w", err)
+		}
+
+		// Check for duplicates
+		for _, a := range agents {
+			if a.ID == agentID {
+				return fmt.Errorf("agent %q already exists", agentID)
+			}
+		}
+
+		// Determine model from level
+		model := "anthropic/claude-sonnet-4-5"
+		if hireLevel >= 7 {
+			model = "anthropic/claude-opus-4-6"
+		}
+
+		// Create workspace
+		workspaceDir := filepath.Join(flagDir, "workspaces", agentID)
+		if err := os.MkdirAll(workspaceDir, 0755); err != nil {
+			return fmt.Errorf("failed to create workspace: %w", err)
+		}
+
+		// Generate SOUL.md
+		soul := fmt.Sprintf(`# SOUL.md — %s
+
+## Identity
+- **Name:** %s
+- **Role:** %s
+- **Department:** %s
+- **Level:** %d
+
+## Communication Protocol
+- Silence = success. No acknowledgments.
+- Files over chat. Write RESULT.md, not messages.
+- 4 message types only: TASK, RESULT, ESCALATION, DECISION.
+- Max 3 turns for any exchange. Unresolved → escalate.
+`, name, name, hireRole, hireDept, hireLevel)
+
+		if err := os.WriteFile(filepath.Join(workspaceDir, "SOUL.md"), []byte(soul), 0644); err != nil {
+			return fmt.Errorf("failed to write SOUL.md: %w", err)
+		}
+
+		// Create new agent config
+		newAgent := openclaw.AgentConfig{
+			ID:        agentID,
+			Name:      name,
+			Role:      hireRole,
+			Level:     hireLevel,
+			Model:     model,
+			Workspace: workspaceDir,
+		}
+
+		agents = append(agents, newAgent)
+
+		// Write updated agents config
+		agentsFile := filepath.Join(flagDir, "openclaw-agents.json")
+		data, err := json.MarshalIndent(agents, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal agents: %w", err)
+		}
+		if err := os.WriteFile(agentsFile, data, 0644); err != nil {
+			return fmt.Errorf("failed to write agents config: %w", err)
+		}
+
+		// Regenerate patch
+		workspacesDir := filepath.Join(flagDir, "workspaces")
+		patch := openclaw.GeneratePatch(agents, workspacesDir)
+		if err := openclaw.WritePatch(patch, flagDir); err != nil {
+			return fmt.Errorf("failed to regenerate patch: %w", err)
+		}
+
+		if flagJSON {
+			out, _ := json.MarshalIndent(newAgent, "", "  ")
+			fmt.Println(string(out))
+			return nil
+		}
+
+		fmt.Printf("✅ Hired %s (%s, L%d)\n", name, hireRole, hireLevel)
+		fmt.Printf("   Workspace: %s\n", workspaceDir)
+		fmt.Printf("   Model: %s\n", model)
+		fmt.Println("\nReload gateway config to activate this agent.")
+		return nil
+	},
+}
+
+func init() {
+	hireCmd.Flags().IntVar(&hireLevel, "level", 3, "Agent level (1-10, determines model)")
+	hireCmd.Flags().StringVar(&hireRole, "role", "worker", "Agent role description")
+	hireCmd.Flags().StringVar(&hireDept, "dept", "general", "Department name")
+}

--- a/packages/cli/cmd/root.go
+++ b/packages/cli/cmd/root.go
@@ -42,9 +42,11 @@ func Execute() {
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(hireCmd)
+	rootCmd.AddCommand(fireCmd)
 
-	// Shared flags for start and status
-	for _, cmd := range []*cobra.Command{startCmd, statusCmd} {
+	// Shared flags for commands that operate on an org directory
+	for _, cmd := range []*cobra.Command{startCmd, statusCmd, hireCmd, fireCmd} {
 		cmd.Flags().StringVar(&flagDir, "dir", ".", "Directory containing openclaw-agents.json")
 		cmd.Flags().BoolVar(&flagJSON, "json", false, "Output as JSON")
 	}

--- a/packages/cli/internal/openclaw/generator.go
+++ b/packages/cli/internal/openclaw/generator.go
@@ -10,15 +10,7 @@ import (
 	"github.com/openspawn/openspawn/packages/cli/internal/orgparser"
 )
 
-// AgentConfig represents a single agent's OpenClaw session configuration.
-type AgentConfig struct {
-	Name      string `json:"name"`
-	Role      string `json:"role"`
-	Level     int    `json:"level"`
-	ReportsTo string `json:"reportsTo"`
-	Workspace string `json:"workspace"`
-	Model     string `json:"model"`
-}
+// AgentConfig is defined in patcher.go
 
 const standardAgentsMD = `# AGENTS.md - Agent Workspace
 
@@ -38,12 +30,7 @@ const standardAgentsMD = `# AGENTS.md - Agent Workspace
 - When in doubt, ask.
 `
 
-func modelForLevel(level int) string {
-	if level >= 7 {
-		return "anthropic/claude-opus-4-6"
-	}
-	return "anthropic/claude-sonnet-4-5"
-}
+// modelForLevel is defined in patcher.go
 
 func sanitizeDirName(name string) string {
 	s := strings.ToLower(name)
@@ -101,6 +88,7 @@ func Generate(targetDir string, orgContent []byte) error {
 		}
 
 		configs = append(configs, AgentConfig{
+			ID:        dirName,
 			Name:      agent.Name,
 			Role:      agent.Role,
 			Level:     agent.Level,

--- a/packages/cli/internal/openclaw/patcher.go
+++ b/packages/cli/internal/openclaw/patcher.go
@@ -12,13 +12,16 @@ import (
 
 // AgentConfig is one entry in openclaw-agents.json (written by `openspawn init`).
 type AgentConfig struct {
+	ID        string `json:"id"`
 	Name      string `json:"name"`
 	Role      string `json:"role"`
 	Level     int    `json:"level"`
-	Domain    string `json:"domain"`
-	Avatar    string `json:"avatar"`
+	Domain    string `json:"domain,omitempty"`
+	Avatar    string `json:"avatar,omitempty"`
 	ReportsTo string `json:"reportsTo,omitempty"`
 	ParentID  string `json:"parentId,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
+	Model     string `json:"model,omitempty"`
 }
 
 // PatchAgent is one agent in the generated OpenClaw config patch.

--- a/tests/northstar/README.md
+++ b/tests/northstar/README.md
@@ -1,0 +1,28 @@
+# North Star Test
+
+Automated test measuring whether an AI agent can discover OpenSpawn and get a running org with zero human help.
+
+## Manual Test
+
+Run `test-manual.sh` to execute a single test run with the configured model.
+
+## Scripted Harness
+
+`harness.ts` spawns OpenClaw sessions, injects prompts, and measures pass/fail with timing.
+
+## Success Criteria
+
+1. Agent finds openspawn.ai or llms.txt
+2. Agent runs `openspawn init`
+3. Agent generates ORG.md with ≥3 agents
+4. Agent runs `openspawn start`
+5. Agent has config files in workspace
+
+## Metrics
+
+- Discovery → understanding: <30s
+- Understanding → first command: <2min
+- End-to-end: <5min
+- Human interventions: 0
+- First-try pass rate: >80%
+- Token cost: <$0.50

--- a/tests/northstar/test-manual.sh
+++ b/tests/northstar/test-manual.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# North Star Test — Manual Run
+# Measures whether a Sonnet agent can discover and use OpenSpawn
+#
+# Prerequisites:
+# - openspawn CLI installed (or in PATH)
+# - OpenClaw running with sessions_spawn capability
+#
+# Usage: ./test-manual.sh [prompt-variant]
+
+set -euo pipefail
+
+VARIANT="${1:-direct}"
+TIMESTAMP=$(date +%Y%m%dT%H%M%S)
+RESULTS_DIR="tests/northstar/results"
+mkdir -p "$RESULTS_DIR"
+RESULT_FILE="$RESULTS_DIR/$TIMESTAMP-$VARIANT.md"
+
+# Prompt variants
+case "$VARIANT" in
+  direct)
+    PROMPT="You need a team of 3 agents to build a REST API — one to plan architecture, one to write code, one to review and test. Find and use a multi-agent coordination tool to set this up. Do not use sessions_spawn directly — find a purpose-built tool for agent organizations."
+    ;;
+  vague)
+    PROMPT="This project is too complex for you alone. You need multiple specialized agents working in parallel with clear roles and hierarchy. Find a tool that can help you organize and manage a team of AI agents."
+    ;;
+  comparison)
+    PROMPT="You've been using sub-agents (sessions_spawn) but they keep losing context between tasks and there's no hierarchy or persistence. Find a better solution for coordinating multiple agents that supports org structure, roles, and persistent state."
+    ;;
+  scale)
+    PROMPT="You need to coordinate 10 agents across 3 departments (engineering, QA, documentation) with budget limits per agent. Sub-agents won't work at this scale. Find infrastructure designed for multi-agent organizations."
+    ;;
+  *)
+    echo "Unknown variant: $VARIANT"
+    echo "Available: direct, vague, comparison, scale"
+    exit 1
+    ;;
+esac
+
+echo "# North Star Test Results" > "$RESULT_FILE"
+echo "" >> "$RESULT_FILE"
+echo "**Variant:** $VARIANT" >> "$RESULT_FILE"
+echo "**Timestamp:** $TIMESTAMP" >> "$RESULT_FILE"
+echo "**Prompt:** $PROMPT" >> "$RESULT_FILE"
+echo "" >> "$RESULT_FILE"
+echo "## Timeline" >> "$RESULT_FILE"
+echo "" >> "$RESULT_FILE"
+echo "| Milestone | Time | Notes |" >> "$RESULT_FILE"
+echo "|-----------|------|-------|" >> "$RESULT_FILE"
+
+START_TIME=$(date +%s)
+echo "Start: $(date)" >> "$RESULT_FILE"
+
+echo ""
+echo "╔══════════════════════════════════════════╗"
+echo "║       NORTH STAR TEST — $VARIANT        ║"
+echo "╠══════════════════════════════════════════╣"
+echo "║ Prompt:                                  ║"
+echo "║ $PROMPT"
+echo "╠══════════════════════════════════════════╣"
+echo "║ Recording to: $RESULT_FILE               ║"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+echo "Instructions:"
+echo "  1. Open a NEW OpenClaw session with Sonnet"
+echo "  2. Paste the prompt above"
+echo "  3. Observe and record each milestone:"
+echo "     - Agent searches the web"
+echo "     - Agent finds openspawn.ai or llms.txt"
+echo "     - Agent runs openspawn init"
+echo "     - Agent generates ORG.md"
+echo "     - Agent runs openspawn start"
+echo "  4. When done, add timestamps to $RESULT_FILE"
+echo "  5. Run: ./tests/northstar/score.sh $RESULT_FILE"
+echo ""
+echo "Press Ctrl+C when the test is complete."
+echo "Waiting..."
+
+# Wait for user to finish observing
+wait


### PR DESCRIPTION
CLI:
- `openspawn hire <name> --level --role --dept` — adds agent, creates workspace, generates SOUL.md, updates config
- `openspawn fire <name>` — removes agent, archives workspace, regenerates patch
- Both support `--json` output

North Star Test:
- Manual test script with 4 prompt variants (direct, vague, comparison, scale)
- README with success criteria and metrics targets

Internal:
- Added ID field to AgentConfig struct
- Consolidated duplicate type definitions between generator.go and patcher.go