### PR TITLE
fix(dashboard): remove remaining BB references from OpenSpawn theme

### DIFF
--- a/apps/dashboard/src/components/error-boundary.tsx
+++ b/apps/dashboard/src/components/error-boundary.tsx
@@ -92,7 +92,7 @@ export class AppErrorBoundary extends Component<Props, State> {
               marginBottom: "0.5rem",
             }}
           >
-            A runtime error crashed the app. SpongeBob is already on it.
+            A runtime error crashed the app. The team is already on it.
           </p>
 
           {/* Error detail — collapsible via details/summary */}

--- a/apps/dashboard/src/routes.tsx
+++ b/apps/dashboard/src/routes.tsx
@@ -20,6 +20,7 @@ import { IntroPage } from "./pages/intro";
 import { MobileStatusPage } from "./pages/mobile-status";
 import { LiveViewPage } from "./pages/live-view";
 import { isSandboxMode } from "./graphql/fetcher";
+import { isBBTheme } from "./lib/dashboard-theme";
 import type { ReactNode } from "react";
 
 // Check for demo/sandbox mode via URL param or env
@@ -214,8 +215,7 @@ const layoutChildren = [
 ];
 
 const rootChildren = [
-  introRoute,
-  liveRoute,
+  ...(isBBTheme ? [introRoute, liveRoute] : []),
   layoutRoute.addChildren(layoutChildren),
   ...(!isDemoMode && !isSandboxMode ? [loginRoute, authCallbackRoute] : []),
 ];


### PR DESCRIPTION
Full audit of every dashboard page on the OpenSpawn theme:

**All 11 sidebar pages (Dashboard, Network, Tasks, Kanban, Task Board, Agents, Messages, Router, Credits, Events, Settings):** ✅ Clean

**Fixed:**
- Error boundary: 'SpongeBob is already on it' → 'The team is already on it'
- /intro and /live routes now gated behind isBBTheme — not accessible on team.openspawn.ai

**Dead code in bundle (not rendered on OpenSpawn theme):**
- components/bb/*, demo/DemoWelcome — BB content in JS but behind isBBTheme guards