### PR TITLE
feat: SQLite + MCP coordination server (@openspawn/coordinator)

### DIFF
--- a/packages/coordinator/package.json
+++ b/packages/coordinator/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@openspawn/coordinator",
+  "version": "0.1.0",
+  "description": "SQLite-backed MCP coordination server for OpenSpawn agent organizations",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "better-sqlite3": "^11.10.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/coordinator/src/db.test.ts
+++ b/packages/coordinator/src/db.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createDb, registerAgent, listAgents, updateAgentStatus,
+  createTask, claimTask, completeTask, listTasks,
+  escalate, resolveEscalation, listEscalations,
+  getEvents, orgStatus,
+} from './db.js';
+import type Database from 'better-sqlite3';
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = createDb(':memory:');
+});
+
+describe('agents', () => {
+  it('registers and lists agents', () => {
+    registerAgent(db, { id: 'a1', name: 'Alice', role: 'engineer', level: 5 });
+    registerAgent(db, { id: 'a2', name: 'Bob', role: 'reviewer', level: 7 });
+    const agents = listAgents(db);
+    expect(agents).toHaveLength(2);
+  });
+
+  it('filters by status', () => {
+    registerAgent(db, { id: 'a1', name: 'Alice' });
+    registerAgent(db, { id: 'a2', name: 'Bob' });
+    updateAgentStatus(db, 'a2', 'paused');
+    expect(listAgents(db, 'active')).toHaveLength(1);
+    expect(listAgents(db, 'paused')).toHaveLength(1);
+  });
+
+  it('fires agent', () => {
+    registerAgent(db, { id: 'a1', name: 'Alice' });
+    updateAgentStatus(db, 'a1', 'fired');
+    expect(listAgents(db, 'fired')).toHaveLength(1);
+  });
+});
+
+describe('tasks', () => {
+  beforeEach(() => {
+    registerAgent(db, { id: 'a1', name: 'Alice' });
+    registerAgent(db, { id: 'a2', name: 'Bob' });
+  });
+
+  it('creates and lists tasks', () => {
+    const id = createTask(db, { title: 'Fix bug', created_by: 'a1' });
+    expect(id).toBeTruthy();
+    const tasks = listTasks(db);
+    expect(tasks).toHaveLength(1);
+    expect((tasks[0] as any).title).toBe('Fix bug');
+  });
+
+  it('claims a task', () => {
+    const id = createTask(db, { title: 'Fix bug' });
+    claimTask(db, id, 'a1');
+    const tasks = listTasks(db, { assignee: 'a1' });
+    expect(tasks).toHaveLength(1);
+    expect((tasks[0] as any).status).toBe('in_progress');
+  });
+
+  it('rejects claiming non-todo task', () => {
+    const id = createTask(db, { title: 'Fix bug' });
+    claimTask(db, id, 'a1');
+    expect(() => claimTask(db, id, 'a2')).toThrow('not claimable');
+  });
+
+  it('completes a task', () => {
+    const id = createTask(db, { title: 'Fix bug' });
+    claimTask(db, id, 'a1');
+    completeTask(db, id, 'a1');
+    const tasks = listTasks(db, { status: 'done' });
+    expect(tasks).toHaveLength(1);
+    expect((tasks[0] as any).completed_at).toBeTruthy();
+  });
+
+  it('filters by status', () => {
+    createTask(db, { title: 'Todo 1' });
+    const id2 = createTask(db, { title: 'In progress' });
+    claimTask(db, id2, 'a1');
+    expect(listTasks(db, { status: 'todo' })).toHaveLength(1);
+    expect(listTasks(db, { status: 'in_progress' })).toHaveLength(1);
+  });
+
+  it('supports subtasks', () => {
+    const parent = createTask(db, { title: 'Epic' });
+    const child = createTask(db, { title: 'Subtask', parent_id: parent });
+    const tasks = listTasks(db);
+    expect(tasks).toHaveLength(2);
+    expect((tasks.find((t: any) => t.id === child) as any).parent_id).toBe(parent);
+  });
+});
+
+describe('escalations', () => {
+  beforeEach(() => {
+    registerAgent(db, { id: 'a1', name: 'Alice' });
+    registerAgent(db, { id: 'a2', name: 'Bob' });
+  });
+
+  it('creates and resolves escalation', () => {
+    const id = escalate(db, { from_agent: 'a1', to_agent: 'a2', reason: 'Blocked on API key' });
+    expect(listEscalations(db, 'open')).toHaveLength(1);
+    resolveEscalation(db, id, 'a2');
+    expect(listEscalations(db, 'open')).toHaveLength(0);
+    expect(listEscalations(db, 'resolved')).toHaveLength(1);
+  });
+});
+
+describe('events', () => {
+  it('logs all operations', () => {
+    registerAgent(db, { id: 'a1', name: 'Alice' });
+    const taskId = createTask(db, { title: 'Test', created_by: 'a1' });
+    claimTask(db, taskId, 'a1');
+    completeTask(db, taskId, 'a1');
+
+    const events = getEvents(db);
+    expect(events.length).toBeGreaterThanOrEqual(4); // hire, create, claim, complete
+    expect((events[0] as any).event_type).toBe('task.complete');
+  });
+});
+
+describe('orgStatus', () => {
+  it('returns summary', () => {
+    registerAgent(db, { id: 'a1', name: 'Alice' });
+    createTask(db, { title: 'T1' });
+    createTask(db, { title: 'T2' });
+    escalate(db, { from_agent: 'a1', reason: 'Help' });
+
+    const status = orgStatus(db);
+    expect(status.agents.active).toBe(1);
+    expect(status.tasks.todo).toBe(2);
+    expect(status.openEscalations).toBe(1);
+    expect(status.recentEvents.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/coordinator/src/db.ts
+++ b/packages/coordinator/src/db.ts
@@ -1,0 +1,253 @@
+import Database from 'better-sqlite3';
+import { randomUUID } from 'crypto';
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS agents (
+  id          TEXT PRIMARY KEY,
+  name        TEXT NOT NULL,
+  role        TEXT,
+  level       INTEGER DEFAULT 3,
+  department  TEXT,
+  status      TEXT NOT NULL DEFAULT 'active'
+                CHECK(status IN ('active','paused','fired')),
+  model       TEXT,
+  hired_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  metadata    TEXT
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+  id          TEXT PRIMARY KEY,
+  title       TEXT NOT NULL,
+  description TEXT,
+  status      TEXT NOT NULL DEFAULT 'todo'
+                CHECK(status IN ('todo','in_progress','review','done','blocked','cancelled')),
+  assignee    TEXT,
+  created_by  TEXT,
+  priority    INTEGER DEFAULT 0,
+  parent_id   TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  completed_at TEXT,
+  metadata    TEXT,
+  FOREIGN KEY (assignee) REFERENCES agents(id),
+  FOREIGN KEY (parent_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS events (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp   TEXT NOT NULL DEFAULT (datetime('now')),
+  agent_id    TEXT,
+  event_type  TEXT NOT NULL,
+  payload     TEXT,
+  task_id     TEXT,
+  FOREIGN KEY (agent_id) REFERENCES agents(id),
+  FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS escalations (
+  id          TEXT PRIMARY KEY,
+  from_agent  TEXT NOT NULL,
+  to_agent    TEXT,
+  task_id     TEXT,
+  reason      TEXT NOT NULL,
+  status      TEXT NOT NULL DEFAULT 'open'
+                CHECK(status IN ('open','acknowledged','resolved','dismissed')),
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  resolved_at TEXT,
+  FOREIGN KEY (from_agent) REFERENCES agents(id),
+  FOREIGN KEY (to_agent) REFERENCES agents(id),
+  FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_assignee ON tasks(assignee);
+CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);
+CREATE INDEX IF NOT EXISTS idx_events_agent ON events(agent_id);
+CREATE INDEX IF NOT EXISTS idx_escalations_status ON escalations(status);
+`;
+
+export function createDb(path: string): Database.Database {
+  const db = new Database(path);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(SCHEMA);
+  return db;
+}
+
+export function generateId(): string {
+  return randomUUID().split('-')[0];
+}
+
+// --- Agent operations ---
+
+export function registerAgent(db: Database.Database, agent: {
+  id: string; name: string; role?: string; level?: number;
+  department?: string; model?: string;
+}) {
+  const stmt = db.prepare(`
+    INSERT INTO agents (id, name, role, level, department, model)
+    VALUES (@id, @name, @role, @level, @department, @model)
+  `);
+  stmt.run({
+    id: agent.id,
+    name: agent.name,
+    role: agent.role ?? null,
+    level: agent.level ?? 3,
+    department: agent.department ?? null,
+    model: agent.model ?? null,
+  });
+  logEvent(db, agent.id, 'agent.hire', { name: agent.name, role: agent.role });
+}
+
+export function listAgents(db: Database.Database, status?: string) {
+  if (status) {
+    return db.prepare('SELECT * FROM agents WHERE status = ?').all(status);
+  }
+  return db.prepare('SELECT * FROM agents').all();
+}
+
+export function updateAgentStatus(db: Database.Database, id: string, status: string) {
+  db.prepare('UPDATE agents SET status = ? WHERE id = ?').run(status, id);
+  logEvent(db, id, `agent.${status}`, { id });
+}
+
+// --- Task operations ---
+
+export function createTask(db: Database.Database, task: {
+  title: string; description?: string; assignee?: string;
+  created_by?: string; priority?: number; parent_id?: string;
+}) {
+  const id = generateId();
+  db.prepare(`
+    INSERT INTO tasks (id, title, description, assignee, created_by, priority, parent_id)
+    VALUES (@id, @title, @description, @assignee, @created_by, @priority, @parent_id)
+  `).run({
+    id,
+    title: task.title,
+    description: task.description ?? null,
+    assignee: task.assignee ?? null,
+    created_by: task.created_by ?? null,
+    priority: task.priority ?? 0,
+    parent_id: task.parent_id ?? null,
+  });
+  logEvent(db, task.created_by ?? null, 'task.create', { id, title: task.title }, id);
+  return id;
+}
+
+export function claimTask(db: Database.Database, taskId: string, agentId: string) {
+  const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as any;
+  if (!task) throw new Error(`Task ${taskId} not found`);
+  if (task.status !== 'todo') throw new Error(`Task ${taskId} is ${task.status}, not claimable`);
+
+  db.prepare(`
+    UPDATE tasks SET assignee = ?, status = 'in_progress', updated_at = datetime('now')
+    WHERE id = ?
+  `).run(agentId, taskId);
+  logEvent(db, agentId, 'task.claim', { taskId }, taskId);
+}
+
+export function completeTask(db: Database.Database, taskId: string, agentId: string) {
+  const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as any;
+  if (!task) throw new Error(`Task ${taskId} not found`);
+
+  db.prepare(`
+    UPDATE tasks SET status = 'done', completed_at = datetime('now'), updated_at = datetime('now')
+    WHERE id = ?
+  `).run(taskId);
+  logEvent(db, agentId, 'task.complete', { taskId }, taskId);
+}
+
+export function listTasks(db: Database.Database, filters?: {
+  status?: string; assignee?: string;
+}) {
+  let query = 'SELECT * FROM tasks WHERE 1=1';
+  const params: any[] = [];
+  if (filters?.status) { query += ' AND status = ?'; params.push(filters.status); }
+  if (filters?.assignee) { query += ' AND assignee = ?'; params.push(filters.assignee); }
+  query += ' ORDER BY priority DESC, created_at ASC';
+  return db.prepare(query).all(...params);
+}
+
+export function updateTaskStatus(db: Database.Database, taskId: string, status: string, agentId?: string) {
+  db.prepare(`
+    UPDATE tasks SET status = ?, updated_at = datetime('now') WHERE id = ?
+  `).run(status, taskId);
+  logEvent(db, agentId ?? null, `task.${status}`, { taskId }, taskId);
+}
+
+// --- Escalation operations ---
+
+export function escalate(db: Database.Database, opts: {
+  from_agent: string; to_agent?: string; task_id?: string; reason: string;
+}) {
+  const id = generateId();
+  db.prepare(`
+    INSERT INTO escalations (id, from_agent, to_agent, task_id, reason)
+    VALUES (@id, @from_agent, @to_agent, @task_id, @reason)
+  `).run({
+    id,
+    from_agent: opts.from_agent,
+    to_agent: opts.to_agent ?? null,
+    task_id: opts.task_id ?? null,
+    reason: opts.reason,
+  });
+  logEvent(db, opts.from_agent, 'escalation.create', { id, reason: opts.reason }, opts.task_id ?? null);
+  return id;
+}
+
+export function resolveEscalation(db: Database.Database, id: string, agentId: string) {
+  db.prepare(`
+    UPDATE escalations SET status = 'resolved', resolved_at = datetime('now') WHERE id = ?
+  `).run(id);
+  logEvent(db, agentId, 'escalation.resolve', { id });
+}
+
+export function listEscalations(db: Database.Database, status?: string) {
+  if (status) {
+    return db.prepare('SELECT * FROM escalations WHERE status = ?').all(status);
+  }
+  return db.prepare('SELECT * FROM escalations ORDER BY created_at DESC').all();
+}
+
+// --- Event operations ---
+
+export function logEvent(
+  db: Database.Database,
+  agentId: string | null,
+  eventType: string,
+  payload?: any,
+  taskId?: string | null,
+) {
+  db.prepare(`
+    INSERT INTO events (agent_id, event_type, payload, task_id)
+    VALUES (?, ?, ?, ?)
+  `).run(agentId, eventType, payload ? JSON.stringify(payload) : null, taskId ?? null);
+}
+
+export function getEvents(db: Database.Database, opts?: {
+  limit?: number; agent_id?: string; event_type?: string;
+}) {
+  let query = 'SELECT * FROM events WHERE 1=1';
+  const params: any[] = [];
+  if (opts?.agent_id) { query += ' AND agent_id = ?'; params.push(opts.agent_id); }
+  if (opts?.event_type) { query += ' AND event_type = ?'; params.push(opts.event_type); }
+  query += ' ORDER BY id DESC';
+  if (opts?.limit) { query += ' LIMIT ?'; params.push(opts.limit); }
+  return db.prepare(query).all(...params);
+}
+
+// --- Status/Dashboard ---
+
+export function orgStatus(db: Database.Database) {
+  const agents = db.prepare('SELECT status, COUNT(*) as count FROM agents GROUP BY status').all() as any[];
+  const tasks = db.prepare('SELECT status, COUNT(*) as count FROM tasks GROUP BY status').all() as any[];
+  const openEscalations = db.prepare('SELECT COUNT(*) as count FROM escalations WHERE status = ?').get('open') as any;
+  const recentEvents = db.prepare('SELECT * FROM events ORDER BY id DESC LIMIT 10').all();
+
+  return {
+    agents: Object.fromEntries(agents.map((r: any) => [r.status, r.count])),
+    tasks: Object.fromEntries(tasks.map((r: any) => [r.status, r.count])),
+    openEscalations: openEscalations.count,
+    recentEvents,
+  };
+}

--- a/packages/coordinator/src/index.ts
+++ b/packages/coordinator/src/index.ts
@@ -1,0 +1,186 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createServer } from 'http';
+import { z } from 'zod';
+import {
+  createDb, registerAgent, listAgents, updateAgentStatus,
+  createTask, claimTask, completeTask, listTasks, updateTaskStatus,
+  escalate, resolveEscalation, listEscalations,
+  getEvents, orgStatus, logEvent,
+} from './db.js';
+
+const DB_PATH = process.env.OPENSPAWN_DB ?? 'openspawn.db';
+const PORT = parseInt(process.env.OPENSPAWN_PORT ?? '8787');
+
+const db = createDb(DB_PATH);
+
+const server = new McpServer({
+  name: 'openspawn-coordinator',
+  version: '0.1.0',
+});
+
+// --- Agent tools ---
+
+server.tool('agent_register', 'Register a new agent in the org', {
+  id: z.string().describe('Unique agent identifier'),
+  name: z.string().describe('Display name'),
+  role: z.string().optional().describe('Role description'),
+  level: z.number().min(1).max(10).optional().describe('Agent level (1-10)'),
+  department: z.string().optional(),
+  model: z.string().optional().describe('LLM model identifier'),
+}, async (params) => {
+  try {
+    registerAgent(db, params);
+    return { content: [{ type: 'text', text: `Registered agent ${params.id} (${params.name})` }] };
+  } catch (e: any) {
+    return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+  }
+});
+
+server.tool('agent_list', 'List all agents', {
+  status: z.string().optional().describe('Filter by status: active, paused, fired'),
+}, async (params) => {
+  const agents = listAgents(db, params.status);
+  return { content: [{ type: 'text', text: JSON.stringify(agents, null, 2) }] };
+});
+
+server.tool('agent_pause', 'Pause an agent', {
+  id: z.string(),
+}, async (params) => {
+  updateAgentStatus(db, params.id, 'paused');
+  return { content: [{ type: 'text', text: `Paused agent ${params.id}` }] };
+});
+
+server.tool('agent_resume', 'Resume a paused agent', {
+  id: z.string(),
+}, async (params) => {
+  updateAgentStatus(db, params.id, 'active');
+  return { content: [{ type: 'text', text: `Resumed agent ${params.id}` }] };
+});
+
+server.tool('agent_fire', 'Remove an agent from the org', {
+  id: z.string(),
+}, async (params) => {
+  updateAgentStatus(db, params.id, 'fired');
+  return { content: [{ type: 'text', text: `Fired agent ${params.id}` }] };
+});
+
+// --- Task tools ---
+
+server.tool('task_create', 'Create a new task', {
+  title: z.string(),
+  description: z.string().optional(),
+  assignee: z.string().optional().describe('Agent ID to assign'),
+  priority: z.number().optional().describe('Higher = more important'),
+  parent_id: z.string().optional().describe('Parent task ID for subtasks'),
+}, async (params, extra) => {
+  const agentId = (extra as any)?.agentId;
+  const id = createTask(db, { ...params, created_by: agentId });
+  return { content: [{ type: 'text', text: `Created task ${id}: ${params.title}` }] };
+});
+
+server.tool('task_claim', 'Claim an unassigned task', {
+  task_id: z.string(),
+  agent_id: z.string(),
+}, async (params) => {
+  try {
+    claimTask(db, params.task_id, params.agent_id);
+    return { content: [{ type: 'text', text: `Agent ${params.agent_id} claimed task ${params.task_id}` }] };
+  } catch (e: any) {
+    return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+  }
+});
+
+server.tool('task_complete', 'Mark a task as done', {
+  task_id: z.string(),
+  agent_id: z.string(),
+}, async (params) => {
+  try {
+    completeTask(db, params.task_id, params.agent_id);
+    return { content: [{ type: 'text', text: `Task ${params.task_id} completed` }] };
+  } catch (e: any) {
+    return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+  }
+});
+
+server.tool('task_list', 'List tasks with optional filters', {
+  status: z.string().optional(),
+  assignee: z.string().optional(),
+}, async (params) => {
+  const tasks = listTasks(db, params);
+  return { content: [{ type: 'text', text: JSON.stringify(tasks, null, 2) }] };
+});
+
+server.tool('task_update', 'Update task status', {
+  task_id: z.string(),
+  status: z.enum(['todo', 'in_progress', 'review', 'done', 'blocked', 'cancelled']),
+  agent_id: z.string().optional(),
+}, async (params) => {
+  updateTaskStatus(db, params.task_id, params.status, params.agent_id);
+  return { content: [{ type: 'text', text: `Task ${params.task_id} → ${params.status}` }] };
+});
+
+// --- Escalation tools ---
+
+server.tool('escalate', 'Escalate an issue to a higher-level agent', {
+  from_agent: z.string(),
+  to_agent: z.string().optional().describe('Target agent (omit for auto-routing)'),
+  task_id: z.string().optional(),
+  reason: z.string(),
+}, async (params) => {
+  const id = escalate(db, params);
+  return { content: [{ type: 'text', text: `Escalation ${id} created: ${params.reason}` }] };
+});
+
+server.tool('escalation_resolve', 'Resolve an escalation', {
+  id: z.string(),
+  agent_id: z.string(),
+}, async (params) => {
+  resolveEscalation(db, params.id, params.agent_id);
+  return { content: [{ type: 'text', text: `Escalation ${params.id} resolved` }] };
+});
+
+server.tool('escalation_list', 'List escalations', {
+  status: z.string().optional(),
+}, async (params) => {
+  const list = listEscalations(db, params.status);
+  return { content: [{ type: 'text', text: JSON.stringify(list, null, 2) }] };
+});
+
+// --- Org status ---
+
+server.tool('org_status', 'Get organization overview', {}, async () => {
+  const status = orgStatus(db);
+  return { content: [{ type: 'text', text: JSON.stringify(status, null, 2) }] };
+});
+
+server.tool('event_log', 'Query the event log', {
+  limit: z.number().optional().default(20),
+  agent_id: z.string().optional(),
+  event_type: z.string().optional(),
+}, async (params) => {
+  const events = getEvents(db, params);
+  return { content: [{ type: 'text', text: JSON.stringify(events, null, 2) }] };
+});
+
+// --- HTTP server ---
+
+const httpServer = createServer(async (req, res) => {
+  if (req.method === 'POST' && req.url === '/mcp') {
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined as any });
+    await server.connect(transport);
+    await transport.handleRequest(req, res);
+  } else if (req.method === 'GET' && req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, agents: listAgents(db).length }));
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+httpServer.listen(PORT, () => {
+  console.log(`OpenSpawn Coordinator running on http://localhost:${PORT}`);
+  console.log(`MCP endpoint: POST http://localhost:${PORT}/mcp`);
+  console.log(`DB: ${DB_PATH}`);
+});

--- a/packages/coordinator/tsconfig.json
+++ b/packages/coordinator/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
The coordination backbone for OpenSpawn agent organizations.

**What:** A new package `@openspawn/coordinator` — an MCP server backed by SQLite that handles all agent coordination.

**Tables:** agents, tasks, events, escalations (4 core + 2 support indexes)

**14 MCP tools:**
- Agent lifecycle: `agent_register`, `agent_list`, `agent_pause`, `agent_resume`, `agent_fire`
- Task management: `task_create`, `task_claim`, `task_complete`, `task_list`, `task_update`
- Escalations: `escalate`, `escalation_resolve`, `escalation_list`
- Observability: `org_status`, `event_log`

**Design:**
- SQLite WAL mode for concurrent reads
- Full event audit trail (every operation logged)
- Streamable HTTP MCP transport (`POST /mcp`)
- Health endpoint (`GET /health`)
- 12 passing tests

This is the backend that dashboard controls (#424) and CLI commands (#423) will wire into.