### PR TITLE
feat(dashboard): add task board kanban for repo backlog

### DIFF
--- a/.openspawn/.openspawn/tasks.json
+++ b/.openspawn/.openspawn/tasks.json
@@ -1,0 +1,75 @@
+{
+  "version": 1,
+  "tasks": [
+    {
+      "id": "task-001",
+      "description": "Homepage positioning refresh — persistent governed orgs",
+      "assignee": "dennis",
+      "status": "done",
+      "createdAt": "2026-03-01T19:07:48.803Z",
+      "updatedAt": "2026-03-01T19:07:48.804Z"
+    },
+    {
+      "id": "task-002",
+      "description": "MCP server + CLI skeleton (13 tools, 10 commands)",
+      "assignee": "dennis",
+      "status": "done",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-003",
+      "description": "Team ORG.md + org tree command",
+      "assignee": "dennis",
+      "status": "done",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-004",
+      "description": "npm publish — openspawn@0.1.0",
+      "assignee": "dennis",
+      "status": "done",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-005",
+      "description": "README + getting started guide",
+      "assignee": "dennis",
+      "status": "done",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-006",
+      "description": "Tone cleanup — additive not competitive",
+      "assignee": "dennis",
+      "status": "in-progress",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-007",
+      "description": "Dogfood task flow — use openspawn for real work",
+      "status": "open",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-008",
+      "description": "End-to-end demo recording for homepage",
+      "status": "open",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-009",
+      "description": "Deploy homepage with new positioning",
+      "status": "open",
+      "createdAt": "2026-03-01T19:07:48.806Z",
+      "updatedAt": "2026-03-01T19:07:48.806Z"
+    }
+  ],
+  "budgets": {}
+}

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -28,6 +28,7 @@ import {
   PanelLeft,
   Star,
   Layers,
+  ClipboardList,
 } from "lucide-react";
 import { AnimatePresence } from "motion/react";
 import { cn } from "../lib/utils";
@@ -80,6 +81,7 @@ const navigation: { name: string; href: string; icon: typeof LayoutDashboard; to
   { name: "Network", href: "/network", icon: Network, tourId: "network" },
   { name: "Tasks", href: "/tasks", icon: CheckSquare, tourId: "tasks" },
   { name: "Kanban", href: "/kanban", icon: Layers },
+  { name: "Task Board", href: "/task-board", icon: ClipboardList },
   { name: "Agents", href: "/agents", icon: Users, tourId: "agents" },
   { name: "Messages", href: "/messages", icon: MessageSquare },
   { name: "Model Router", href: "/router", icon: GitBranch },

--- a/apps/dashboard/src/hooks/use-repo-tasks.ts
+++ b/apps/dashboard/src/hooks/use-repo-tasks.ts
@@ -1,0 +1,127 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export type RepoTaskStatus = 'open' | 'claimed' | 'in-progress' | 'done' | 'blocked';
+
+export interface RepoTask {
+  id: string;
+  description: string;
+  assignee?: string;
+  delegatedBy?: string;
+  status: RepoTaskStatus;
+  createdAt: string;
+  updatedAt: string;
+  pr?: number;
+  budget?: { spent: number; currency: string };
+}
+
+interface TaskStore {
+  version: number;
+  tasks: RepoTask[];
+}
+
+const GITHUB_RAW_URL =
+  'https://raw.githubusercontent.com/openspawn/openspawn/main/.openspawn/tasks.json';
+
+const DEMO_TASKS: RepoTask[] = [
+  {
+    id: 'task-001',
+    description: 'Set up CI pipeline for dashboard builds',
+    assignee: 'dennis',
+    status: 'done',
+    createdAt: '2026-02-25T10:00:00Z',
+    updatedAt: '2026-02-26T14:30:00Z',
+    pr: 450,
+  },
+  {
+    id: 'task-002',
+    description: 'Add agent reputation scoring to dashboard',
+    assignee: 'ceo',
+    status: 'in-progress',
+    createdAt: '2026-02-26T09:00:00Z',
+    updatedAt: '2026-02-28T16:00:00Z',
+    pr: 455,
+  },
+  {
+    id: 'task-003',
+    description: 'Implement task delegation protocol',
+    status: 'open',
+    createdAt: '2026-02-27T11:00:00Z',
+    updatedAt: '2026-02-27T11:00:00Z',
+  },
+  {
+    id: 'task-004',
+    description: 'Budget tracking per-agent breakdown',
+    assignee: 'dennis',
+    status: 'in-progress',
+    createdAt: '2026-02-27T14:00:00Z',
+    updatedAt: '2026-03-01T09:00:00Z',
+    budget: { spent: 0.42, currency: 'USD' },
+  },
+  {
+    id: 'task-005',
+    description: 'Wire up escalation alerts to Discord',
+    status: 'open',
+    delegatedBy: 'ceo',
+    createdAt: '2026-02-28T08:00:00Z',
+    updatedAt: '2026-02-28T08:00:00Z',
+  },
+  {
+    id: 'task-006',
+    description: 'Tone cleanup — additive not competitive',
+    assignee: 'dennis',
+    status: 'done',
+    createdAt: '2026-02-28T12:00:00Z',
+    updatedAt: '2026-03-01T10:00:00Z',
+    pr: 460,
+  },
+  {
+    id: 'task-007',
+    description: 'Add kanban board route to dashboard',
+    assignee: 'dennis',
+    status: 'in-progress',
+    createdAt: '2026-03-01T15:00:00Z',
+    updatedAt: '2026-03-01T15:00:00Z',
+  },
+  {
+    id: 'task-008',
+    description: 'Review and merge infrastructure docs',
+    status: 'blocked',
+    assignee: 'ceo',
+    createdAt: '2026-02-28T10:00:00Z',
+    updatedAt: '2026-03-01T08:00:00Z',
+  },
+];
+
+const REFRESH_INTERVAL = 30_000;
+
+export function useRepoTasks() {
+  const [tasks, setTasks] = useState<RepoTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [source, setSource] = useState<'github' | 'demo'>('demo');
+
+  const fetchTasks = useCallback(async () => {
+    try {
+      const res = await fetch(GITHUB_RAW_URL, { cache: 'no-store' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: TaskStore = await res.json();
+      setTasks(data.tasks);
+      setSource('github');
+      setError(null);
+    } catch {
+      setTasks(DEMO_TASKS);
+      setSource('demo');
+      setError(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTasks();
+    const id = setInterval(fetchTasks, REFRESH_INTERVAL);
+    return () => clearInterval(id);
+  }, [fetchTasks]);
+
+  return { tasks, loading, error, source, refetch: fetchTasks };
+}

--- a/apps/dashboard/src/pages/task-board.tsx
+++ b/apps/dashboard/src/pages/task-board.tsx
@@ -1,0 +1,186 @@
+import { useMemo } from 'react';
+import { useRepoTasks, type RepoTask, type RepoTaskStatus } from '../hooks/use-repo-tasks';
+import { PageHeader } from '../components/ui/page-header';
+import { Badge } from '../components/ui/badge';
+import { Clock, User, ExternalLink, Wifi, WifiOff, RefreshCw, AlertTriangle } from 'lucide-react';
+import { cn } from '../lib/utils';
+
+/* ── Column config ── */
+type Column = { key: RepoTaskStatus[]; label: string; color: string; bg: string; border: string };
+
+const COLUMNS: Column[] = [
+  { key: ['open', 'blocked'], label: 'Open', color: 'text-slate-400', bg: 'bg-slate-500/5', border: 'border-slate-500/20' },
+  { key: ['claimed', 'in-progress'], label: 'In Progress', color: 'text-cyan-400', bg: 'bg-cyan-500/5', border: 'border-cyan-500/20' },
+  { key: ['done'], label: 'Done', color: 'text-emerald-400', bg: 'bg-emerald-500/5', border: 'border-emerald-500/20' },
+];
+
+const STATUS_BADGE: Record<RepoTaskStatus, { class: string; label: string }> = {
+  open: { class: 'bg-slate-500/20 text-slate-300 border-slate-500/30', label: 'open' },
+  claimed: { class: 'bg-violet-500/20 text-violet-300 border-violet-500/30', label: 'claimed' },
+  'in-progress': { class: 'bg-cyan-500/20 text-cyan-300 border-cyan-500/30', label: 'in progress' },
+  done: { class: 'bg-emerald-500/20 text-emerald-300 border-emerald-500/30', label: 'done' },
+  blocked: { class: 'bg-rose-500/20 text-rose-300 border-rose-500/30', label: 'blocked' },
+};
+
+/* ── Helpers ── */
+function timeAgo(dateStr: string) {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+/* ── TaskCard ── */
+function TaskCard({ task }: { task: RepoTask }) {
+  const badge = STATUS_BADGE[task.status];
+  return (
+    <div className={cn(
+      'rounded-lg border border-white/5 bg-[var(--card)] p-3 space-y-2 transition-all duration-200',
+      'hover:border-cyan-500/30 hover:bg-[var(--card)]/80 hover:translate-y-[-1px] hover:shadow-lg',
+    )}>
+      {/* Header: ID + status */}
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-mono text-muted-foreground">🔧 {task.id}</span>
+        <span className={cn('text-[10px] font-semibold px-1.5 py-0.5 rounded border', badge.class)}>
+          {badge.label}
+        </span>
+      </div>
+
+      {/* Description */}
+      <p className="text-sm font-medium text-[var(--foreground)] leading-tight line-clamp-3">
+        {task.description}
+      </p>
+
+      {/* Blocked warning */}
+      {task.status === 'blocked' && (
+        <div className="flex items-center gap-1 text-xs text-rose-400">
+          <AlertTriangle className="w-3 h-3" />
+          <span>Blocked</span>
+        </div>
+      )}
+
+      {/* Footer: assignee, PR, updated */}
+      <div className="flex items-center gap-3 text-xs text-muted-foreground flex-wrap">
+        {task.assignee && (
+          <span className="flex items-center gap-1">
+            <User className="w-3 h-3" />
+            {task.assignee}
+          </span>
+        )}
+        {task.pr && (
+          <a
+            href={`https://github.com/openspawn/openspawn/pull/${task.pr}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-cyan-400 hover:text-cyan-300 transition-colors"
+            onClick={(e) => e.stopPropagation()}
+          >
+            PR #{task.pr}
+            <ExternalLink className="w-2.5 h-2.5" />
+          </a>
+        )}
+        <span className="flex items-center gap-1 ml-auto">
+          <Clock className="w-3 h-3" />
+          {timeAgo(task.updatedAt)}
+        </span>
+      </div>
+
+      {/* Budget */}
+      {task.budget && (
+        <div className="text-[10px] text-muted-foreground/70">
+          💰 ${task.budget.spent.toFixed(2)} {task.budget.currency}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── TaskBoard page ── */
+export function TaskBoardPage() {
+  const { tasks, loading, source, refetch } = useRepoTasks();
+
+  const grouped = useMemo(() => {
+    return COLUMNS.map((col) => ({
+      ...col,
+      tasks: tasks.filter((t) => col.key.includes(t.status)),
+    }));
+  }, [tasks]);
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="animate-pulse text-muted-foreground">Loading repo tasks…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-4">
+      <PageHeader
+        title="Task Board"
+        description="Tasks from .openspawn/tasks.json — the repo backlog"
+        actions={
+          <div className="flex items-center gap-3">
+            <span className={cn(
+              'flex items-center gap-1.5 text-xs px-2 py-1 rounded-full border',
+              source === 'github'
+                ? 'border-emerald-500/30 text-emerald-400 bg-emerald-500/10'
+                : 'border-amber-500/30 text-amber-400 bg-amber-500/10',
+            )}>
+              {source === 'github' ? <Wifi className="w-3 h-3" /> : <WifiOff className="w-3 h-3" />}
+              {source === 'github' ? 'Live' : 'Demo Data'}
+            </span>
+            <button
+              onClick={refetch}
+              className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              title="Refresh"
+            >
+              <RefreshCw className="w-4 h-4" />
+            </button>
+          </div>
+        }
+      />
+
+      {/* Kanban columns */}
+      <div className="flex gap-4 overflow-x-auto pb-4 snap-x snap-mandatory md:snap-none min-h-[400px]">
+        {grouped.map((col) => (
+          <div
+            key={col.label}
+            className={cn(
+              'flex-shrink-0 w-[300px] md:w-auto md:flex-1 rounded-xl border p-3 snap-center transition-colors',
+              col.bg, col.border,
+            )}
+          >
+            {/* Column header */}
+            <div className="flex items-center gap-2 mb-3">
+              <span className={cn('text-sm font-semibold', col.color)}>{col.label}</span>
+              <span className="text-xs text-muted-foreground bg-white/5 px-1.5 py-0.5 rounded-full">
+                {col.tasks.length}
+              </span>
+            </div>
+
+            {/* Cards */}
+            <div className="space-y-2">
+              {col.tasks.length === 0 && (
+                <div className="text-xs text-muted-foreground text-center py-8 opacity-50">No tasks</div>
+              )}
+              {col.tasks.map((task) => (
+                <TaskCard key={task.id} task={task} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs text-muted-foreground text-center">
+        Auto-refreshes every 30s • {tasks.length} total tasks
+      </p>
+    </div>
+  );
+}
+
+export default TaskBoardPage;

--- a/apps/dashboard/src/routes.tsx
+++ b/apps/dashboard/src/routes.tsx
@@ -12,6 +12,7 @@ import { TourProvider, TourBar, TourSpotlight } from "./components/tour";
 import { CommandPalette } from "./components/command-palette";
 import { TasksPage, AgentsPage, CreditsPage, EventsPage, LoginPage, AuthCallbackPage, SettingsPage, MessagesPage } from "./pages";
 import { KanbanPage } from "./pages/kanban";
+import { TaskBoardPage } from "./pages/task-board";
 import { RouterPage } from "./pages/router";
 import { DashboardPage } from "./pages/dashboard";
 import { NetworkPage } from "./pages/network";
@@ -171,6 +172,12 @@ const kanbanRoute = createRoute({
   component: KanbanPage,
 });
 
+const taskBoardRoute = createRoute({
+  getParentRoute: () => layoutRoute,
+  path: "/task-board",
+  component: TaskBoardPage,
+});
+
 const statusRoute = createRoute({
   getParentRoute: () => layoutRoute,
   path: "/status",
@@ -203,6 +210,7 @@ const layoutChildren = [
   settingsRoute,
   statusRoute,
   kanbanRoute,
+  taskBoardRoute,
 ];
 
 const rootChildren = [


### PR DESCRIPTION
## What

Adds a `/task-board` route to the dashboard showing a read-only kanban board of tasks from `.openspawn/tasks.json`.

## Details

- **Data source:** Fetches from GitHub raw content API (`main` branch), falls back to hardcoded demo data if the repo is private or request fails
- **Three columns:** Open (includes blocked) | In Progress (includes claimed) | Done
- **Task cards show:** ID, description, assignee, status badge, PR link, relative timestamps, budget if present
- **Auto-refresh:** Every 30 seconds
- **Styling:** Matches existing dashboard theme (dark navy, cyan/violet accents)
- **Nav:** Added "Task Board" link with ClipboardList icon to sidebar

## Files

- `apps/dashboard/src/hooks/use-repo-tasks.ts` — hook to fetch & parse tasks
- `apps/dashboard/src/pages/task-board.tsx` — TaskCard + TaskBoardPage components
- `apps/dashboard/src/routes.tsx` — new route registration
- `apps/dashboard/src/components/layout.tsx` — nav link added