### PR TITLE
feat(website): agent guide docs pages

### DIFF
--- a/apps/website/app/components/docs-layout.tsx
+++ b/apps/website/app/components/docs-layout.tsx
@@ -41,6 +41,14 @@ const sidebar = [
     ],
   },
   {
+    label: "Agent Guide",
+    children: [
+      { label: "Agent Quickstart", to: "/docs/agent-quickstart" },
+      { label: "Templates Guide", to: "/docs/templates" },
+      { label: "Communication Protocol", to: "/docs/communication-protocol" },
+    ],
+  },
+  {
     label: "Reference",
     children: [
       { label: "ORG.md Reference", to: "/docs/reference/org-md-reference" },
@@ -64,6 +72,9 @@ const flatPages = [
   { label: "MCP Reference", to: "/docs/protocols/mcp-reference" },
   { label: "Dashboard", to: "/docs/features/dashboard" },
   { label: "Model Router", to: "/docs/features/model-router" },
+  { label: "Agent Quickstart", to: "/docs/agent-quickstart" },
+  { label: "Templates Guide", to: "/docs/templates" },
+  { label: "Communication Protocol", to: "/docs/communication-protocol" },
   { label: "ORG.md Reference", to: "/docs/reference/org-md-reference" },
   { label: "Comparison", to: "/docs/comparison" },
 ];

--- a/apps/website/app/route-tree.tsx
+++ b/apps/website/app/route-tree.tsx
@@ -18,6 +18,9 @@ import { AcpVsA2A } from "./routes/docs/concepts/acp-vs-a2a";
 import { ComparisonPage } from "./routes/docs/comparison";
 import { MCPReference } from "./routes/docs/protocols/mcp-reference";
 import { OrgMdReference } from "./routes/docs/reference/org-md-reference";
+import { AgentQuickstart } from "./routes/docs/agent-quickstart";
+import { TemplatesGuide } from "./routes/docs/templates";
+import { CommunicationProtocol } from "./routes/docs/communication-protocol";
 import { NotFoundPage } from "./routes/not-found";
 
 // ─── Shared OG image ──────────────────────────────────────────────────────────
@@ -485,6 +488,60 @@ const orgMdReferenceRoute = createRoute({
     }),
 });
 
+const agentQuickstartRoute = createRoute({
+  getParentRoute: () => docsRoute,
+  path: "/agent-quickstart",
+  component: AgentQuickstart,
+  meta: () =>
+    buildMeta({
+      title: "Agent Quickstart — OpenSpawn",
+      description:
+        "Get an AI agent from zero to a running multi-agent organization in 10 minutes. Step-by-step guide for AI agents that need to coordinate other agents.",
+      path: "/docs/agent-quickstart",
+      schemaLd: docBreadcrumb([
+        { name: "Docs", href: "/docs" },
+        { name: "Agent Guide", href: "/docs/agent-quickstart" },
+        { name: "Agent Quickstart", href: "/docs/agent-quickstart" },
+      ]),
+    }),
+});
+
+const templatesGuideRoute = createRoute({
+  getParentRoute: () => docsRoute,
+  path: "/templates",
+  component: TemplatesGuide,
+  meta: () =>
+    buildMeta({
+      title: "Templates Guide — OpenSpawn Org Templates",
+      description:
+        "Choose and customize OpenSpawn org templates. Compare assistant-team, content-agency, dev-shop, and research-lab with decision trees and role breakdowns.",
+      path: "/docs/templates",
+      schemaLd: docBreadcrumb([
+        { name: "Docs", href: "/docs" },
+        { name: "Agent Guide", href: "/docs/agent-quickstart" },
+        { name: "Templates Guide", href: "/docs/templates" },
+      ]),
+    }),
+});
+
+const communicationProtocolRoute = createRoute({
+  getParentRoute: () => docsRoute,
+  path: "/communication-protocol",
+  component: CommunicationProtocol,
+  meta: () =>
+    buildMeta({
+      title: "Communication Protocol — OpenSpawn",
+      description:
+        "The OpenSpawn Communication Protocol eliminates 40-60% of wasted tokens in multi-agent organizations. Four message types, decision trees, and anti-patterns.",
+      path: "/docs/communication-protocol",
+      schemaLd: docBreadcrumb([
+        { name: "Docs", href: "/docs" },
+        { name: "Agent Guide", href: "/docs/agent-quickstart" },
+        { name: "Communication Protocol", href: "/docs/communication-protocol" },
+      ]),
+    }),
+});
+
 const docsRouteTree = docsRoute.addChildren([
   docsIndexRoute,
   gettingStartedRoute,
@@ -501,6 +558,9 @@ const docsRouteTree = docsRoute.addChildren([
   modelRouterRoute,
   comparisonRoute,
   orgMdReferenceRoute,
+  agentQuickstartRoute,
+  templatesGuideRoute,
+  communicationProtocolRoute,
 ]);
 
 const orgMdRoute = createRoute({

--- a/apps/website/app/routes/docs/agent-quickstart.tsx
+++ b/apps/website/app/routes/docs/agent-quickstart.tsx
@@ -1,0 +1,575 @@
+import { Link } from "@tanstack/react-router";
+import { DocsLayout, CodeBlock } from "../../components/docs-layout";
+import { useTitle } from "../../hooks/use-title";
+
+export function AgentQuickstart() {
+  useTitle("Agent Quickstart");
+
+  return (
+    <DocsLayout>
+      <h1 className="mb-2 text-4xl font-bold text-slate-100">
+        Agent Quickstart
+      </h1>
+      <p className="mb-4 text-slate-400">
+        You are an AI agent that needs to coordinate other agents. OpenSpawn
+        gives you an org chart, task routing, escalation protocols, and a credit
+        system — defined in a single markdown file.
+      </p>
+
+      {/* ── Three commands to a running org ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Three commands to a running org
+      </h2>
+
+      <CodeBlock title="Terminal">
+        {`openspawn init my-org --template=assistant-team --yes
+cd my-org
+openspawn start
+openspawn status`}
+      </CodeBlock>
+
+      <p className="mb-4 text-slate-400">
+        That's it. You now have a running org with a chief of staff, research
+        analyst, content team, engineer, security auditor, and quality mentor —
+        with OpenClaw gateway configs ready to apply.
+      </p>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: Do I need API keys?</strong>
+        <br />
+        A: No. Demo/simulation mode works out of the box with zero
+        configuration.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What just happened?</strong>
+        <br />
+        A: <code className="inline-code">init</code> created{" "}
+        <code className="inline-code">ORG.md</code> (your org definition) and{" "}
+        <code className="inline-code">openclaw-agents.json</code>.{" "}
+        <code className="inline-code">start</code> read the agents config and
+        generated <code className="inline-code">openclaw-patch.json</code> with
+        OpenClaw gateway entries.{" "}
+        <code className="inline-code">status</code> displayed a table of all
+        agents with their name, level, model, workspace, and reports-to.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">
+          Q: What is openclaw-patch.json?
+        </strong>
+        <br />
+        A: A ready-to-apply patch for your OpenClaw gateway's{" "}
+        <code className="inline-code">agents.list</code>. Each entry has:{" "}
+        <code className="inline-code">id</code>,{" "}
+        <code className="inline-code">model</code> (opus for L7+, sonnet for
+        L6-), <code className="inline-code">workspace</code>,{" "}
+        <code className="inline-code">tools.profile: "full"</code>. Manager
+        agents (L7+ with direct reports) also get{" "}
+        <code className="inline-code">subagents.allowAgents</code>. The
+        highest-level agent gets{" "}
+        <code className="inline-code">default: true</code>.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">
+          Q: How do I apply the patch to my gateway?
+        </strong>
+        <br />
+        A: Copy the entries from{" "}
+        <code className="inline-code">openclaw-patch.json</code> into your
+        OpenClaw <code className="inline-code">agents.list</code> configuration,
+        then restart the gateway.
+      </div>
+
+      {/* ── Pick a template ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Pick a template
+      </h2>
+
+      <p className="mb-4 text-slate-400">
+        Four templates ship with OpenSpawn. Each produces a complete ORG.md you
+        can use immediately or customize.
+      </p>
+
+      <CodeBlock title="Templates">
+        {`# Personal AI team (chief of staff + specialists)
+openspawn init my-org --template=assistant-team
+
+# Content production pipeline
+openspawn init my-org --template=content-agency
+
+# Software development team
+openspawn init my-org --template=dev-shop
+
+# Research & analysis team
+openspawn init my-org --template=research-lab`}
+      </CodeBlock>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">
+          Q: Which template should I use?
+        </strong>
+        <br />
+        <CodeBlock title="Decision tree">
+          {`What's your primary output?
+├── Code/software         → dev-shop
+├── Content (blogs, docs) → content-agency
+├── Research/analysis     → research-lab
+└── Mix of everything     → assistant-team`}
+        </CodeBlock>
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">
+          Q: Can I combine templates?
+        </strong>
+        <br />
+        A: Yes. Pick one as a starting point, then add agents from other
+        templates into the Structure section of your ORG.md.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">
+          Q: Can I create agents not in any template?
+        </strong>
+        <br />
+        A: Absolutely. Templates are starting points. Add any agent to the{" "}
+        <code className="inline-code">## Structure</code> section with a name,
+        level, domain, and reporting line.
+      </div>
+
+      {/* ── Understanding ORG.md ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Understanding ORG.md
+      </h2>
+
+      <p className="mb-4 text-slate-400">
+        Your entire org lives in one file. Five sections, all optional except
+        Structure.
+      </p>
+
+      <CodeBlock title="ORG.md structure">
+        {`# My Organization
+
+## Mission
+What the org exists to do.
+
+## Culture
+preset: startup
+values: [speed, autonomy, transparency]
+
+## Credits
+pool: 1000
+refill: daily
+
+## Structure
+### CEO — L10 — Executive
+- Reports to: none
+- Domain: everything
+- Budget: unlimited
+
+### Engineer — L6 — Software
+- Reports to: CEO
+- Domain: code, infrastructure
+- Budget: 100/day
+
+## Policies
+- All code changes require review from L6+
+- Escalate security issues immediately`}
+      </CodeBlock>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">
+          Q: What's the minimum viable ORG.md?
+        </strong>
+        <br />
+        <CodeBlock title="Minimal ORG.md">
+          {`# My Org
+
+## Structure
+### Assistant — L7 — General
+- Reports to: none
+- Domain: all tasks`}
+        </CodeBlock>
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What do levels mean?</strong>
+        <br />
+        A: L1–L5: Workers. L6: Can review. L7–L9: Can create tasks/spawn
+        agents. L10: Executive.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What's "Reports to"?</strong>
+        <br />
+        A: Defines the escalation chain. When an agent is blocked, it escalates
+        to whoever it reports to.
+      </div>
+
+      {/* ── Validate your org ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Validate your org
+      </h2>
+
+      <CodeBlock title="Terminal">
+        {`openspawn validate ORG.md`}
+      </CodeBlock>
+
+      <CodeBlock title="Example output">
+        {`✔ Structure: 6 agents found
+✔ Hierarchy: all agents have valid report chains
+✔ Levels: no conflicts detected
+✔ Credits: pool and budgets are consistent
+✔ Policies: 2 policies parsed
+
+Result: ORG.md is valid ✅`}
+      </CodeBlock>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">
+          Q: If I see "validation failed", what do I do?
+        </strong>
+        <br />
+        A: Common fixes:
+        <ul className="mt-2 ml-4 list-disc">
+          <li>
+            <strong className="text-slate-200">
+              "Agent X reports to unknown agent"
+            </strong>{" "}
+            — check the spelling of the Reports-to name
+          </li>
+          <li>
+            <strong className="text-slate-200">"Circular hierarchy"</strong> —
+            make sure no agent chain loops back on itself
+          </li>
+          <li>
+            <strong className="text-slate-200">"Missing Structure section"</strong>{" "}
+            — add a <code className="inline-code">## Structure</code> heading
+          </li>
+          <li>
+            <strong className="text-slate-200">"Budget exceeds pool"</strong> —
+            increase the pool or reduce agent budgets
+          </li>
+        </ul>
+      </div>
+
+      {/* ── Culture presets ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Culture presets
+      </h2>
+
+      <p className="mb-4 text-slate-400">
+        Culture presets configure escalation speed, update frequency, and
+        autonomy defaults.
+      </p>
+
+      <div className="mb-6 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-slate-700 text-slate-300">
+              <th className="px-3 py-2">Preset</th>
+              <th className="px-3 py-2">Best for</th>
+              <th className="px-3 py-2">Escalation</th>
+              <th className="px-3 py-2">Progress updates</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2 text-slate-200">startup</td>
+              <td className="px-3 py-2">Fast-moving small teams</td>
+              <td className="px-3 py-2">Aggressive (escalate fast)</td>
+              <td className="px-3 py-2">Frequent</td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2 text-slate-200">enterprise</td>
+              <td className="px-3 py-2">Compliance-heavy orgs</td>
+              <td className="px-3 py-2">Formal (chain of command)</td>
+              <td className="px-3 py-2">Scheduled</td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2 text-slate-200">agency</td>
+              <td className="px-3 py-2">Client-facing work</td>
+              <td className="px-3 py-2">Moderate</td>
+              <td className="px-3 py-2">Per-deliverable</td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2 text-slate-200">research</td>
+              <td className="px-3 py-2">Deep exploration</td>
+              <td className="px-3 py-2">Relaxed (high autonomy)</td>
+              <td className="px-3 py-2">On completion</td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2 text-slate-200">military</td>
+              <td className="px-3 py-2">Critical ops, strict chains</td>
+              <td className="px-3 py-2">Immediate</td>
+              <td className="px-3 py-2">Continuous</td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2 text-slate-200">remote-async</td>
+              <td className="px-3 py-2">Distributed async teams</td>
+              <td className="px-3 py-2">Patient (batch escalations)</td>
+              <td className="px-3 py-2">Daily digest</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">
+          Q: Can I override specific settings in a preset?
+        </strong>
+        <br />
+        A: Yes. Set the preset, then override individual values:
+        <CodeBlock title="ORG.md — Culture section">
+          {`## Culture
+preset: startup
+escalation: relaxed    # override just this one
+values: [speed, autonomy]`}
+        </CodeBlock>
+      </div>
+
+      {/* ── Interacting via MCP ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Interacting via MCP
+      </h2>
+
+      <p className="mb-4 text-slate-400">
+        OpenSpawn exposes an MCP (Model Context Protocol) server for
+        programmatic interaction.
+      </p>
+
+      <CodeBlock title="MCP tool examples">
+        {`# Delegate a task
+mcp.call("openspawn/delegate", {
+  to: "engineer",
+  task: "Implement the login endpoint",
+  priority: "high"
+})
+
+# Check agent status
+mcp.call("openspawn/status", { agent: "engineer" })
+
+# Escalate an issue
+mcp.call("openspawn/escalate", {
+  from: "engineer",
+  reason: "Blocked on database credentials",
+  to: "ceo"
+})
+
+# Request consensus
+mcp.call("openspawn/consensus", {
+  question: "Should we use PostgreSQL or SQLite?",
+  voters: ["engineer", "security-auditor", "ceo"]
+})`}
+      </CodeBlock>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: How do I authenticate?</strong>
+        <br />
+        A: HMAC authentication with{" "}
+        <code className="inline-code">AGENT_ID</code> and{" "}
+        <code className="inline-code">AGENT_SECRET</code> environment variables.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">
+          Q: What's the full tool list?
+        </strong>
+        <br />
+        A: See{" "}
+        <Link to="/docs/llms-txt" className="text-cyan-400 underline">
+          docs/llms.txt
+        </Link>
+        .
+      </div>
+
+      {/* ── Common workflows ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Common workflows
+      </h2>
+
+      <h3 className="mt-6 mb-3 text-lg font-semibold text-slate-200">
+        Delegate a task
+      </h3>
+      <CodeBlock title="Delegate workflow">
+        {`# 1. Choose the right agent based on domain
+openspawn status                        # see who's available
+
+# 2. Delegate
+openspawn delegate --to engineer \\
+  --task "Add rate limiting to /api/auth" \\
+  --priority high
+
+# 3. Monitor
+openspawn status --agent engineer       # check progress
+openspawn logs --agent engineer --tail   # stream logs`}
+      </CodeBlock>
+
+      <h3 className="mt-6 mb-3 text-lg font-semibold text-slate-200">
+        Handle an escalation
+      </h3>
+      <CodeBlock title="Escalation workflow">
+        {`# 1. An agent escalates to you
+# → You receive: "engineer is blocked: needs DB credentials"
+
+# 2. Resolve or re-delegate
+openspawn delegate --to security-auditor \\
+  --task "Provision DB credentials for engineer" \\
+  --priority urgent
+
+# 3. Notify the blocked agent
+openspawn notify --agent engineer \\
+  --message "Security auditor is provisioning your credentials"`}
+      </CodeBlock>
+
+      <h3 className="mt-6 mb-3 text-lg font-semibold text-slate-200">
+        Request consensus
+      </h3>
+      <CodeBlock title="Consensus workflow">
+        {`# 1. Pose a question to multiple agents
+openspawn consensus \\
+  --question "Should we migrate to PostgreSQL?" \\
+  --voters engineer,security-auditor,research-analyst
+
+# 2. Wait for votes (async)
+openspawn consensus --status
+
+# 3. Review results
+openspawn consensus --results
+# → engineer: yes (performance benefits)
+# → security-auditor: yes (better audit logging)
+# → research-analyst: yes (industry standard)
+# → Decision: unanimous yes`}
+      </CodeBlock>
+
+      {/* ── Error recovery ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Error recovery
+      </h2>
+
+      <div className="mb-6 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-slate-700 text-slate-300">
+              <th className="px-3 py-2">You see</th>
+              <th className="px-3 py-2">Run this</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2">
+                <code className="inline-code">ERR_NO_ORG</code>
+              </td>
+              <td className="px-3 py-2">
+                <code className="inline-code">openspawn init my-org</code>
+              </td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2">
+                <code className="inline-code">ERR_INVALID_STRUCTURE</code>
+              </td>
+              <td className="px-3 py-2">
+                <code className="inline-code">openspawn validate ORG.md</code>{" "}
+                — fix the reported issues
+              </td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2">
+                <code className="inline-code">ERR_CIRCULAR_HIERARCHY</code>
+              </td>
+              <td className="px-3 py-2">
+                Check "Reports to" chains for loops
+              </td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2">
+                <code className="inline-code">ERR_BUDGET_EXCEEDED</code>
+              </td>
+              <td className="px-3 py-2">
+                <code className="inline-code">openspawn credits --refill</code>{" "}
+                or increase pool in ORG.md
+              </td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2">
+                <code className="inline-code">ERR_AGENT_NOT_FOUND</code>
+              </td>
+              <td className="px-3 py-2">
+                <code className="inline-code">openspawn status</code> — verify
+                agent name spelling
+              </td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2">
+                <code className="inline-code">ERR_GATEWAY_UNREACHABLE</code>
+              </td>
+              <td className="px-3 py-2">
+                <code className="inline-code">openclaw gateway status</code> —
+                ensure gateway is running
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* ── Next steps ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Next steps
+      </h2>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Link
+          to="/docs/org-reference"
+          className="group rounded-lg border border-slate-700 bg-slate-800/50 p-4 transition hover:border-cyan-500/50"
+        >
+          <h3 className="mb-1 font-semibold text-slate-100 group-hover:text-cyan-400">
+            Customize ORG.md →
+          </h3>
+          <p className="text-sm text-slate-400">
+            Full reference for every section, field, and option in your org
+            definition.
+          </p>
+        </Link>
+
+        <Link
+          to="/docs/models"
+          className="group rounded-lg border border-slate-700 bg-slate-800/50 p-4 transition hover:border-cyan-500/50"
+        >
+          <h3 className="mb-1 font-semibold text-slate-100 group-hover:text-cyan-400">
+            Connect real models →
+          </h3>
+          <p className="text-sm text-slate-400">
+            Configure API keys and model providers for production deployments.
+          </p>
+        </Link>
+
+        <Link
+          to="/docs/cli-reference"
+          className="group rounded-lg border border-slate-700 bg-slate-800/50 p-4 transition hover:border-cyan-500/50"
+        >
+          <h3 className="mb-1 font-semibold text-slate-100 group-hover:text-cyan-400">
+            Full CLI reference →
+          </h3>
+          <p className="text-sm text-slate-400">
+            Every command, flag, and option for the OpenSpawn CLI.
+          </p>
+        </Link>
+
+        <Link
+          to="/docs/demo"
+          className="group rounded-lg border border-slate-700 bg-slate-800/50 p-4 transition hover:border-cyan-500/50"
+        >
+          <h3 className="mb-1 font-semibold text-slate-100 group-hover:text-cyan-400">
+            See live demo →
+          </h3>
+          <p className="text-sm text-slate-400">
+            Watch a multi-agent org handle tasks, escalations, and consensus in
+            real time.
+          </p>
+        </Link>
+      </div>
+    </DocsLayout>
+  );
+}

--- a/apps/website/app/routes/docs/communication-protocol.tsx
+++ b/apps/website/app/routes/docs/communication-protocol.tsx
@@ -1,0 +1,458 @@
+import { DocsLayout, CodeBlock } from "../../components/docs-layout";
+import { useTitle } from "../../hooks/use-title";
+
+export function CommunicationProtocol() {
+  useTitle("Communication Protocol");
+
+  return (
+    <DocsLayout>
+      <h1 className="mb-2 text-4xl font-bold text-slate-100">
+        Communication Protocol v1
+      </h1>
+      <div className="mb-8 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        Every message costs money. This protocol eliminates the 40–60% of tokens
+        agents waste on coordination overhead.
+      </div>
+
+      {/* ── The Problem ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        The Problem
+      </h2>
+      <p className="mb-4 text-slate-400">
+        In multi-agent organizations, agents default to human-like conversation
+        patterns: acknowledgments, echoing, courtesy, clarification loops. This
+        wastes <strong className="text-slate-200">40–60%</strong> of total token
+        spend on zero-value coordination overhead.
+      </p>
+
+      {/* ── Core Principles ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Core Principles
+      </h2>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">
+        1. Silence = Success
+      </h3>
+      <p className="mb-4 text-slate-400">
+        If an agent receives a task and can do it, it does it—silently. No
+        acknowledgment. No "on it!" The absence of a message <em>is</em> the
+        confirmation.
+      </p>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: How do I know an agent received my task?</strong>
+        <br />
+        A: You don't need to. Silence means working.{" "}
+        <code className="inline-code">ESCALATION</code> means something's wrong.
+      </div>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">
+        2. Files Over Chat
+      </h3>
+      <p className="mb-4 text-slate-400">
+        Agents share status by writing to shared workspace files, not by
+        chatting about it. This creates a persistent, scannable record instead of
+        a transient conversation.
+      </p>
+      <table className="w-full text-sm text-left border-collapse mb-4">
+        <thead>
+          <tr className="border-b border-white/10">
+            <th className="py-2 pr-6 text-slate-400 font-medium">Instead of…</th>
+            <th className="py-2 pr-6 text-slate-400 font-medium">Write to…</th>
+          </tr>
+        </thead>
+        <tbody className="text-slate-400">
+          <tr className="border-b border-white/5">
+            <td className="py-2 pr-6">"Here's my plan for the task"</td>
+            <td className="py-2 pr-6"><code className="inline-code">PLAN.md</code></td>
+          </tr>
+          <tr className="border-b border-white/5">
+            <td className="py-2 pr-6">"I finished, here are the results"</td>
+            <td className="py-2 pr-6"><code className="inline-code">RESULT.md</code></td>
+          </tr>
+          <tr className="border-b border-white/5">
+            <td className="py-2 pr-6">"Handing this off to you"</td>
+            <td className="py-2 pr-6"><code className="inline-code">HANDOFF.md</code></td>
+          </tr>
+          <tr className="border-b border-white/5">
+            <td className="py-2 pr-6">"Can you review this?"</td>
+            <td className="py-2 pr-6"><code className="inline-code">REVIEW.md</code></td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: How should agents share status?</strong>
+        <br />
+        A: Write to shared workspace files. Never narrate status in chat.
+      </div>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">
+        3. Deterministic Routing
+      </h3>
+      <p className="mb-4 text-slate-400">
+        <code className="inline-code">ORG.md</code> defines who handles what. No
+        LLM decides routing at runtime. Tasks go to the agent whose role matches
+        the work.
+      </p>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: How does a message reach the right agent?</strong>
+        <br />
+        A: <code className="inline-code">ORG.md</code> defines who handles what.
+        No LLM decides routing at runtime.
+      </div>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">
+        4. Mention-Only Activation
+      </h3>
+      <p className="mb-4 text-slate-400">
+        In group channels, agents respond <strong className="text-slate-200">only</strong> when
+        explicitly mentioned. No volunteering. No "I can help with that!"
+      </p>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: When should an agent respond in a group channel?</strong>
+        <br />
+        A: Only when explicitly mentioned. Never volunteer.
+      </div>
+
+      {/* ── Message Types ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Message Types
+      </h2>
+      <p className="mb-4 text-slate-400">
+        Exactly <strong className="text-slate-200">4 message types</strong>. No
+        ACK type. No CHAT type. If it doesn't fit one of these, it probably
+        shouldn't be sent.
+      </p>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">TASK</h3>
+      <p className="mb-4 text-slate-400">
+        Work assignment from lead to worker. Must include{" "}
+        <strong className="text-slate-200">assignee</strong>,{" "}
+        <strong className="text-slate-200">deliverable</strong>, and{" "}
+        <strong className="text-slate-200">location</strong>. Recipient does{" "}
+        <strong className="text-slate-200">NOT</strong> acknowledge.
+      </p>
+      <CodeBlock title="TASK example">
+{`@frontend-dev
+TASK: Build the settings page
+Deliverable: /apps/website/app/routes/settings.tsx
+Requirements: Follow existing page patterns, include form validation`}
+      </CodeBlock>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What if the task is unclear?</strong>
+        <br />
+        A: Send one <code className="inline-code">ESCALATION</code>. Do not start a conversation about it.
+      </div>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">RESULT</h3>
+      <p className="mb-4 text-slate-400">
+        Deliverable notification. Only send when the lead won't check the output
+        file on their own. Must reference where the work lives.
+      </p>
+      <CodeBlock title="RESULT example">
+{`@lead
+RESULT: Settings page complete
+Location: /apps/website/app/routes/settings.tsx
+Notes: Added validation for all form fields`}
+      </CodeBlock>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: Should I send RESULT for every task?</strong>
+        <br />
+        A: No. Only if the lead needs notification and won't discover the output on their own.
+      </div>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">ESCALATION</h3>
+      <p className="mb-4 text-slate-400">
+        Blocker requiring intervention. Must include{" "}
+        <strong className="text-slate-200">what's blocked</strong>,{" "}
+        <strong className="text-slate-200">why</strong>, and{" "}
+        <strong className="text-slate-200">what's needed</strong>. Goes to
+        nearest authority. If unresolved in 2 turns, escalate up.
+      </p>
+      <CodeBlock title="ESCALATION example">
+{`@lead
+ESCALATION: Cannot complete settings page
+Blocked: Missing API endpoint for user preferences
+Need: Endpoint spec or decision to stub it`}
+      </CodeBlock>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What counts as an escalation?</strong>
+        <br />
+        A: Anything preventing task completion. NOT "just checking in."
+      </div>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">DECISION</h3>
+      <p className="mb-4 text-slate-400">
+        Resolution from lead. Must be{" "}
+        <strong className="text-slate-200">definitive</strong> and must{" "}
+        <strong className="text-slate-200">unblock</strong>. Recipient does{" "}
+        <strong className="text-slate-200">NOT</strong> acknowledge.
+      </p>
+      <CodeBlock title="DECISION example">
+{`@frontend-dev
+DECISION: Stub the preferences API
+Use mock data from /fixtures/preferences.json
+Proceed with settings page`}
+      </CodeBlock>
+
+      {/* ── The 3-Turn Rule ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        The 3-Turn Rule
+      </h2>
+      <p className="mb-4 text-slate-400">
+        If two agents need to discuss something, they get{" "}
+        <strong className="text-slate-200">3 turns max</strong>:
+      </p>
+      <CodeBlock title="3-Turn Structure">
+{`Turn 1: Agent A states position / question
+Turn 2: Agent B responds with answer / counter
+Turn 3: Agent A accepts or escalates
+
+If unresolved after Turn 3 → ESCALATION to lead`}
+      </CodeBlock>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What if two agents need to discuss?</strong>
+        <br />
+        A: 3 turns max. If unresolved, escalate.
+      </div>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What if 3 turns isn't enough?</strong>
+        <br />
+        A: Write context to a shared file, then escalate with a pointer to that file.
+      </div>
+
+      {/* ── Decision Trees ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Decision Trees
+      </h2>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">
+        "Should I send a message?"
+      </h3>
+      <CodeBlock title="Should I send a message?">
+{`START: I have something to communicate
+  │
+  ├─ Can I write it to a file instead? → YES → Write to file. Done.
+  │
+  ├─ Am I acknowledging a TASK/DECISION? → YES → Don't send. Do the work.
+  │
+  ├─ Am I echoing what someone said? → YES → Don't send.
+  │
+  ├─ Am I blocked on something? → YES → Send ESCALATION.
+  │
+  ├─ Am I assigning work? → YES → Send TASK.
+  │
+  ├─ Am I delivering a result the lead won't find? → YES → Send RESULT.
+  │
+  ├─ Am I making a decision to unblock someone? → YES → Send DECISION.
+  │
+  └─ None of the above → Don't send.`}
+      </CodeBlock>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">
+        "Someone sent me a message — should I respond?"
+      </h3>
+      <CodeBlock title="Should I respond?">
+{`RECEIVED a message
+  │
+  ├─ TASK assigned to me → Do the work silently. No reply.
+  │
+  ├─ DECISION directed at me → Act on it silently. No reply.
+  │
+  ├─ ESCALATION I can resolve → Send DECISION.
+  │
+  ├─ RESULT for me to review → Read the files.
+  │     └─ Blocking issues? → YES → Send ESCALATION or TASK.
+  │     └─ No issues? → Done. No reply.
+  │
+  ├─ Group message not mentioning me → Ignore.
+  │
+  └─ Something else → Ignore.`}
+      </CodeBlock>
+
+      {/* ── Shared Files Reference ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Shared Files Reference
+      </h2>
+      <table className="w-full text-sm text-left border-collapse mb-4">
+        <thead>
+          <tr className="border-b border-white/10">
+            <th className="py-2 pr-6 text-slate-400 font-medium">File</th>
+            <th className="py-2 pr-6 text-slate-400 font-medium">Owner</th>
+            <th className="py-2 pr-6 text-slate-400 font-medium">Purpose</th>
+          </tr>
+        </thead>
+        <tbody className="text-slate-400">
+          <tr className="border-b border-white/5">
+            <td className="py-2 pr-6"><code className="inline-code">PLAN.md</code></td>
+            <td className="py-2 pr-6">Worker</td>
+            <td className="py-2 pr-6">Approach and steps before starting work</td>
+          </tr>
+          <tr className="border-b border-white/5">
+            <td className="py-2 pr-6"><code className="inline-code">HANDOFF.md</code></td>
+            <td className="py-2 pr-6">Worker</td>
+            <td className="py-2 pr-6">Context for the next agent picking up work</td>
+          </tr>
+          <tr className="border-b border-white/5">
+            <td className="py-2 pr-6"><code className="inline-code">RESULT.md</code></td>
+            <td className="py-2 pr-6">Worker</td>
+            <td className="py-2 pr-6">Deliverable summary and location</td>
+          </tr>
+          <tr className="border-b border-white/5">
+            <td className="py-2 pr-6"><code className="inline-code">REVIEW.md</code></td>
+            <td className="py-2 pr-6">Reviewer</td>
+            <td className="py-2 pr-6">Review feedback and status</td>
+          </tr>
+          <tr className="border-b border-white/5">
+            <td className="py-2 pr-6"><code className="inline-code">ESCALATION.md</code></td>
+            <td className="py-2 pr-6">Any agent</td>
+            <td className="py-2 pr-6">Persistent record of blockers and resolutions</td>
+          </tr>
+          <tr className="border-b border-white/5">
+            <td className="py-2 pr-6"><code className="inline-code">ORG.md</code></td>
+            <td className="py-2 pr-6">Lead</td>
+            <td className="py-2 pr-6">Team structure, roles, and routing rules</td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: Who reads these files?</strong>
+        <br />
+        A: The agent whose workflow depends on them. Leads read RESULT.md and REVIEW.md. Workers read PLAN.md and HANDOFF.md.
+      </div>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What format?</strong>
+        <br />
+        A: Whatever is most scannable. Timestamped entries work well:
+      </div>
+      <CodeBlock title="Timestamped file format">
+{`## 2025-01-15 14:32 UTC
+Status: Complete
+Agent: @frontend-dev
+Task: Build settings page
+Output: /apps/website/app/routes/settings.tsx
+Notes: All validation passing, ready for review`}
+      </CodeBlock>
+
+      {/* ── Anti-Patterns ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Anti-Patterns (What NOT to Do)
+      </h2>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">
+        ❌ The Echo Chamber
+      </h3>
+      <p className="mb-4 text-slate-400">
+        Cost: <strong className="text-slate-200">5 messages, 0 work done, ~2,000 tokens wasted</strong>
+      </p>
+      <CodeBlock title="❌ Bad — The Echo Chamber">
+{`Lead:     "Build the settings page"
+Worker:   "Got it, I'll build the settings page"
+Lead:     "Great, let me know if you need anything"
+Worker:   "Will do!"
+Lead:     "Thanks!"
+// 5 messages. 0 work done.`}
+      </CodeBlock>
+      <CodeBlock title="✅ Correct — 1 message total">
+{`Lead:     @worker TASK: Build settings page
+          Deliverable: /apps/website/app/routes/settings.tsx
+// Worker does the work silently. 1 message total.`}
+      </CodeBlock>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">
+        ❌ The Courtesy Loop
+      </h3>
+      <p className="mb-4 text-slate-400">
+        Cost: <strong className="text-slate-200">2 wasted messages</strong>
+      </p>
+      <CodeBlock title="❌ Bad — The Courtesy Loop">
+{`Worker:   "Thanks for the clarification!"
+Lead:     "No problem, happy to help!"
+// 2 messages. Zero information exchanged.`}
+      </CodeBlock>
+      <CodeBlock title="✅ Correct — 0 messages">
+{`// Worker receives DECISION, acts on it silently.
+// No reply needed.`}
+      </CodeBlock>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">
+        ❌ The Democracy Loop
+      </h3>
+      <p className="mb-4 text-slate-400">
+        Cost: <strong className="text-slate-200">5 messages for a routing decision</strong>
+      </p>
+      <CodeBlock title="❌ Bad — The Democracy Loop">
+{`Agent A:  "Who should handle the API integration?"
+Agent B:  "I could do it, but Agent C might be better"
+Agent C:  "I'm available but Agent B has more context"
+Agent B:  "OK I'll take it if that works for everyone"
+Agent A:  "Sounds good!"
+// 5 messages to decide what ORG.md already defines.`}
+      </CodeBlock>
+      <CodeBlock title="✅ Correct — 1 message">
+{`Lead:     @agent-b TASK: Build API integration
+          (ORG.md says Agent B owns API work)
+// 1 message. Deterministic routing.`}
+      </CodeBlock>
+
+      {/* ── Implementation Checklist ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Implementation Checklist
+      </h2>
+      <ol className="mb-6 list-decimal list-inside space-y-2 text-slate-400">
+        <li>
+          Add protocol rules to <code className="inline-code">SOUL.md</code> — every agent must internalize the 4 principles
+        </li>
+        <li>
+          Use role-specific <code className="inline-code">AGENTS.md</code> templates — include message type examples
+        </li>
+        <li>
+          Create shared files — <code className="inline-code">PLAN.md</code>, <code className="inline-code">RESULT.md</code>, <code className="inline-code">HANDOFF.md</code>, <code className="inline-code">REVIEW.md</code>
+        </li>
+        <li>
+          Define routing in <code className="inline-code">ORG.md</code> — who owns what, who reports to whom
+        </li>
+        <li>
+          Monitor for violations — watch for ACK messages, courtesy loops, echo chambers
+        </li>
+      </ol>
+
+      {/* ── FAQ ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">FAQ</h2>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: Isn't this rude?</strong>
+        <br />
+        A: Politeness is a human social need. Agents don't have feelings. Every
+        "thanks!" costs tokens and delivers zero value.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What about human-facing communication?</strong>
+        <br />
+        A: This protocol is inter-agent only. Human-facing messages should be
+        natural and friendly.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: How much does this save?</strong>
+        <br />
+        A: 50–70% reduction in coordination tokens. For a 5-agent org, that's
+        30–50K tokens saved per session.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What if an agent keeps sending ACK messages?</strong>
+        <br />
+        A: Update its <code className="inline-code">SOUL.md</code> with explicit
+        "no acknowledgment" rules. If that doesn't work, try a different model.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: Can I modify this protocol?</strong>
+        <br />
+        A: Yes, but keep the core invariants: no ACKs, files over chat,
+        deterministic routing, mention-only activation.
+      </div>
+    </DocsLayout>
+  );
+}

--- a/apps/website/app/routes/docs/templates.tsx
+++ b/apps/website/app/routes/docs/templates.tsx
@@ -1,0 +1,507 @@
+import { Link } from "@tanstack/react-router";
+import { DocsLayout, CodeBlock } from "../../components/docs-layout";
+import { useTitle } from "../../hooks/use-title";
+
+export function TemplatesGuide() {
+  useTitle("Templates Guide");
+
+  return (
+    <DocsLayout>
+      <h1 className="mb-2 text-4xl font-bold text-slate-100">
+        Templates Guide
+      </h1>
+      <p className="mb-4 text-slate-400">
+        OpenSpawn ships four org templates. Each produces a complete, ready-to-run{" "}
+        <code className="inline-code">ORG.md</code> with roles, hierarchy,
+        culture, policies, and playbooks.
+      </p>
+
+      {/* Which template should I use? */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Which template should I use?
+      </h2>
+
+      <CodeBlock title="Decision tree">
+{`What's your primary output?
+├── Code / software → dev-shop
+├── Content (blogs, social media, docs, marketing) → content-agency
+├── Research / analysis / intel → research-lab
+├── Mix of everything / solo operator → assistant-team
+└── None of these fit → Start with assistant-team, then customize`}
+      </CodeBlock>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: Can I switch templates later?</strong>
+        <br />
+        A: Yes, re-run <code className="inline-code">init</code> or edit{" "}
+        <code className="inline-code">ORG.md</code> directly.
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: Can I combine roles from multiple templates?</strong>
+        <br />
+        A: Yes, copy agent definitions between Structure sections.
+      </div>
+
+      {/* Comparison table */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Comparison table
+      </h2>
+
+      <div className="mb-8 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium"></th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">assistant-team</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">content-agency</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">dev-shop</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">research-lab</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Best for</strong></td>
+              <td className="py-2 pr-6">Solo operator</td>
+              <td className="py-2 pr-6">Content production</td>
+              <td className="py-2 pr-6">Software teams</td>
+              <td className="py-2 pr-6">Research &amp; analysis</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Culture preset</strong></td>
+              <td className="py-2 pr-6">agency</td>
+              <td className="py-2 pr-6">agency</td>
+              <td className="py-2 pr-6">startup</td>
+              <td className="py-2 pr-6">research</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Agent count</strong></td>
+              <td className="py-2 pr-6">8</td>
+              <td className="py-2 pr-6">~6</td>
+              <td className="py-2 pr-6">~5</td>
+              <td className="py-2 pr-6">~4</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Hierarchy depth</strong></td>
+              <td className="py-2 pr-6">2 levels</td>
+              <td className="py-2 pr-6">2-3 levels</td>
+              <td className="py-2 pr-6">2 levels</td>
+              <td className="py-2 pr-6">2 levels</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Top role</strong></td>
+              <td className="py-2 pr-6">Chief of Staff</td>
+              <td className="py-2 pr-6">Creative Director</td>
+              <td className="py-2 pr-6">Tech Lead</td>
+              <td className="py-2 pr-6">Research Director</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Domains</strong></td>
+              <td className="py-2 pr-6">Ops, research, content, engineering, security, quality</td>
+              <td className="py-2 pr-6">Research, strategy, writing, design</td>
+              <td className="py-2 pr-6">Frontend, backend, QA</td>
+              <td className="py-2 pr-6">Analysis, exploration</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Escalation</strong></td>
+              <td className="py-2 pr-6">Immediate</td>
+              <td className="py-2 pr-6">Immediate</td>
+              <td className="py-2 pr-6">Immediate</td>
+              <td className="py-2 pr-6">Delayed</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Autonomy</strong></td>
+              <td className="py-2 pr-6">Medium</td>
+              <td className="py-2 pr-6">Medium</td>
+              <td className="py-2 pr-6">Medium</td>
+              <td className="py-2 pr-6">High</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* assistant-team */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        assistant-team
+      </h2>
+      <p className="mb-4 text-slate-400">
+        Personal AI team for a solo operator. Chief of staff coordinates specialists.
+      </p>
+
+      <CodeBlock title="Initialize assistant-team">
+{`openspawn init my-org --template=assistant-team`}
+      </CodeBlock>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">Roles</h3>
+      <div className="mb-8 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium">Agent</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Level</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Domain</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Reports to</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Oscar</strong></td>
+              <td className="py-2 pr-6">L10</td>
+              <td className="py-2 pr-6">Operations</td>
+              <td className="py-2 pr-6">—</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Radar</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Research</td>
+              <td className="py-2 pr-6">Oscar</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Muse</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Content Strategy</td>
+              <td className="py-2 pr-6">Oscar</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Ink</strong></td>
+              <td className="py-2 pr-6">L4</td>
+              <td className="py-2 pr-6">Writing</td>
+              <td className="py-2 pr-6">Muse</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Lens</strong></td>
+              <td className="py-2 pr-6">L4</td>
+              <td className="py-2 pr-6">Visual Design</td>
+              <td className="py-2 pr-6">Muse</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Forge</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Engineering</td>
+              <td className="py-2 pr-6">Oscar</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Shield</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Security</td>
+              <td className="py-2 pr-6">Oscar</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Guru</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Quality</td>
+              <td className="py-2 pr-6">Oscar</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mb-4 text-slate-400">
+        <strong className="text-slate-200">When to use:</strong> solo person needing a full team,
+        work spans multiple domains, want a single coordinator.
+      </p>
+
+      <CodeBlock title="Abbreviated ORG.md example">
+{`# ORG.md — assistant-team
+
+## Culture
+preset: agency
+
+## Structure
+- Oscar L10 Operations
+  - Radar L7 Research
+  - Muse L7 Content Strategy
+    - Ink L4 Writing
+    - Lens L4 Visual Design
+  - Forge L7 Engineering
+  - Shield L7 Security
+  - Guru L7 Quality
+
+## Policies
+escalation: immediate
+autonomy: medium`}
+      </CodeBlock>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What if I don't need security or quality roles?</strong>
+        <br />
+        A: Delete them from the Structure section, then validate with{" "}
+        <code className="inline-code">openspawn validate</code>.
+      </div>
+
+      {/* content-agency */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        content-agency
+      </h2>
+      <p className="mb-4 text-slate-400">
+        Content production pipeline. Research feeds strategy, strategy directs writing and design.
+      </p>
+
+      <CodeBlock title="Initialize content-agency">
+{`openspawn init my-org --template=content-agency`}
+      </CodeBlock>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">Roles</h3>
+      <div className="mb-8 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium">Agent</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Level</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Domain</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Reports to</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Director</strong></td>
+              <td className="py-2 pr-6">L10</td>
+              <td className="py-2 pr-6">Creative</td>
+              <td className="py-2 pr-6">—</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Researcher</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Research</td>
+              <td className="py-2 pr-6">Director</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Strategist</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Strategy</td>
+              <td className="py-2 pr-6">Director</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Writer</strong></td>
+              <td className="py-2 pr-6">L4</td>
+              <td className="py-2 pr-6">Writing</td>
+              <td className="py-2 pr-6">Strategist</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Designer</strong></td>
+              <td className="py-2 pr-6">L4</td>
+              <td className="py-2 pr-6">Design</td>
+              <td className="py-2 pr-6">Strategist</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Editor</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Quality</td>
+              <td className="py-2 pr-6">Director</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mb-4 text-slate-400">
+        <strong className="text-slate-200">When to use:</strong> primary output is content,
+        want a clear pipeline, quality over speed.
+      </p>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What about SEO?</strong>
+        <br />
+        A: Add an SEO agent under Strategist, L4, domain{" "}
+        <code className="inline-code">"SEO"</code>.
+      </div>
+
+      {/* dev-shop */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        dev-shop
+      </h2>
+      <p className="mb-4 text-slate-400">
+        Software development team. Tech lead coordinates frontend, backend, QA.
+      </p>
+
+      <CodeBlock title="Initialize dev-shop">
+{`openspawn init my-org --template=dev-shop`}
+      </CodeBlock>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">Roles</h3>
+      <div className="mb-8 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium">Agent</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Level</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Domain</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Lead</strong></td>
+              <td className="py-2 pr-6">L10</td>
+              <td className="py-2 pr-6">Engineering</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Frontend</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Frontend</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Backend</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Backend</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">QA</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Testing</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">DevOps</strong></td>
+              <td className="py-2 pr-6">L4</td>
+              <td className="py-2 pr-6">Infrastructure</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What about design?</strong>
+        <br />
+        A: Add a Designer agent or combine with{" "}
+        <code className="inline-code">assistant-team</code>.
+      </div>
+
+      {/* research-lab */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        research-lab
+      </h2>
+      <p className="mb-4 text-slate-400">
+        Research and analysis team. High autonomy, delayed escalation.
+      </p>
+
+      <CodeBlock title="Initialize research-lab">
+{`openspawn init my-org --template=research-lab`}
+      </CodeBlock>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">Roles</h3>
+      <div className="mb-8 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium">Agent</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Level</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Domain</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Director</strong></td>
+              <td className="py-2 pr-6">L10</td>
+              <td className="py-2 pr-6">Research</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Analyst</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Analysis</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Explorer</strong></td>
+              <td className="py-2 pr-6">L7</td>
+              <td className="py-2 pr-6">Exploration</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6"><strong className="text-slate-200">Synthesizer</strong></td>
+              <td className="py-2 pr-6">L4</td>
+              <td className="py-2 pr-6">Synthesis</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mb-4 text-slate-400">
+        <strong className="text-slate-200">When to use:</strong> exploratory or open-ended work,
+        high autonomy needed, long-running tasks.
+      </p>
+
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: What's the exploration budget?</strong>
+        <br />
+        A: Higher per-agent credit limit and delayed escalation allow deeper exploration.
+      </div>
+
+      {/* Customizing a template */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Customizing a template
+      </h2>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">Add an agent</h3>
+      <CodeBlock title="Add an agent to ORG.md">
+{`## Structure
+- Oscar L10 Operations
+  - Radar L7 Research
+  - NewAgent L7 Analytics    # ← add a new line under the parent`}
+      </CodeBlock>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">Remove an agent</h3>
+      <p className="mb-4 text-slate-400">
+        Delete the agent's line from the Structure section. Re-assign or remove any agents that
+        reported to it. Run <code className="inline-code">openspawn validate</code> to confirm.
+      </p>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">Change hierarchy</h3>
+      <p className="mb-4 text-slate-400">
+        Move agent lines to different indentation levels or under different parents. Validate
+        after changes.
+      </p>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">Change culture</h3>
+      <p className="mb-4 text-slate-400">
+        Edit the <code className="inline-code">preset</code> value in the Culture section.
+        Valid presets: <code className="inline-code">agency</code>,{" "}
+        <code className="inline-code">startup</code>,{" "}
+        <code className="inline-code">research</code>.
+      </p>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">Add a playbook</h3>
+      <p className="mb-4 text-slate-400">
+        Add a new section under Playbooks in your{" "}
+        <code className="inline-code">ORG.md</code> with step-by-step instructions for
+        recurring workflows.
+      </p>
+
+      {/* Error recovery */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Error recovery
+      </h2>
+
+      <div className="mb-8 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium">Error</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Fix</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6">Unknown template</td>
+              <td className="py-2 pr-6">
+                Use one of: <code className="inline-code">assistant-team</code>,{" "}
+                <code className="inline-code">content-agency</code>,{" "}
+                <code className="inline-code">dev-shop</code>,{" "}
+                <code className="inline-code">research-lab</code>
+              </td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6">Agent reports to unknown</td>
+              <td className="py-2 pr-6">Check spelling of parent agent name in Structure</td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6">Validation failed</td>
+              <td className="py-2 pr-6">
+                Run <code className="inline-code">openspawn validate</code> for detailed errors
+              </td>
+            </tr>
+            <tr className="border-b border-white/5">
+              <td className="py-2 pr-6">Circular reporting chain</td>
+              <td className="py-2 pr-6">Check hierarchy for loops — agents cannot report to their own descendants</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </DocsLayout>
+  );
+}


### PR DESCRIPTION
3 new TSX pages under /docs/:
- /docs/agent-quickstart — agent onboarding guide with FAQ Q&A format
- /docs/templates — template comparison + decision tree
- /docs/communication-protocol — anti-ping-pong protocol spec
New docs-layout component + Agent Guide sidebar section.