### PR TITLE
fix: disable Tremor charts — React 19 crash

### DIFF
--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -2,7 +2,8 @@ import { useState, useMemo, useRef, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { motion, AnimatePresence } from "motion/react";
 import { Bot, MoreVertical, Plus, Coins, Edit, Eye, Ban, Filter, ArrowUpDown, Search, Users, Wallet, Zap, Trophy, Network, BarChart3 } from "lucide-react";
-import { TremorCreditsByAgent, TremorTasksOverTime } from "../components/charts/tremor-agent-metrics";
+// Tremor disabled — incompatible with React 19
+// import { TremorCreditsByAgent, TremorTasksOverTime } from "../components/charts/tremor-agent-metrics";
 import { HoverLiftCard } from "../components/motion-primitives";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { Button } from "../components/ui/button";
@@ -762,8 +763,8 @@ function AgentMetricsTab() {
 
   return (
     <div className="grid gap-6 lg:grid-cols-2">
-      <TremorTasksOverTime data={tasksOverTime} />
-      <TremorCreditsByAgent data={creditsByAgent} />
+      <div className="p-4 text-sm text-muted-foreground rounded-lg border">Charts temporarily disabled</div>
+      <div className="p-4 text-sm text-muted-foreground rounded-lg border">Charts temporarily disabled</div>
     </div>
   );
 }

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -15,9 +15,9 @@ import {
   Layers,
   CheckCircle,
 } from "lucide-react";
-// Tremor wraps recharts v2 internally — replaces custom SVG charts
-import { TremorCreditArea } from "../components/charts/tremor-credit-area";
-import { TremorTaskDonut } from "../components/charts/tremor-task-donut";
+// Tremor disabled — incompatible with React 19 (crashes @headlessui __store)
+// import { TremorCreditArea } from "../components/charts/tremor-credit-area";
+// import { TremorTaskDonut } from "../components/charts/tremor-task-donut";
 import { StaggerContainer, StaggerItem } from "../components/stagger";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { Badge } from "../components/ui/badge";
@@ -274,11 +274,11 @@ export function DashboardPage() {
   }, [activeAgents, pendingAgents, inProgressTasks, completedTasks, reviewTasks, tasks.length, totalCreditsEarned, totalCreditsSpent, sparklines, navigate]);
 
   function renderCreditChart() {
-    return <TremorCreditArea creditHistory={creditHistory} />;
+    return <Card><CardContent className="p-4 text-sm text-muted-foreground">Credit chart temporarily disabled</CardContent></Card>;
   }
 
     function renderTasksChart() {
-    return <TremorTaskDonut tasksByStatus={tasksByStatus} />;
+    return <Card><CardContent className="p-4 text-sm text-muted-foreground">Task donut temporarily disabled</CardContent></Card>;
   }
 
     function renderRecentActivity() {


### PR DESCRIPTION
Tremor v3 uses @headlessui/react which has __store internals incompatible with React 19. Disables the 3 Tremor chart components with placeholders until we migrate to a React 19 compatible charting lib.