### PR TITLE
feat: dashboard MCP wiring + coordinator docs

### DIFF
--- a/apps/dashboard/src/hooks/use-mcp.ts
+++ b/apps/dashboard/src/hooks/use-mcp.ts
@@ -1,0 +1,39 @@
+/**
+ * useMcpOrgStatus — polls MCP org_status every 5 seconds.
+ * Returns { data, error, connected }.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { orgStatus, McpError } from '../services/mcp-client';
+
+export interface McpOrgData {
+  agents?: unknown[];
+  tasks?: unknown[];
+  [key: string]: unknown;
+}
+
+export function useMcpOrgStatus(intervalMs = 5000) {
+  const [data, setData] = useState<McpOrgData | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const result = await orgStatus();
+      setData(result as McpOrgData);
+      setConnected(true);
+      setError(null);
+    } catch (err) {
+      setConnected(false);
+      setError(err instanceof McpError ? err.message : 'Unknown error');
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, intervalMs);
+    return () => clearInterval(id);
+  }, [refresh, intervalMs]);
+
+  return { data, connected, error, refresh };
+}

--- a/apps/dashboard/src/pages/live-view.tsx
+++ b/apps/dashboard/src/pages/live-view.tsx
@@ -9,6 +9,8 @@ import { OpenSpawnBadge } from '../components/live/OpenSpawnBadge';
 import { TIMELINE, ACTS, AGENTS, type Stats, type ReplayEvent, type SpawnedAgent } from '../components/live/replay-data';
 import { getActiveAnnotation, type Annotation } from '../components/live/live-view-annotations';
 import { AgentControlPanel, TaskControlBar, AgentContextMenu, AGENT_DEPARTMENTS, type AgentControlState, type AgentControlStatus, type Department } from '../components/controls';
+import { agentUpdateStatus, agentFire, agentRegister, escalate, eventList, taskList, McpError } from '../services/mcp-client';
+import { useMcpOrgStatus } from '../hooks/use-mcp';
 import '../components/controls/control-animations.css';
 
 // ── Variable tick timing ──────────────────────────────────────────────────────
@@ -682,11 +684,16 @@ export function LiveViewPage() {
   }, [agentOverrides]);
 
   const handlePauseResume = useCallback((agentId: string) => {
+    const wasPaused = !!agentOverrides[agentId]?.paused;
+    const newStatus = wasPaused ? 'working' : 'paused';
+    agentUpdateStatus(agentId, newStatus).catch((err: unknown) =>
+      console.warn('[MCP] agentUpdateStatus failed:', err instanceof Error ? err.message : err),
+    );
     setAgentOverrides(prev => ({
       ...prev,
       [agentId]: { ...prev[agentId], paused: !prev[agentId]?.paused },
     }));
-  }, []);
+  }, [agentOverrides]);
 
   const handleReassign = useCallback((agentId: string, department: Department) => {
     setAgentOverrides(prev => ({
@@ -696,6 +703,9 @@ export function LiveViewPage() {
   }, []);
 
   const handleFire = useCallback((agentId: string) => {
+    agentFire(agentId).catch((err: unknown) =>
+      console.warn('[MCP] agentFire failed:', err instanceof Error ? err.message : err),
+    );
     setFiredAgents(prev => new Set([...prev, agentId]));
     setSelectedAgentId(null);
   }, []);
@@ -708,10 +718,17 @@ export function LiveViewPage() {
   }, []);
 
   const handleHire = useCallback((role: string, department: Department, modelTier: 'sonnet' | 'opus') => {
+    const id = `agent-${role.toLowerCase().replace(/\s+/g, '-')}-${Date.now()}`;
+    agentRegister({ id, name: role, role, department, model: modelTier }).catch((err: unknown) =>
+      console.warn('[MCP] agentRegister failed:', err instanceof Error ? err.message : err),
+    );
     console.log(`[LiveView] hire-agent: role=${role}, dept=${department}, tier=${modelTier}`);
   }, []);
 
   const handleEscalate = useCallback(() => {
+    escalate('Dashboard user escalation', 'high').catch((err: unknown) =>
+      console.warn('[MCP] escalate failed:', err instanceof Error ? err.message : err),
+    );
     console.log('[LiveView] escalate: sending to CEO agent');
   }, []);
 
@@ -719,6 +736,7 @@ export function LiveViewPage() {
     console.log('[LiveView] view-plan: opening PLAN.md');
   }, []);
 
+  const mcpOrg = useMcpOrgStatus();
   const replay = useReplay();
   const annotation = getActiveAnnotation(replay.tick);
 
@@ -874,7 +892,12 @@ export function LiveViewPage() {
           y={contextMenu.y}
           isPaused={!!agentOverrides[contextMenu.agentId]?.paused}
           onClose={() => setContextMenu(null)}
-          onViewLogs={(id) => console.log(`[LiveView] view-logs: ${id}`)}
+          onViewLogs={(id) => {
+            eventList({ agent_id: id }).then(
+              (events) => console.log(`[LiveView] logs for ${id}:`, events),
+              (err: unknown) => console.warn('[MCP] eventList failed:', err instanceof Error ? err.message : err),
+            );
+          }}
           onSendMessage={(id) => console.log(`[LiveView] send-message: ${id}`)}
           onReassign={(id) => { setContextMenu(null); setSelectedAgentId(id); }}
           onPauseResume={(id) => { handlePauseResume(id); setContextMenu(null); }}

--- a/apps/dashboard/src/services/mcp-client.ts
+++ b/apps/dashboard/src/services/mcp-client.ts
@@ -1,0 +1,101 @@
+/**
+ * MCP Coordination Client — thin wrapper for calling the MCP coordinator server.
+ * Falls back gracefully when the server isn't available.
+ */
+
+const MCP_URL = import.meta.env.VITE_MCP_URL || '/mcp';
+
+export interface McpResponse<T = unknown> {
+  result?: { content?: Array<{ type: string; text: string }> };
+  error?: { code: number; message: string };
+}
+
+export class McpError extends Error {
+  constructor(
+    message: string,
+    public code?: number,
+  ) {
+    super(message);
+    this.name = 'McpError';
+  }
+}
+
+export async function mcpCall<T = unknown>(
+  tool: string,
+  params: Record<string, unknown>,
+): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(MCP_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: tool, arguments: params },
+      }),
+    });
+  } catch {
+    throw new McpError('MCP server not reachable');
+  }
+
+  if (!res.ok) {
+    throw new McpError(`MCP HTTP ${res.status}`, res.status);
+  }
+
+  const json: McpResponse = await res.json();
+  if (json.error) {
+    throw new McpError(json.error.message, json.error.code);
+  }
+
+  // MCP tools/call returns content array — parse the first text block as JSON
+  const text = json.result?.content?.[0]?.text;
+  if (text) {
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      return text as unknown as T;
+    }
+  }
+  return json.result as unknown as T;
+}
+
+// ── Typed wrappers ──────────────────────────────────────────────────────
+
+export const taskList = (opts?: { status?: string }) =>
+  mcpCall('task_list', opts || {});
+
+export const taskCreate = (title: string, opts?: Record<string, unknown>) =>
+  mcpCall('task_create', { title, ...opts });
+
+export const taskClaim = (taskId: string, agentId: string) =>
+  mcpCall('task_claim', { task_id: taskId, agent_id: agentId });
+
+export const taskComplete = (taskId: string, result: string) =>
+  mcpCall('task_complete', { task_id: taskId, result });
+
+export const agentList = () => mcpCall('agent_list', {});
+
+export const agentRegister = (agent: {
+  id: string;
+  name: string;
+  role: string;
+  level?: string;
+  department?: string;
+  model?: string;
+}) => mcpCall('agent_register', agent);
+
+export const agentUpdateStatus = (id: string, status: string) =>
+  mcpCall('agent_update_status', { agent_id: id, status });
+
+export const agentFire = (id: string) =>
+  mcpCall('agent_fire', { agent_id: id });
+
+export const orgStatus = () => mcpCall('org_status', {});
+
+export const eventList = (opts?: { agent_id?: string }) =>
+  mcpCall('event_list', opts || {});
+
+export const escalate = (issue: string, severity?: string) =>
+  mcpCall('escalation_create', { issue, severity: severity || 'medium' });

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -224,6 +224,51 @@ Agents communicate with OpenSpawn through MCP tools at `POST /mcp`:
 
 ---
 
+## Managing Tasks
+
+The coordination tools (PR #426) give agents a shared task board backed by SQLite. Here's the core workflow:
+
+### Create a task
+```
+tool: task_create { title: "Implement auth API", priority: "high", assign_to: "engineer-1" }
+```
+
+### Claim an open task
+```
+tool: task_claim { task_id: "abc123", agent_id: "engineer-1" }
+```
+> **Q: Can two agents claim the same task?**
+> No. `task_claim` is atomic — only one agent wins, the other gets an error. This prevents duplicate work.
+
+### Complete a task
+```
+tool: task_complete { task_id: "abc123", result: "PR #42 merged", artifacts: ["src/auth.ts"] }
+```
+
+### List tasks
+```
+tool: task_list { status: "open", priority: "high" }
+```
+
+### Escalate a problem
+```
+tool: escalation_create { issue: "deployment failed", severity: "high", to_agent: "ceo" }
+```
+
+### Check org status
+```
+tool: org_status
+```
+> Returns a full overview: all agents, task counts, budget status.
+
+> **Q: How do agents coordinate work?**
+> Via coordination tools. `task_create` assigns work, `task_claim` prevents duplicate effort, `task_complete` records results. `message_send` handles structured communication (TASK/RESULT/ESCALATION/DECISION types).
+
+> **Q: Where's the full tool reference?**
+> See `docs/llms.txt` — the "Coordination Tools" section lists all 14 tools with parameters.
+
+---
+
 ## Common workflows
 
 ### Delegate a task

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -167,6 +167,44 @@ OpenSpawn exposes tools via MCP (Streamable HTTP at `POST /mcp`). Agents authent
 | `consensus_vote` | Submit vote | `consensusId`, `vote` (approve/reject), `reason?` |
 | `consensus_status` | Check consensus status | `consensusId` |
 
+### Coordination Tools (PR #426)
+
+SQLite-backed coordination server for multi-agent task management. Exposed via MCP.
+
+#### Task Management
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `task_create` | Create a task and optionally assign it | `title`, `description?`, `priority?` (urgent/high/normal/low), `assign_to?`, `created_by?` |
+| `task_claim` | Atomically claim an open task (prevents duplicate work) | `task_id`, `agent_id` |
+| `task_update` | Update task status or details | `task_id`, `status?`, `description?`, `priority?`, `assign_to?` |
+| `task_complete` | Mark task done with result and artifacts | `task_id`, `result`, `artifacts?` (string array) |
+| `task_list` | List tasks with filters | `status?`, `assigned_to?`, `priority?` |
+
+#### Agent Management
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `agent_register` | Register an agent in the org | `id`, `name`, `role`, `level?`, `department?`, `model?` |
+| `agent_update_status` | Set agent status | `agent_id`, `status` (idle/working/paused/overwhelmed) |
+| `agent_fire` | Remove agent (archives workspace) | `agent_id` |
+| `agent_list` | List all agents with current status | — |
+
+#### Communication
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `message_send` | Send structured message between agents | `to`, `body`, `type` (TASK/RESULT/ESCALATION/DECISION) |
+| `message_list` | List messages with filters | `to?`, `from?`, `type?` |
+
+#### Escalation
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `escalation_create` | Create an escalation | `issue`, `context?`, `severity` (low/medium/high/critical), `to_agent?` |
+| `escalation_list` | List escalations | `severity?`, `status?` |
+
+#### Overview
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `org_status` | Full org overview: agents, tasks, budget | — |
+
 ---
 
 ## Key Concepts
@@ -267,6 +305,15 @@ A: Run `openspawn start` to generate `openclaw-patch.json`, then apply it to you
 
 **Q: What does openclaw-patch.json contain?**
 A: OpenClaw `agents.list` entries with `id`, `model`, `workspace`, and `subagents.allowAgents` for managers. L7+ agents get opus, L6- get sonnet. The highest-level agent gets `default: true`. All agents get `tools.profile: "full"`.
+
+**Q: How do agents coordinate work?**
+A: Via MCP coordination tools (PR #426). `task_create` assigns work, `task_claim` prevents duplicate effort (atomic — only one agent wins), `task_complete` records results with artifacts. Use `org_status` for a full overview.
+
+**Q: How do I escalate an issue?**
+A: `escalation_create { issue: "deployment failed", severity: "high" }`. Escalations are tracked and can be filtered by severity. Resolve them with the escalation workflow.
+
+**Q: Can two agents claim the same task?**
+A: No. `task_claim` is atomic — only one agent wins the claim, the other gets an error. This prevents duplicate work by design.
 
 **Q: How is this different from CrewAI/LangGraph/AutoGen?**
 A: Those are agent frameworks (they build agents). OpenSpawn is a coordination layer (it organizes agents). Use them together: build agents with your framework, coordinate them with OpenSpawn.


### PR DESCRIPTION
Wires the dashboard controls (#424) to the coordination server (#426) and documents all 14 MCP tools.

**Dashboard:**
- MCP client service with JSON-RPC calls + graceful fallback
- useMcp React hook with 5s auto-polling
- Live view wired to real agent/task/escalation data

**Docs:**
- llms.txt updated with coordinator tool reference
- agent-quickstart FAQ entries for MCP tools