### PR TITLE
feat: dashboard theme toggle — OpenSpawn clean theme for team.openspawn.ai

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -34,7 +34,7 @@
     <!-- BikiniBottom fonts: Baloo 2 (display) + Nunito (body) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600;700;800&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600;700;800&family=Inter:wght@400;500;600;700&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet" />
     
     <link rel="stylesheet" href="/src/styles.css" />
     

--- a/apps/dashboard/src/app/app.tsx
+++ b/apps/dashboard/src/app/app.tsx
@@ -8,12 +8,15 @@ import { isSandboxMode } from "../graphql/fetcher";
 import { CommandPalette } from "../components/command-palette";
 import { OfflineIndicator } from "../components/offline-indicator";
 
+import { isBBTheme } from "../lib/dashboard-theme";
+
 declare const __COMMIT_SHA__: string;
 declare const __BUILD_TIME__: string;
 
 // Log build info to console
+const brand = isBBTheme ? '🌊 BikiniBottom' : '⚡ OpenSpawn';
 console.log(
-  `%c🌊 BikiniBottom %c${__COMMIT_SHA__}%c built ${__BUILD_TIME__}`,
+  `%c${brand} %c${__COMMIT_SHA__}%c built ${__BUILD_TIME__}`,
   'color: #06b6d4; font-weight: bold; font-size: 14px',
   'color: #10b981; background: #0a1628; padding: 2px 6px; border-radius: 4px; font-family: monospace',
   'color: #64748b'

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -62,7 +62,11 @@ import { PhaseTransitionOverlay } from "./phase-transition-overlay";
 import { ScenarioEventToasts } from "./scenario-event-toasts";
 import { FirstVisitOverlay } from "./first-visit-overlay";
 import { Toaster } from "sonner";
+import { isBBTheme } from "../lib/dashboard-theme";
 import type { ReactNode } from "react";
+
+const BRAND_NAME = isBBTheme ? "BikiniBottom" : "OpenSpawn";
+const BRAND_SUBTITLE = isBBTheme ? "Multi-Agent Coordination" : "Team Dashboard";
 
 interface LayoutProps {
   children: ReactNode;
@@ -192,12 +196,14 @@ export function Layout({ children }: LayoutProps) {
   return (
     <TooltipProvider>
       <div className="flex h-screen bg-background relative">
-        {/* Bikini Bottom ambient backdrop */}
-        <div
-          className="fixed inset-0 z-0 pointer-events-none bg-cover bg-center bg-no-repeat"
-          style={{ backgroundImage: 'url(/app/bikini-bottom-bg.jpg)', opacity: 0.06 }}
-          aria-hidden="true"
-        />
+        {/* Bikini Bottom ambient backdrop — only in BB theme */}
+        {isBBTheme && (
+          <div
+            className="fixed inset-0 z-0 pointer-events-none bg-cover bg-center bg-no-repeat"
+            style={{ backgroundImage: 'url(/app/bikini-bottom-bg.jpg)', opacity: 0.06 }}
+            aria-hidden="true"
+          />
+        )}
         {/* Sidebar */}
         <motion.aside
           className="hidden flex-shrink-0 flex-col border-r border-border lg:flex overflow-hidden"
@@ -207,7 +213,7 @@ export function Layout({ children }: LayoutProps) {
           {/* Logo */}
           <div className={cn("flex h-16 items-center gap-2 border-b border-border relative overflow-hidden", sidebarCollapsed ? "justify-center px-2" : "px-4")}>
             <div className="absolute inset-0 opacity-5 bg-gradient-to-r from-cyan-500 to-blue-600 pointer-events-none" />
-            <Logo size="sm" style={{ animation: "wave-subtle 6s ease-in-out infinite" }} />
+            <Logo size="sm" style={isBBTheme ? { animation: "wave-subtle 6s ease-in-out infinite" } : undefined} />
             {!sidebarCollapsed && (
               <motion.div
                 initial={{ opacity: 0, width: 0 }}
@@ -217,10 +223,10 @@ export function Layout({ children }: LayoutProps) {
                 className="flex flex-col overflow-hidden whitespace-nowrap"
               >
                 <span className="text-lg font-semibold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">
-                  BikiniBottom
+                  {BRAND_NAME}
                 </span>
                 <span className="text-[9px] text-muted-foreground tracking-wide">
-                  Multi-Agent Coordination
+                  {BRAND_SUBTITLE}
                 </span>
               </motion.div>
             )}
@@ -533,13 +539,13 @@ export function Layout({ children }: LayoutProps) {
           <div className="flex h-16 items-center justify-between border-b border-border px-4 relative overflow-hidden">
             <div className="absolute inset-0 opacity-5 bg-gradient-to-r from-cyan-500 to-blue-600 pointer-events-none" />
             <div className="flex items-center gap-2">
-              <Logo size="sm" style={{ animation: "wave-subtle 6s ease-in-out infinite" }} />
+              <Logo size="sm" style={isBBTheme ? { animation: "wave-subtle 6s ease-in-out infinite" } : undefined} />
               <div className="flex flex-col">
               <span className="text-lg font-semibold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">
-                BikiniBottom
+                {BRAND_NAME}
               </span>
               <span className="text-[9px] text-muted-foreground tracking-wide">
-                Multi-Agent Coordination
+                {BRAND_SUBTITLE}
               </span>
             </div>
             </div>
@@ -667,13 +673,13 @@ export function Layout({ children }: LayoutProps) {
               <Menu className="h-5 w-5" />
             </Button>
             <div className="flex items-center gap-2">
-              <Logo size="sm" style={{ animation: "wave-subtle 6s ease-in-out infinite" }} />
+              <Logo size="sm" style={isBBTheme ? { animation: "wave-subtle 6s ease-in-out infinite" } : undefined} />
               <div className="flex flex-col">
               <span className="text-lg font-semibold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">
-                BikiniBottom
+                {BRAND_NAME}
               </span>
               <span className="text-[9px] text-muted-foreground tracking-wide">
-                Multi-Agent Coordination
+                {BRAND_SUBTITLE}
               </span>
             </div>
             </div>

--- a/apps/dashboard/src/components/theme-provider.tsx
+++ b/apps/dashboard/src/components/theme-provider.tsx
@@ -7,6 +7,8 @@ import {
   type ReactNode,
 } from "react";
 
+import { DASHBOARD_THEME, isOpenSpawnTheme } from "../lib/dashboard-theme";
+
 // Named ocean themes
 export const THEME_NAMES = [
   "deep-ocean",
@@ -14,6 +16,7 @@ export const THEME_NAMES = [
   "arctic-ice",
   "bioluminescent",
   "midnight-abyss",
+  "openspawn",
 ] as const;
 
 export type OceanTheme = (typeof THEME_NAMES)[number];
@@ -65,6 +68,13 @@ export const THEMES: ThemeDefinition[] = [
     isDark: true,
     swatches: ["hsl(0,0%,0%)", "hsl(210,50%,55%)", "hsl(210,40%,50%)"],
   },
+  {
+    id: "openspawn",
+    label: "OpenSpawn",
+    description: "Clean dark cyan",
+    isDark: true,
+    swatches: ["hsl(220,20%,4%)", "hsl(192,91%,50%)", "hsl(220,15%,14%)"],
+  },
 ];
 
 const THEME_STORAGE_KEY = "bb-theme";
@@ -99,7 +109,7 @@ interface ThemeProviderProps {
 
 export function ThemeProvider({
   children,
-  defaultTheme = "deep-ocean",
+  defaultTheme = isOpenSpawnTheme ? "openspawn" : "deep-ocean",
 }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<OceanTheme>(() => {
     if (typeof window === "undefined") return defaultTheme;

--- a/apps/dashboard/src/lib/dashboard-theme.ts
+++ b/apps/dashboard/src/lib/dashboard-theme.ts
@@ -1,0 +1,16 @@
+/**
+ * Dashboard theme detection via VITE_DASHBOARD_THEME env var.
+ * 
+ * "openspawn" = clean shadcn dashboard for team.openspawn.ai
+ * "bikinibottom" (default) = BB-themed demo for bikinibottom.ai
+ */
+
+export type DashboardTheme = 'openspawn' | 'bikinibottom';
+
+export const DASHBOARD_THEME: DashboardTheme =
+  (import.meta.env.VITE_DASHBOARD_THEME as string) === 'openspawn'
+    ? 'openspawn'
+    : 'bikinibottom';
+
+export const isBBTheme = DASHBOARD_THEME === 'bikinibottom';
+export const isOpenSpawnTheme = DASHBOARD_THEME === 'openspawn';

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -1,4 +1,8 @@
 @import "tailwindcss";
+
+/* BB tokens are always loaded (they use :root overrides).
+   When VITE_DASHBOARD_THEME=openspawn, the [data-theme="openspawn"] selector
+   overrides them back to clean shadcn values via higher specificity. */
 @import "./styles/bb-tokens.css";
 
 @layer base {
@@ -213,6 +217,45 @@
   }
 
   /* ========================================
+     Theme: OpenSpawn (clean team dashboard)
+     Near-black + cyan primary, Inter font
+     ======================================== */
+  [data-theme="openspawn"] {
+    --background: 220 20% 4%;
+    --foreground: 210 10% 93%;
+    --card: 220 20% 7%;
+    --card-foreground: 210 10% 93%;
+    --popover: 220 20% 9%;
+    --popover-foreground: 210 10% 93%;
+    --primary: 192 91% 50%;
+    --primary-foreground: 220 20% 4%;
+    --secondary: 220 15% 14%;
+    --secondary-foreground: 210 10% 93%;
+    --muted: 220 15% 12%;
+    --muted-foreground: 215 10% 50%;
+    --accent: 220 15% 14%;
+    --accent-foreground: 210 10% 93%;
+    --success: 160 84% 39%;
+    --success-foreground: 160 84% 95%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 38 20% 10%;
+    --destructive: 350 89% 60%;
+    --destructive-foreground: 0 0% 98%;
+    --info: 192 91% 50%;
+    --info-foreground: 220 20% 4%;
+    --special: 258 90% 66%;
+    --special-foreground: 258 90% 95%;
+    --border: 220 13% 18%;
+    --input: 220 13% 18%;
+    --ring: 192 91% 50%;
+    --radius: 0.5rem;
+
+    /* Reset BB font overrides */
+    --bb-font-display: 'Inter', system-ui, sans-serif;
+    --bb-font-body: 'Inter', system-ui, sans-serif;
+  }
+
+  /* ========================================
      Density: Compact
      ======================================== */
   .density-compact {
@@ -233,6 +276,17 @@
 
   body {
     @apply bg-background text-foreground antialiased;
+  }
+
+  /* OpenSpawn theme: use Inter, override BB fonts */
+  [data-theme="openspawn"] body,
+  [data-theme="openspawn"] {
+    font-family: 'Inter', system-ui, sans-serif;
+  }
+  [data-theme="openspawn"] h1,
+  [data-theme="openspawn"] h2,
+  [data-theme="openspawn"] h3 {
+    font-family: 'Inter', system-ui, sans-serif;
   }
 
   /* Smooth theme transitions */

--- a/apps/dashboard/tailwind.config.js
+++ b/apps/dashboard/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
         'portrait': { 'raw': '(orientation: portrait)' },
       },
       fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
         display: ['"Baloo 2"', 'cursive'],
         body: ['Nunito', 'sans-serif'],
       },


### PR DESCRIPTION
Adds VITE_DASHBOARD_THEME env var to switch between bikinibottom (default) and openspawn theme.

- OpenSpawn theme: near-black bg, cyan primary, Inter font, zinc neutrals
- Conditional BB decorations (kelp/bubbles only in BB mode)
- Auto-selects theme based on env var
- Sidebar already exists, no layout changes needed

Set VITE_DASHBOARD_THEME=openspawn in team-ops container for clean dashboard.