### PR TITLE
feat(dashboard): rebrand internal dashboard to OpenSpawn

### DIFF
--- a/.openspawn/tasks.json
+++ b/.openspawn/tasks.json
@@ -1,0 +1,75 @@
+{
+  "version": 1,
+  "tasks": [
+    {
+      "id": "task-001",
+      "description": "Homepage positioning refresh — persistent governed orgs",
+      "assignee": "dennis",
+      "status": "done",
+      "createdAt": "2026-03-01T19:07:48.803Z",
+      "updatedAt": "2026-03-01T19:07:48.804Z"
+    },
+    {
+      "id": "task-002",
+      "description": "MCP server + CLI skeleton (13 tools, 10 commands)",
+      "assignee": "dennis",
+      "status": "done",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-003",
+      "description": "Team ORG.md + org tree command",
+      "assignee": "dennis",
+      "status": "done",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-004",
+      "description": "npm publish — openspawn@0.1.0",
+      "assignee": "dennis",
+      "status": "done",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-005",
+      "description": "README + getting started guide",
+      "assignee": "dennis",
+      "status": "done",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-006",
+      "description": "Tone cleanup — additive not competitive",
+      "assignee": "dennis",
+      "status": "in-progress",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-007",
+      "description": "Dogfood task flow — use openspawn for real work",
+      "status": "open",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-008",
+      "description": "End-to-end demo recording for homepage",
+      "status": "open",
+      "createdAt": "2026-03-01T19:07:48.805Z",
+      "updatedAt": "2026-03-01T19:07:48.805Z"
+    },
+    {
+      "id": "task-009",
+      "description": "Deploy homepage with new positioning",
+      "status": "open",
+      "createdAt": "2026-03-01T19:07:48.806Z",
+      "updatedAt": "2026-03-01T19:07:48.806Z"
+    }
+  ],
+  "budgets": {}
+}

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -2,36 +2,36 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>BikiniBottom — 22 SpongeBob Agents Running a Company</title>
+    <title>OpenSpawn — Multi-Agent Coordination Platform</title>
     <base href="/" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <meta name="description" content="BikiniBottom — Open source multi-agent coordination platform. Where your agents come together." />
+    <meta name="description" content="OpenSpawn — Open source multi-agent coordination platform. Where your agents come together." />
     <meta name="theme-color" content="#0a1929" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#1a2942" media="(prefers-color-scheme: light)" />
     
     <!-- Favicon (pineapple emoji) -->
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍍</text></svg>" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>" />
     
     <!-- PWA -->
     <link rel="manifest" href="/manifest.json" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="BikiniBottom" />
+    <meta name="apple-mobile-web-app-title" content="OpenSpawn" />
     
     <!-- Open Graph / Social Sharing -->
-    <meta property="og:title" content="BikiniBottom — Multi-Agent Coordination" />
+    <meta property="og:title" content="OpenSpawn — Multi-Agent Coordination" />
     <meta property="og:description" content="Open source multi-agent coordination platform. Where your agents come together." />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://openspawn.github.io/openspawn/og-image.html" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="BikiniBottom — Multi-Agent Coordination" />
+    <meta name="twitter:title" content="OpenSpawn — Multi-Agent Coordination" />
     <meta name="twitter:description" content="Open source multi-agent coordination platform. Where your agents come together." />
     
-    <!-- BikiniBottom fonts: Baloo 2 (display) + Nunito (body) -->
+    <!-- Fonts: Baloo 2 (display) + Nunito (body) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600;700;800&family=Inter:wght@400;500;600;700&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/apps/dashboard/public/404.html
+++ b/apps/dashboard/public/404.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Lost in the Deep? 🌊 — BikiniBottom</title>
+  <title>Page Not Found — OpenSpawn</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>" />
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -77,7 +77,7 @@
     <div class="code">404</div>
     <h1>Lost in the deep?</h1>
     <p>This page drifted away with the current. Let's get you back to the surface.</p>
-    <a href="/">🌊 Back to BikiniBottom</a>
+    <a href="/">⚡ Back to OpenSpawn</a>
   </div>
 </body>
 </html>

--- a/apps/dashboard/public/manifest.json
+++ b/apps/dashboard/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "BikiniBottom Dashboard",
-  "short_name": "BikiniBottom",
+  "name": "OpenSpawn Dashboard",
+  "short_name": "OpenSpawn",
   "description": "Multi-agent coordination platform dashboard",
   "start_url": ".",
   "display": "standalone",

--- a/apps/dashboard/public/offline.html
+++ b/apps/dashboard/public/offline.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>BikiniBottom — Offline</title>
+    <title>OpenSpawn — Offline</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0a1929" />
     <style>
@@ -61,7 +61,7 @@
       <div class="wave">🌊</div>
       <h1>You're Offline</h1>
       <p>
-        BikiniBottom can't reach the ocean right now.
+        OpenSpawn is temporarily offline.
         Check your internet connection and try again.
       </p>
       <button onclick="window.location.reload()">Try Again</button>

--- a/apps/dashboard/public/og-image.html
+++ b/apps/dashboard/public/og-image.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=1200, height=630">
-  <title>BikiniBottom — Multi-Agent Coordination</title>
+  <title>OpenSpawn — Multi-Agent Coordination</title>
   <style>
     * {
       margin: 0;
@@ -235,7 +235,7 @@
     <!-- Main content -->
     <div class="content">
       <div class="emoji">🌊</div>
-      <h1 class="title">BikiniBottom</h1>
+      <h1 class="title">OpenSpawn</h1>
       <p class="tagline">Where your agents come together</p>
       <div class="badge">Open Source Multi-Agent Coordination</div>
     </div>

--- a/apps/dashboard/src/components/onboarding/welcome-screen.tsx
+++ b/apps/dashboard/src/components/onboarding/welcome-screen.tsx
@@ -75,7 +75,7 @@ export function WelcomeScreen() {
                 transition={{ delay: 0.3 }}
                 className="text-4xl font-bold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent mb-3"
               >
-                BikiniBottom
+                OpenSpawn
               </motion.h1>
 
               {/* Tagline */}

--- a/apps/dashboard/src/components/pwa-install-prompt.tsx
+++ b/apps/dashboard/src/components/pwa-install-prompt.tsx
@@ -70,7 +70,7 @@ export function PwaInstallPrompt() {
 
                 <div className="flex-1 min-w-0">
                   <h3 className="text-sm font-semibold text-cyan-50">
-                    Install BikiniBottom
+                    Install OpenSpawn
                   </h3>
                   <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
                     Add to your home screen for the full ocean experience

--- a/apps/dashboard/src/components/settings/github-settings.tsx
+++ b/apps/dashboard/src/components/settings/github-settings.tsx
@@ -238,7 +238,7 @@ export function GitHubSettings() {
               <div>
                 <CardTitle>GitHub Integration</CardTitle>
                 <CardDescription>
-                  Bidirectional sync between GitHub issues/PRs and BikiniBottom tasks
+                  Bidirectional sync between GitHub issues/PRs and OpenSpawn tasks
                 </CardDescription>
               </div>
             </div>
@@ -469,7 +469,7 @@ export function GitHubSettings() {
               Linked Items
             </CardTitle>
             <CardDescription>
-              Active links between GitHub and BikiniBottom
+              Active links between GitHub and OpenSpawn
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/apps/dashboard/src/components/settings/inbound-webhooks-settings.tsx
+++ b/apps/dashboard/src/components/settings/inbound-webhooks-settings.tsx
@@ -241,7 +241,7 @@ export function InboundWebhooksSettings() {
               Inbound Webhooks
             </CardTitle>
             <CardDescription>
-              Allow external services to create tasks in BikiniBottom via HTTP POST
+              Allow external services to create tasks in OpenSpawn via HTTP POST
             </CardDescription>
           </div>
           <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>

--- a/apps/dashboard/src/components/settings/org-settings.tsx
+++ b/apps/dashboard/src/components/settings/org-settings.tsx
@@ -33,7 +33,7 @@ const MOCK_MEMBERS: OrgMember[] = [
 
 export function OrgSettings() {
   const { user } = useAuth();
-  const [orgName, setOrgName] = useState("BikiniBottom");
+  const [orgName, setOrgName] = useState("OpenSpawn");
   const [isSaving, setIsSaving] = useState(false);
   const [members] = useState<OrgMember[]>(MOCK_MEMBERS);
 

--- a/apps/dashboard/src/components/ui/logo.tsx
+++ b/apps/dashboard/src/components/ui/logo.tsx
@@ -18,7 +18,7 @@ export function Logo({ size = 'md', className = '', style }: LogoProps) {
   return (
     <span
       role="img"
-      aria-label="BikiniBottom"
+      aria-label="OpenSpawn"
       className={`flex-shrink-0 leading-none select-none ${className}`}
       style={{ fontSize: px, lineHeight: 1, ...style }}
     >

--- a/apps/dashboard/src/lib/confetti.ts
+++ b/apps/dashboard/src/lib/confetti.ts
@@ -1,5 +1,5 @@
 /**
- * Confetti celebration effects for BikiniBottom dashboard
+ * Confetti celebration effects for OpenSpawn dashboard
  * Uses canvas-confetti for lightweight, performant animations
  */
 

--- a/apps/dashboard/src/lib/dashboard-theme.ts
+++ b/apps/dashboard/src/lib/dashboard-theme.ts
@@ -1,16 +1,16 @@
 /**
  * Dashboard theme detection via VITE_DASHBOARD_THEME env var.
  * 
- * "openspawn" = clean shadcn dashboard for team.openspawn.ai
- * "bikinibottom" (default) = BB-themed demo for bikinibottom.ai
+ * "openspawn" (default) = clean shadcn dashboard for team.openspawn.ai
+ * "bikinibottom" = BB-themed demo for bikinibottom.ai
  */
 
 export type DashboardTheme = 'openspawn' | 'bikinibottom';
 
 export const DASHBOARD_THEME: DashboardTheme =
-  (import.meta.env.VITE_DASHBOARD_THEME as string) === 'openspawn'
-    ? 'openspawn'
-    : 'bikinibottom';
+  (import.meta.env.VITE_DASHBOARD_THEME as string) === 'bikinibottom'
+    ? 'bikinibottom'
+    : 'openspawn';
 
 export const isBBTheme = DASHBOARD_THEME === 'bikinibottom';
 export const isOpenSpawnTheme = DASHBOARD_THEME === 'openspawn';

--- a/apps/dashboard/src/pages/login.tsx
+++ b/apps/dashboard/src/pages/login.tsx
@@ -47,7 +47,7 @@ export function LoginPage() {
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl">Welcome to BikiniBottom</CardTitle>
+          <CardTitle className="text-2xl">Welcome to OpenSpawn</CardTitle>
           <CardDescription>
             Sign in to access your agent dashboard
           </CardDescription>


### PR DESCRIPTION
Swaps all BikiniBottom branding to OpenSpawn across 14 dashboard files.

- Page title, sidebar header, PWA manifest
- Login page, welcome screen, theme config
- 404/offline pages, og-image template
- Demo simulation content (SpongeBob characters) intentionally kept

Also includes .openspawn/tasks.json at the correct path for the kanban board.