### PR TITLE
fix(team): strip auth dependency, serve as static files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# ── BikiniBottom Live Demo ────────────────────────────────────────────────────
-# Lean build: dashboard static files + sandbox server only
+# ── OpenSpawn Platform ────────────────────────────────────────────────────────
+# Builds: demo dashboard, team dashboard, website, sandbox server
 
-# Stage 1: Build dashboard
+# Stage 1: Build all apps
 FROM node:24-alpine AS build
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@latest --activate
@@ -21,6 +21,7 @@ ARG VITE_DASHBOARD_THEME=bikinibottom
 ENV VITE_SANDBOX_MODE=true
 ENV VITE_DASHBOARD_THEME=${VITE_DASHBOARD_THEME}
 RUN pnpm nx run dashboard:build --configuration=production
+RUN pnpm nx run team:build --configuration=production
 RUN pnpm nx run website:build
 
 # Stage 2: Minimal runtime
@@ -39,11 +40,13 @@ COPY tools/sandbox/src/ ./src/
 COPY tools/sandbox/ORG.md ./
 COPY tools/sandbox/org/ ./org/
 
-# Copy built dashboard and website
+# Copy built apps
 COPY --from=build /app/dist/apps/dashboard ./dashboard-dist
+COPY --from=build /app/dist/apps/team ./team-dist
 COPY --from=build /app/dist/apps/website ./website-dist
 
 ENV WEBSITE_DIR=/app/website-dist
+ENV TEAM_DIR=/app/team-dist
 ENV NODE_ENV=production
 ENV SANDBOX_PORT=3333
 ENV SERVE_DASHBOARD=1

--- a/apps/team/src/app/app.tsx
+++ b/apps/team/src/app/app.tsx
@@ -1,6 +1,6 @@
 import { RouterProvider } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { AuthProvider, SidePanelProvider } from "../contexts";
+import { SidePanelProvider } from "@openspawn/dashboard-data";
 import { router } from "../routes";
 
 declare const __COMMIT_SHA__: string;
@@ -26,13 +26,11 @@ const queryClient = new QueryClient({
 
 export function App() {
   return (
-    <AuthProvider>
-      <QueryClientProvider client={queryClient}>
-        <SidePanelProvider>
-          <RouterProvider router={router} />
-        </SidePanelProvider>
-      </QueryClientProvider>
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <SidePanelProvider>
+        <RouterProvider router={router} />
+      </SidePanelProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/apps/team/src/components/layout.tsx
+++ b/apps/team/src/components/layout.tsx
@@ -13,11 +13,9 @@ import {
   MessageSquare,
   Layers,
   ClipboardList,
-  LogOut,
   PanelLeft,
 } from "lucide-react";
 import { cn } from "../lib/utils";
-import { useAuth } from "../contexts";
 import type { ReactNode } from "react";
 
 const BRAND_NAME = "OpenSpawn";
@@ -68,7 +66,6 @@ function useSidebarCollapsed() {
 
 export function Layout({ children }: LayoutProps) {
   const location = useLocation();
-  const { user, logout } = useAuth();
   const { collapsed, toggle: toggleCollapse } = useSidebarCollapsed();
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -139,15 +136,6 @@ export function Layout({ children }: LayoutProps) {
             <PanelLeft className="h-4 w-4" />
             {!collapsed && <span>Collapse</span>}
           </button>
-          {user && (
-            <button
-              onClick={() => logout()}
-              className="flex items-center gap-2 w-full rounded-lg px-3 py-2 text-xs text-white/40 hover:text-white/60 hover:bg-white/5 transition-colors"
-            >
-              <LogOut className="h-4 w-4" />
-              {!collapsed && <span>Sign out</span>}
-            </button>
-          )}
         </div>
       </aside>
 

--- a/apps/team/src/routes.tsx
+++ b/apps/team/src/routes.tsx
@@ -3,10 +3,8 @@ import {
   createRoute,
   createRouter,
   Outlet,
-  Navigate,
 } from "@tanstack/react-router";
 import { Layout } from "./components/layout";
-import { useAuth } from "./contexts";
 import { DashboardPage } from "./pages/dashboard";
 import { AgentsPage } from "./pages/agents";
 import { TasksPage } from "./pages/tasks";
@@ -17,86 +15,54 @@ import { CreditsPage } from "./pages/credits";
 import { KanbanPage } from "./pages/kanban";
 import { TaskBoardPage } from "./pages/task-board";
 import { NetworkPage } from "./pages/network";
-import { LoginPage } from "./pages/login";
-import { AuthCallbackPage } from "./pages/auth-callback";
-import type { ReactNode } from "react";
 
-// Protected route wrapper — redirects to /login if not authenticated
-function ProtectedRoute({ children }: { children: ReactNode }) {
-  const { user, isLoading } = useAuth();
-  if (isLoading) return <div className="flex h-screen items-center justify-center text-white/40">Loading...</div>;
-  if (!user) return <Navigate to="/login" />;
-  return <>{children}</>;
-}
-
-// Root route
 const rootRoute = createRootRoute({
   component: () => <Outlet />,
 });
 
-// Auth routes — standalone, no layout
-const loginRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/login",
-  component: LoginPage,
-});
-
-const authCallbackRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/auth/callback",
-  component: AuthCallbackPage,
-});
-
-// Layout route for all protected pages
 const layoutRoute = createRoute({
   getParentRoute: () => rootRoute,
   id: "layout",
   component: () => (
-    <ProtectedRoute>
-      <Layout>
-        <Outlet />
-      </Layout>
-    </ProtectedRoute>
+    <Layout>
+      <Outlet />
+    </Layout>
   ),
 });
 
-// Child routes
-const indexRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/", component: DashboardPage });
-const tasksRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/tasks", component: TasksPage });
+const indexRoute = createRoute({
+  getParentRoute: () => layoutRoute,
+  path: "/",
+  component: DashboardPage,
+});
+
 const agentsRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/agents", component: AgentsPage });
-const creditsRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/credits", component: CreditsPage });
+const tasksRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/tasks", component: TasksPage });
 const eventsRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/events", component: EventsPage });
 const messagesRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/messages", component: MessagesPage });
-const networkRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/network", component: NetworkPage });
 const settingsRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/settings", component: SettingsPage });
+const creditsRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/credits", component: CreditsPage });
 const kanbanRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/kanban", component: KanbanPage });
 const taskBoardRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/task-board", component: TaskBoardPage });
+const networkRoute = createRoute({ getParentRoute: () => layoutRoute, path: "/network", component: NetworkPage });
 
 const routeTree = rootRoute.addChildren([
-  loginRoute,
-  authCallbackRoute,
   layoutRoute.addChildren([
     indexRoute,
-    tasksRoute,
     agentsRoute,
-    creditsRoute,
+    tasksRoute,
     eventsRoute,
     messagesRoute,
-    networkRoute,
     settingsRoute,
+    creditsRoute,
     kanbanRoute,
     taskBoardRoute,
+    networkRoute,
   ]),
 ]);
 
-export const router = createRouter({
-  routeTree,
-  basepath: "/app",
-  defaultPreload: "intent",
-});
+export const router = createRouter({ routeTree, basepath: "/app" });
 
 declare module "@tanstack/react-router" {
-  interface Register {
-    router: typeof router;
-  }
+  interface Register { router: typeof router; }
 }


### PR DESCRIPTION
Removes AuthProvider/ProtectedRoute from team app since there's no backend API yet. Team dashboard loads clean at team.openspawn.ai/app/. Auth will be wired to Authentik OIDC in a follow-up.