### PR TITLE
docs: comprehensive agent-friendly docs audit

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,272 @@
+---
+purpose: Answer the top questions agents and humans ask about OpenSpawn
+audience: AI agents (primary), developers (secondary)
+related: [agent-quickstart.md, getting-started.md, mcp-reference.md, troubleshooting.md]
+---
+
+# OpenSpawn FAQ
+
+**What you'll learn:** Answers to the 20 most common questions about OpenSpawn — what it is, how to use it, how it compares to alternatives, and how agents interact with it.
+
+> **TL;DR for agents:** OpenSpawn is a coordination layer. You define an org in `ORG.md`, run `openspawn start`, and agents communicate via MCP tools at `POST /mcp`. If you're blocked, escalate up the chain. If you're done, `task_complete`.
+
+---
+
+## General
+
+### Q1: What is OpenSpawn?
+
+OpenSpawn is an **open-source coordination layer for AI agent organizations**. You define your entire agent org — roles, hierarchy, culture, policies — in a single markdown file (`ORG.md`). OpenSpawn parses it, assigns agents, routes tasks through the hierarchy, and provides a real-time dashboard.
+
+It is **infrastructure, not a framework**: it works with any agent stack (OpenClaw, LangGraph, CrewAI, AutoGen, raw API calls).
+
+### Q2: How is OpenSpawn different from CrewAI or LangGraph?
+
+```
+CrewAI / LangGraph = agent frameworks (how you BUILD agents)
+OpenSpawn = coordination layer (how you ORGANIZE agents)
+```
+
+- **CrewAI/LangGraph** define how agents execute tasks
+- **OpenSpawn** defines who does what, who they report to, what they can spend, and who approves decisions
+
+They're designed to work together, not replace each other.
+
+### Q3: Do I need to rewrite my agents to use OpenSpawn?
+
+**No.** OpenSpawn connects to your existing agents via standard protocols:
+- **MCP** (Model Context Protocol) — for tool calls
+- **A2A** (Agent-to-Agent) — for inter-org communication
+- **REST** — for direct API calls
+
+Your agents keep running as-is. OpenSpawn adds the coordination layer on top.
+
+### Q4: Do I need API keys to try it?
+
+**No.** Demo/simulation mode works out of the box:
+
+```bash
+npx openspawn init my-org --template=assistant-team --non-interactive
+cd my-org
+openspawn preview
+# Open http://localhost:3333
+```
+
+You'll see the full coordination flow with simulated agents, no API keys needed.
+
+### Q5: Is OpenSpawn free?
+
+**Yes.** MIT open source. Self-hosted. No usage fees.
+
+Optional: paid hosted tier (in development) for teams that don't want to self-host.
+
+---
+
+## Setup & Installation
+
+### Q6: What are the prerequisites?
+
+- **Required:** Node.js 18+ (`node --version`)
+- **Optional for real inference:**
+  - [Ollama](https://ollama.ai) — free local models
+  - [Groq](https://groq.com) API key — fast mid-tier models
+  - [OpenRouter](https://openrouter.ai) API key — Claude/GPT-4o for executives
+
+### Q7: What are the three commands to get a running org?
+
+```bash
+openspawn init my-org --template=assistant-team --yes
+cd my-org
+openspawn start
+openspawn status
+```
+
+- `init` — creates `ORG.md` and `openclaw-agents.json`
+- `start` — reads agents config, generates `openclaw-patch.json`
+- `status` — displays agent table (name, level, model, workspace, reports-to)
+
+### Q8: Which template should I use?
+
+```
+What's your primary output?
+├── Code/software      → dev-shop
+├── Content            → content-agency
+├── Research/analysis  → research-lab
+└── Mix / solo op      → assistant-team
+```
+
+All templates are starting points — edit the generated `ORG.md` freely.
+
+### Q9: What is `openclaw-patch.json` and what do I do with it?
+
+`openclaw-patch.json` is a ready-to-apply patch for your OpenClaw gateway's `agents.list`. It contains entries with:
+- `id` — agent identifier (lowercase hyphenated name)
+- `model` — `opus` for L7+ agents, `sonnet` for L6 and below
+- `workspace` — agent workspace path
+- `tools.profile: "full"` — full tool access
+- `subagents.allowAgents` — for manager agents (L7+ with direct reports)
+- `default: true` — on the highest-level agent
+
+**To apply:** copy the entries from `openclaw-patch.json` into your OpenClaw `agents.list` config, then restart the gateway.
+
+### Q10: How do I validate my ORG.md?
+
+```bash
+openspawn validate
+# or
+openspawn validate path/to/ORG.md
+```
+
+Checks: valid markdown structure, required sections, agent role definitions, hierarchy consistency, policy completeness.
+
+**Common errors and fixes:**
+
+| Error | Fix |
+|-------|-----|
+| `Missing Structure section` | Add `## Structure` with at least one agent |
+| `Agent reports to unknown agent` | Check `Reports to` matches an agent name exactly |
+| `No top-level agent` | One agent must have `Reports to: Human Principal` |
+| `Circular reporting chain` | No agent can report to itself or create a loop |
+
+---
+
+## ORG.md
+
+### Q11: What's the minimum viable ORG.md?
+
+```markdown
+# My Org
+
+## Structure
+
+### Boss — Leader
+- **Level:** 10
+- **Reports to:** Human Principal
+```
+
+That's it. One heading, one agent, one level, one reporting line.
+
+### Q12: What do agent levels mean?
+
+| Level | Role type | Permissions |
+|-------|-----------|-------------|
+| L1-L5 | Workers | Execute tasks |
+| L6 | Seniors | Review and approve work |
+| L7-L9 | Leads | Create tasks, spawn agents, manage teams |
+| L10 | Executives | Top of hierarchy |
+
+### Q13: What are the five ORG.md sections?
+
+| Section | Purpose | Required? |
+|---------|---------|-----------|
+| `## Identity` | Name, mission, values — ambient context for all agents | No |
+| `## Culture` | Communication norms, escalation speed, preset | No |
+| `## Structure` | Agent roles and hierarchy | **Yes** |
+| `## Policies` | Budget limits, caps, permissions | No |
+| `## Playbooks` | Step-by-step procedures for common scenarios | No |
+
+### Q14: What are culture presets?
+
+Presets are shorthand for configuring communication norms. Use one line:
+
+```markdown
+## Culture
+preset: startup
+```
+
+| Preset | Escalation | Progress | Best for |
+|--------|-----------|----------|---------|
+| `startup` | Immediate | Frequent | Small fast teams |
+| `enterprise` | Batched (hourly) | On phase change | Large orgs with process |
+| `agency` | Immediate | Every tick | Client work with deadlines |
+| `research` | Delayed | On request | Exploration, long tasks |
+| `military` | Immediate | Every tick | Zero-ambiguity operations |
+| `remote-async` | Delayed | On request | Distributed async teams |
+
+---
+
+## MCP & Agent Interaction
+
+### Q15: How do agents interact with OpenSpawn?
+
+Via **MCP tools** at `POST /mcp`. Authentication is HMAC — set `AGENT_ID` and `AGENT_SECRET` env vars.
+
+Core workflow:
+
+```
+agent_list           → see who's in the org
+task_create          → assign work to another agent
+task_claim           → atomically claim an open task
+task_complete        → mark work done with results
+escalation_create    → flag a blocker to your manager
+message_send         → send TASK/RESULT/ESCALATION/DECISION
+credits_balance      → check your budget
+org_status           → full org overview
+```
+
+Full tool reference: [`docs/mcp-reference.md`](./mcp-reference.md)
+
+### Q16: Can two agents claim the same task?
+
+**No.** `task_claim` is **atomic** — only one agent wins the claim, the other gets an error. This prevents duplicate work by design.
+
+```
+tool: task_claim { task_id: "abc123", agent_id: "engineer-1" }
+```
+
+### Q17: What happens when an agent is blocked?
+
+1. Agent sends `escalation_create` to its direct manager (never skips the chain)
+2. Manager has 2 cycles to respond: unblock, reassign, or escalate further
+3. If unresolved after 2 levels, alert goes to the Human Principal
+
+---
+
+## Communication Protocol
+
+### Q18: How do agents communicate efficiently?
+
+The [Agent Communication Protocol](./communication-protocol.md) defines 4 message types — **no ACKs, no courtesy messages**:
+
+| Type | Direction | When |
+|------|-----------|------|
+| `TASK` | Lead → Worker | Work assignment |
+| `RESULT` | Worker → Lead | Deliverable notification |
+| `ESCALATION` | Worker → Lead | Blocker requiring help |
+| `DECISION` | Lead → Worker | Resolves an escalation |
+
+**Core rule:** Silence = success. If an agent is working, it stays silent. Only message when blocked, assigning, delivering, or resolving.
+
+### Q19: What files do agents use to share state?
+
+Instead of sending messages, agents write to shared workspace files:
+
+| File | Owner | Purpose |
+|------|-------|---------|
+| `PLAN.md` | Lead agent | Current sprint plan with task assignments |
+| `RESULT.md` | Workers | Completed deliverables |
+| `HANDOFF.md` | Any agent | Work ready for next stage |
+| `REVIEW.md` | Reviewers | Feedback and approvals |
+| `ESCALATION.md` | Any agent | Complex issues needing >3 turns |
+
+---
+
+## Troubleshooting
+
+### Q20: Where do I go when something's broken?
+
+1. Run `openspawn validate` — catches most config issues
+2. Check [`docs/troubleshooting.md`](./troubleshooting.md) — common errors and fixes
+3. Check port conflicts: `lsof -i :3333`
+4. Review auth: verify `AGENT_ID` and `AGENT_SECRET` match API config
+5. GitHub issues: https://github.com/openspawn/openspawn/issues
+
+---
+
+## Next steps
+
+- **Start building:** [`docs/agent-quickstart.md`](./agent-quickstart.md)
+- **Full setup walkthrough:** [`docs/getting-started.md`](./getting-started.md)
+- **All MCP tools:** [`docs/mcp-reference.md`](./mcp-reference.md)
+- **Fix a specific error:** [`docs/troubleshooting.md`](./troubleshooting.md)
+- **Live demo:** https://bikinibottom.ai/app/

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -4,9 +4,12 @@ audience: AI agents (LLMs) that need to coordinate other agents
 prerequisites: Node.js 18+, npm
 time_estimate: 10 minutes
 commands_used: [openspawn init, openspawn start, openspawn status, openspawn validate, openspawn preview]
+related: [llms.txt, mcp-reference.md, communication-protocol.md, FAQ.md, troubleshooting.md]
 ---
 
 # Agent Quickstart
+
+**What you'll learn:** How to go from zero to a running multi-agent org in 3 commands — templates, ORG.md structure, MCP tool usage, error recovery, and the boot sequence protocol.
 
 You are an AI agent that needs to coordinate other agents. OpenSpawn gives you an org chart, task routing, escalation protocols, and a credit system — defined in a single markdown file.
 
@@ -345,7 +348,12 @@ See `templates/boot-sequence.md` for the full protocol, `templates/SOUL-lead.md`
 
 ## Next steps
 
-- Customize your ORG.md: add agents, change levels, write playbooks
-- Connect real models: set Ollama/Groq/OpenRouter keys in `openspawn.config.json`
-- Read the full reference: `docs/llms.txt`
-- See the live demo: https://bikinibottom.ai/app/
+- **Customize your ORG.md:** add agents, change levels, write playbooks — see [`docs/org-md-reference.md`](./org-md-reference.md)
+- **Connect real models:** set Ollama/Groq/OpenRouter keys in `openspawn.config.json`
+- **All MCP tools:** [`docs/mcp-reference.md`](./mcp-reference.md) — full parameter reference
+- **Communication rules:** [`docs/communication-protocol.md`](./communication-protocol.md) — save 50-70% on coordination tokens
+- **Template deep dive:** [`docs/templates-guide.md`](./templates-guide.md) — all 4 templates
+- **Top 20 FAQ:** [`docs/FAQ.md`](./FAQ.md) — common questions answered
+- **Fix errors:** [`docs/troubleshooting.md`](./troubleshooting.md) — common issues and fixes
+- **Full reference:** [`docs/llms.txt`](./llms.txt)
+- **Live demo:** https://bikinibottom.ai/app/

--- a/docs/communication-protocol.md
+++ b/docs/communication-protocol.md
@@ -1,5 +1,9 @@
 # OpenSpawn Communication Protocol v1
 
+**What you'll learn:** The 4 message types agents use to communicate, decision trees for when to send (and when not to), the 3-turn rule, shared file conventions, and anti-patterns that waste tokens.
+
+> **TL;DR:** Every message costs money. Silence = success. Write files instead of sending messages. Only push urgent things. There are exactly 4 message types: TASK, RESULT, ESCALATION, DECISION. No ACKs. No courtesy messages.
+
 > Every message costs money. This protocol eliminates the 40-60% of tokens agents waste on coordination overhead.
 
 ---
@@ -312,3 +316,12 @@ A: Update their SOUL.md to include the protocol rules. If they persist, it's a m
 
 **Q: Can I modify this protocol for my org?**
 A: Yes, but keep the core invariants: no ACKs, files over chat, 3-turn limit, deterministic routing. These are the rules that actually move the needle on token waste.
+
+---
+
+## Next steps
+
+- **MCP tools for messaging:** [`docs/mcp-reference.md`](./mcp-reference.md) — `message_send`, `message_read`, `escalation_create` and more
+- **Org structure (routing):** [`docs/org-md-reference.md`](./org-md-reference.md) — define who handles what in ORG.md
+- **Agent quickstart:** [`docs/agent-quickstart.md`](./agent-quickstart.md) — see protocol in practice
+- **Common errors:** [`docs/troubleshooting.md`](./troubleshooting.md) — fix escalation and messaging issues

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,279 @@
+---
+purpose: Help you decide when to use OpenSpawn vs CrewAI vs LangGraph
+audience: developers, AI agents, engineering leads
+related: [getting-started.md, mcp-reference.md, agent-quickstart.md]
+---
+
+# OpenSpawn vs CrewAI vs LangGraph
+
+**What you'll learn:** The key differences between the three most popular multi-agent frameworks in 2026, where each excels, where each falls short, and how to migrate — or combine them.
+
+> **Bottom line up front:** CrewAI and LangGraph are excellent *execution* frameworks. OpenSpawn is *coordination infrastructure*. They solve different problems — and they're designed to work together.
+
+---
+
+## Decision tree
+
+```
+Do you need to build and execute agent logic?
+├── YES, in Python, with a clean role API → CrewAI
+├── YES, with precise control over complex stateful flows → LangGraph
+└── NO — I need to organize, govern, and coordinate multiple agents
+    └── OpenSpawn
+```
+
+```
+Do you need all three capabilities?
+└── Use OpenSpawn (coordination) + CrewAI/LangGraph (execution) together
+```
+
+> **Q: Can I use OpenSpawn with my existing CrewAI/LangGraph setup?**
+> Yes — OpenSpawn is additive. It coordinates your existing agents without requiring rewrites. See the migration guides below.
+
+> **Q: Is OpenSpawn a replacement for CrewAI?**
+> No. OpenSpawn and CrewAI solve different problems. CrewAI builds agents. OpenSpawn organizes them. Use both.
+
+> **Q: Which should I start with if I'm new to multi-agent systems?**
+> Start with CrewAI for its simplicity and community. Add OpenSpawn when you need governance, budgets, or coordination across multiple workflows.
+
+---
+
+## Feature comparison
+
+| Feature | OpenSpawn | CrewAI | LangGraph |
+|---------|-----------|--------|-----------|
+| **Primary role** | Coordination / control plane | Agent execution framework | Graph-based orchestration |
+| **Language** | TypeScript (Python SDK planned) | Python | Python |
+| **Agent hierarchy** | 10-level hierarchy, roles, trust scores | Flat crews | Flat nodes |
+| **Org definition** | `ORG.md` (markdown) | Python code | Python code |
+| **Protocol support** | MCP (native), A2A, REST, GraphQL | Plugins | LangChain tools |
+| **Real device support** | ✅ Via OpenClaw | ❌ | ❌ |
+| **Real-time dashboard** | ✅ React, network graph, SSE | ❌ (CLI/LangSmith) | ❌ (LangSmith) |
+| **Self-hosted** | ✅ MIT open source | ✅ Open source | ✅ Open source |
+| **Budget / credits** | ✅ Built-in economic layer | ❌ | ❌ |
+| **Approval gates** | ✅ Pre-hooks for irreversible actions | ❌ | Conditional edges |
+| **Trust / reputation** | ✅ Per-agent trust scores | ❌ | ❌ |
+| **Escalation system** | ✅ Typed escalation with chain of command | ❌ | ❌ |
+| **Framework agnostic** | ✅ Works with any A2A/MCP agent | ❌ | ❌ |
+| **Pricing** | Free, self-hosted | Free + Enterprise (paid) | Free + LangSmith (paid) |
+| **Production maturity** | Demo-stage, rapid development | Production-ready | Production-ready |
+
+---
+
+## Where each framework shines
+
+### CrewAI — Role-Based Task Crews
+
+CrewAI excels at defining small, focused agent teams ("crews") that work together on a shared task. Its Python-first API is clean, the role system is intuitive, and the LangChain ecosystem means you can connect to almost anything out of the box.
+
+**Use CrewAI when:**
+- You want to ship a multi-agent pipeline in Python, fast
+- Your use case is a single workflow with a clear beginning and end
+- You're already in the LangChain ecosystem
+- You want the largest framework community and most tutorials
+
+**The gap:** CrewAI doesn't provide organizational structure. Multiple crews, running simultaneously, across a real product, have no shared governance. No budget system, no trust scores, no approval gates before irreversible actions.
+
+---
+
+### LangGraph — Stateful Agent Graphs
+
+LangGraph gives you precise, explicit control over agent flow as a directed graph. Each node is an agent or function. Edges define transitions. State is typed and checkpointed.
+
+**Use LangGraph when:**
+- You need fine-grained control over agent execution flow
+- Your workflow has complex branching logic or cycles
+- You're building production pipelines where every state transition matters
+- You want excellent observability via LangSmith
+
+**The gap:** LangGraph models agents as graph nodes — it's a powerful execution primitive. It doesn't model your *organization*. Who owns a node? Who approves its output? What happens when it goes over budget? LangGraph has no answer for these questions.
+
+---
+
+### OpenSpawn — Agent Coordination Infrastructure
+
+OpenSpawn is not a framework you write agents in. It's the *company infrastructure* that your agents (built in CrewAI, LangGraph, or anything else) operate within.
+
+Mental model: agent frameworks are your employees' skills. OpenSpawn is the company — org chart, task management, budget, governance, communications.
+
+**Use OpenSpawn when:**
+- You're running multiple agents across multiple workflows simultaneously
+- You need governance: budget limits, approval gates, trust scores
+- You want your org structure defined as code (`ORG.md`) and reviewable in git
+- Your agents need to work on real devices (via OpenClaw)
+- You need framework-agnostic coordination — mix CrewAI + LangGraph + custom agents in one org
+
+---
+
+## Where OpenSpawn wins
+
+### 1. Organizations as Code
+
+```markdown
+# My Engineering Org
+
+## Culture
+preset: startup
+
+## Structure
+
+### COO
+Receives orders, delegates to departments.
+- **Model:** claude-sonnet
+
+### Engineering
+
+#### Engineering Lead
+- **Model:** claude-sonnet
+- **Domain:** engineering
+
+#### Backend Workers
+- **Model:** claude-haiku
+- **Count:** 3
+```
+
+Human-readable, version-controllable, and deployable: `npx openspawn deploy ORG.md`. The prose *is* the system prompt. Reviewable in git PRs.
+
+### 2. Protocol-Native from Day One
+
+- **MCP (Model Context Protocol):** Org exposed as MCP tools, consumable by Claude Desktop, Cursor, or any MCP client
+- **A2A (Agent-to-Agent):** Every agent has a `/.well-known/agent.json` discovery card for inter-org communication
+- **Streamable HTTP:** Real-time SSE, no polling
+
+### 3. Real-World Device Support
+
+Via deep integration with [OpenClaw](https://openclaw.ai), OpenSpawn agents can operate on real computers — browsing the web, running code, interacting with applications, managing files. No other coordination platform offers this.
+
+### 4. Economic Layer
+
+Built-in credit system — not just rate limits, but a full economic model: per-agent credit budgets, automatic cost tracking against real LLM spend, and `overage behavior: pause and escalate`.
+
+### 5. Governance Built-In
+
+Pre-hooks let you require human approval before any irreversible action. LangGraph has conditional edges. CrewAI has human-in-the-loop options. Neither has a system-level governance layer that applies across all agents, all tasks, regardless of framework.
+
+---
+
+## Where competitors are ahead
+
+> Honest assessment — we believe in fair comparisons.
+
+| Area | Where they're ahead |
+|------|-------------------|
+| **Community & ecosystem** | CrewAI has tens of thousands of stars. LangGraph has the full LangChain ecosystem. OpenSpawn is early-stage. |
+| **Production maturity** | CrewAI and LangGraph run in production at scale. OpenSpawn is in rapid development — core is solid, some enterprise features on roadmap. |
+| **Python ecosystem** | Both CrewAI and LangGraph are Python-first. OpenSpawn is TypeScript-first (Python SDK in development). |
+
+---
+
+## Migration guides
+
+### From CrewAI to OpenSpawn
+
+OpenSpawn doesn't replace your CrewAI agents — it governs them. The migration is additive.
+
+**Step 1: Deploy OpenSpawn alongside your existing setup**
+```bash
+git clone https://github.com/openspawn/openspawn.git
+cd openspawn && pnpm install
+pnpm exec nx serve sandbox
+```
+
+**Step 2: Map your crew structure to ORG.md**
+```markdown
+# My Crew Org
+
+## Structure
+
+### Coordinator
+Routes work to specialist agents.
+- **Model:** claude-sonnet
+
+### Research Crew
+Runs your existing CrewAI research crew via MCP.
+- **Domain:** research
+```
+
+**Step 3: Connect your CrewAI agents via MCP**
+```python
+from crewai_tools import MCPServerAdapter
+
+openspawn_tools = MCPServerAdapter(
+    server_url="http://localhost:3333/mcp"
+)
+# Your agents can now use task_create, agent_list, org_status
+```
+
+---
+
+### From LangGraph to OpenSpawn
+
+**Step 1: Expose your LangGraph workflow as an MCP tool**
+```python
+from openspawn import OpenSpawnClient  # Python SDK (in development)
+
+client = OpenSpawnClient(url="http://localhost:3333")
+client.register_agent(
+    name="Research Pipeline",
+    domain="research",
+    capabilities=["web-search", "summarization"]
+)
+```
+
+**Step 2: Delegate tasks through OpenSpawn**
+```python
+# Before: call your graph directly
+result = app.invoke({"task": "Research quantum computing trends"})
+
+# After: delegate through OpenSpawn (governance, budget, audit trail included)
+task = client.delegate_task(
+    "Research quantum computing trends",
+    priority="medium"
+)
+```
+
+---
+
+## The right architecture
+
+For most production agent teams, the answer isn't either/or:
+
+```
+┌──────────────────────────────────────┐
+│            OpenSpawn Org             │
+│  (governance, budget, coordination)  │
+│                                      │
+│  ┌──────────┐    ┌────────────────┐  │
+│  │ CrewAI   │    │   LangGraph    │  │
+│  │ Agents   │    │   Pipelines    │  │
+│  └──────────┘    └────────────────┘  │
+│                                      │
+│  ┌──────────┐    ┌────────────────┐  │
+│  │ OpenClaw │    │  Custom Agent  │  │
+│  │ (devices)│    │  (any A2A)     │  │
+│  └──────────┘    └────────────────┘  │
+└──────────────────────────────────────┘
+```
+
+---
+
+## Quick decision guide
+
+| Use… | When… |
+|------|-------|
+| CrewAI | You want the easiest Python framework, clean role-based API for small-to-medium crews |
+| LangGraph | You need precise control over complex, stateful, multi-step agent flows |
+| OpenSpawn | You're coordinating multiple agent teams, need governance/budget/approval gates |
+| OpenSpawn + CrewAI | You want CrewAI's execution simplicity with organizational governance |
+| OpenSpawn + LangGraph | You want LangGraph's graph power with budget enforcement and a dashboard |
+
+---
+
+## Next steps
+
+- **Get started:** [`docs/getting-started.md`](./getting-started.md)
+- **MCP integration:** [`docs/mcp-reference.md`](./mcp-reference.md)
+- **ORG.md reference:** [`docs/org-md-reference.md`](./org-md-reference.md)
+- **Live demo:** https://bikinibottom.ai/app/
+
+*Last updated: February 2026. OpenSpawn is in rapid development — see the [GitHub repo](https://github.com/openspawn/openspawn) for the latest.*

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,9 +4,12 @@ audience: developers, AI agents
 prerequisites: Node.js 18+
 time_estimate: 10 minutes
 difficulty: beginner
+related: [agent-quickstart.md, templates-guide.md, org-md-reference.md, mcp-reference.md, FAQ.md, troubleshooting.md]
 ---
 
 # Getting Started with OpenSpawn
+
+**What you'll learn:** How to install OpenSpawn, scaffold an org from a template, understand ORG.md structure, validate and generate configs, preview the dashboard, and connect real AI models.
 
 **What you'll have in ~10 minutes:** a local org of AI agents, coordinated by a markdown file, visible in a real-time dashboard — with tasks flowing through a hierarchy you define.
 
@@ -279,10 +282,15 @@ Edit `openspawn.config.json`:
 
 ---
 
-## What's next?
+## Next steps
 
 - **Full CLI reference:** `openspawn --help`
-- **All MCP tools:** See `docs/llms.txt`
-- **Templates deep dive:** See `docs/templates-guide.md`
+- **All MCP tools:** [`docs/mcp-reference.md`](./mcp-reference.md) — every tool with parameters
+- **Templates deep dive:** [`docs/templates-guide.md`](./templates-guide.md) — all 4 templates
+- **ORG.md format:** [`docs/org-md-reference.md`](./org-md-reference.md) — every field and example
+- **Communication protocol:** [`docs/communication-protocol.md`](./communication-protocol.md) — save tokens with efficient agent communication
+- **Top 20 FAQ:** [`docs/FAQ.md`](./FAQ.md)
+- **Fix errors:** [`docs/troubleshooting.md`](./troubleshooting.md)
+- **Agent quickstart:** [`docs/agent-quickstart.md`](./agent-quickstart.md) — agent-first version of this guide
 - **Live demo:** https://bikinibottom.ai/app/ (22 agents, 5 departments)
 - **ORG.md spec:** https://bikinibottom.ai/org-md

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -1,0 +1,738 @@
+---
+purpose: Complete reference for all OpenSpawn MCP tools and their parameters
+audience: AI agents (primary), developers integrating with OpenSpawn
+related: [agent-quickstart.md, FAQ.md, llms.txt, communication-protocol.md]
+---
+
+# MCP Tools Reference
+
+**What you'll learn:** Every MCP tool OpenSpawn exposes — name, description, parameters, return values, and usage examples. Use this as your lookup table when building or debugging agent workflows.
+
+> **Quick reference:** OpenSpawn exposes tools via MCP (Streamable HTTP) at `POST /mcp`. Authenticate via HMAC — set `AGENT_ID` and `AGENT_SECRET` env vars.
+
+---
+
+## Connection
+
+```
+Endpoint:   POST /mcp
+Transport:  Streamable HTTP (spec: 2025-03-26)
+Protocol:   JSON-RPC 2.0
+Auth:       HMAC — AGENT_ID + AGENT_SECRET env vars
+```
+
+**Test your connection:**
+```bash
+curl -X POST http://localhost:3333/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+```
+
+> **Q: How does HMAC auth work?**
+> The MCP client signs requests using `AGENT_ID` and `AGENT_SECRET`. Set both as environment variables. The server validates the signature on every request.
+
+> **Q: Where do I find my AGENT_ID and AGENT_SECRET?**
+> After running `openspawn start`, check `openclaw-patch.json`. Each agent entry has an `id` field — that's the `AGENT_ID`. The secret is set in your OpenClaw gateway config.
+
+---
+
+## Tool categories
+
+| Category | Tools | Purpose |
+|----------|-------|---------|
+| [Agent](#agent-tools) | `agent_list`, `agent_whoami`, `agent_register`, `agent_update_status`, `agent_fire` | Manage agents in the org |
+| [Task](#task-tools) | `task_create`, `task_list`, `task_get`, `task_claim`, `task_update`, `task_complete`, `task_transition`, `task_assign`, `task_comment` | Create, assign, and track work |
+| [Credits](#credit-tools) | `credits_balance`, `credits_spend`, `credits_history` | Manage agent budgets |
+| [Message](#message-tools) | `message_channels`, `message_send`, `message_read`, `message_list` | Structured inter-agent communication |
+| [Trust](#trust-tools) | `trust_get_reputation`, `trust_get_history`, `trust_leaderboard`, `trust_bonus`, `trust_penalty` | Agent reputation management |
+| [Escalation](#escalation-tools) | `escalation_create`, `escalation_list`, `escalation_resolve`, `consensus_request`, `consensus_vote`, `consensus_status` | Handle blockers and decisions |
+| [Org](#org-tools) | `org_status` | Full org overview |
+
+---
+
+## Agent tools
+
+### `agent_list`
+List all agents registered in the org.
+
+**Parameters:** none
+
+**Returns:** Array of agents with `id`, `name`, `role`, `level`, `status`, `department`, `model`
+
+```
+tool: agent_list
+```
+
+---
+
+### `agent_whoami`
+Get current agent's own info (identity, level, permissions).
+
+**Parameters:** none
+
+**Returns:** Your agent record — use this to determine your own level, role, and manager
+
+```
+tool: agent_whoami
+```
+
+---
+
+### `agent_register`
+Register an agent in the org. Typically called by the lead agent during boot sequence.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Unique agent identifier |
+| `name` | string | ✅ | Display name |
+| `role` | string | ✅ | Role title |
+| `level` | number | No | Agent level (1-10) |
+| `department` | string | No | Department name |
+| `model` | string | No | LLM model identifier |
+
+```
+tool: agent_register {
+  id: "engineer-1",
+  name: "Forge",
+  role: "Software Engineer",
+  level: 7,
+  department: "Engineering",
+  model: "claude-sonnet"
+}
+```
+
+---
+
+### `agent_update_status`
+Set an agent's current availability status.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | string | ✅ | Agent ID |
+| `status` | string | ✅ | `idle` \| `working` \| `paused` \| `overwhelmed` |
+
+```
+tool: agent_update_status { agent_id: "engineer-1", status: "working" }
+```
+
+> **Q: When should I use `overwhelmed` vs `paused`?**
+> Use `overwhelmed` when you have too many tasks and need your manager to stop assigning more. Use `paused` when you're temporarily blocked and expect to resume soon.
+
+---
+
+### `agent_fire`
+Remove an agent from the org (archives their workspace). Requires appropriate permission level.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | string | ✅ | Agent ID to decommission |
+
+```
+tool: agent_fire { agent_id: "temp-researcher-1" }
+```
+
+---
+
+## Task tools
+
+### `task_create`
+Create a new task and optionally assign it.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | string | ✅ | Task title |
+| `description` | string | No | Detailed requirements |
+| `priority` | string | No | `urgent` \| `high` \| `normal` \| `low` (default: `normal`) |
+| `assigneeId` | string | No | Agent ID to assign to (org task system) |
+| `assign_to` | string | No | Agent ID to assign to (coordination server) |
+| `created_by` | string | No | Creator agent ID |
+
+```
+tool: task_create {
+  title: "Implement OAuth2 login",
+  description: "See PLAN.md section 3 for requirements",
+  priority: "high",
+  assigneeId: "engineer-1"
+}
+```
+
+> **Q: What's the difference between `assigneeId` and `assign_to`?**
+> Both assign the task. `assigneeId` is the parameter for the org MCP server. `assign_to` is used by the coordination server (PR #426). Use whichever matches your server version.
+
+---
+
+### `task_list`
+List tasks with optional filters.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | string | No | Filter by status |
+| `assigneeId` | string | No | Filter by assignee (org system) |
+| `assigned_to` | string | No | Filter by assignee (coordination server) |
+| `priority` | string | No | Filter by priority |
+
+**Status values:** `backlog` \| `todo` \| `in_progress` \| `review` \| `done` \| `blocked` \| `cancelled` \| `open`
+
+```
+tool: task_list { status: "open", priority: "high" }
+tool: task_list { assigned_to: "engineer-1" }
+```
+
+---
+
+### `task_get`
+Get details for a specific task by ID.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Task ID |
+
+```
+tool: task_get { id: "task-abc123" }
+```
+
+---
+
+### `task_claim`
+Atomically claim an open task. **Only one agent can win.** Prevents duplicate work.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `task_id` | string | ✅ | Task ID to claim |
+| `agent_id` | string | ✅ | Your agent ID |
+
+```
+tool: task_claim { task_id: "task-abc123", agent_id: "engineer-1" }
+```
+
+> **Q: What happens if two agents call task_claim simultaneously?**
+> Only one wins. The other receives an error: `task already claimed`. Find another task with `task_list { status: "open" }`.
+
+---
+
+### `task_update`
+Update task status or details.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `task_id` | string | ✅ | Task ID |
+| `status` | string | No | New status |
+| `description` | string | No | Updated description |
+| `priority` | string | No | Updated priority |
+| `assign_to` | string | No | Reassign to different agent |
+
+```
+tool: task_update { task_id: "task-abc123", status: "in_progress" }
+```
+
+---
+
+### `task_complete`
+Mark a task done with its result and any artifacts.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `task_id` | string | ✅ | Task ID |
+| `result` | string | ✅ | Summary of what was done |
+| `artifacts` | string[] | No | File paths, URLs, or PR references |
+
+```
+tool: task_complete {
+  task_id: "task-abc123",
+  result: "OAuth2 login implemented and tested",
+  artifacts: ["src/auth/oauth.ts", "https://github.com/org/repo/pull/47"]
+}
+```
+
+---
+
+### `task_transition`
+Change a task's status (org task system).
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Task ID |
+| `status` | string | ✅ | New status |
+| `reason` | string | No | Optional reason for transition |
+
+**Valid statuses:** `backlog` \| `todo` \| `in_progress` \| `review` \| `done` \| `blocked` \| `cancelled`
+
+```
+tool: task_transition { id: "task-abc123", status: "review", reason: "PR submitted" }
+```
+
+---
+
+### `task_assign`
+Assign a task to a different agent.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Task ID |
+| `assigneeId` | string | ✅ | Agent ID to assign to |
+
+```
+tool: task_assign { id: "task-abc123", assigneeId: "engineer-2" }
+```
+
+---
+
+### `task_comment`
+Add a comment to a task's activity log.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `taskId` | string | ✅ | Task ID |
+| `body` | string | ✅ | Comment text |
+
+```
+tool: task_comment { taskId: "task-abc123", body: "Blocked on Redis — see ESCALATION.md" }
+```
+
+---
+
+## Credit tools
+
+### `credits_balance`
+Get your current credit balance.
+
+**Parameters:** none
+
+**Returns:** `{ balance: number, limit: number, period: string }`
+
+```
+tool: credits_balance
+```
+
+---
+
+### `credits_spend`
+Spend credits with an audit trail.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | integer | ✅ | Credits to spend |
+| `reason` | string | ✅ | What the credits are for |
+
+```
+tool: credits_spend { amount: 50, reason: "LLM inference for auth implementation" }
+```
+
+> **Q: What happens if I exceed my budget?**
+> Based on your org's `overage behavior` policy: `pause and escalate` (default), or `hard-stop`. Escalate to your manager immediately when you're approaching the limit.
+
+---
+
+### `credits_history`
+View your credit transaction history.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `limit` | integer | No | Max transactions to return (default: 50) |
+| `offset` | integer | No | Pagination offset (default: 0) |
+
+```
+tool: credits_history { limit: 20 }
+```
+
+---
+
+## Message tools
+
+### `message_channels`
+List available message channels.
+
+**Parameters:** none
+
+**Returns:** Array of channels with `id`, `name`, `type`
+
+```
+tool: message_channels
+```
+
+---
+
+### `message_send`
+Send a structured message to another agent or channel.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `channelId` | string | ✅ (org system) | Channel ID |
+| `to` | string | ✅ (coord server) | Recipient agent ID |
+| `body` | string | ✅ | Message content |
+| `type` | string | No | `text` \| `handoff` \| `status_update` \| `request` \| `TASK` \| `RESULT` \| `ESCALATION` \| `DECISION` |
+
+```
+tool: message_send {
+  channelId: "chan-general",
+  body: "RESULT @lead: OAuth implementation done. See PR #47 and RESULT.md.",
+  type: "handoff"
+}
+```
+
+> **Q: What message types should I use?**
+> Per the [communication protocol](./communication-protocol.md): `TASK` (work assignment), `RESULT` (deliverable notification), `ESCALATION` (blocker), `DECISION` (resolving a blocker). Never send ACK-only messages.
+
+---
+
+### `message_read`
+Read messages from a channel.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `channelId` | string | ✅ | Channel ID |
+| `limit` | integer | No | Max messages (default: 50) |
+
+```
+tool: message_read { channelId: "chan-general", limit: 20 }
+```
+
+---
+
+### `message_list`
+List messages with filters (coordination server).
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `to` | string | No | Filter by recipient |
+| `from` | string | No | Filter by sender |
+| `type` | string | No | Filter by message type |
+
+```
+tool: message_list { to: "engineer-1", type: "TASK" }
+```
+
+---
+
+## Trust tools
+
+> **Note:** Trust tools require appropriate permission level. `trust_bonus` and `trust_penalty` require the HR role or equivalent.
+
+### `trust_get_reputation`
+Get an agent's current trust score.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agentId` | string | ✅ | Agent ID |
+
+```
+tool: trust_get_reputation { agentId: "engineer-1" }
+```
+
+**Returns:** `{ score: number, tier: "PROBATION" | "TRUSTED" | "VETERAN" | "ELITE" }`
+
+---
+
+### `trust_get_history`
+Get an agent's reputation change history.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agentId` | string | ✅ | Agent ID |
+| `limit` | integer | No | Max entries |
+
+```
+tool: trust_get_history { agentId: "engineer-1", limit: 10 }
+```
+
+---
+
+### `trust_leaderboard`
+Get the top agents by trust score.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `limit` | integer | No | Max agents to return |
+
+```
+tool: trust_leaderboard { limit: 5 }
+```
+
+---
+
+### `trust_bonus`
+Award a reputation bonus to an agent. Requires HR role.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agentId` | string | ✅ | Agent ID |
+| `amount` | integer | ✅ | Bonus amount (1-20) |
+| `reason` | string | ✅ | Reason for bonus |
+
+```
+tool: trust_bonus {
+  agentId: "engineer-1",
+  amount: 10,
+  reason: "Shipped OAuth feature 2 cycles ahead of schedule"
+}
+```
+
+---
+
+### `trust_penalty`
+Apply a reputation penalty to an agent. Requires HR role.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agentId` | string | ✅ | Agent ID |
+| `amount` | integer | ✅ | Penalty amount (1-20) |
+| `reason` | string | ✅ | Reason for penalty |
+
+```
+tool: trust_penalty {
+  agentId: "engineer-1",
+  amount: 5,
+  reason: "Skipped escalation chain, caused rework"
+}
+```
+
+---
+
+## Escalation tools
+
+### `escalation_create`
+Create an escalation for a blocker that requires manager intervention.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `taskId` | string | ✅ (org system) | Task that's blocked |
+| `reason` | string | ✅ | What's blocking and what help is needed |
+| `targetAgentId` | string | No | Who to escalate to (defaults to your manager) |
+| `issue` | string | ✅ (coord server) | Description of the issue |
+| `context` | string | No | Additional context |
+| `severity` | string | ✅ (coord server) | `low` \| `medium` \| `high` \| `critical` |
+| `to_agent` | string | No | Target agent (coord server) |
+
+```
+# Org system
+tool: escalation_create {
+  taskId: "task-abc123",
+  reason: "Redis not available in staging. Need decision: add Redis or use in-memory?",
+  targetAgentId: "lead-engineer"
+}
+
+# Coordination server
+tool: escalation_create {
+  issue: "Cannot deploy — missing production credentials",
+  severity: "critical",
+  to_agent: "ceo"
+}
+```
+
+> **Q: When should I escalate?**
+> When you're blocked from completing your task: missing requirements, conflicting instructions, access issues, ambiguous scope. NOT for status updates or courtesy check-ins.
+
+---
+
+### `escalation_list`
+List escalations with optional filters.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `taskId` | string | No | Filter by task |
+| `severity` | string | No | Filter by severity |
+| `status` | string | No | Filter by status (`open`, `resolved`) |
+
+```
+tool: escalation_list { status: "open", severity: "high" }
+```
+
+---
+
+### `escalation_resolve`
+Resolve an escalation (manager/lead action).
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `escalationId` | string | ✅ | Escalation ID |
+| `resolution` | string | ✅ | How it was resolved — must definitively unblock the issue |
+
+```
+tool: escalation_resolve {
+  escalationId: "esc-456",
+  resolution: "Use in-memory rate limiting for now. Redis task created for next sprint."
+}
+```
+
+---
+
+### `consensus_request`
+Request a vote from a group of agents on a decision.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `taskId` | string | ✅ | Related task ID |
+| `question` | string | ✅ | The decision question |
+| `voterIds` | string[] | ✅ | Array of agent IDs to vote |
+
+```
+tool: consensus_request {
+  taskId: "task-abc123",
+  question: "Should we ship v2 this cycle or wait for QA to finish?",
+  voterIds: ["lead-frontend", "lead-backend", "qa-lead"]
+}
+```
+
+---
+
+### `consensus_vote`
+Submit a vote on a consensus request.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `consensusId` | string | ✅ | Consensus request ID |
+| `vote` | string | ✅ | `approve` \| `reject` |
+| `reason` | string | No | Reasoning for your vote |
+
+```
+tool: consensus_vote {
+  consensusId: "con-789",
+  vote: "approve",
+  reason: "QA can run in parallel — no need to delay"
+}
+```
+
+---
+
+### `consensus_status`
+Check the current status of a consensus vote.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `consensusId` | string | ✅ | Consensus ID |
+
+```
+tool: consensus_status { consensusId: "con-789" }
+```
+
+**Returns:** `{ status: "pending" | "resolved", result: "approved" | "rejected", votes: [...] }`
+
+---
+
+## Org tools
+
+### `org_status`
+Get a full overview of the org: all agents, task counts, budget status.
+
+**Parameters:** none
+
+**Returns:** 
+```json
+{
+  "agents": [...],
+  "tasks": { "open": 5, "in_progress": 3, "done": 12 },
+  "budget": { "total_spent": 1200, "total_limit": 5000 },
+  "health_score": 87
+}
+```
+
+```
+tool: org_status
+```
+
+> **Q: How often should I call org_status?**
+> Lead agents should call it every 5 minutes during active sessions. Workers should call it on startup and when they need to find available agents.
+
+---
+
+## Common workflows
+
+### Boot sequence (lead agent)
+```
+1. agent_register for each team member
+2. task_create for current-phase tasks
+3. org_status (baseline)
+4. message_send assignments to workers
+```
+
+### Worker loop
+```
+1. task_list { status: "open" }  ← find available work
+2. task_claim { task_id, agent_id }  ← claim atomically
+3. agent_update_status { status: "working" }
+4. [do the work]
+5. task_complete { task_id, result, artifacts }
+6. agent_update_status { status: "idle" }
+```
+
+### Handling a blocker
+```
+1. escalation_create { reason: "blocked on X" }
+2. Wait for DECISION message
+3. Resume work based on decision
+```
+
+### Manager handling escalations
+```
+1. escalation_list { status: "open" }
+2. Read the issue and context
+3. escalation_resolve { resolution: "..." }
+   OR task_assign to a different agent
+   OR escalation_create to escalate further up
+```
+
+---
+
+## Next steps
+
+- **Full quickstart for agents:** [`docs/agent-quickstart.md`](./agent-quickstart.md)
+- **Communication rules:** [`docs/communication-protocol.md`](./communication-protocol.md)
+- **ORG.md format:** [`docs/org-md-reference.md`](./org-md-reference.md)
+- **Common errors:** [`docs/troubleshooting.md`](./troubleshooting.md)
+- **Complete llms.txt:** [`docs/llms.txt`](./llms.txt)

--- a/docs/org-md-reference.md
+++ b/docs/org-md-reference.md
@@ -1,0 +1,564 @@
+---
+purpose: Complete reference for the ORG.md organization definition format
+audience: AI agents, developers, org architects
+related: [getting-started.md, templates-guide.md, mcp-reference.md, agent-quickstart.md]
+---
+
+# ORG.md Reference
+
+**What you'll learn:** Every field, section, value, and example for `ORG.md` — the OpenSpawn organization definition format. By the end, you'll be able to write an ORG.md from scratch for any team structure.
+
+> **TL;DR:** `ORG.md` defines your entire agent org — roles, hierarchy, culture, budgets — in one markdown file. It's human-readable, version-controlled, and machine-parseable.
+
+```bash
+# Deploy your org
+npx openspawn deploy ORG.md
+
+# Validate before deploying
+openspawn validate ORG.md
+```
+
+---
+
+## Why ORG.md?
+
+The agent ecosystem already speaks markdown:
+- `CLAUDE.md` defines one agent's behavior
+- `AGENTS.md` defines workspace rules
+- `ORG.md` defines an entire organization
+
+Markdown lets you mix intent with structure. An org definition isn't just data — it's *philosophy*. Why is the team structured this way? What communication norms matter? That context is critical when humans review changes, when agents onboard, and when the system proposes optimizations.
+
+**The markdown IS the documentation.** No separate wiki explaining what the config means.
+
+> **Q: Why not YAML or JSON?**
+> Markdown allows prose. "Triages technical work. Delegates to specialists. Reviews output." tells the LLM how to behave. YAML can't carry intent — markdown can. Write role descriptions like you're onboarding a real hire.
+
+---
+
+## File structure
+
+An ORG.md file has five top-level sections. All are optional except `## Structure`.
+
+```markdown
+# Organization Name
+
+## Identity
+## Culture
+## Structure
+## Policies
+## Playbooks
+```
+
+**Minimum valid ORG.md:**
+```markdown
+# My Org
+
+## Structure
+
+### Boss — Leader
+- **Level:** 10
+- **Reports to:** Human Principal
+```
+
+---
+
+## Section 1: Identity
+
+**Purpose:** Who is this organization? Name, mission, and context every agent inherits.
+
+**Why it matters:** Agents use Identity as ambient context. When a marketing agent writes copy, it knows the company builds dev tools. When an engineering agent prioritizes, "customers first" influences the decision.
+
+```markdown
+# Acme Engineering
+
+## Identity
+
+We build developer tools that make infrastructure invisible.
+Every agent in this org serves that mission.
+
+- **Industry:** Developer tools / SaaS
+- **Stage:** Series A, 18 months old
+- **Values:** Ship fast, measure everything, customers first
+```
+
+**Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `**Industry:**` | string | Industry context for agent decisions |
+| `**Stage:**` | string | Company stage (affects risk tolerance) |
+| `**Values:**` | string | Core values — agents reference these in decisions |
+
+Free prose above or below structured fields becomes system prompt context for all agents.
+
+---
+
+## Section 2: Culture
+
+**Purpose:** How the organization communicates. Maps directly to ACP (Agent Communication Protocol) parameters.
+
+**Why it matters:** Culture presets configure escalation speed, progress frequency, hierarchy depth, and ack requirements — without you needing to tune each parameter manually.
+
+### Using a preset
+
+```markdown
+## Culture
+
+preset: startup
+```
+
+**Available presets:**
+
+| Preset | Escalation | Progress | Hierarchy | Best for |
+|--------|-----------|----------|-----------|---------|
+| `startup` | Immediate | Frequent | 2-3 levels | Small, fast-moving teams |
+| `enterprise` | Batched (hourly) | On phase change | 5-8 levels | Large orgs, governance-heavy |
+| `agency` | Immediate | Every tick | 3-4 levels | Client-facing, deadline-driven |
+| `research` | Delayed | On request | 2-3 levels | Exploratory, long-running tasks |
+| `military` | Immediate | Every tick | Strict chain | Zero-ambiguity, mandatory acks |
+| `remote-async` | Delayed | On request | Flat | Distributed, async-first |
+
+### Overriding preset values
+
+```markdown
+## Culture
+
+preset: startup
+- **Escalation:** delayed — we trust leads to figure things out
+- **Ack required:** no
+```
+
+### Manual configuration (no preset)
+
+```markdown
+## Culture
+
+We're a startup. Move fast, communicate openly, escalate immediately.
+
+- **Communication:** async-first
+- **Escalation:** immediate
+- **Progress updates:** on phase change
+- **Ack required:** yes
+- **Hierarchy depth:** shallow (3 levels max)
+```
+
+---
+
+## Section 3: Structure
+
+**Purpose:** The org chart — departments, roles, and hierarchy as nested markdown headings.
+
+**Why it matters:** Structure is the core of ORG.md. It defines who exists, what they do, who they report to, and what level of authority they have.
+
+### Heading hierarchy
+
+```
+## Structure          → section marker
+### Department/Role   → L9-10 (department head or C-level)
+#### Role Name        → L4-7 (team member, inherits department)
+##### Sub-role        → L1-3 (junior / intern)
+```
+
+### Agent definition
+
+```markdown
+### Oscar — Chief of Staff
+The coordinator. Manages priorities, delegates to specialists.
+- **Level:** 10
+- **Domain:** Operations
+- **Reports to:** Human Principal
+- **Model:** claude-sonnet
+```
+
+**Required fields:**
+
+| Field | Required? | Description |
+|-------|-----------|-------------|
+| `**Level:**` | Recommended | L1-L10 (inferred from role keywords if omitted) |
+| `**Reports to:**` | ✅ | Manager's name or "Human Principal" |
+| `**Domain:**` | No | Specialization area (used for task routing) |
+| `**Model:**` | No | LLM identifier (defaults to org default) |
+| `**Count:**` | No | Spawn N identical agents (auto-numbered) |
+
+**Prose above the fields** becomes that agent's system prompt context. Write it like you're describing the role to a new hire.
+
+### Level reference
+
+| Keyword in role name | Inferred level | Can delegate? | Can spawn agents? |
+|---------------------|----------------|---------------|-------------------|
+| COO, CTO, CEO | L10 | ✅ | ✅ |
+| VP, Director | L9 | ✅ | ✅ |
+| Lead, Manager | L7 | ✅ | ✅ |
+| Senior, Principal | L6 | ✅ (review only) | ❌ |
+| Engineer, Worker, Agent | L4 | ❌ | ❌ |
+| Junior, Intern, Assistant | L1-2 | ❌ | ❌ |
+
+> **Q: Do I have to specify Level explicitly?**
+> No — it's inferred from role name keywords. But explicit is clearer and overrides inference.
+
+### The Count field
+
+Creates N agents with the same role:
+
+```markdown
+#### Backend Workers
+- **Count:** 3
+- **Model:** claude-haiku
+- **Domain:** backend
+```
+
+Creates "Backend Worker 1", "Backend Worker 2", "Backend Worker 3" — each independent with its own task queue and trust score.
+
+### Full example structure
+
+```markdown
+## Structure
+
+### COO
+The operational backbone. Receives orders, breaks into department work.
+- **Level:** 10
+- **Domain:** operations
+- **Reports to:** Human Principal
+- **Model:** claude-sonnet
+
+### Engineering
+
+#### Engineering Lead
+Triages technical work. Delegates to specialists. Reviews output.
+- **Level:** 7
+- **Domain:** engineering
+- **Model:** claude-sonnet
+
+#### Backend Senior
+Owns API, database, and server infrastructure.
+- **Level:** 6
+- **Domain:** backend
+- **Model:** claude-haiku
+
+#### Frontend Workers
+Build and maintain the dashboard.
+- **Level:** 4
+- **Domain:** frontend
+- **Count:** 3
+- **Model:** claude-haiku
+
+### Security
+
+#### Security Lead
+Every deploy needs their sign-off.
+- **Level:** 7
+- **Domain:** appsec
+- **Model:** claude-sonnet
+```
+
+> **Q: How does hierarchy get inferred from headings?**
+> H3 (`###`) roles are top-level. H4 (`####`) roles under an H3 department inherit that department. The first H4 role in a department with no explicit `Reports to` is treated as the department lead.
+
+---
+
+## Section 4: Policies
+
+**Purpose:** Rules that govern how the org operates — budget, routing, permissions, constraints.
+
+**Why it matters:** Policies are enforced by the system, not suggestions. An agent that exceeds budget gets paused. An agent that tries to spawn when at department cap gets denied.
+
+```markdown
+## Policies
+
+### Budget
+- **Per-agent limit:** 1000 credits/period
+- **Alert threshold:** 80%
+- **Overage behavior:** pause and escalate
+- **Period:** weekly
+
+### Task Routing
+Tasks are auto-routed by matching domain keywords, agent expertise,
+current workload, and trust score.
+If no match: task goes to COO for manual delegation.
+
+### Permissions
+- **L7+ can create tasks**
+- **L7+ can spawn agents** (up to department cap)
+- **L6+ can review**
+- **All agents can escalate**
+
+### Department Caps
+- Engineering: max 10 agents
+- Security: max 4 agents
+- No department can exceed 15 agents without human approval
+
+### Working Hours
+- **Active hours:** 08:00-22:00 (org timezone)
+- **Off-hours behavior:** queue tasks, don't process
+- **Exceptions:** critical priority tasks process 24/7
+```
+
+**Policy fields:**
+
+| Field | Description |
+|-------|-------------|
+| `**Per-agent limit:**` | Credits per agent per period |
+| `**Alert threshold:**` | % of budget that triggers alert (default: 80%) |
+| `**Overage behavior:**` | `pause and escalate` or `hard-stop` |
+| `**Period:**` | `daily` \| `weekly` \| `monthly` |
+
+---
+
+## Section 5: Playbooks
+
+**Purpose:** Reusable step-by-step procedures for common scenarios.
+
+**Why it matters:** When an agent encounters a situation (e.g., "BLOCKED"), it looks up the matching playbook and follows the procedure. Playbooks are simultaneously documentation and machine instructions.
+
+```markdown
+## Playbooks
+
+### New Task Arrives
+1. COO receives task from Human Principal
+2. COO categorizes by domain and priority
+3. COO delegates to appropriate department lead
+4. Lead breaks into subtasks if needed
+5. Lead assigns to available workers by trust score
+6. Workers begin — progress logged to task activity
+
+### Escalation: BLOCKED
+1. Agent creates escalation with blocker details
+2. Escalation goes to direct manager (never skip levels)
+3. Manager has 2 cycles to respond:
+   - Provide missing resource/context
+   - Reassign to different agent
+   - Escalate further up
+4. If unresolved after 2 levels → alert Human Principal
+
+### New Agent Onboarding
+1. Agent spawned by a lead
+2. First 3 tasks are LOW priority (warm-up period)
+3. Trust score starts at 30 (PROBATION)
+4. Mentor assigned: closest senior in same domain
+5. After 5 successful tasks → TRUSTED
+6. After 20 successful tasks → eligible for VETERAN
+```
+
+---
+
+## Parsing rules
+
+> **Q: How does OpenSpawn parse ORG.md?**
+
+### Metadata extraction
+
+Structured data extracted from bullet lists:
+```
+- **Key:** Value
+```
+Keys are case-insensitive, normalized (spaces → underscores).
+
+### Free text = context
+
+Any text that isn't structured metadata becomes system prompt context:
+- Department descriptions → department-level context
+- Role descriptions → agent-level context
+- Policy explanations → enforcement rules
+- Playbook steps → procedural instructions
+
+### Model references
+
+```markdown
+- **Model:** anthropic/claude-sonnet-4-5    # Full provider/model
+- **Model:** claude-sonnet                  # Alias
+- **Model:** fastest                        # Relative (system picks)
+- **Model:** cheapest                       # Relative
+```
+
+---
+
+## Lifecycle commands
+
+### Deploy
+```bash
+npx openspawn deploy ORG.md
+```
+Parses → creates agents → applies culture → enforces policies → loads playbooks.
+
+### Validate (before deploy)
+```bash
+openspawn validate ORG.md
+```
+
+### Preview (no deploy)
+```bash
+openspawn preview
+```
+
+### Apply changes to running org
+```bash
+openspawn apply ORG.md
+```
+Diffs current state: new roles → spawn agents, removed roles → graceful wind-down, policy changes → apply immediately.
+
+### Export current state
+```bash
+openspawn export > ORG.md
+```
+Captures the actual org including dynamically spawned agents. Becomes the new source of truth.
+
+---
+
+## Git workflow
+
+ORG.md lives in git. Treat org changes like code changes:
+
+```bash
+git diff ORG.md      # See what changed in the org
+git log ORG.md       # History of org changes
+git blame ORG.md     # Who changed the escalation policy?
+```
+
+**Example PR for org change:**
+```
+PR #42: Add data team (2 agents)
+
++ ### Data & Analytics
++ Owns data pipelines, reporting, and business intelligence.
++
++ #### Data Lead
++ - **Model:** claude-sonnet
++ - **Domain:** data-engineering
++
++ #### Data Worker
++ - **Model:** claude-haiku
++ - **Domain:** analytics
+```
+
+---
+
+## Full examples
+
+### Solo developer + agents
+
+```markdown
+# My Dev Team
+
+## Culture
+preset: startup
+
+## Structure
+
+### Code Agent
+Writes code, runs tests, submits PRs.
+- **Level:** 7
+- **Domain:** fullstack
+- **Reports to:** Human Principal
+- **Model:** claude-sonnet
+
+### Review Agent
+Reviews PRs, checks for bugs and style.
+- **Level:** 4
+- **Domain:** code-review
+- **Reports to:** Code Agent
+- **Model:** claude-haiku
+
+### Docs Agent
+Keeps documentation in sync with code.
+- **Level:** 4
+- **Domain:** documentation
+- **Reports to:** Code Agent
+- **Model:** claude-haiku
+```
+
+### Agency with client teams
+
+```markdown
+# Creative Agency
+
+## Culture
+preset: agency
+- **Progress updates:** every tick — clients expect visibility
+
+## Structure
+
+### Account Director
+Manages client relationships. Routes work to the right team.
+- **Level:** 10
+- **Domain:** account-management
+- **Reports to:** Human Principal
+- **Model:** claude-sonnet
+
+### Design Team
+
+#### Design Lead
+- **Level:** 7
+- **Domain:** visual-design
+- **Model:** claude-sonnet
+
+#### Designers
+- **Level:** 4
+- **Domain:** ui-ux
+- **Count:** 3
+- **Model:** claude-haiku
+
+## Policies
+
+### Client SLA
+- Critical tasks: response within 1 cycle
+- Normal tasks: completion within 10 cycles
+```
+
+### Research lab
+
+```markdown
+# AI Research Lab
+
+## Culture
+preset: research
+- **Escalation:** delayed — let researchers explore before flagging blockers
+
+## Structure
+
+### Principal Investigator
+Sets research direction. Reviews findings. Publishes papers.
+- **Level:** 10
+- **Domain:** ml-research
+- **Reports to:** Human Principal
+- **Model:** claude-opus
+
+### Senior Researchers
+- **Level:** 6
+- **Domain:** experimentation
+- **Count:** 2
+- **Model:** claude-sonnet
+
+### Research Assistants
+Run experiments, collect data, write up results.
+- **Level:** 4
+- **Domain:** data-collection
+- **Count:** 3
+- **Model:** claude-haiku
+
+## Policies
+
+### Exploration Budget
+- **Per-agent limit:** 5000 credits/period
+- No hard stops — flag at 90% but don't interrupt an experiment
+```
+
+---
+
+## Relationship to other formats
+
+| Format | Scope | Relationship to ORG.md |
+|--------|-------|----------------------|
+| `CLAUDE.md` | One agent's behavior | ORG.md wraps multiple agents, each with implicit CLAUDE.md (their role description) |
+| `AGENTS.md` | Workspace rules | ORG.md is the superset — workspace rules + org structure + policies |
+| Terraform/Pulumi | Infrastructure as code | Same pattern applied to agent organizations |
+
+---
+
+## Next steps
+
+- **Try it now:** [`docs/getting-started.md`](./getting-started.md) — deploy your first ORG.md in 10 minutes
+- **Pick a template:** [`docs/templates-guide.md`](./templates-guide.md) — start from a working example
+- **MCP tools:** [`docs/mcp-reference.md`](./mcp-reference.md) — how agents interact with the org
+- **Communication rules:** [`docs/communication-protocol.md`](./communication-protocol.md) — how agents talk to each other
+- **Live demo:** https://bikinibottom.ai/app/

--- a/docs/templates-guide.md
+++ b/docs/templates-guide.md
@@ -2,9 +2,14 @@
 purpose: Choose and customize OpenSpawn org templates
 audience: developers, AI agents
 prerequisites: openspawn CLI installed
+related: [getting-started.md, org-md-reference.md, agent-quickstart.md]
 ---
 
 # Templates Guide
+
+**What you'll learn:** The four OpenSpawn org templates — what they include, when to use each, how to customize them, and how to combine roles from multiple templates.
+
+> **Quick answer:** Use `assistant-team` if you're not sure. It's the most flexible starting point. All templates are just starting points — edit the generated `ORG.md` freely.
 
 OpenSpawn ships four org templates. Each produces a complete, ready-to-run ORG.md with roles, hierarchy, culture, policies, and playbooks.
 
@@ -265,3 +270,13 @@ Or override individual settings after the preset.
 | `Agent reports to unknown agent` | Check `Reports to` matches an existing agent name exactly |
 | `Validation failed after customization` | Run `openspawn validate` and fix each listed issue |
 | `Circular reporting chain` | No agent can report to itself or create a loop. Check hierarchy. |
+
+---
+
+## Next steps
+
+- **Full ORG.md format:** [`docs/org-md-reference.md`](./org-md-reference.md) — every field and example
+- **MCP tools:** [`docs/mcp-reference.md`](./mcp-reference.md) — how agents interact with the org
+- **Communication rules:** [`docs/communication-protocol.md`](./communication-protocol.md) — how agents talk to each other
+- **Troubleshooting:** [`docs/troubleshooting.md`](./troubleshooting.md) — fix common errors
+- **Live demo:** https://bikinibottom.ai/app/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,380 @@
+---
+purpose: Diagnose and fix common OpenSpawn problems
+audience: AI agents, developers
+related: [FAQ.md, agent-quickstart.md, getting-started.md, mcp-reference.md]
+---
+
+# Troubleshooting Guide
+
+**What you'll learn:** How to diagnose and fix the most common OpenSpawn problems — CLI errors, validation failures, MCP auth issues, port conflicts, and task coordination bugs.
+
+> **Quick start:** Run `openspawn validate` first. It catches ~80% of config problems and tells you exactly what to fix.
+
+> **Q: Where should I start when something is broken?**
+> Always run `openspawn validate` first. Most problems are config or syntax issues in ORG.md that validation will catch and explain.
+
+> **Q: My agent isn't doing anything — what do I check?**
+> In order: (1) Is the server running? `curl http://localhost:3333/health`. (2) Is the agent registered? `tool: agent_list`. (3) Does the agent have open tasks? `tool: task_list { assigned_to: "agent-id" }`. (4) Is the agent's status `idle`? `tool: agent_update_status { status: "idle" }`.
+
+> **Q: How do I reset an org back to a clean state?**
+> Stop the server, delete the SQLite DB (usually `openspawn.db` in your project directory), and restart with `openspawn preview`. All task/agent state is wiped. ORG.md is preserved.
+
+---
+
+## CLI Errors
+
+### `Cannot read ORG.md` / `File not found`
+
+**Symptom:** `openspawn start` or `openspawn validate` reports it can't find your org file.
+
+**Diagnosis:**
+```bash
+ls -la ORG.md          # Is the file there?
+pwd                     # Are you in the right directory?
+openspawn validate ./path/to/ORG.md  # Explicit path
+```
+
+**Fix:**
+- Make sure you're in the directory containing `ORG.md`
+- Or pass the path explicitly: `openspawn validate path/to/ORG.md`
+
+---
+
+### `Unknown template: foo`
+
+**Symptom:** `openspawn init --template=foo` fails.
+
+**Valid template names:**
+```bash
+openspawn init my-org --template=assistant-team
+openspawn init my-org --template=content-agency
+openspawn init my-org --template=dev-shop
+openspawn init my-org --template=research-lab
+```
+
+---
+
+### `Port 3333 already in use`
+
+**Symptom:** `openspawn preview` fails because port 3333 is taken.
+
+**Fix option 1 — Kill the existing process:**
+```bash
+lsof -i :3333           # Find what's using port 3333
+kill <PID>              # Kill it
+openspawn preview       # Try again
+```
+
+**Fix option 2 — Change the port:**
+```json
+// openspawn.config.json
+{
+  "port": 3334
+}
+```
+
+---
+
+### `openspawn: command not found`
+
+**Symptom:** Running `openspawn` fails with command not found.
+
+**Fix:**
+```bash
+# Use npx (no install required)
+npx openspawn init my-org
+
+# Or install globally
+npm install -g openspawn
+openspawn --version
+```
+
+---
+
+## Validation Errors
+
+### `Missing Structure section`
+
+**Symptom:** `openspawn validate` reports the Structure section is missing.
+
+**Fix:** Add a `## Structure` section with at least one agent:
+
+```markdown
+## Structure
+
+### MyAgent — Role
+- **Level:** 10
+- **Reports to:** Human Principal
+```
+
+---
+
+### `Agent reports to unknown agent: "SomeName"`
+
+**Symptom:** An agent's `Reports to` value doesn't match any defined agent.
+
+**Common causes:**
+- Typo in the agent name (case-sensitive)
+- Agent was renamed but `Reports to` wasn't updated
+- Agent was deleted but others still reference it
+
+**Fix:**
+```markdown
+# WRONG — typo
+#### Engineer — Backend Dev
+- **Reports to:** Techh Lead   ← typo
+
+# RIGHT
+#### Engineer — Backend Dev
+- **Reports to:** Tech Lead
+```
+
+**Pro tip:** Run `grep -n "Reports to" ORG.md` to list all references at once.
+
+---
+
+### `No top-level agent`
+
+**Symptom:** No agent has `Reports to: Human Principal`.
+
+**Fix:** Exactly one agent must report to the human:
+
+```markdown
+### CEO — Chief Executive
+- **Level:** 10
+- **Reports to:** Human Principal   ← required
+```
+
+---
+
+### `Circular reporting chain detected`
+
+**Symptom:** Agent A reports to Agent B, and Agent B reports to Agent A (or a longer cycle).
+
+**Fix:** Draw out your hierarchy and check for loops. Every chain must terminate at `Human Principal`.
+
+```bash
+# Check all reporting lines
+grep -A5 "### " ORG.md | grep "Reports to"
+```
+
+---
+
+## MCP & Auth Issues
+
+### `HMAC authentication failed`
+
+**Symptom:** MCP tool calls return `401 Unauthorized`.
+
+**Diagnosis:**
+```bash
+echo $AGENT_ID      # Should be set
+echo $AGENT_SECRET  # Should be set
+```
+
+**Fix:** Set the env vars to match your API config:
+```bash
+export AGENT_ID="my-agent-id"
+export AGENT_SECRET="my-agent-secret"
+```
+
+If you're unsure what the values should be, check `openclaw-patch.json` — the `id` field is the agent ID. The secret is set in your OpenClaw gateway config.
+
+---
+
+### `task_claim returns error: task already claimed`
+
+**Symptom:** You try to claim a task but another agent already claimed it.
+
+**This is expected behavior.** `task_claim` is atomic — only one agent wins. 
+
+**Fix:**
+```
+tool: task_list { status: "open" }   ← find another open task
+```
+
+If you need to take over a claimed task, use `task_update` to reassign it (requires appropriate permissions).
+
+---
+
+### `MCP endpoint unreachable`
+
+**Symptom:** MCP calls fail to connect.
+
+**Diagnosis:**
+```bash
+curl http://localhost:3333/health    # Is the server up?
+openspawn preview                    # Start it if not
+```
+
+**Common causes:**
+- Server isn't running — run `openspawn preview`
+- Wrong port — check `openspawn.config.json`
+- Firewall blocking — check network rules if running remotely
+
+---
+
+### `credits_balance returns 0 or insufficient credits`
+
+**Symptom:** Agent can't perform operations due to zero or insufficient credits.
+
+**Diagnosis:**
+```
+tool: credits_balance
+tool: credits_history { limit: 10 }
+```
+
+**Fix:**
+- If budget is genuinely exhausted: escalate to your manager via `escalation_create`
+- If budget seems wrong: check `## Policies` in `ORG.md` for per-agent limits
+- Managers can reallocate via the dashboard or by updating policy
+
+---
+
+## Task Coordination Issues
+
+### Agent isn't receiving tasks
+
+**Symptom:** Tasks are created but an agent isn't picking them up.
+
+**Diagnosis:**
+```
+tool: task_list { status: "open" }          ← are tasks in the queue?
+tool: agent_list                            ← is the agent registered?
+tool: agent_update_status { agent_id: "...", status: "idle" }  ← update status
+```
+
+**Common causes:**
+- Agent status is `paused` or `overwhelmed` — update to `idle`
+- Agent isn't registered — run `agent_register`
+- Tasks are assigned to a different `assigneeId` — check `task_list { assigned_to: "agent-id" }`
+
+---
+
+### Escalations not resolving
+
+**Symptom:** Escalations pile up without resolution.
+
+**Diagnosis:**
+```
+tool: escalation_list { status: "open" }
+```
+
+**Fix — for managers:**
+```
+tool: escalation_resolve { 
+  escalationId: "esc-123", 
+  resolution: "Use in-memory storage for now, Redis is a future task" 
+}
+```
+
+**The 2-cycle rule:** If an escalation isn't resolved in 2 cycles, escalate it further up the chain. If it reaches the top without resolution, it alerts the Human Principal.
+
+---
+
+### Task is stuck in `in_progress` with no updates
+
+**Symptom:** A task was claimed but there's no progress and the agent seems stuck.
+
+**Diagnosis:**
+```
+tool: task_get { id: "task-123" }            ← check status and assignee
+tool: message_read { channelId: "general" }  ← any escalations?
+```
+
+**Fix:**
+```
+# Option 1: Reassign the task
+tool: task_assign { id: "task-123", assigneeId: "other-agent" }
+
+# Option 2: Reset to open
+tool: task_update { task_id: "task-123", status: "todo" }
+```
+
+---
+
+## Dashboard Issues
+
+### Dashboard shows no agents
+
+**Symptom:** The React dashboard at `http://localhost:3333` shows an empty org.
+
+**Fix:**
+```bash
+openspawn start   # Generate openclaw-patch.json
+openspawn status  # Verify agents are listed
+```
+
+Then apply `openclaw-patch.json` to your OpenClaw gateway config and restart.
+
+---
+
+### Real-time updates not working (SSE)
+
+**Symptom:** Dashboard shows stale data, no live updates.
+
+**Diagnosis:**
+- Check browser console for SSE connection errors
+- Check `EventSource` is connecting to `http://localhost:3333/events`
+
+**Fix:**
+- Refresh the browser
+- Verify the server is running: `curl http://localhost:3333/health`
+- Check for proxy interference if running behind a reverse proxy (SSE requires long-lived connections — disable buffering)
+
+---
+
+## ORG.md Format Issues
+
+### Agent not appearing in `openspawn status` output
+
+**Symptom:** You added an agent to `ORG.md` but it doesn't show in status output.
+
+**Common causes:**
+```markdown
+# WRONG — H5 heading (too deep for direct agent)
+##### NewAgent — Role
+
+# RIGHT — H3 or H4 depending on hierarchy level
+### NewAgent — Role
+```
+
+Also check that the agent has the required fields:
+```markdown
+### NewAgent — Role
+- **Level:** 7
+- **Reports to:** ExistingAgent
+```
+
+---
+
+### Culture preset not applying
+
+**Symptom:** Culture settings aren't affecting agent behavior.
+
+**Fix:** Check syntax:
+```markdown
+## Culture
+preset: startup      ← lowercase, no quotes
+```
+
+**Valid presets:** `startup`, `enterprise`, `agency`, `research`, `military`, `remote-async`
+
+---
+
+## Getting More Help
+
+1. **Run validation first:** `openspawn validate` — most issues appear here
+2. **Check the FAQ:** [`docs/FAQ.md`](./FAQ.md)
+3. **Read the quickstart:** [`docs/agent-quickstart.md`](./agent-quickstart.md)
+4. **GitHub issues:** https://github.com/openspawn/openspawn/issues
+5. **Live demo for comparison:** https://bikinibottom.ai/app/
+
+---
+
+## Next steps
+
+- **Back to basics:** [`docs/getting-started.md`](./getting-started.md)
+- **All MCP tools:** [`docs/mcp-reference.md`](./mcp-reference.md)
+- **Communication protocol:** [`docs/communication-protocol.md`](./communication-protocol.md)
+- **Template options:** [`docs/templates-guide.md`](./templates-guide.md)


### PR DESCRIPTION
5 new docs + 4 updated. ~2,250 lines of agent-friendly documentation:
- FAQ.md — common questions in Q&A format
- troubleshooting.md — error resolution guide
- mcp-reference.md — all 14 MCP tools documented
- org-md-reference.md — ORG.md format spec
- comparison.md — OpenSpawn vs alternatives
- Updates to quickstart, comms protocol, getting-started, templates