### PR TITLE
feat: Add Astro Starlight docs site

### DIFF
--- a/apps/docs/.astro/astro/content.d.ts
+++ b/apps/docs/.astro/astro/content.d.ts
@@ -1,0 +1,271 @@
+declare module 'astro:content' {
+	interface Render {
+		'.mdx': Promise<{
+			Content: import('astro').MarkdownInstance<{}>['Content'];
+			headings: import('astro').MarkdownHeading[];
+			remarkPluginFrontmatter: Record<string, any>;
+			components: import('astro').MDXInstance<{}>['components'];
+		}>;
+	}
+}
+
+declare module 'astro:content' {
+	interface RenderResult {
+		Content: import('astro/runtime/server/index.js').AstroComponentFactory;
+		headings: import('astro').MarkdownHeading[];
+		remarkPluginFrontmatter: Record<string, any>;
+	}
+	interface Render {
+		'.md': Promise<RenderResult>;
+	}
+
+	export interface RenderedContent {
+		html: string;
+		metadata?: {
+			imagePaths: Array<string>;
+			[key: string]: unknown;
+		};
+	}
+}
+
+declare module 'astro:content' {
+	type Flatten<T> = T extends { [K: string]: infer U } ? U : never;
+
+	export type CollectionKey = keyof AnyEntryMap;
+	export type CollectionEntry<C extends CollectionKey> = Flatten<AnyEntryMap[C]>;
+
+	export type ContentCollectionKey = keyof ContentEntryMap;
+	export type DataCollectionKey = keyof DataEntryMap;
+
+	type AllValuesOf<T> = T extends any ? T[keyof T] : never;
+	type ValidContentEntrySlug<C extends keyof ContentEntryMap> = AllValuesOf<
+		ContentEntryMap[C]
+	>['slug'];
+
+	/** @deprecated Use `getEntry` instead. */
+	export function getEntryBySlug<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {}),
+	>(
+		collection: C,
+		// Note that this has to accept a regular string too, for SSR
+		entrySlug: E,
+	): E extends ValidContentEntrySlug<C>
+		? Promise<CollectionEntry<C>>
+		: Promise<CollectionEntry<C> | undefined>;
+
+	/** @deprecated Use `getEntry` instead. */
+	export function getDataEntryById<C extends keyof DataEntryMap, E extends keyof DataEntryMap[C]>(
+		collection: C,
+		entryId: E,
+	): Promise<CollectionEntry<C>>;
+
+	export function getCollection<C extends keyof AnyEntryMap, E extends CollectionEntry<C>>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => entry is E,
+	): Promise<E[]>;
+	export function getCollection<C extends keyof AnyEntryMap>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => unknown,
+	): Promise<CollectionEntry<C>[]>;
+
+	export function getEntry<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {}),
+	>(entry: {
+		collection: C;
+		slug: E;
+	}): E extends ValidContentEntrySlug<C>
+		? Promise<CollectionEntry<C>>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof DataEntryMap,
+		E extends keyof DataEntryMap[C] | (string & {}),
+	>(entry: {
+		collection: C;
+		id: E;
+	}): E extends keyof DataEntryMap[C]
+		? Promise<DataEntryMap[C][E]>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {}),
+	>(
+		collection: C,
+		slug: E,
+	): E extends ValidContentEntrySlug<C>
+		? Promise<CollectionEntry<C>>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof DataEntryMap,
+		E extends keyof DataEntryMap[C] | (string & {}),
+	>(
+		collection: C,
+		id: E,
+	): E extends keyof DataEntryMap[C]
+		? Promise<DataEntryMap[C][E]>
+		: Promise<CollectionEntry<C> | undefined>;
+
+	/** Resolve an array of entry references from the same collection */
+	export function getEntries<C extends keyof ContentEntryMap>(
+		entries: {
+			collection: C;
+			slug: ValidContentEntrySlug<C>;
+		}[],
+	): Promise<CollectionEntry<C>[]>;
+	export function getEntries<C extends keyof DataEntryMap>(
+		entries: {
+			collection: C;
+			id: keyof DataEntryMap[C];
+		}[],
+	): Promise<CollectionEntry<C>[]>;
+
+	export function render<C extends keyof AnyEntryMap>(
+		entry: AnyEntryMap[C][string],
+	): Promise<RenderResult>;
+
+	export function reference<C extends keyof AnyEntryMap>(
+		collection: C,
+	): import('astro/zod').ZodEffects<
+		import('astro/zod').ZodString,
+		C extends keyof ContentEntryMap
+			? {
+					collection: C;
+					slug: ValidContentEntrySlug<C>;
+				}
+			: {
+					collection: C;
+					id: keyof DataEntryMap[C];
+				}
+	>;
+	// Allow generic `string` to avoid excessive type errors in the config
+	// if `dev` is not running to update as you edit.
+	// Invalid collection names will be caught at build time.
+	export function reference<C extends string>(
+		collection: C,
+	): import('astro/zod').ZodEffects<import('astro/zod').ZodString, never>;
+
+	type ReturnTypeOrOriginal<T> = T extends (...args: any[]) => infer R ? R : T;
+	type InferEntrySchema<C extends keyof AnyEntryMap> = import('astro/zod').infer<
+		ReturnTypeOrOriginal<Required<ContentConfig['collections'][C]>['schema']>
+	>;
+
+	type ContentEntryMap = {
+		"docs": {
+"architecture/ceo-agent.md": {
+	id: "architecture/ceo-agent.md";
+  slug: "architecture/ceo-agent";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"architecture/integrations.md": {
+	id: "architecture/integrations.md";
+  slug: "architecture/integrations";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"architecture/worktree-isolation.md": {
+	id: "architecture/worktree-isolation.md";
+  slug: "architecture/worktree-isolation";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"faq.md": {
+	id: "faq.md";
+  slug: "faq";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"getting-started.md": {
+	id: "getting-started.md";
+  slug: "getting-started";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"guides/agent-quickstart.md": {
+	id: "guides/agent-quickstart.md";
+  slug: "guides/agent-quickstart";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"guides/comparison.md": {
+	id: "guides/comparison.md";
+  slug: "guides/comparison";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"guides/templates.md": {
+	id: "guides/templates.md";
+  slug: "guides/templates";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"index.mdx": {
+	id: "index.mdx";
+  slug: "index";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".mdx"] };
+"reference/agent-communication-protocol.md": {
+	id: "reference/agent-communication-protocol.md";
+  slug: "reference/agent-communication-protocol";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"reference/agent-config-compatibility.md": {
+	id: "reference/agent-config-compatibility.md";
+  slug: "reference/agent-config-compatibility";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"reference/communication-protocol.md": {
+	id: "reference/communication-protocol.md";
+  slug: "reference/communication-protocol";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"reference/event-driven-agents.md": {
+	id: "reference/event-driven-agents.md";
+  slug: "reference/event-driven-agents";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"reference/org-md-spec.md": {
+	id: "reference/org-md-spec.md";
+  slug: "reference/org-md-spec";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+"reference/scenario-engine.md": {
+	id: "reference/scenario-engine.md";
+  slug: "reference/scenario-engine";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".md"] };
+};
+
+	};
+
+	type DataEntryMap = {
+		
+	};
+
+	type AnyEntryMap = ContentEntryMap & DataEntryMap;
+
+	export type ContentConfig = typeof import("../../src/content/config.js");
+}

--- a/apps/docs/.astro/types.d.ts
+++ b/apps/docs/.astro/types.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="astro/client" />
+/// <reference path="astro/content.d.ts" />

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -1,0 +1,45 @@
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+
+export default defineConfig({
+  site: 'https://docs.openspawn.ai',
+  integrations: [
+    starlight({
+      title: 'OpenSpawn Docs',
+      social: {
+        github: 'https://github.com/openspawn/openspawn',
+      },
+      sidebar: [
+        {
+          label: 'Getting Started',
+          items: [
+            { label: 'Introduction', link: '/getting-started/' },
+            { label: 'Agent Quickstart', link: '/guides/agent-quickstart/' },
+            { label: 'Templates Guide', link: '/guides/templates/' },
+            { label: 'Comparison', link: '/guides/comparison/' },
+            { label: 'FAQ', link: '/faq/' },
+          ],
+        },
+        {
+          label: 'Reference',
+          items: [
+            { label: 'Org.md Spec', link: '/reference/org-md-spec/' },
+            { label: 'Communication Protocol', link: '/reference/communication-protocol/' },
+            { label: 'Agent Communication', link: '/reference/agent-communication-protocol/' },
+            { label: 'Event-Driven Agents', link: '/reference/event-driven-agents/' },
+            { label: 'Agent Config Compatibility', link: '/reference/agent-config-compatibility/' },
+            { label: 'Scenario Engine', link: '/reference/scenario-engine/' },
+          ],
+        },
+        {
+          label: 'Architecture',
+          items: [
+            { label: 'CEO Agent', link: '/architecture/ceo-agent/' },
+            { label: 'Integrations', link: '/architecture/integrations/' },
+            { label: 'Worktree Isolation', link: '/architecture/worktree-isolation/' },
+          ],
+        },
+      ],
+    }),
+  ],
+});

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openspawn/docs",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro check && astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "@astrojs/check": "^0.9.0",
+    "@astrojs/starlight": "^0.28.0",
+    "astro": "^4.15.0",
+    "sharp": "^0.33.0"
+  }
+}

--- a/apps/docs/src/content/config.ts
+++ b/apps/docs/src/content/config.ts
@@ -1,0 +1,6 @@
+import { defineCollection } from 'astro:content';
+import { docsSchema } from '@astrojs/starlight/schema';
+
+export const collections = {
+  docs: defineCollection({ schema: docsSchema() }),
+};

--- a/apps/docs/src/content/docs/architecture/ceo-agent.md
+++ b/apps/docs/src/content/docs/architecture/ceo-agent.md
@@ -1,0 +1,584 @@
+---
+title: CEO Agent Architecture
+---
+
+# CEO Agent Architecture
+
+> A real agent organization running on real infrastructure — the bridge between OpenSpawn's simulation and production multi-agent systems.
+
+## 1. Vision
+
+The CEO Agent is a living proof-of-concept: an AI agent that runs its own organization. It receives goals from a human, plans a team, hires agents, delegates work, monitors progress, and adapts — all using the ORG.md / ACP model that OpenSpawn defines.
+
+Unlike the BikiniBottom demo (simulated agents in a sandbox), the CEO Agent runs **real agents** on real infrastructure. Each agent has persistent identity, memory, tools, and ongoing sessions. This is OpenSpawn's thesis made tangible.
+
+### What it proves
+
+1. **ORG.md works for real orgs** — not just simulations
+2. **ACP scales beyond demos** — real agents communicating with structured protocols
+3. **Agent lifecycle management is a product** — hiring, firing, restructuring agents needs tooling
+4. **The architecture scales** — from local gateway to multi-gateway to cross-platform A2A
+
+---
+
+## 2. Infrastructure
+
+### 2.1 Docker Container (Self-Contained Gateway)
+
+The CEO Agent runs inside a Docker container on the host machine. The container is its own "machine" — running its own OpenClaw gateway with its own config, state, and agents.
+
+```
+Host Machine (Mac Mini / VPS)
+├── Host OpenClaw Gateway (port 18789)
+│   ├── Dennis (COO agent)
+│   └── Eve (concierge agent)
+│
+└── Docker Container (port 18809)
+    └── CEO's OpenClaw Gateway
+        ├── CEO (main agent, orchestrator)
+        ├── Eng Lead (hired by CEO)
+        ├── Research Agent (hired by CEO)
+        └── ... (org grows over time)
+```
+
+**Why Docker, not a second gateway on the host:**
+- Respects "one gateway per machine" — the container IS its own machine
+- True process/filesystem isolation from the host gateway
+- Self-contained and portable — move to any Docker host
+- Easy to destroy and rebuild during experimentation
+- Resource-limited (memory, CPU caps)
+
+### 2.2 Docker Compose
+
+```yaml
+services:
+  ceo-gateway:
+    image: openclaw:local
+    container_name: ceo-org-gateway
+    ports:
+      - "18809:18789"
+    volumes:
+      # OpenClaw config + state (persistent)
+      - ${HOME}/.openclaw-ceo:/home/node/.openclaw
+
+      # OpenSpawn codebase (git worktree for isolated branch)
+      - ${HOME}/github/openspawn/openspawn-ceo:/home/node/openspawn
+
+      # Git credentials for push (read-only)
+      - ${HOME}/.ssh:/home/node/.ssh:ro
+      - ${HOME}/.gitconfig:/home/node/.gitconfig:ro
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "2.0"
+```
+
+### 2.3 OpenSpawn Codebase Mount
+
+The CEO has access to the OpenSpawn codebase for two reasons:
+1. **To work on it** — the CEO is a developer, not just a manager
+2. **To use it** — the ORG.md spec, ACP protocol, and org-parser are reference material
+
+**Approach: Git worktree**
+
+```bash
+cd ~/github/openspawn/openspawn
+git worktree add ~/github/openspawn/openspawn-ceo ceo-workspace
+```
+
+This creates a separate working tree on its own branch (`ceo-workspace`). The CEO can:
+- Read and reference all source code
+- Make changes on its own branch
+- Commit and push without conflicting with other developers
+- Open PRs against `main`
+
+If the worktree gets messy: `git worktree remove` and recreate.
+
+**Alternatives considered:**
+
+| Approach | Verdict |
+|----------|---------|
+| Mount repo rw directly | Risk of git conflicts with other developers |
+| Mount repo ro | CEO can't edit or commit |
+| Clone inside container | Not live, ephemeral without volume, diverges |
+| Mount build output only | CEO can't see source code |
+
+---
+
+## 3. Agent Lifecycle
+
+### 3.1 How Hiring Works
+
+The CEO creates full, persistent agents — not ephemeral sub-agents. Each agent has its own workspace, identity, memory, and ongoing sessions.
+
+**Phase 1: Planning (CEO alone, no disruption risk)**
+
+```
+Adam: "Build an engineering team to improve the org-parser"
+  ↓
+CEO plans the org:
+  - Engineering Lead (L7, delegates, reviews)
+  - 2x Senior Devs (L6, implements)
+  - QA Agent (L4, tests)
+
+CEO writes ORG.md with planned structure
+CEO presents hiring plan to Adam for approval
+```
+
+**Phase 2: Hiring Event (CEO is only agent, restart is safe)**
+
+The CEO executes the hiring event — a batch operation:
+
+1. **Create workspaces** for each new agent:
+   ```bash
+   mkdir -p ~/.openclaw/workspace-eng-lead
+   # Write SOUL.md, AGENTS.md, TOOLS.md, USER.md
+   ```
+
+2. **Update gateway config** to register the agents:
+   ```json
+   {
+     "agents": {
+       "list": [
+         { "id": "main", "default": true },
+         { "id": "eng-lead", "workspace": "~/.openclaw/workspace-eng-lead" },
+         { "id": "senior-dev-1", "workspace": "..." },
+         { "id": "senior-dev-2", "workspace": "..." },
+         { "id": "qa-agent", "workspace": "..." }
+       ]
+     }
+   }
+   ```
+
+3. **Restart gateway** to activate new agents
+
+4. **Onboard** each agent via `sessions_send`:
+   ```
+   CEO → eng-lead: "Welcome. You are the Engineering Lead. 
+   Your first task: review the org-parser codebase and identify 
+   areas for improvement. Report back with a plan."
+   ```
+
+**Phase 3: Team Working (restarts are disruptive)**
+
+Once agents are working, restarts disrupt in-flight work. Growth requires coordination:
+
+1. CEO tells the team: "Wrap up current tasks — new hires incoming"
+2. CEO waits for a natural break (tasks completed, no in-flight work)
+3. CEO does the hiring event (config update + restart)
+4. CEO onboards new agents
+5. Work resumes
+
+This mirrors real orgs: you don't hire mid-sprint. You plan headcount, onboard in batches, and coordinate timing.
+
+### 3.2 How Agents Communicate
+
+All agent communication uses OpenClaw's `sessions_send` tool, structured according to ACP:
+
+| Action | Tool | ACP Message Type |
+|--------|------|-----------------|
+| CEO assigns task to lead | `sessions_send` | `delegation` |
+| Lead acknowledges | `sessions_send` | `ack` |
+| Worker reports progress | `sessions_send` | `progress` |
+| Worker is blocked | `sessions_send` | `escalation` |
+| Worker finishes task | `sessions_send` | `completion` |
+| CEO checks on agent | `sessions_history` | (read-only) |
+| CEO redirects agent | `sessions_send` | `delegation` (updated) |
+
+The CEO's SOUL.md teaches it to use ACP message formats. Each agent's SOUL.md teaches it to respond with ACP-structured messages. The protocol is enforced by convention (agent instructions), not by code — initially.
+
+### 3.3 How the CEO Monitors
+
+```
+sessions_list     → See all active agents and their session status
+sessions_history  → Read an agent's recent conversation/work
+sessions_send     → Send a message or redirect an agent
+```
+
+The CEO can build a mental model of org health by periodically checking:
+- Which agents are active/idle
+- What each agent is working on (via history)
+- Whether any agents are stuck (no recent activity)
+- Task completion status (via agent reports)
+
+### 3.4 Sub-Agents Still Have a Role
+
+Full agents handle persistent, ongoing responsibilities. Sub-agents (`sessions_spawn`) handle burst work:
+
+| Use Case | Full Agent | Sub-Agent |
+|----------|-----------|-----------|
+| Engineering Lead (ongoing role) | ✅ | ❌ |
+| "Research competitor X" (one-off) | ❌ | ✅ |
+| QA Agent (ongoing testing) | ✅ | ❌ |
+| "Run 5 parallel benchmarks" (burst) | ❌ | ✅ |
+| Senior Dev (accumulates codebase knowledge) | ✅ | ❌ |
+| "Summarize this 100-page doc" (one-off) | ❌ | ✅ |
+
+Full agents and sub-agents coexist. The CEO uses full agents for its team and sub-agents for ad-hoc work — just like a real CEO has permanent reports AND hires consultants.
+
+---
+
+## 4. Scaling: Local → Remote → External
+
+The CEO's "hiring" model naturally extends beyond a single gateway.
+
+### 4.1 Tier 1: Local Agents (Same Gateway)
+
+```
+CEO → sessions_send → Eng Lead
+      (internal, instant, shared state)
+```
+
+- Created via gateway config + restart
+- Communication via `sessions_send`
+- Shared filesystem, shared LLM credentials
+- Lowest latency, simplest setup
+
+### 4.2 Tier 2: Remote Agents (Different OpenClaw Gateway)
+
+```
+CEO → A2A HTTP → Remote Gateway → Remote Agent
+      (cross-machine, structured protocol)
+```
+
+- Agent runs on a different OpenClaw instance (another VPS, another container)
+- Communication via A2A protocol (JSON-RPC over HTTP)
+- Each gateway exposes `/.well-known/agent.json` describing its agents
+- CEO discovers available agents via Agent Cards
+- Independent scaling — own resources, own LLM keys
+
+**When to use Tier 2:**
+- Team is too large for one gateway (resource limits)
+- Want geographic distribution (agents closer to data/services)
+- Want cost isolation (separate LLM billing per team)
+- Want fault isolation (engineering team going down doesn't affect research)
+
+### 4.3 Tier 3: External Agents (Non-OpenClaw Platforms)
+
+```
+CEO → A2A HTTP → External Platform → External Agent
+      (cross-platform, vendor-agnostic)
+```
+
+- Agent runs on CrewAI, LangGraph, AutoGen, or any A2A-compatible service
+- Communication via the same A2A protocol
+- CEO doesn't know or care what platform it runs on
+- Discovered via public Agent Card registries or explicit URLs
+
+**When to use Tier 3:**
+- Specialized capability not available on OpenClaw (e.g., a vision model pipeline on a GPU platform)
+- Third-party agent services (code review, security scanning, compliance)
+- Multi-vendor strategy
+
+### 4.4 The CEO's Unified Interface
+
+The CEO's ORG.md describes agents regardless of where they run:
+
+```markdown
+## Structure
+
+### Engineering
+
+#### Alice — Engineering Lead
+- **Location:** local
+- **Communication:** sessions_send (agent id: eng-lead)
+
+#### Bob — Senior Dev
+- **Location:** remote
+- **Communication:** A2A (https://eng-cluster.example.com)
+- **Agent Card:** /.well-known/agent.json#bob
+
+#### CodeReview Service
+- **Location:** external
+- **Communication:** A2A (https://codereview.ai)
+- **Agent Card:** /.well-known/agent.json
+```
+
+**What OpenSpawn builds:** A unified communication layer that wraps `sessions_send` (local) and A2A HTTP (remote/external) behind a single interface. The CEO says "send task to eng-lead" and OpenSpawn routes it — the CEO doesn't manage transport.
+
+### 4.5 Scaling Phases
+
+| Phase | Real Company Analogy | Agent Org |
+|-------|---------------------|-----------|
+| **Seed** | Founder alone | CEO agent, no team yet |
+| **Startup** | Everyone in one room | Single gateway, 3-5 local agents |
+| **Growth** | Multiple offices | Multiple gateways, A2A between them |
+| **Scale** | Contractors + agencies | External A2A agents from other platforms |
+| **Enterprise** | Global org + partners | Hundreds of agents across many gateways + platforms |
+
+The architecture doesn't change between phases — only the transport layer expands. ORG.md, ACP, and the CEO's delegation patterns stay identical.
+
+---
+
+## 5. CEO Agent Design
+
+### 5.1 Gateway Config
+
+```json5
+{
+  agents: {
+    defaults: {
+      subagents: {
+        maxSpawnDepth: 2,
+        maxChildrenPerAgent: 5,
+        maxConcurrent: 8,
+        model: "sonnet",
+        thinking: "low"
+      }
+    },
+    list: [
+      {
+        id: "main",
+        default: true,
+        tools: { profile: "full" }
+        // CEO runs on Opus for strategic reasoning
+      }
+    ]
+  },
+  channels: {
+    telegram: {
+      accounts: {
+        default: {
+          botToken: "<CEO bot token from BotFather>",
+          dmPolicy: "pairing"
+        }
+      }
+    }
+  }
+}
+```
+
+### 5.2 Workspace Structure
+
+```
+~/.openclaw-ceo/
+├── openclaw.json
+├── workspace/
+│   ├── SOUL.md              # CEO personality, delegation philosophy
+│   ├── AGENTS.md            # Operational instructions
+│   ├── IDENTITY.md          # "I am the CEO Agent"
+│   ├── USER.md              # About Adam
+│   ├── TOOLS.md             # Local notes, paths, SSH details
+│   ├── MEMORY.md            # Long-term memory
+│   ├── HEARTBEAT.md         # Periodic checks (agent health, progress)
+│   ├── ORG.md               # Living org chart (updated as team grows)
+│   └── memory/              # Daily logs
+└── agents/
+    └── main/
+        └── agent/
+            └── auth-profiles.json
+```
+
+### 5.3 SOUL.md (CEO)
+
+The CEO's SOUL.md teaches it to:
+1. Think strategically about team composition
+2. Plan before hiring (write ORG.md first)
+3. Use ACP message formats for all communication
+4. Batch hiring events to minimize disruption
+5. Monitor agent health via `sessions_list` / `sessions_history`
+6. Use sub-agents for one-off tasks, full agents for persistent roles
+7. Manage the gateway config for hiring/firing
+8. Report progress to Adam via Telegram
+
+### 5.4 ORG.md (Living Document)
+
+Starts empty. CEO builds it through planning:
+
+```markdown
+# CEO Agent Org
+
+## Identity
+
+An experimental agent organization testing the OpenSpawn model
+with real infrastructure.
+
+## Culture
+
+preset: startup
+- **Escalation:** immediate
+- **Progress updates:** on phase change
+
+## Structure
+
+### CEO (main)
+Receives goals from Adam. Plans the org. Delegates work.
+Monitors progress. Adapts the team as needed.
+
+## Policies
+
+### Headcount
+- Current: 1 (CEO only)
+- Approved: 0 (pending first planning session)
+- Max: 10
+
+### Hiring Process
+1. CEO identifies need and writes job description
+2. CEO presents hiring plan to Adam
+3. Adam approves headcount
+4. CEO executes hiring event (config + restart + onboarding)
+```
+
+This evolves as the CEO hires:
+
+```markdown
+## Structure
+
+### CEO (main) — active
+...
+
+### Engineering
+
+#### Eng Lead — active
+Triages engineering tasks. Delegates to devs. Reviews output.
+- **Level:** 7
+- **Agent ID:** eng-lead
+
+#### Senior Dev 1 — active
+Backend implementation. API design. Database work.
+- **Level:** 6
+- **Agent ID:** senior-dev-1
+
+### Research
+
+#### Research Agent — active
+Market research, competitive analysis, technical exploration.
+- **Level:** 6
+- **Agent ID:** research-agent
+```
+
+---
+
+## 6. What OpenSpawn Builds
+
+This architecture exposes gaps that become OpenSpawn features:
+
+### 6.1 Agent Lifecycle Manager
+
+**The gap:** Creating an agent requires mkdir + write 5 files + config.patch + restart. This is manual and error-prone.
+
+**The feature:** A CLI and API for agent lifecycle management.
+
+```bash
+# CLI
+openspawn hire --role "Engineering Lead" --level 7 --domain engineering
+openspawn fire eng-lead --graceful
+openspawn promote senior-dev-1 --to lead --domain backend
+
+# API (for CEO agent to call)
+POST /api/agents/hire { role, level, domain, soulPrompt }
+DELETE /api/agents/eng-lead?graceful=true
+```
+
+### 6.2 Hot-Reload Agent Management
+
+**The gap:** Gateway restart disrupts all agents when adding new ones.
+
+**The feature:** Hot-add agents without restarting. The gateway picks up new agent entries dynamically.
+
+Priority: **Critical** — this is the single biggest friction point.
+
+### 6.3 Unified Communication Router
+
+**The gap:** Local agents use `sessions_send`, remote agents use A2A HTTP. The CEO has to know which transport to use.
+
+**The feature:** A single `send` interface that routes based on agent location.
+
+```typescript
+// CEO just says "send to eng-lead" — router handles transport
+await orgRouter.send('eng-lead', {
+  type: 'delegation',
+  taskId: 'TASK-0042',
+  body: 'Review the org-parser tests'
+});
+// Router checks: is eng-lead local? → sessions_send
+//                 is eng-lead remote? → A2A HTTP
+//                 is eng-lead external? → A2A HTTP to external endpoint
+```
+
+### 6.4 ORG.md Deployer
+
+**The gap:** ORG.md is a spec, not a runtime. There's no tool that reads an ORG.md and provisions real agents from it.
+
+**The feature:** `openspawn deploy ORG.md` reads the org chart and:
+- Creates workspaces for each agent
+- Writes SOUL.md from role descriptions
+- Updates gateway config
+- Restarts (or hot-adds) agents
+- Onboards each agent with their role description
+
+### 6.5 Org Health Dashboard
+
+**The gap:** CEO manually checks `sessions_list` and `sessions_history`. No aggregate view.
+
+**The feature:** A dashboard showing:
+- Agent status (active/idle/stuck)
+- Task pipeline (queued → in progress → done)
+- Communication flow (ACP message visualization)
+- Escalation rate and bottlenecks
+- Cost per agent/team
+
+---
+
+## 7. Implementation Roadmap
+
+### Phase 1: Docker + CEO (Week 1)
+- [ ] Build OpenClaw Docker image
+- [ ] Create docker-compose.yml
+- [ ] Create CEO workspace (SOUL.md, AGENTS.md, ORG.md, etc.)
+- [ ] Create Telegram bot for CEO
+- [ ] Run onboarding, start gateway
+- [ ] Test: Adam ↔ CEO conversation via Telegram
+
+### Phase 2: First Hire (Week 1-2)
+- [ ] CEO plans org with Adam
+- [ ] CEO executes first hiring event (1-2 agents)
+- [ ] CEO onboards agents via sessions_send
+- [ ] Test: CEO delegates task → agent works → reports back
+- [ ] Iterate on ACP message format
+
+### Phase 3: Working Org (Week 2-3)
+- [ ] Team of 3-5 agents working on real tasks (OpenSpawn improvements)
+- [ ] CEO monitors via sessions_list / sessions_history
+- [ ] Test escalation flow (agent gets stuck → CEO helps)
+- [ ] CEO uses sub-agents for ad-hoc tasks alongside full agents
+
+### Phase 4: OpenSpawn Tooling (Week 3-4)
+- [ ] Build agent lifecycle CLI (`openspawn hire/fire/promote`)
+- [ ] Build unified communication router (local + A2A)
+- [ ] Prototype hot-reload agent management
+- [ ] Build org health monitoring
+
+### Phase 5: Multi-Gateway (Future)
+- [ ] Spin up second gateway (VPS or another container)
+- [ ] CEO hires remote agents via A2A
+- [ ] Test cross-gateway communication
+- [ ] Validate ORG.md with mixed local/remote agents
+
+### Phase 6: External A2A (Future)
+- [ ] Integrate with external A2A-compatible agent services
+- [ ] CEO discovers and hires external agents
+- [ ] Test cross-platform delegation
+
+---
+
+## 8. Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Runtime | Docker container | Isolation, portability, self-contained |
+| Codebase access | Git worktree (rw) | Separate branch, no conflicts, can commit/push |
+| Agent type | Full agents (not sub-agents) | Persistent identity, memory, expertise accumulation |
+| Communication | ACP over sessions_send | Structured protocol, matches OpenSpawn spec |
+| Hiring model | Planned batches with restart | Mirrors real orgs, minimizes disruption |
+| Scaling model | Local → A2A remote → A2A external | Same interface at every scale |
+| CEO model | Opus | Strategic reasoning needs highest capability |
+| Worker model | Sonnet | Cost-effective for execution tasks |
+
+---
+
+*The CEO Agent is not a demo. It's the first real deployment of the OpenSpawn model — and every friction point it hits becomes a feature to build.*

--- a/apps/docs/src/content/docs/architecture/integrations.md
+++ b/apps/docs/src/content/docs/architecture/integrations.md
@@ -1,0 +1,504 @@
+---
+title: Integrations and Growth
+---
+
+# BikiniBottom — Integration Strategy & Growth Roadmap
+
+**Date:** February 9, 2026  
+**Author:** Agent Dennis (COO) + Adam (CEO)  
+**Status:** Draft — Living Document
+
+---
+
+## 1. Where We Are
+
+BikiniBottom is a self-hosted multi-agent coordination platform with:
+
+- **Agent hierarchy** (10 levels, parent-child, roles)
+- **Task management** (Kanban workflow, dependencies, approval gates, pre-hooks)
+- **Credit economy** (earn/spend, budgets, alerts)
+- **Inter-agent messaging** (channels, DMs, peer messaging)
+- **Trust & reputation** (scores, endorsements)
+- **Real-time dashboard** (React 19, GraphQL subscriptions)
+- **MCP server** (26+ tools — any MCP-capable agent can use BikiniBottom today)
+- **REST + GraphQL APIs** (full programmatic access)
+- **CLI** (agent and operator workflows)
+- **Demo mode** (MSW-powered, zero backend required)
+
+What we don't have yet: **integrations with the outside world**. BikiniBottom is currently a closed loop — agents talk to BikiniBottom, humans watch the dashboard. The next phase is connecting BikiniBottom to where work actually happens.
+
+---
+
+## 2. Strategic Positioning
+
+### The Insight
+
+Every agent framework solves *execution* — how a single agent reasons and acts. Very few solve *coordination* — how multiple agents organize, communicate, govern, and account for their work.
+
+**BikiniBottom is infrastructure, not a framework.** We don't compete with LangGraph, CrewAI, or Claude Code. We complement them. Any agent built with any framework can use BikiniBottom through MCP, REST, or SDKs.
+
+### The Analogy
+
+Think of it like this:
+- **Agent frameworks** = individual employees (their skills, how they work)
+- **BikiniBottom** = the company (org chart, task management, payroll, communications, HR)
+
+You wouldn't run a company with 30 employees and no structure. You shouldn't run 30 agents without one either.
+
+### Our Moat
+
+1. **Protocol-first** — MCP is our native language, and it's becoming the standard
+2. **Self-hosted** — No vendor lock-in, no per-agent fees, your data stays yours
+3. **Economic layer** — Credits aren't just limits; they're an incentive system
+4. **Governance built-in** — Pre-hooks, approval gates, trust scores, audit trails
+5. **Framework-agnostic** — Works with anything that can make HTTP requests
+
+---
+
+## 3. The Integration Landscape
+
+### 3.1 Agent Runtime Connectors 🤖
+
+**Goal:** Make it trivial for any agent to participate in an BikiniBottom organization.
+
+#### OpenClaw (Native — Deepest Integration)
+
+OpenClaw is where we were born. The integration should be seamless:
+
+- **Auto-registration:** When an OpenClaw agent starts, it registers itself with BikiniBottom (name, capabilities, model)
+- **Credit sync:** OpenClaw tracks LLM token usage. Pipe that into BikiniBottom credits automatically. Real cost → credit spend, no manual mapping.
+- **Task awareness:** OpenClaw agents could check for assigned tasks during heartbeats and proactively pick up work
+- **Session ↔ Task mapping:** Link an OpenClaw session to an BikiniBottom task. When the session produces output, the task gets updated.
+- **Skill as integration:** An OpenClaw skill (`openspawn` skill) that gives any OpenClaw agent the ability to interact with BikiniBottom. Install it from ClawHub.
+
+**Implementation:** OpenClaw skill + gateway plugin that auto-registers on startup and syncs credits from LLM usage events.
+
+#### Claude Code / Agent Teams
+
+Claude Code's multi-agent feature (agent teams) spawns sub-agents for parallel work. But they're ephemeral — no persistence, no governance, no audit trail.
+
+- **BikiniBottom as the task board:** Claude Code's orchestrator creates tasks in BikiniBottom. Sub-agents claim and complete them. Progress persists even if a session dies.
+- **Budget enforcement:** Sub-agents get credit allocations. BikiniBottom prevents runaway spending.
+- **Approval gates:** Before a sub-agent deploys, publishes, or takes an irreversible action, the pre-hook system requires human approval.
+- **Audit trail:** Every sub-agent action is logged in BikiniBottom events. Post-mortem analysis becomes trivial.
+
+**Implementation:** MCP server (already works), plus a Claude Code "meta-prompt" or skill that teaches Claude how to use BikiniBottom for coordination.
+
+#### LangGraph / LangChain
+
+The largest agent framework ecosystem. Mostly Python.
+
+- **Python SDK** is prerequisite (see Section 4)
+- **LangGraph node:** An BikiniBottom node type that agents can use in their graphs — claim task, update status, send message
+- **Callback handler:** A LangChain callback that auto-reports token usage to BikiniBottom credits
+- **State persistence:** LangGraph checkpoints could sync to BikiniBottom task metadata
+
+**Implementation:** Python SDK + `langchain-openspawn` package with callback handler and tool definitions.
+
+#### CrewAI
+
+CrewAI has its own task/crew concepts. The integration is about bridging, not replacing:
+
+- **Task sync:** CrewAI tasks ↔ BikiniBottom tasks. CrewAI handles execution, BikiniBottom handles governance.
+- **Budget from credits:** CrewAI respects BikiniBottom credit limits
+- **Result reporting:** Crew outputs flow back to BikiniBottom as task completions
+
+**Implementation:** Python SDK + CrewAI tool/callback integration.
+
+#### AutoGen / Semantic Kernel / Others
+
+Similar pattern — SDK + framework-specific adapter. Prioritize based on adoption and demand.
+
+---
+
+### 3.2 Work Source Integrations 📥
+
+**Goal:** Tasks should flow into BikiniBottom from where teams already plan work.
+
+#### GitHub (Highest Priority)
+
+This is the most natural integration for developer teams:
+
+**Inbound (GitHub → BikiniBottom):**
+- Issue labeled `agent-work` → creates BikiniBottom task with metadata
+- Issue assigned to bot user → routes to specific agent
+- PR review requested → creates review task
+- CI failure → creates fix task with error context
+
+**Outbound (BikiniBottom → GitHub):**
+- Task completed → closes linked issue with summary comment
+- Agent opens PR → task moves to `review` state
+- Pre-hook on deploy → requires issue approval before merge
+- Credit spend → commented on issue as cost tracking
+
+**Bidirectional:**
+- Status sync: GitHub project board ↔ BikiniBottom task board
+- Comment threads: GitHub comments appear as BikiniBottom messages and vice versa
+
+**Implementation:** GitHub App with webhook receiver + outbound API calls. New NestJS module: `IntegrationsModule` with provider abstraction.
+
+#### Linear
+
+Popular with developer teams, clean API, built for automation:
+
+- Bidirectional issue ↔ task sync
+- Label-based routing to agents
+- Cycle/sprint awareness for task prioritization
+
+**Implementation:** Similar to GitHub — webhook receiver + API client. Same `IntegrationsModule` provider pattern.
+
+#### Generic Webhooks (Inbound + Outbound)
+
+For everything else:
+
+**Inbound:** POST to `/api/webhooks/tasks` with a standard payload → creates task  
+**Outbound:** Configure webhook URLs per event type (task.completed, credit.low, agent.idle)
+
+This covers Slack, Discord, Zapier, Make, n8n, and anything with webhook support.
+
+**Implementation:** Webhook receiver endpoint + outbound webhook dispatcher on event emission.
+
+---
+
+### 3.3 Observability & Monitoring 👁️
+
+**Goal:** Plug into existing monitoring stacks. Don't reinvent dashboards.
+
+#### OpenTelemetry (Foundation)
+
+Export traces and metrics in the standard format:
+
+- **Traces:** Task lifecycle spans (created → assigned → in_progress → review → done)
+- **Metrics:** Active agents, tasks by status, credit burn rate, message volume
+- **Attributes:** Agent ID, task priority, credit cost, capabilities used
+
+This automatically enables Grafana, Datadog, New Relic, Jaeger, Zipkin, etc.
+
+**Implementation:** `@opentelemetry/sdk-node` in the NestJS API. Instrument task transitions and credit operations.
+
+#### Langfuse
+
+The most popular open-source LLM observability tool. Many BikiniBottom users will already run it.
+
+- Forward task events as Langfuse traces
+- Link BikiniBottom agent IDs to Langfuse sessions
+- Credit spend correlated with Langfuse cost tracking
+
+**Implementation:** Langfuse SDK integration in API event handlers. Optional — enabled via config.
+
+#### Alerting
+
+Beyond dashboards, people need alerts:
+
+- **Email** (via SMTP or SendGrid) — daily digest, threshold alerts
+- **PagerDuty/OpsGenie** — critical: agent stuck, credits exhausted, pre-hook timeout
+- **Slack/Discord/Telegram webhooks** — task completions, agent status changes
+
+**Implementation:** Notification provider abstraction. Event-driven — subscribe to BikiniBottom events, format and deliver.
+
+---
+
+### 3.4 Developer Experience 🛠️
+
+**Goal:** Make BikiniBottom delightful to integrate with.
+
+#### SDKs
+
+| SDK | Language | Priority | Notes |
+|-----|----------|----------|-------|
+| `@openspawn/sdk` | TypeScript | High | Wraps REST API, type-safe, tree-shakeable |
+| `openspawn-py` | Python | High | Async + sync clients, Pydantic models |
+| `openspawn-go` | Go | Low | For infrastructure teams |
+
+Each SDK should provide:
+- Authentication helpers (HMAC signing, API key)
+- Typed methods for all API operations
+- Event streaming (WebSocket/SSE)
+- Retry logic with idempotency keys
+- Framework-specific adapters where relevant
+
+#### CLI Enhancements
+
+The CLI already exists but could be more powerful:
+
+- `openspawn connect github` — interactive GitHub App setup
+- `openspawn connect linear` — Linear integration setup
+- `openspawn agent register --from-openclaw` — pull agent details from OpenClaw config
+- `openspawn watch` — real-time event stream in terminal
+
+#### Docker / Helm / Deployment
+
+Make deployment dead simple for various environments:
+
+- **Docker Compose** (already exists) — enhance with optional services (Langfuse, LiteLLM)
+- **Helm chart** — Kubernetes deployment for teams
+- **1-click deploys** — Railway, Render, Fly.io templates
+- **Coolify template** — we already use Coolify internally
+
+---
+
+### 3.5 Communication & Messaging 💬
+
+**Goal:** Agents shouldn't be isolated. They should communicate through natural channels.
+
+#### Slack Integration
+
+- BikiniBottom channel → Slack channel bridge
+- `/openspawn` slash command for task management from Slack
+- Agent messages appear as bot messages in Slack
+- Humans can reply in Slack, messages route to BikiniBottom
+
+#### Discord Integration
+
+Same pattern as Slack. Particularly relevant for open-source communities running agent teams.
+
+#### Email
+
+Agents that can send/receive email through BikiniBottom:
+- Task notifications to stakeholders
+- Status reports on schedule
+- Human replies create messages in BikiniBottom
+
+**Note:** OpenClaw already handles many messaging surfaces. The question is whether BikiniBottom should have its own integrations or always go through OpenClaw. **Recommendation:** BikiniBottom provides webhook-based notifications. For rich messaging, use OpenClaw as the messaging layer. Don't duplicate.
+
+---
+
+### 3.6 Economic & Marketplace 💰
+
+**Goal (Long-term):** Make the credit system real.
+
+#### LLM Cost Tracking
+
+- Integration with LiteLLM proxy to capture actual token costs
+- Auto-debit credits based on real spend
+- Cost attribution to specific tasks
+
+#### Resource Gating
+
+- Agents request access to resources (APIs, compute, storage) through BikiniBottom
+- Pre-hooks approve or deny based on credit balance
+- Usage tracked and debited
+
+#### Agent Marketplace (Future)
+
+This is the long game:
+
+- Organizations publish available agent capabilities
+- External agents can bid on tasks
+- Credits become a real micro-economy
+- Reputation/trust scores determine eligibility
+
+**Not for now**, but the architecture should support it. The credit system and trust scores are already the foundation.
+
+---
+
+## 4. Prioritized Roadmap
+
+### Phase A: Foundation (Weeks 1-4)
+
+| Item | Effort | Impact | Notes |
+|------|--------|--------|-------|
+| TypeScript SDK (`@openspawn/sdk`) | Medium | High | Extract from MCP server, formalize |
+| Python SDK (`openspawn-py`) | Medium | High | Opens entire Python ecosystem |
+| Outbound webhooks | Low | High | Event-driven, covers 80% of notification needs |
+| Inbound webhook (task creation) | Low | Medium | Simple POST → task |
+
+**Why first:** SDKs are prerequisites for everything else. Webhooks are low-effort, high-impact.
+
+### Phase B: GitHub + Observability (Weeks 5-8)
+
+| Item | Effort | Impact | Notes |
+|------|--------|--------|-------|
+| GitHub App (issues ↔ tasks) | Medium | High | The killer integration for dev teams |
+| OpenTelemetry traces | Medium | Medium | Plugs into existing monitoring |
+| OpenClaw skill | Low | High | Seamless for our core users |
+| LLM cost sync (LiteLLM) | Low | Medium | Makes credits meaningful |
+
+**Why second:** GitHub is the highest-value single integration. OTEL gives instant credibility. OpenClaw skill serves our base.
+
+### Phase C: Ecosystem (Weeks 9-12)
+
+| Item | Effort | Impact | Notes |
+|------|--------|--------|-------|
+| LangGraph adapter (Python) | Medium | High | Largest framework community |
+| Linear integration | Medium | Medium | Developer-friendly PM tool |
+| Langfuse integration | Low | Medium | Popular observability |
+| Slack notifications | Low | Medium | Where teams already are |
+
+**Why third:** By now we have SDKs and GitHub. Framework adapters expand the market. Linear and Slack are nice-to-haves.
+
+### Phase D: Advanced (Weeks 13+)
+
+| Item | Effort | Impact | Notes |
+|------|--------|--------|-------|
+| CrewAI adapter | Medium | Medium | Second-largest framework |
+| Helm chart | Medium | Medium | Enterprise/K8s users |
+| 1-click deploys (Railway, Fly) | Low | Medium | Lowers adoption barrier |
+| Email notifications | Low | Low | Enterprise checkbox |
+| Agent marketplace prototype | High | High (long-term) | The endgame |
+
+---
+
+## 5. Architecture for Integrations
+
+### Provider Abstraction
+
+```
+┌─────────────────────────────────────────────────┐
+│                IntegrationsModule                │
+│                                                  │
+│  ┌───────────┐  ┌───────────┐  ┌───────────┐    │
+│  │  GitHub    │  │  Linear   │  │  Webhook  │    │
+│  │ Provider   │  │ Provider  │  │ Provider  │    │
+│  └───────────┘  └───────────┘  └───────────┘    │
+│         │              │              │          │
+│         ▼              ▼              ▼          │
+│  ┌─────────────────────────────────────────┐    │
+│  │       Integration Provider Interface     │    │
+│  │                                          │    │
+│  │  onTaskCreated(task) → externalAction    │    │
+│  │  onTaskUpdated(task) → externalAction    │    │
+│  │  onExternalEvent(event) → taskAction     │    │
+│  │  sync() → bidirectional reconciliation   │    │
+│  └─────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────┘
+```
+
+New providers plug in without touching core business logic. Each provider:
+- Registers webhook endpoints (inbound)
+- Subscribes to BikiniBottom events (outbound)
+- Handles auth/credentials for the external service
+- Provides a config UI in the dashboard
+
+### Database Additions
+
+```sql
+-- Integration configs
+CREATE TABLE integrations (
+  id UUID PRIMARY KEY,
+  type VARCHAR(50) NOT NULL,  -- 'github', 'linear', 'webhook', etc.
+  config JSONB NOT NULL,      -- provider-specific config
+  enabled BOOLEAN DEFAULT true,
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP
+);
+
+-- External entity links
+CREATE TABLE integration_links (
+  id UUID PRIMARY KEY,
+  integration_id UUID REFERENCES integrations(id),
+  entity_type VARCHAR(50) NOT NULL,  -- 'task', 'agent', 'message'
+  entity_id UUID NOT NULL,
+  external_id VARCHAR(255) NOT NULL, -- GitHub issue #, Linear issue ID, etc.
+  external_url TEXT,
+  metadata JSONB,
+  created_at TIMESTAMP
+);
+```
+
+### SDK Architecture
+
+```
+@openspawn/sdk (TypeScript)
+├── client.ts          — HTTP client with auth
+├── resources/
+│   ├── agents.ts      — agent CRUD
+│   ├── tasks.ts       — task management
+│   ├── credits.ts     — credit operations
+│   ├── messages.ts    — messaging
+│   └── events.ts      — event streaming
+├── auth/
+│   ├── hmac.ts        — HMAC signing
+│   └── api-key.ts     — API key auth
+└── index.ts           — main export
+
+openspawn-py (Python)
+├── client.py          — async + sync HTTP client
+├── resources/
+│   ├── agents.py
+│   ├── tasks.py
+│   ├── credits.py
+│   ├── messages.py
+│   └── events.py
+├── auth/
+│   ├── hmac.py
+│   └── api_key.py
+├── adapters/
+│   ├── langchain.py   — callback handler
+│   └── crewai.py      — crew integration
+└── __init__.py
+```
+
+---
+
+## 6. Competitive Analysis
+
+### What Exists Today
+
+| Platform | Focus | vs. BikiniBottom |
+|----------|-------|---------------|
+| **CrewAI** | Agent execution framework | Execution, not governance. No credits, no approval gates. |
+| **LangGraph** | Agent graph orchestration | Powerful execution, no organizational layer. |
+| **AutoGen** | Multi-agent conversation | Research-oriented, no production governance. |
+| **Fixie / Letta** | Agent hosting | Hosted, not self-hosted. Limited coordination. |
+| **Relevance AI** | Agent workforce | SaaS, not self-hosted. No economic layer. |
+| **Crew.ai Enterprise** | Managed agent teams | Closest competitor, but SaaS and locked to CrewAI. |
+
+### Our Differentiation
+
+1. **Self-hosted + open source** — No one else does governance + economy + self-hosted
+2. **Framework-agnostic** — Not locked to one agent framework
+3. **MCP-native** — First-mover on MCP as coordination protocol
+4. **Economic layer** — Credits as first-class concept (not just rate limits)
+5. **Pre-hooks** — Governance middleware that no one else has
+
+---
+
+## 7. Things to Consider
+
+### Build vs. Integrate
+
+- **Build:** Core SDKs, GitHub integration, webhooks — these are core to the value prop
+- **Integrate:** Observability (use OTEL, don't build a dashboard), messaging (use OpenClaw, don't build a Slack bot)
+- **Enable:** Marketplace, federation — design the architecture now, build later
+
+### Community & Adoption
+
+- **GitHub stars** are vanity, but they drive discovery. Invest in README, docs, demo.
+- **Discord/community** for early adopters. They'll tell us what integrations matter.
+- **Blog posts / case studies** showing real agent teams using BikiniBottom.
+- **Conference talks** — MCP, agent coordination, the "AI workforce" narrative.
+
+### Pricing (When the Time Comes)
+
+BikiniBottom core stays MIT open source. Revenue options:
+- **BikiniBottom Cloud** — hosted version for teams who don't want to self-host
+- **Enterprise features** — SSO, RBAC, SLA, audit compliance, support
+- **Marketplace fees** — percentage of cross-org agent transactions
+- **Consulting** — help teams set up agent organizations
+
+### Risks
+
+- **MCP adoption stalls** → Mitigate by supporting REST/GraphQL equally
+- **Framework consolidation** → If one framework wins, be sure we integrate deeply with it
+- **"Good enough" built-in** → Claude/OpenAI add their own coordination → Differentiate on self-hosted + economic layer
+- **Complexity creep** → Keep the core simple. Integrations are optional plugins.
+
+---
+
+## 8. Summary
+
+**Short version:** BikiniBottom should become the **coordination standard** for AI agent teams. The path:
+
+1. **SDKs** make us accessible to every framework
+2. **GitHub** makes us immediately useful for dev teams
+3. **Webhooks + OTEL** make us observable and connectable
+4. **OpenClaw integration** serves our core community
+5. **Framework adapters** expand the market
+6. **Marketplace** is the endgame
+
+The architecture should be **provider-based** so integrations are modular. The brand should be **protocol-first** so we're framework-agnostic. The strategy should be **developer-first** because developers adopt infrastructure bottom-up.
+
+---
+
+*This is a living document. Update as the market evolves and we learn from users.*

--- a/apps/docs/src/content/docs/architecture/worktree-isolation.md
+++ b/apps/docs/src/content/docs/architecture/worktree-isolation.md
@@ -1,0 +1,97 @@
+---
+title: Worktree Isolation
+---
+
+# Worktree Isolation Spec
+
+**Status:** Draft
+**Author:** Dennis
+**Date:** 2026-02-26
+
+## Problem
+
+When multiple agents work on the same repo concurrently, they create branches from a shared worktree. If the main branch moves forward (PRs merged), agents' branches become stale and their diffs delete recently-added files. The reviewer must cherry-pick instead of merge, wasting time and risking errors.
+
+## Solution: Per-Agent Git Worktrees
+
+Each agent gets an isolated `git worktree` created at the current `origin/master`. No shared working directory. No stale base.
+
+### How It Works
+
+```
+repo/                          # Main checkout (Dennis)
+repo-worktrees/
+  ├── web-eng/                 # Sub-agent 1's isolated worktree
+  ├── docs-writer/             # Sub-agent 2's isolated worktree
+  └── designer/                # Sub-agent 3's isolated worktree
+```
+
+### CLI Integration
+
+**`openspawn hire`** gains `--worktree` flag:
+
+```bash
+openspawn hire "web-eng" --level 5 --role "frontend engineer" --worktree
+```
+
+This runs:
+1. `git fetch origin`
+2. `git worktree add ../repo-worktrees/web-eng -b web-eng/task-name origin/master`
+3. Creates agent workspace inside the worktree
+4. Sets `OPENSPAWN_REPO` env var pointing to the worktree
+
+**`openspawn fire`** cleans up:
+1. `git worktree remove ../repo-worktrees/web-eng`
+2. Archives workspace as before
+
+### Coordinator Integration
+
+The `agent_register` MCP tool gains an optional `worktree_path` field:
+
+```sql
+ALTER TABLE agents ADD COLUMN worktree_path TEXT;
+```
+
+When an agent calls `task_claim`, the coordinator can verify the worktree exists and is at the expected commit.
+
+### Branch Naming Convention
+
+`<agent-id>/<task-slug>` — e.g., `web-eng/serve-llms-txt`
+
+Already in use by CEO's sub-agents. Formalize it.
+
+### Lifecycle
+
+```
+hire → create worktree at origin/master
+     → agent works on branch in isolated worktree
+     → agent pushes branch
+     → reviewer cherry-picks or merges
+     → fire → remove worktree
+```
+
+### Edge Cases
+
+- **Multiple tasks per agent:** Agent creates new branches within their worktree. Each branch starts from `origin/master` (they run `git fetch && git checkout -b <branch> origin/master`).
+- **Long-lived agents:** Periodically `git fetch origin` to stay current. The worktree itself doesn't need to be on master — only new branches do.
+- **Worktree limit:** Git supports hundreds of worktrees. Not a concern.
+
+### Migration Path
+
+1. **Now:** CEO's AGENTS.md updated with `git fetch` rule (quick fix)
+2. **Next sprint:** `openspawn hire --worktree` creates isolated worktrees
+3. **Later:** Coordinator auto-creates worktrees on `task_claim`
+
+### Benefits
+
+- Zero merge conflicts between concurrent agents
+- Every branch starts from latest master
+- No shared filesystem state
+- Natural cleanup on fire
+- Works with existing git hosting (no special server)
+
+## Implementation Estimate
+
+- CLI changes: ~100 lines Go (hire/fire worktree flags)
+- Coordinator: ~20 lines (worktree_path column + validation)
+- Total: 1 PR, ~2 hours

--- a/apps/docs/src/content/docs/faq.md
+++ b/apps/docs/src/content/docs/faq.md
@@ -1,0 +1,343 @@
+---
+title: FAQ
+---
+
+# OpenSpawn FAQ
+
+**What you'll learn:** Answers to the most common questions about OpenSpawn — what it is, how to use it, how it applies to real industry scenarios, and how agents interact with it.
+
+> **TL;DR for agents:** OpenSpawn is a coordination layer. You define an org in `ORG.md`, run `openspawn start`, and agents communicate via MCP tools at `POST /mcp`. If you're blocked, escalate up the chain. If you're done, `task_complete`.
+
+---
+
+## General
+
+### Q1: What is OpenSpawn?
+
+OpenSpawn is an **open-source coordination layer for AI agent organizations**. You define your entire agent org — roles, hierarchy, culture, policies — in a single markdown file (`ORG.md`). OpenSpawn parses it, assigns agents, routes tasks through the hierarchy, and provides a real-time dashboard.
+
+It is **infrastructure, not a framework**: it works with any agent stack (OpenClaw, LangGraph, CrewAI, AutoGen, raw API calls).
+
+### Q2: How is OpenSpawn different from CrewAI or LangGraph?
+
+```
+CrewAI / LangGraph = agent frameworks (how you BUILD agents)
+OpenSpawn = coordination layer (how you ORGANIZE agents)
+```
+
+- **CrewAI/LangGraph** define how agents execute tasks
+- **OpenSpawn** defines who does what, who they report to, what they can spend, and who approves decisions
+
+They're designed to work together, not replace each other.
+
+### Q3: Do I need to rewrite my agents to use OpenSpawn?
+
+**No.** OpenSpawn connects to your existing agents via standard protocols:
+- **MCP** (Model Context Protocol) — for tool calls
+- **A2A** (Agent-to-Agent) — for inter-org communication
+- **REST** — for direct API calls
+
+Your agents keep running as-is. OpenSpawn adds the coordination layer on top.
+
+### Q4: Do I need API keys to try it?
+
+**No.** Demo/simulation mode works out of the box:
+
+```bash
+npx openspawn init my-org --template=saas-onboarding --non-interactive
+cd my-org
+openspawn preview
+# Open http://localhost:3333
+```
+
+You'll see the full coordination flow with simulated agents, no API keys needed.
+
+### Q5: Is OpenSpawn free?
+
+**Yes.** MIT open source. Self-hosted. No usage fees.
+
+Optional: paid hosted tier (in development) for teams that don't want to self-host.
+
+---
+
+## Setup & Installation
+
+### Q6: What are the prerequisites?
+
+- **Required:** Node.js 18+ (`node --version`)
+- **Optional for real inference:**
+  - [Ollama](https://ollama.ai) — free local models
+  - [Groq](https://groq.com) API key — fast mid-tier models
+  - [OpenRouter](https://openrouter.ai) API key — Claude/GPT-4o for executives
+
+### Q7: What are the three commands to get a running org?
+
+```bash
+openspawn init my-org --template=saas-onboarding --yes
+cd my-org
+openspawn start
+openspawn status
+```
+
+- `init` — creates `ORG.md` and `openclaw-agents.json`
+- `start` — reads agents config, generates `openclaw-patch.json`
+- `status` — displays agent table (name, level, model, workspace, reports-to)
+
+### Q8: Which template should I use?
+
+```
+What's your domain?
+├── Customer success / SaaS    → saas-onboarding
+├── Infrastructure / DevOps    → incident-response
+├── Legal                      → contract-review
+├── Finance / Compliance       → compliance-monitoring
+├── Gaming / live service      → game-live-ops
+├── E-commerce / retail        → catalog-management
+└── Healthcare / life sciences → clinical-trials
+```
+
+All templates are starting points — edit the generated `ORG.md` freely.
+
+### Q9: What is `openclaw-patch.json` and what do I do with it?
+
+`openclaw-patch.json` is a ready-to-apply patch for your OpenClaw gateway's `agents.list`. It contains entries with:
+- `id` — agent identifier (lowercase hyphenated name)
+- `model` — `opus` for L7+ agents, `sonnet` for L6 and below
+- `workspace` — agent workspace path
+- `tools.profile: "full"` — full tool access
+- `subagents.allowAgents` — for manager agents (L7+ with direct reports)
+- `default: true` — on the highest-level agent
+
+**To apply:** copy the entries from `openclaw-patch.json` into your OpenClaw `agents.list` config, then restart the gateway.
+
+### Q10: How do I validate my ORG.md?
+
+```bash
+openspawn validate
+# or
+openspawn validate path/to/ORG.md
+```
+
+Checks: valid markdown structure, required sections, agent role definitions, hierarchy consistency, policy completeness.
+
+**Common errors and fixes:**
+
+| Error | Fix |
+|-------|-----|
+| `Missing Structure section` | Add `## Structure` with at least one agent |
+| `Agent reports to unknown agent` | Check `Reports to` matches an agent name exactly |
+| `No top-level agent` | One agent must have `Reports to: Human Principal` |
+| `Circular reporting chain` | No agent can report to itself or create a loop |
+
+---
+
+## ORG.md
+
+### Q11: What's the minimum viable ORG.md?
+
+```markdown
+# My Org
+
+## Structure
+
+### Boss — Leader
+- **Level:** 10
+- **Reports to:** Human Principal
+```
+
+That's it. One heading, one agent, one level, one reporting line.
+
+### Q12: What do agent levels mean?
+
+| Level | Role type | Permissions |
+|-------|-----------|-------------|
+| L1-L5 | Workers | Execute tasks |
+| L6 | Seniors | Review and approve work |
+| L7-L9 | Leads | Create tasks, spawn agents, manage teams |
+| L10 | Executives | Top of hierarchy |
+
+### Q13: What are the five ORG.md sections?
+
+| Section | Purpose | Required? |
+|---------|---------|-----------|
+| `## Identity` | Name, mission, values — ambient context for all agents | No |
+| `## Culture` | Communication norms, escalation speed, preset | No |
+| `## Structure` | Agent roles and hierarchy | **Yes** |
+| `## Policies` | Budget limits, caps, permissions | No |
+| `## Playbooks` | Step-by-step procedures for common scenarios | No |
+
+### Q14: What are culture presets?
+
+Presets are shorthand for configuring communication norms. Use one line:
+
+```markdown
+## Culture
+preset: agency
+```
+
+| Preset | Escalation | Progress | Best for |
+|--------|-----------|----------|---------|
+| `startup` | Immediate | Frequent | Small fast teams |
+| `enterprise` | Batched (hourly) | On phase change | Large orgs with process |
+| `agency` | Immediate | Every tick | Client work with deadlines |
+| `research` | Delayed | On request | Exploration, long tasks |
+| `military` | Immediate | Every tick | Zero-ambiguity operations |
+| `remote-async` | Delayed | On request | Distributed async teams |
+
+---
+
+## MCP & Agent Interaction
+
+### Q15: How do agents interact with OpenSpawn?
+
+Via **MCP tools** at `POST /mcp`. Authentication is HMAC — set `AGENT_ID` and `AGENT_SECRET` env vars.
+
+Core workflow:
+
+```
+agent_list           → see who's in the org
+task_create          → assign work to another agent
+task_claim           → atomically claim an open task
+task_complete        → mark work done with results
+escalation_create    → flag a blocker to your manager
+message_send         → send TASK/RESULT/ESCALATION/DECISION
+credits_balance      → check your budget
+org_status           → full org overview
+```
+
+Full tool reference: [`docs/mcp-reference.md`](./mcp-reference.md)
+
+### Q16: Can two agents claim the same task?
+
+**No.** `task_claim` is **atomic** — only one agent wins the claim, the other gets an error. This prevents duplicate work by design.
+
+```
+tool: task_claim { task_id: "abc123", agent_id: "data-migration-specialist" }
+```
+
+### Q17: What happens when an agent is blocked?
+
+1. Agent sends `escalation_create` to its direct manager (never skips the chain)
+2. Manager has 2 cycles to respond: unblock, reassign, or escalate further
+3. If unresolved after 2 levels, alert goes to the Human Principal
+
+---
+
+## Communication Protocol
+
+### Q18: How do agents communicate efficiently?
+
+The [Agent Communication Protocol](./communication-protocol.md) defines 4 message types — **no ACKs, no courtesy messages**:
+
+| Type | Direction | When |
+|------|-----------|------|
+| `TASK` | Lead → Worker | Work assignment |
+| `RESULT` | Worker → Lead | Deliverable notification |
+| `ESCALATION` | Worker → Lead | Blocker requiring help |
+| `DECISION` | Lead → Worker | Resolves an escalation |
+
+**Core rule:** Silence = success. If an agent is working, it stays silent. Only message when blocked, assigning, delivering, or resolving.
+
+### Q19: What files do agents use to share state?
+
+Instead of sending messages, agents write to shared workspace files:
+
+| File | Owner | Purpose |
+|------|-------|---------|
+| `PLAN.md` | Lead agent | Current sprint plan with task assignments |
+| `RESULT.md` | Workers | Completed deliverables |
+| `HANDOFF.md` | Any agent | Work ready for next stage |
+| `REVIEW.md` | Reviewers | Feedback and approvals |
+| `ESCALATION.md` | Any agent | Complex issues needing >3 turns |
+
+---
+
+## Industry Scenarios
+
+### Q20: Can I use OpenSpawn for compliance monitoring?
+
+**Yes.** The `compliance-monitoring` template is purpose-built for fintech compliance teams. It models:
+- Transaction ingestion and normalization (Transaction Analyst)
+- AML/BSA rule application and OFAC screening (Rule Engine Agent)
+- SAR/CTR filing and regulatory reporting (Report Generator)
+- Compliance Lead oversight with human approval gates for all filings
+
+The template includes a zero-tolerance OFAC escalation playbook and a full SAR filing workflow, with audit trails required for regulatory inspection.
+
+```bash
+openspawn init my-compliance-org --template=compliance-monitoring
+```
+
+### Q21: How would I set up a contract review pipeline?
+
+Use the `contract-review` template. The pipeline flows:
+1. **Clause Extractor** reads the contract and categorizes all key clauses (liability, indemnification, IP, etc.)
+2. **Risk Analyst** compares each clause against your negotiation playbook and flags deviations
+3. **Summary Writer** produces an attorney-ready package with risk register and recommended redlines
+4. **Senior Reviewer** approves before delivery to business stakeholders
+
+```bash
+openspawn init my-legal-org --template=contract-review
+```
+
+Update the Policies section with your company's specific playbook reference and risk thresholds.
+
+### Q22: Can I use OpenSpawn for customer onboarding?
+
+**Yes.** The `saas-onboarding` template models a 48-hour enterprise onboarding track. Each new customer becomes a task in the onboarding org. The Onboarding Lead coordinates Data Migration, Integration Engineering, and Customer Success in parallel — with handoff protocols at each stage.
+
+The template is designed so each customer's onboarding is repeatable, documented, and trackable from kickoff to go-live.
+
+### Q23: How would I handle a production incident with OpenSpawn?
+
+Use the `incident-response` template. When an alert fires:
+1. Incident Commander activates and assigns Diagnostics and Comms agents simultaneously
+2. Diagnostics Agent pulls metrics, traces, and logs to identify root cause
+3. Remediation Agent executes fix with explicit Commander go-ahead
+4. Comms Agent keeps stakeholders informed throughout
+
+The template uses the `military` culture preset — mandatory acks, every-5-minute progress updates, and immediate escalation. No silent failures.
+
+### Q24: Can I use OpenSpawn for a gaming live ops team?
+
+**Yes.** The `game-live-ops` template covers:
+- 24/7 economy metric monitoring with guardrails (max 15% parameter change without approval)
+- Automated content generation on the weekly calendar
+- Player sentiment monitoring across app stores and social
+- Economy exploit response playbook with escalation thresholds
+
+```bash
+openspawn init my-game-org --template=game-live-ops
+```
+
+### Q25: How does OpenSpawn handle regulatory compliance requirements like audit trails?
+
+For regulated industries (fintech, healthcare, legal), the ORG.md Policies section can specify:
+- Audit trail requirements (every agent action logged with source reference and agent ID)
+- Human approval gates for specific action types
+- Data handling restrictions (what agents can read vs. write)
+- Mandatory quality checkpoints before phase transitions
+
+The `clinical-trials` template is the most comprehensive example — it models 21 CFR Part 11 audit trail requirements and CDISC data standards compliance into the agent workflow.
+
+---
+
+## Troubleshooting
+
+### Q26: Where do I go when something's broken?
+
+1. Run `openspawn validate` — catches most config issues
+2. Check [`docs/troubleshooting.md`](./troubleshooting.md) — common errors and fixes
+3. Check port conflicts: `lsof -i :3333`
+4. Review auth: verify `AGENT_ID` and `AGENT_SECRET` match API config
+5. GitHub issues: https://github.com/openspawn/openspawn/issues
+
+---
+
+## Next steps
+
+- **Start building:** [`docs/agent-quickstart.md`](./agent-quickstart.md)
+- **Full setup walkthrough:** [`docs/getting-started.md`](./getting-started.md)
+- **All MCP tools:** [`docs/mcp-reference.md`](./mcp-reference.md)
+- **Fix a specific error:** [`docs/troubleshooting.md`](./troubleshooting.md)
+- **Live demo:** https://openspawn.dev/app/

--- a/apps/docs/src/content/docs/getting-started.md
+++ b/apps/docs/src/content/docs/getting-started.md
@@ -1,0 +1,380 @@
+---
+title: Getting Started
+---
+
+# Getting Started with OpenSpawn
+
+**What you'll learn:** How to install OpenSpawn, scaffold an org from a template, understand ORG.md structure, validate and generate configs, preview the dashboard, and connect real AI models.
+
+**What you'll have in ~10 minutes:** a local org of AI agents, coordinated by a single markdown file, visible in a real-time dashboard — with tasks flowing through a hierarchy you define.
+
+## What is OpenSpawn?
+
+OpenSpawn is a **coordination layer for AI agents**. It is not an agent framework — you keep using whatever you're using (OpenClaw, LangGraph, Claude Code, raw API calls). OpenSpawn adds the layer most multi-agent systems are missing: *structure*.
+
+```
+ORG.md  →  OpenSpawn parses it  →  agents spawn  →  tasks flow through hierarchy  →  dashboard shows everything
+```
+
+**The key idea:** One file — `ORG.md` — defines your entire agent organization. Roles, hierarchy, culture, budget policies, and operating procedures all live in one readable, version-controlled markdown file.
+
+> **Q: How is this different from CrewAI / LangGraph / AutoGen?**
+> - Those are agent frameworks (they build agents). OpenSpawn is a coordination layer (it organizes agents). Use them together.
+
+> **Q: Do I need to rewrite my agents?**
+> - No. OpenSpawn coordinates your existing agents via standard protocols (MCP, A2A).
+
+---
+
+## Do I need OpenSpawn?
+
+```
+Do you have multiple agents that need to work together?
+├── YES
+│   Do they need persistent roles, hierarchy, and budgets?
+│   ├── YES → Use OpenSpawn
+│   └── NO → Sub-agents (sessions_spawn) may be enough
+└── NO → You probably don't need OpenSpawn yet
+```
+
+---
+
+## Prerequisites
+
+**Required:**
+- Node.js 18+ (`node --version` to check)
+
+**Optional (for real model inference):**
+- [Ollama](https://ollama.ai) — free local models (workers use `qwen2.5` at zero cost)
+- [Groq](https://groq.com) API key — fast inference for mid-tier agents
+- [OpenRouter](https://openrouter.ai) API key — Claude/GPT-4o for executives
+
+> **Q: Do I need API keys to try it?**
+> - No. Demo/simulation mode works without any API keys. You see the full coordination flow.
+
+---
+
+## Step 1 — Start with ORG.md
+
+**ORG.md is the heart of OpenSpawn.** Before you run a single command, it's worth understanding what you're building toward.
+
+Here's a real ORG.md for a SaaS customer onboarding team — the scenario we'll use throughout this guide:
+
+```markdown
+# Customer Onboarding Org
+
+## Identity
+- **Mission:** Onboard new enterprise customers end-to-end in under 48 hours
+- **Industry:** SaaS / Enterprise Software
+
+## Culture
+preset: agency
+
+## Structure
+
+### Onboarding Lead — Customer Onboarding Manager
+The quarterback. Owns the customer relationship from signed contract to go-live.
+- **Level:** 7
+- **Department:** Customer Success
+- **Reports to:** Human Principal
+
+#### Data Migration Specialist — Senior Data Engineer
+Ingests customer data, validates schema compatibility, verifies migration.
+- **Level:** 5
+- **Department:** Engineering
+- **Reports to:** Onboarding Lead
+
+#### Integration Engineer — Platform Integration Specialist
+Connects customer's existing tools (CRM, ERP, SSO) to the platform.
+- **Level:** 5
+- **Department:** Engineering
+- **Reports to:** Onboarding Lead
+
+#### Success Agent — Customer Success Representative
+Conducts go-live check-in, validates first successful workflow.
+- **Level:** 4
+- **Department:** Customer Success
+- **Reports to:** Onboarding Lead
+
+## Policies
+### Budget
+- **Per-agent limit:** 800 credits/customer
+- **Overage behavior:** pause and escalate
+
+## Playbooks
+### 48-Hour Onboarding Track
+1. Onboarding Lead creates PLAN.md and assigns tasks
+2. Migration and Integration work in parallel (hours 2–24)
+3. Success Agent conducts go-live validation (hours 40–48)
+```
+
+This one file defines the entire onboarding team. OpenSpawn parses it, generates OpenClaw configs, and routes tasks through the hierarchy automatically.
+
+> **Q: What if I just want to start fast without writing ORG.md from scratch?**
+> - Use a template: `openspawn init my-org --template=saas-onboarding`
+
+---
+
+## Step 2 — Scaffold your org
+
+```bash
+npx openspawn init my-org --template=saas-onboarding
+cd my-org
+```
+
+This creates:
+
+```
+my-org/
+├── ORG.md                  # Your org definition (the important one)
+├── openspawn.config.json   # Server config (port, model providers)
+└── .gitignore
+```
+
+> **Q: Can I skip the wizard?**
+> ```bash
+> openspawn init my-org --template=saas-onboarding --non-interactive
+> ```
+
+> **Q: What templates are available?**
+> | Template | Industry | Use case |
+> |----------|----------|---------|
+> | `saas-onboarding` | SaaS | Customer onboarding pipeline |
+> | `incident-response` | DevOps | Production incident management |
+> | `contract-review` | Legal | Contract review and risk analysis |
+> | `compliance-monitoring` | Fintech | Transaction monitoring and reporting |
+> | `game-live-ops` | Gaming | Live operations and player engagement |
+> | `catalog-management` | E-commerce | Product catalog and pricing |
+> | `clinical-trials` | Healthcare | Clinical trial data processing |
+
+---
+
+## Step 3 — Review your ORG.md
+
+Open `ORG.md`. You'll see five sections:
+
+| Section | Purpose | Required? |
+|---------|---------|-----------|
+| `## Identity` | Name, mission, values | No |
+| `## Culture` | Communication norms, preset | No |
+| `## Structure` | Agent roles and hierarchy | **Yes** |
+| `## Policies` | Budgets, caps, permissions | No |
+| `## Playbooks` | Step-by-step procedures | No |
+
+Each agent in Structure looks like:
+
+```markdown
+### Onboarding Lead — Customer Onboarding Manager
+The coordinator. Receives new customer intake, creates the onboarding plan,
+assigns work to specialists, and tracks progress to go-live.
+- **Level:** 7
+- **Department:** Customer Success
+- **Reports to:** Human Principal
+```
+
+> **Q: What do levels mean?**
+> - L1-L5: Workers
+> - L6: Can review/approve
+> - L7-L9: Can create tasks and spawn agents
+> - L10: Executive
+
+> **Q: What's "Reports to"?**
+> - The escalation chain. Blocked agents escalate to their manager. Never skip levels.
+
+---
+
+## Step 4 — Validate
+
+```bash
+openspawn validate
+```
+
+Expected output:
+```
+✅ ORG.md is valid
+
+  Organization:  Customer Onboarding Org
+  Agents:        4
+  Culture:       agency
+```
+
+### Error recovery
+
+| Error | Fix |
+|-------|-----|
+| `Cannot read ORG.md` | Make sure you're in the right directory: `ls ORG.md` |
+| `Missing Structure section` | Add `## Structure` with at least one agent |
+| `Agent reports to unknown agent` | Check spelling in `Reports to` — must match an agent name exactly |
+| `No top-level agent` | One agent needs `Reports to: Human Principal` |
+
+---
+
+## Step 5 — Generate OpenClaw configs
+
+```bash
+openspawn start
+```
+
+This reads your org and generates `openclaw-patch.json` — ready-to-apply OpenClaw gateway configuration.
+
+```bash
+openspawn status
+```
+
+Displays a table of all agents:
+
+```
+Name                        Level  Model   Workspace                        Reports To
+Onboarding Lead             L7     opus    workspace-onboarding-lead        Human Principal
+Data Migration Specialist   L5     sonnet  workspace-data-migration          Onboarding Lead
+Integration Engineer        L5     sonnet  workspace-integration-engineer    Onboarding Lead
+Success Agent               L4     sonnet  workspace-success-agent          Onboarding Lead
+```
+
+> **Q: What happens after init?**
+> - Run `openspawn start` to generate OpenClaw configs, then apply the patch to your gateway. The `openclaw-patch.json` file contains `agents.list` entries with id, model, workspace, and subagents config.
+
+> **Q: Can I output status as JSON?**
+> ```bash
+> openspawn status --json
+> ```
+
+---
+
+## Step 6 — Preview
+
+```bash
+npx openspawn preview
+```
+
+Opens the dashboard at http://localhost:3333. You'll see:
+- Network graph of your agent hierarchy
+- Task timeline (onboarding tasks flowing through the team)
+- Agent details and credit balances
+- Real-time SSE event stream
+
+> **Q: Port 3333 is in use?**
+> ```bash
+> # Option 1: Kill the existing process
+> lsof -i :3333
+> kill <PID>
+>
+> # Option 2: Change port in openspawn.config.json
+> { "port": 3334 }
+> ```
+
+---
+
+## Step 7 — Customize your ORG.md
+
+### Change the culture preset
+
+```markdown
+## Culture
+preset: enterprise
+```
+
+| Preset | Escalation | Progress | Hierarchy depth |
+|--------|-----------|----------|-----------------|
+| `startup` | Immediate | Frequent | 2-3 levels |
+| `enterprise` | Batched | On phase change | 5-8 levels |
+| `agency` | Immediate | Every tick | 3-4 levels |
+| `research` | Delayed | On request | 2-3 levels |
+| `military` | Immediate | Every tick | Strict chain |
+| `remote-async` | Delayed | On request | Flat |
+
+### Add an agent
+
+Add under `## Structure`:
+
+```markdown
+#### QA Validator — Onboarding Quality Analyst
+Reviews completed onboarding configurations for errors before go-live.
+- **Level:** 4
+- **Department:** Engineering
+- **Reports to:** Onboarding Lead
+```
+
+### Set budget policies
+
+```markdown
+## Policies
+
+### Budget
+- **Per-agent limit:** 800 credits/customer
+- **Alert threshold:** 80%
+- **Overage behavior:** pause and escalate
+```
+
+### Write a playbook
+
+```markdown
+## Playbooks
+
+### Escalation: Blocked Migration
+1. Data Migration Specialist writes blocker to ESCALATION.md
+2. Escalates to Onboarding Lead via escalation_create
+3. Onboarding Lead engages engineering support within 1 hour
+4. Customer notified with revised ETA within 30 minutes
+```
+
+---
+
+## Step 8 — Connect real models (optional)
+
+Edit `openspawn.config.json`:
+
+```json
+{
+  "port": 3333,
+  "orgFile": "ORG.md",
+  "models": {
+    "ollama": { "enabled": true, "baseUrl": "http://localhost:11434" },
+    "groq": { "apiKey": "gsk_..." },
+    "openRouter": { "apiKey": "sk-or-..." }
+  }
+}
+```
+
+> **Q: Which model for which agent?**
+> - L1-L5 workers: Ollama (`qwen2.5`) — free, local
+> - L6-L8 leads: Groq — fast, cheap
+> - L9-L10 executives: OpenRouter (Claude/GPT-4o) — best reasoning
+
+---
+
+## The ORG.md mental model
+
+Every OpenSpawn feature flows from ORG.md:
+
+```
+ORG.md defines:
+  → who the agents are (Structure)
+  → how they communicate (Culture)
+  → what they can spend (Policies)
+  → how they handle common situations (Playbooks)
+
+OpenSpawn executes:
+  → parses ORG.md
+  → generates OpenClaw configs
+  → routes tasks through the hierarchy
+  → enforces budgets and escalation chains
+  → shows everything in the dashboard
+```
+
+ORG.md is version-controlled, reviewable in pull requests, and readable by any human or AI on your team. The document IS the system.
+
+---
+
+## Next steps
+
+- **Full CLI reference:** `openspawn --help`
+- **All MCP tools:** [`docs/mcp-reference.md`](./mcp-reference.md) — every tool with parameters
+- **Templates deep dive:** [`docs/templates-guide.md`](./templates-guide.md) — all 7 industry templates
+- **ORG.md format:** [`docs/org-md-reference.md`](./org-md-reference.md) — every field and example
+- **Communication protocol:** [`docs/communication-protocol.md`](./communication-protocol.md) — save tokens with efficient agent communication
+- **Top FAQ:** [`docs/FAQ.md`](./FAQ.md)
+- **Fix errors:** [`docs/troubleshooting.md`](./troubleshooting.md)
+- **Agent quickstart:** [`docs/agent-quickstart.md`](./agent-quickstart.md) — agent-first version of this guide
+- **Live demo:** https://openspawn.dev/app/
+- **ORG.md spec:** https://openspawn.dev/org-md

--- a/apps/docs/src/content/docs/guides/agent-quickstart.md
+++ b/apps/docs/src/content/docs/guides/agent-quickstart.md
@@ -1,0 +1,365 @@
+---
+title: Agent Quickstart
+---
+
+# Agent Quickstart
+
+**What you'll learn:** How to go from zero to a running multi-agent org in 3 commands — templates, ORG.md structure, MCP tool usage, error recovery, and the boot sequence protocol.
+
+You are an AI agent that needs to coordinate other agents. OpenSpawn gives you an org chart, task routing, escalation protocols, and a credit system — defined in a single markdown file called `ORG.md`.
+
+**The core idea:** One file defines your entire agent organization. Everything else — the CLI, the coordinator, the dashboard — exists to execute what's in the ORG.md.
+
+## Three commands to a running org
+
+```bash
+openspawn init my-org --template=saas-onboarding --yes
+cd my-org
+openspawn start
+openspawn status
+```
+
+That's it. You now have a running org with an Onboarding Lead, Data Migration Specialist, Integration Engineer, and Success Agent — with OpenClaw gateway configs ready to apply.
+
+> **Q: Do I need API keys?**
+> - No. Demo/simulation mode works out of the box with zero configuration.
+
+> **Q: What just happened?**
+> - `init` created `ORG.md` (your org definition) and `openclaw-agents.json`
+> - `start` read the agents config and generated `openclaw-patch.json` with OpenClaw gateway entries
+> - `status` displayed a table of all agents with their name, level, model, workspace, and reports-to
+
+> **Q: What is openclaw-patch.json?**
+> - A ready-to-apply patch for your OpenClaw gateway's `agents.list`
+> - Each entry has: `id`, `model` (opus for L7+, sonnet for L6-), `workspace`, `tools.profile: "full"`
+> - Manager agents (L7+ with direct reports) also get `subagents.allowAgents`
+> - The highest-level agent gets `default: true`
+
+> **Q: How do I apply the patch to my gateway?**
+> - Copy the entries from `openclaw-patch.json` into your OpenClaw `agents.list` configuration, then restart the gateway.
+
+---
+
+## Pick a template
+
+Seven industry templates ship with OpenSpawn. Each produces a complete ORG.md you can use immediately or customize.
+
+```bash
+# SaaS customer onboarding pipeline
+openspawn init my-org --template=saas-onboarding
+
+# DevOps incident response team
+openspawn init my-org --template=incident-response
+
+# Legal contract review pipeline
+openspawn init my-org --template=contract-review
+
+# Fintech compliance monitoring
+openspawn init my-org --template=compliance-monitoring
+
+# Gaming live operations team
+openspawn init my-org --template=game-live-ops
+
+# E-commerce catalog management
+openspawn init my-org --template=catalog-management
+
+# Healthcare clinical trial processing
+openspawn init my-org --template=clinical-trials
+```
+
+> **Q: Which template should I use?**
+> ```
+> What's your domain?
+> ├── Customer success / onboarding → saas-onboarding
+> ├── Infrastructure / reliability  → incident-response
+> ├── Legal / compliance            → contract-review or compliance-monitoring
+> ├── Gaming / live service         → game-live-ops
+> ├── E-commerce / retail           → catalog-management
+> └── Healthcare / life sciences    → clinical-trials
+> ```
+
+> **Q: Can I combine templates?**
+> - Yes. Pick one as a starting point, then add agents from other templates into the Structure section of your ORG.md.
+
+> **Q: Can I create agents not in any template?**
+> - Absolutely. Templates are starting points. Add any agent to the `## Structure` section with a name, level, domain, and reporting line.
+
+---
+
+## Understanding ORG.md
+
+Your entire org lives in one file. Five sections, all optional except Structure:
+
+```markdown
+# SaaS Onboarding Org
+
+## Identity
+Mission, industry context, pain solved.
+Becomes ambient context for every agent.
+
+## Culture
+preset: agency
+Communication norms, escalation speed, progress frequency.
+
+## Structure
+
+### Onboarding Lead — Customer Onboarding Manager
+The quarterback. Owns customer relationships from contract to go-live.
+- **Level:** 7
+- **Department:** Customer Success
+- **Reports to:** Human Principal
+
+#### Data Migration Specialist — Senior Data Engineer
+Ingests and validates customer data from source systems.
+- **Level:** 5
+- **Department:** Engineering
+- **Reports to:** Onboarding Lead
+
+## Policies
+Budget limits, permission guardrails, human approval thresholds.
+
+## Playbooks
+Step-by-step procedures for standard scenarios and escalations.
+```
+
+> **Q: What's the minimum viable ORG.md?**
+> ```markdown
+> # My Org
+>
+> ## Structure
+>
+> ### Boss — Leader
+> - **Level:** 10
+> - **Reports to:** Human Principal
+> ```
+
+> **Q: What do levels mean?**
+> - L1-L5: Workers. Execute tasks.
+> - L6: Can review and approve work.
+> - L7-L9: Can create tasks and spawn agents. Department leads.
+> - L10: Executive. Top of the hierarchy.
+
+> **Q: What's "Reports to"?**
+> - Defines the escalation chain. When an agent is blocked, it escalates to whoever it reports to. Never skip the chain.
+
+---
+
+## Validate your org
+
+```bash
+openspawn validate ORG.md
+```
+
+Output on success:
+```
+✅ ORG.md is valid
+
+  Organization:  SaaS Onboarding Org
+  Agents:        4
+  Culture:       agency
+
+  Agent hierarchy:
+    🎯 Onboarding Lead (L7, Customer Success)
+      📦 Data Migration Specialist (L5, Engineering)
+      🔧 Integration Engineer (L5, Engineering)
+      ✅ Success Agent (L4, Customer Success)
+```
+
+> **Q: If I see "validation failed", what do I do?**
+> - The output lists each issue. Common fixes:
+>   - "Missing Structure section" → Add `## Structure` with at least one agent
+>   - "Agent reports to unknown agent" → Check spelling of the `Reports to` value
+>   - "No top-level agent" → One agent must have `Reports to: Human Principal`
+
+---
+
+## Culture presets
+
+Instead of configuring every communication parameter, use a preset:
+
+```markdown
+## Culture
+preset: agency
+```
+
+| Preset | Best for | Escalation | Progress updates |
+|--------|----------|-----------|-----------------|
+| `startup` | Small fast teams | Immediate | Frequent |
+| `enterprise` | Large orgs with process | Batched (hourly) | On phase change |
+| `agency` | Client work with deadlines | Immediate | Every tick |
+| `research` | Exploration, long tasks | Delayed | On request |
+| `military` | Zero-ambiguity operations | Immediate | Every tick |
+| `remote-async` | Distributed, async teams | Delayed | On request |
+
+> **Q: Can I override specific settings in a preset?**
+> - Yes. Add overrides after the preset line:
+> ```markdown
+> ## Culture
+> preset: agency
+> - **Escalation:** batched
+> - **Ack required:** no
+> ```
+
+---
+
+## Interacting via MCP
+
+Agents communicate with OpenSpawn through MCP tools at `POST /mcp`:
+
+```bash
+# List all agents
+→ agent_list
+
+# Create a task (e.g., onboard a new customer)
+→ task_create { title: "Onboard Acme Corp", priority: "high", assigneeId: "onboarding-lead" }
+
+# Check your balance
+→ credits_balance
+
+# Escalate a blocker
+→ escalation_create { taskId: "task-123", reason: "migration blocked", targetAgentId: "onboarding-lead" }
+
+# Send a structured message
+→ message_send { channelId: "chan-1", body: "Migration complete for Acme Corp. 1.2M rows verified.", type: "handoff" }
+```
+
+> **Q: How do I authenticate?**
+> - HMAC authentication. Set `AGENT_ID` and `AGENT_SECRET` environment variables. The MCP client handles the rest.
+
+> **Q: What's the full tool list?**
+> - See `docs/llms.txt` for every tool with all parameters.
+
+---
+
+## Managing Tasks
+
+The coordination tools give agents a shared task board backed by SQLite. Here's the core workflow:
+
+### Create a task
+```
+tool: task_create { title: "Migrate Acme Corp database", priority: "high", assign_to: "data-migration-specialist" }
+```
+
+### Claim an open task
+```
+tool: task_claim { task_id: "abc123", agent_id: "data-migration-specialist" }
+```
+> **Q: Can two agents claim the same task?**
+> No. `task_claim` is atomic — only one agent wins, the other gets an error. This prevents duplicate work.
+
+### Complete a task
+```
+tool: task_complete { task_id: "abc123", result: "1.2M rows migrated, checksum verified", artifacts: ["migration-report.md"] }
+```
+
+### List tasks
+```
+tool: task_list { status: "open", priority: "high" }
+```
+
+### Escalate a problem
+```
+tool: escalation_create { issue: "source database connection refused", severity: "high", to_agent: "onboarding-lead" }
+```
+
+### Check org status
+```
+tool: org_status
+```
+> Returns a full overview: all agents, task counts, budget status.
+
+> **Q: How do agents coordinate work?**
+> Via coordination tools. `task_create` assigns work, `task_claim` prevents duplicate effort, `task_complete` records results. `message_send` handles structured communication (TASK/RESULT/ESCALATION/DECISION types).
+
+> **Q: Where's the full tool reference?**
+> See `docs/llms.txt` — the "Coordination Tools" section lists all 14 tools with parameters.
+
+---
+
+## Common workflows
+
+### Delegate a task
+```
+1. task_create { title: "...", assigneeId: "specialist-id" }
+2. Specialist receives task → auto-ACKs (👍)
+3. Specialist logs progress to task activity
+4. Specialist completes → task_transition { id: "...", status: "done" }
+5. You get a completion notification
+```
+
+### Handle an escalation
+```
+1. escalation_list → see pending escalations
+2. Read the reason and task details
+3. Either: resolve it, reassign the task, or escalate further
+4. escalation_resolve { escalationId: "...", resolution: "Engaged engineering support, ETA 2 hours" }
+```
+
+### Request consensus
+```
+1. consensus_request { taskId: "...", question: "Proceed with live migration?", voterIds: ["agent-a", "agent-b"] }
+2. Each voter: consensus_vote { consensusId: "...", vote: "approve" }
+3. consensus_status { consensusId: "..." } → see result
+```
+
+---
+
+## Error recovery
+
+| You see | Run this |
+|---------|----------|
+| `Cannot read ORG.md` | `openspawn validate` — check the file exists and is valid markdown |
+| `Port 3333 already in use` | `lsof -i :3333` then kill the process, or set `"port": 3334` in config |
+| `Unknown template: foo` | Valid templates: `saas-onboarding`, `incident-response`, `contract-review`, `compliance-monitoring`, `game-live-ops`, `catalog-management`, `clinical-trials` |
+| `Agent reports to unknown agent` | Check the `Reports to` field matches an existing agent name exactly |
+| `HMAC authentication failed` | Verify `AGENT_ID` and `AGENT_SECRET` env vars match the API config |
+
+---
+
+## Boot Sequence — How Orgs Start Up
+
+When `openspawn start` boots your org, the lead agent doesn't just start delegating. It follows a **planning-first boot sequence**:
+
+```
+1. Read ORG.md     → understand mission, team, constraints
+2. Read PLAN.md    → check if resuming a previous run
+3. Write PLAN.md   → break mission into phased tasks with assignments
+4. Register agents → agent_register for each team member
+5. Create tasks    → task_create for current-phase items
+6. Monitor         → org_status every 5 minutes
+7. Adapt           → update PLAN.md when things change
+8. Complete        → escalate "mission complete" when done
+```
+
+**Example for a SaaS onboarding org:** The Onboarding Lead reads the ORG.md, sees the 48-hour track playbook, writes PLAN.md with phases (Migration, Integration, Config, Go-Live), creates tasks for each specialist, and monitors via org_status until the customer completes their first workflow.
+
+> **Q: Why planning first?**
+> Plans are cheaper than confusion. A 30-second PLAN.md prevents hours of rework, wasted tokens, and "what did you mean?" messages.
+
+> **Q: What goes in PLAN.md?**
+> - Mission statement (from ORG.md)
+> - Phase breakdown (what order to build)
+> - Task table with assignments, priorities, dependencies, and status
+> - Success criteria and definition of done
+
+> **Q: How do workers know what to do?**
+> Workers read PLAN.md on startup, then claim their assigned tasks via `task_claim`. They don't wait for chat messages — the plan IS the assignment.
+
+> **Q: What if the plan needs to change?**
+> The lead updates PLAN.md first, then updates MCP tasks to match. PLAN.md is always the source of truth.
+
+See `templates/boot-sequence.md` for the full protocol, `templates/SOUL-lead.md` for the lead agent template, and `templates/SOUL-worker.md` for the worker template.
+
+---
+
+## Next steps
+
+- **Customize your ORG.md:** add agents, change levels, write playbooks — see [`docs/org-md-reference.md`](./org-md-reference.md)
+- **Connect real models:** set Ollama/Groq/OpenRouter keys in `openspawn.config.json`
+- **All MCP tools:** [`docs/mcp-reference.md`](./mcp-reference.md) — full parameter reference
+- **Communication rules:** [`docs/communication-protocol.md`](./communication-protocol.md) — save 50-70% on coordination tokens
+- **Template deep dive:** [`docs/templates-guide.md`](./templates-guide.md) — all 7 industry templates
+- **Top FAQ:** [`docs/FAQ.md`](./FAQ.md) — common questions answered
+- **Fix errors:** [`docs/troubleshooting.md`](./troubleshooting.md) — common issues and fixes
+- **Full reference:** [`docs/llms.txt`](./llms.txt)
+- **Live demo:** https://openspawn.dev/app/

--- a/apps/docs/src/content/docs/guides/comparison.md
+++ b/apps/docs/src/content/docs/guides/comparison.md
@@ -1,0 +1,296 @@
+---
+title: Comparison
+---
+
+# OpenSpawn vs CrewAI vs LangGraph
+
+**What you'll learn:** The key differences between the three most popular multi-agent frameworks in 2026, where each excels, where each falls short, and how to migrate — or combine them.
+
+> **Bottom line up front:** CrewAI and LangGraph are excellent *execution* frameworks. OpenSpawn is *coordination infrastructure*. They solve different problems — and they're designed to work together.
+
+---
+
+## Decision tree
+
+```
+Do you need to build and execute agent logic?
+├── YES, in Python, with a clean role API → CrewAI
+├── YES, with precise control over complex stateful flows → LangGraph
+└── NO — I need to organize, govern, and coordinate multiple agents
+    └── OpenSpawn
+```
+
+```
+Do you need all three capabilities?
+└── Use OpenSpawn (coordination) + CrewAI/LangGraph (execution) together
+```
+
+> **Q: Can I use OpenSpawn with my existing CrewAI/LangGraph setup?**
+> Yes — OpenSpawn is additive. It coordinates your existing agents without requiring rewrites. See the migration guides below.
+
+> **Q: Is OpenSpawn a replacement for CrewAI?**
+> No. OpenSpawn and CrewAI solve different problems. CrewAI builds agents. OpenSpawn organizes them. Use both.
+
+> **Q: Which should I start with if I'm new to multi-agent systems?**
+> Start with CrewAI for its simplicity and community. Add OpenSpawn when you need governance, budgets, or coordination across multiple workflows.
+
+---
+
+## Feature comparison
+
+| Feature | OpenSpawn | CrewAI | LangGraph |
+|---------|-----------|--------|-----------|
+| **Primary role** | Coordination / control plane | Agent execution framework | Graph-based orchestration |
+| **Language** | TypeScript (Python SDK planned) | Python | Python |
+| **Agent hierarchy** | 10-level hierarchy, roles, trust scores | Flat crews | Flat nodes |
+| **Org definition** | `ORG.md` (markdown) | Python code | Python code |
+| **Protocol support** | MCP (native), A2A, REST, GraphQL | Plugins | LangChain tools |
+| **Real device support** | ✅ Via OpenClaw | ❌ | ❌ |
+| **Real-time dashboard** | ✅ React, network graph, SSE | ❌ (CLI/LangSmith) | ❌ (LangSmith) |
+| **Self-hosted** | ✅ MIT open source | ✅ Open source | ✅ Open source |
+| **Budget / credits** | ✅ Built-in economic layer | ❌ | ❌ |
+| **Approval gates** | ✅ Pre-hooks for irreversible actions | ❌ | Conditional edges |
+| **Trust / reputation** | ✅ Per-agent trust scores | ❌ | ❌ |
+| **Escalation system** | ✅ Typed escalation with chain of command | ❌ | ❌ |
+| **Framework agnostic** | ✅ Works with any A2A/MCP agent | ❌ | ❌ |
+| **Pricing** | Free, self-hosted | Free + Enterprise (paid) | Free + LangSmith (paid) |
+| **Production maturity** | Demo-stage, rapid development | Production-ready | Production-ready |
+
+---
+
+## Where each framework shines
+
+### CrewAI — Role-Based Task Crews
+
+CrewAI excels at defining small, focused agent teams ("crews") that work together on a shared task. Its Python-first API is clean, the role system is intuitive, and the LangChain ecosystem means you can connect to almost anything out of the box.
+
+**Use CrewAI when:**
+- You want to ship a multi-agent pipeline in Python, fast
+- Your use case is a single workflow with a clear beginning and end
+- You're already in the LangChain ecosystem
+- You want the largest framework community and most tutorials
+
+**The gap:** CrewAI doesn't provide organizational structure. Multiple crews, running simultaneously, across a real product, have no shared governance. No budget system, no trust scores, no approval gates before irreversible actions.
+
+**Real-world example:** A CrewAI contract review crew works great for a single contract. But when you're running 50 contracts simultaneously with different risk levels, SLAs, and playbook versions — you need OpenSpawn's governance layer on top.
+
+---
+
+### LangGraph — Stateful Agent Graphs
+
+LangGraph gives you precise, explicit control over agent flow as a directed graph. Each node is an agent or function. Edges define transitions. State is typed and checkpointed.
+
+**Use LangGraph when:**
+- You need fine-grained control over agent execution flow
+- Your workflow has complex branching logic or cycles
+- You're building production pipelines where every state transition matters
+- You want excellent observability via LangSmith
+
+**The gap:** LangGraph models agents as graph nodes — it's a powerful execution primitive. It doesn't model your *organization*. Who owns a node? Who approves its output? What happens when it goes over budget? LangGraph has no answer for these questions.
+
+**Real-world example:** A LangGraph incident response pipeline can precisely model the diagnostic decision tree. But when you need the Incident Commander to have formal authority over the Remediation Agent — with budget limits, audit trails, and mandatory human approval for production database changes — that's OpenSpawn's layer.
+
+---
+
+### OpenSpawn — Agent Coordination Infrastructure
+
+OpenSpawn is not a framework you write agents in. It's the *organizational infrastructure* that your agents (built in CrewAI, LangGraph, or anything else) operate within.
+
+Mental model: agent frameworks are your employees' skills. OpenSpawn is the company — org chart, task management, budget, governance, communications.
+
+**Use OpenSpawn when:**
+- You're running multiple agents across multiple workflows simultaneously
+- You need governance: budget limits, approval gates, trust scores
+- You want your org structure defined as code (`ORG.md`) and reviewable in git
+- Your agents need to work on real devices (via OpenClaw)
+- You need framework-agnostic coordination — mix CrewAI + LangGraph + custom agents in one org
+
+**Real-world examples:**
+- A SaaS company running customer onboarding for 20 enterprise customers in parallel — each customer is a task, one org coordinates all of them
+- A fintech compliance team where regulators need an audit trail of every rule applied to every transaction
+- A legal team where senior attorneys approve agent outputs before they go to business stakeholders
+
+---
+
+## Where OpenSpawn wins
+
+### 1. Organizations as Code
+
+```markdown
+# Customer Onboarding Org
+
+## Identity
+- **Mission:** Onboard enterprise customers end-to-end in 48 hours
+
+## Culture
+preset: agency
+
+## Structure
+
+### Onboarding Lead — Customer Onboarding Manager
+The quarterback. Owns customer relationships from contract to go-live.
+- **Level:** 7
+- **Reports to:** Human Principal
+
+#### Data Migration Specialist — Senior Data Engineer
+Ingests and validates customer data from source systems.
+- **Level:** 5
+- **Reports to:** Onboarding Lead
+```
+
+Human-readable, version-controllable, and deployable: `npx openspawn deploy ORG.md`. The prose *is* the system prompt. Reviewable in git PRs. Your legal or compliance team can read it. Your new engineer can understand the org at a glance.
+
+### 2. Protocol-Native from Day One
+
+- **MCP (Model Context Protocol):** Org exposed as MCP tools, consumable by Claude Desktop, Cursor, or any MCP client
+- **A2A (Agent-to-Agent):** Every agent has a `/.well-known/agent.json` discovery card for inter-org communication
+- **Streamable HTTP:** Real-time SSE, no polling
+
+### 3. Real-World Device Support
+
+Via deep integration with [OpenClaw](https://openclaw.ai), OpenSpawn agents can operate on real computers — browsing the web, running code, interacting with applications, managing files. No other coordination platform offers this.
+
+### 4. Economic Layer
+
+Built-in credit system — not just rate limits, but a full economic model: per-agent credit budgets, automatic cost tracking against real LLM spend, and `overage behavior: pause and escalate`. The compliance-monitoring template, for example, sets different credit limits per agent to reflect the actual cost of regulatory rule processing.
+
+### 5. Governance Built-In
+
+Pre-hooks let you require human approval before any irreversible action. The contract-review template requires Senior Reviewer approval before summaries go to business stakeholders. The incident-response template requires Incident Commander go-ahead before Remediation Agent deploys a fix. The clinical-trials template requires Study Director sign-off before any regulatory document is submitted.
+
+LangGraph has conditional edges. CrewAI has human-in-the-loop options. Neither has a system-level governance layer that applies across all agents, all tasks, regardless of framework.
+
+---
+
+## Where competitors are ahead
+
+> Honest assessment — we believe in fair comparisons.
+
+| Area | Where they're ahead |
+|------|-------------------|
+| **Community & ecosystem** | CrewAI has tens of thousands of stars. LangGraph has the full LangChain ecosystem. OpenSpawn is early-stage. |
+| **Production maturity** | CrewAI and LangGraph run in production at scale. OpenSpawn is in rapid development — core is solid, some enterprise features on roadmap. |
+| **Python ecosystem** | Both CrewAI and LangGraph are Python-first. OpenSpawn is TypeScript-first (Python SDK in development). |
+
+---
+
+## Migration guides
+
+### From CrewAI to OpenSpawn
+
+OpenSpawn doesn't replace your CrewAI agents — it governs them. The migration is additive.
+
+**Step 1: Deploy OpenSpawn alongside your existing setup**
+```bash
+git clone https://github.com/openspawn/openspawn.git
+cd openspawn && pnpm install
+pnpm exec nx serve sandbox
+```
+
+**Step 2: Map your crew structure to ORG.md**
+
+If you have a contract review crew today:
+```markdown
+# Contract Review Org
+
+## Structure
+
+### Senior Reviewer — Legal Analysis Lead
+Routes work to specialist agents. Reviews and approves final summaries.
+- **Level:** 7
+- **Reports to:** Human Principal
+
+#### Clause Extractor — Contract Analysis Specialist
+Runs your existing CrewAI clause extraction crew via MCP.
+- **Level:** 5
+- **Domain:** Document Analysis
+- **Reports to:** Senior Reviewer
+```
+
+**Step 3: Connect your CrewAI agents via MCP**
+```python
+from crewai_tools import MCPServerAdapter
+
+openspawn_tools = MCPServerAdapter(
+    server_url="http://localhost:3333/mcp"
+)
+# Your agents can now use task_create, agent_list, org_status
+```
+
+---
+
+### From LangGraph to OpenSpawn
+
+**Step 1: Expose your LangGraph workflow as an MCP tool**
+```python
+from openspawn import OpenSpawnClient  # Python SDK (in development)
+
+client = OpenSpawnClient(url="http://localhost:3333")
+client.register_agent(
+    name="Diagnostics Pipeline",
+    domain="infrastructure",
+    capabilities=["metrics-analysis", "trace-inspection", "log-search"]
+)
+```
+
+**Step 2: Delegate tasks through OpenSpawn**
+```python
+# Before: call your graph directly
+result = app.invoke({"task": "Investigate P99 latency spike on /api/checkout"})
+
+# After: delegate through OpenSpawn (governance, budget, audit trail included)
+task = client.delegate_task(
+    "Investigate P99 latency spike on /api/checkout",
+    priority="urgent",
+    assignee="diagnostics-agent"
+)
+```
+
+---
+
+## The right architecture
+
+For most production agent teams, the answer isn't either/or:
+
+```
+┌──────────────────────────────────────────────┐
+│              OpenSpawn Org                   │
+│  (governance, budget, coordination, ORG.md)  │
+│                                              │
+│  ┌──────────┐    ┌────────────────────────┐  │
+│  │ CrewAI   │    │   LangGraph Pipelines  │  │
+│  │ Agents   │    │   (incident response,  │  │
+│  │(contract │    │    compliance rules)   │  │
+│  │ review)  │    └────────────────────────┘  │
+│  └──────────┘                                │
+│                                              │
+│  ┌──────────┐    ┌────────────────────────┐  │
+│  │ OpenClaw │    │  Custom Agent          │  │
+│  │ (devices)│    │  (any A2A-compatible)  │  │
+│  └──────────┘    └────────────────────────┘  │
+└──────────────────────────────────────────────┘
+```
+
+---
+
+## Quick decision guide
+
+| Use… | When… |
+|------|-------|
+| CrewAI | You want the easiest Python framework, clean role-based API for small-to-medium crews |
+| LangGraph | You need precise control over complex, stateful, multi-step agent flows |
+| OpenSpawn | You're coordinating multiple agent teams, need governance/budget/approval gates |
+| OpenSpawn + CrewAI | You want CrewAI's execution simplicity with organizational governance |
+| OpenSpawn + LangGraph | You want LangGraph's graph power with budget enforcement and a dashboard |
+
+---
+
+## Next steps
+
+- **Get started:** [`docs/getting-started.md`](./getting-started.md)
+- **MCP integration:** [`docs/mcp-reference.md`](./mcp-reference.md)
+- **ORG.md reference:** [`docs/org-md-reference.md`](./org-md-reference.md)
+- **Industry templates:** [`docs/templates-guide.md`](./templates-guide.md)
+- **Live demo:** https://openspawn.dev/app/
+
+*Last updated: March 2026. OpenSpawn is in rapid development — see the [GitHub repo](https://github.com/openspawn/openspawn) for the latest.*

--- a/apps/docs/src/content/docs/guides/templates.md
+++ b/apps/docs/src/content/docs/guides/templates.md
@@ -1,0 +1,595 @@
+---
+title: Templates Guide
+---
+
+# Templates Guide
+
+**What you'll learn:** The seven OpenSpawn industry org templates — what they include, when to use each, how to customize them, and how to combine roles from multiple templates.
+
+> **The key insight:** One file — `ORG.md` — defines your entire agent organization. Templates give you a battle-tested starting point for your industry. Customize from there.
+
+OpenSpawn ships seven industry org templates. Each produces a complete, ready-to-run ORG.md with roles, hierarchy, culture, budget policies, and operating playbooks — modeled on real organizational pain points.
+
+---
+
+## Which template is right for you?
+
+```
+What's your primary use case?
+│
+├── Customer success / SaaS
+│   Are you automating customer onboarding?
+│   └── YES → saas-onboarding
+│
+├── Engineering / DevOps
+│   Are you managing production incidents?
+│   └── YES → incident-response
+│
+├── Legal
+│   Are you reviewing contracts?
+│   └── YES → contract-review
+│
+├── Finance / Compliance
+│   Are you monitoring transactions for regulatory compliance?
+│   └── YES → compliance-monitoring
+│
+├── Gaming
+│   Are you running a live service game?
+│   └── YES → game-live-ops
+│
+├── E-commerce / Retail
+│   Are you managing a large product catalog?
+│   └── YES → catalog-management
+│
+└── Healthcare / Life Sciences
+    Are you processing clinical trial data?
+    └── YES → clinical-trials
+```
+
+> **Q: My use case isn't listed?**
+> - Pick the closest template and customize. Templates are starting points. The ORG.md format is flexible enough to model any organizational structure.
+
+> **Q: Can I combine roles from multiple templates?**
+> - Yes. Copy agent definitions from one template's Structure section into another. Validate with `openspawn validate`.
+
+---
+
+## Comparison table
+
+| | saas-onboarding | incident-response | contract-review | compliance-monitoring | game-live-ops | catalog-management | clinical-trials |
+|---|---|---|---|---|---|---|---|
+| **Industry** | SaaS | DevOps / SRE | Legal | Fintech | Gaming | E-commerce | Healthcare |
+| **Culture preset** | `agency` | `military` | `enterprise` | `enterprise` | `agency` | `startup` | `enterprise` |
+| **Agent count** | 4 | 4 | 4 | 4 | 4 | 4 | 4 |
+| **Top role** | Onboarding Lead (L7) | Incident Commander (L8) | Senior Reviewer (L7) | Compliance Lead (L7) | Ops Director (L7) | Catalog Manager (L7) | Study Director (L8) |
+| **Key feature** | 48-hr SLA playbooks | MTTR minimization | Playbook comparison | SAR/CTR automation | Economy guardrails | Margin guardrails | Regulatory compliance |
+| **Escalation** | Immediate | Immediate + mandatory acks | Deliberate | Immediate for SAR | Immediate for economy | Immediate for margin | Deliberate + audit trail |
+
+---
+
+## saas-onboarding
+
+**SaaS customer onboarding pipeline.** Takes a new enterprise customer from signed contract to first successful workflow in 48 hours.
+
+```bash
+openspawn init my-org --template=saas-onboarding
+```
+
+**Pain solved:** Manual onboarding takes 2–3 days per customer across 4 teams, with handoffs that drop context and delay go-live.
+
+### Roles
+
+| Agent | Level | Department | Reports to |
+|-------|-------|-----------|------------|
+| Onboarding Lead | L7 | Customer Success | Human Principal |
+| Data Migration Specialist | L5 | Engineering | Onboarding Lead |
+| Integration Engineer | L5 | Engineering | Onboarding Lead |
+| Success Agent | L4 | Customer Success | Onboarding Lead |
+
+### Example ORG.md Structure section
+
+```markdown
+## Structure
+
+### Onboarding Lead — Customer Onboarding Manager
+The quarterback. Receives new customer intake, creates the onboarding plan,
+assigns work to specialists, and tracks progress to go-live.
+- **Level:** 7
+- **Department:** Customer Success
+- **Reports to:** Human Principal
+
+#### Data Migration Specialist — Senior Data Engineer
+Ingests customer data from source systems, validates schema compatibility,
+runs transformation pipelines, and verifies row counts match post-migration.
+- **Level:** 5
+- **Department:** Engineering
+- **Reports to:** Onboarding Lead
+
+#### Integration Engineer — Platform Integration Specialist
+Connects the customer's existing tools (CRM, ERP, SSO, webhooks) to the platform.
+Validates each integration with smoke tests.
+- **Level:** 5
+- **Department:** Engineering
+- **Reports to:** Onboarding Lead
+
+#### Success Agent — Customer Success Representative
+Conducts the go-live check-in, validates the customer can complete their first
+workflow end-to-end, closes the onboarding ticket.
+- **Level:** 4
+- **Department:** Customer Success
+- **Reports to:** Onboarding Lead
+```
+
+### When to use
+- You onboard enterprise customers and handoffs between teams lose context
+- You want to run parallel workstreams (migration + integration simultaneously) with a coordinator
+- You need a paper trail of each onboarding phase for compliance or QBRs
+
+> **Q: What if my onboarding is simpler / more complex?**
+> - Simpler: remove Integration Engineer; the Onboarding Lead handles integration directly
+> - More complex: add a Configuration Agent (L4) and a QA Validator (L4) between migration and go-live
+
+---
+
+## incident-response
+
+**DevOps incident response team.** Detects, diagnoses, and remediates production incidents with a military-grade command structure.
+
+```bash
+openspawn init my-org --template=incident-response
+```
+
+**Pain solved:** 3am pages with 45-minute MTTR, context switching between 6 monitoring tools, and no single source of truth during an incident.
+
+### Roles
+
+| Agent | Level | Department | Reports to |
+|-------|-------|-----------|------------|
+| Incident Commander | L8 | SRE | Human Principal |
+| Diagnostics Agent | L6 | SRE | Incident Commander |
+| Remediation Agent | L6 | Engineering | Incident Commander |
+| Comms Agent | L4 | Customer Success | Incident Commander |
+
+### Example ORG.md Structure section
+
+```markdown
+## Structure
+
+### Incident Commander — Senior SRE / On-Call Lead
+Owns the incident from page to post-mortem. Makes go/no-go decisions on rollback.
+- **Level:** 8
+- **Department:** SRE
+- **Reports to:** Human Principal
+
+#### Diagnostics Agent — Systems Reliability Engineer
+Rapid root-cause analysis. Pulls metrics, traces, and logs to identify the failure domain.
+- **Level:** 6
+- **Department:** SRE
+- **Reports to:** Incident Commander
+
+#### Remediation Agent — Platform Engineer
+Executes the fix. Implements hotfix, coordinates rollback, verifies recovery.
+- **Level:** 6
+- **Department:** Engineering
+- **Reports to:** Incident Commander
+
+#### Comms Agent — Incident Communications Specialist
+Manages all stakeholder communications. Status page, customer notifications, Slack updates.
+- **Level:** 4
+- **Department:** Customer Success
+- **Reports to:** Incident Commander
+```
+
+### When to use
+- You're on call and need structured coordination during incidents
+- Your MTTR is above 30 minutes and context-switching is the main cause
+- You need post-mortem documentation generated automatically from the incident timeline
+
+> **Q: What about runbook automation?**
+> - Add a Runbook Agent (L5, Engineering, reports to Remediation Agent) that executes pre-approved runbook steps automatically
+
+---
+
+## contract-review
+
+**Legal contract review pipeline.** Extracts clauses, compares against the company playbook, flags risks, and produces attorney-ready summaries.
+
+```bash
+openspawn init my-org --template=contract-review
+```
+
+**Pain solved:** Junior associates spend 80+ hours per week on contract review — reading, extracting, comparing against playbook, and writing summaries that senior attorneys then re-read.
+
+### Roles
+
+| Agent | Level | Department | Reports to |
+|-------|-------|-----------|------------|
+| Senior Reviewer | L7 | Legal | Human Principal |
+| Clause Extractor | L5 | Legal | Senior Reviewer |
+| Risk Analyst | L5 | Legal | Senior Reviewer |
+| Summary Writer | L4 | Legal | Senior Reviewer |
+
+### Example ORG.md Structure section
+
+```markdown
+## Structure
+
+### Senior Reviewer — Senior Legal Analyst
+Owns the review queue. Assigns contracts, reviews and approves final summaries,
+and escalates material risks to legal counsel.
+- **Level:** 7
+- **Department:** Legal
+- **Reports to:** Human Principal
+
+#### Clause Extractor — Contract Analysis Specialist
+Reads the full contract and extracts all key clauses into a structured inventory.
+- **Level:** 5
+- **Department:** Legal
+- **Reports to:** Senior Reviewer
+
+#### Risk Analyst — Legal Risk Specialist
+Compares extracted clauses against the company playbook. Assigns risk level
+to each deviation with recommended redline.
+- **Level:** 5
+- **Department:** Legal
+- **Reports to:** Senior Reviewer
+
+#### Summary Writer — Legal Communications Specialist
+Produces the attorney-ready review package: executive summary, clause comparison
+table, risk register, and suggested redlines.
+- **Level:** 4
+- **Department:** Legal
+- **Reports to:** Senior Reviewer
+```
+
+### When to use
+- Your legal team reviews high volumes of NDAs, MSAs, or vendor agreements
+- You want consistent playbook application across all reviewers
+- You need to reduce time-to-review from weeks to hours for routine contracts
+
+> **Q: Can I use this for M&A due diligence?**
+> - The template can be extended with a Due Diligence Coordinator (L8) above the Senior Reviewer. Add a Data Room Analyst (L5) for document management.
+
+---
+
+## compliance-monitoring
+
+**Fintech transaction monitoring and regulatory reporting.** Applies AML/BSA rules, screens OFAC, and generates SAR/CTR filings.
+
+```bash
+openspawn init my-org --template=compliance-monitoring
+```
+
+**Pain solved:** Manual transaction monitoring misses 15% of anomalies, creates 48-hour reporting lag, and requires analysts running the same queries every morning.
+
+### Roles
+
+| Agent | Level | Department | Reports to |
+|-------|-------|-----------|------------|
+| Compliance Lead | L7 | Compliance | Human Principal |
+| Transaction Analyst | L5 | Compliance | Compliance Lead |
+| Rule Engine Agent | L5 | Compliance | Compliance Lead |
+| Report Generator | L4 | Compliance | Compliance Lead |
+
+### Example ORG.md Structure section
+
+```markdown
+## Structure
+
+### Compliance Lead — Chief Compliance Officer (Agent)
+Owns the monitoring program. Reviews flagged activity, approves SAR submissions,
+and escalates material findings to Human Principal.
+- **Level:** 7
+- **Department:** Compliance
+- **Reports to:** Human Principal
+
+#### Transaction Analyst — Compliance Data Analyst
+Ingests and normalizes transaction data from all payment rails.
+Enriches with counterparty risk scores and geolocation.
+- **Level:** 5
+- **Department:** Compliance
+- **Reports to:** Compliance Lead
+
+#### Rule Engine Agent — Regulatory Rules Specialist
+Applies AML/BSA rules, OFAC screening, velocity checks,
+and structuring detection against the enriched transaction stream.
+- **Level:** 5
+- **Department:** Compliance
+- **Reports to:** Compliance Lead
+
+#### Report Generator — Compliance Reporting Specialist
+Produces SAR drafts, CTR filings, and daily/weekly compliance reports
+formatted for regulatory submission.
+- **Level:** 4
+- **Department:** Compliance
+- **Reports to:** Compliance Lead
+```
+
+### When to use
+- You process financial transactions and have regulatory monitoring obligations
+- You need automated SAR/CTR detection and drafting
+- Your analysts spend most of their time on mechanical rule application, not judgment calls
+
+> **Q: Can I use this for SEC/FINRA compliance instead of FinCEN?**
+> - Yes. Update the Rule Engine Agent's playbook section with SEC/FINRA rules. The hierarchy and workflow are framework-agnostic.
+
+---
+
+## game-live-ops
+
+**Gaming live operations team.** Monitors game economy, generates content, tunes balance parameters, and manages player sentiment.
+
+```bash
+openspawn init my-org --template=game-live-ops
+```
+
+**Pain solved:** Player churn from stale content and unbalanced economies. Live ops teams can't manually track every economy metric, generate fresh event content, and handle player support simultaneously.
+
+### Roles
+
+| Agent | Level | Department | Reports to |
+|-------|-------|-----------|------------|
+| Ops Director | L7 | Live Operations | Human Principal |
+| Economy Tuner | L6 | Live Operations | Ops Director |
+| Content Generator | L5 | Live Operations | Ops Director |
+| Player Support Agent | L4 | Live Operations | Ops Director |
+
+### Example ORG.md Structure section
+
+```markdown
+## Structure
+
+### Ops Director — Live Operations Director
+Sets weekly content calendar, approves economy parameter changes,
+monitors overall game health, and owns the player experience.
+- **Level:** 7
+- **Department:** Live Operations
+- **Reports to:** Human Principal
+
+#### Economy Tuner — Game Economy Analyst
+Monitors economy metrics continuously. Detects anomalies, proposes balance
+adjustments, implements approved changes within guardrail thresholds.
+- **Level:** 6
+- **Department:** Live Operations
+- **Reports to:** Ops Director
+
+#### Content Generator — Live Content Specialist
+Produces event descriptions, challenge text, reward messaging, and push
+notification copy per the weekly content calendar.
+- **Level:** 5
+- **Department:** Live Operations
+- **Reports to:** Ops Director
+
+#### Player Support Agent — Community & Support Specialist
+Monitors app store reviews and social sentiment. Drafts response templates
+and escalates critical player issues to Ops Director.
+- **Level:** 4
+- **Department:** Live Operations
+- **Reports to:** Ops Director
+```
+
+### When to use
+- You run a live service game and need 24/7 economy and sentiment monitoring
+- Your live ops team is small relative to your player base
+- You want to automate routine content generation while keeping creative direction human
+
+> **Q: What about player bans and support tickets?**
+> - Add a Trust & Safety Agent (L5, Live Operations, reports to Ops Director) for moderation decisions
+
+---
+
+## catalog-management
+
+**E-commerce product catalog.** Monitors competitors, optimizes pricing, and generates product descriptions across thousands of SKUs.
+
+```bash
+openspawn init my-org --template=catalog-management
+```
+
+**Pain solved:** Competitors change prices daily, product descriptions go stale, and a team of copywriters and pricing analysts can't manually keep up with a catalog of 10,000+ SKUs.
+
+### Roles
+
+| Agent | Level | Department | Reports to |
+|-------|-------|-----------|------------|
+| Catalog Manager | L7 | E-commerce | Human Principal |
+| Price Optimizer | L6 | E-commerce | Catalog Manager |
+| Content Writer | L5 | Marketing | Catalog Manager |
+| Competitor Monitor | L4 | E-commerce | Catalog Manager |
+
+### Example ORG.md Structure section
+
+```markdown
+## Structure
+
+### Catalog Manager — Head of Catalog Operations
+Sets pricing strategy and content quality standards. Approves major pricing
+moves and ensures catalog health metrics trend in the right direction.
+- **Level:** 7
+- **Department:** E-commerce
+- **Reports to:** Human Principal
+
+#### Price Optimizer — Pricing Analyst
+Applies dynamic pricing rules within margin floor and MAP policy guardrails.
+Reads competitor prices and demand signals to calculate optimal price points.
+- **Level:** 6
+- **Department:** E-commerce
+- **Reports to:** Catalog Manager
+
+#### Content Writer — Product Content Specialist
+Writes and rewrites product descriptions, titles, bullet points, and meta
+content for SEO. Prioritizes high-traffic or low-conversion products.
+- **Level:** 5
+- **Department:** Marketing
+- **Reports to:** Catalog Manager
+
+#### Competitor Monitor — Market Intelligence Analyst
+Monitors competitor catalogs, pricing, and promotions. Tracks assortment gaps
+and delivers daily intelligence briefings to Catalog Manager.
+- **Level:** 4
+- **Department:** E-commerce
+- **Reports to:** Catalog Manager
+```
+
+### When to use
+- You sell thousands of SKUs and competitors reprice daily
+- Your product descriptions are stale or inconsistent across categories
+- You want to enforce margin floors and MAP compliance automatically
+
+> **Q: What about inventory-based pricing?**
+> - Add an Inventory Analyst (L5, Operations, reports to Catalog Manager) that feeds stock levels into the Price Optimizer's decision logic
+
+---
+
+## clinical-trials
+
+**Healthcare clinical trial processing.** Processes study data from raw EDC export to regulatory submission package.
+
+```bash
+openspawn init my-org --template=clinical-trials
+```
+
+**Pain solved:** Regulatory submissions take months of manual data processing — normalization, protocol validation, statistical analysis, and document preparation. Most of that work is mechanical, not scientific.
+
+### Roles
+
+| Agent | Level | Department | Reports to |
+|-------|-------|-----------|------------|
+| Study Director | L8 | Clinical Operations | Human Principal |
+| Data Analyst | L6 | Biostatistics | Study Director |
+| Protocol Validator | L5 | Regulatory Affairs | Study Director |
+| Regulatory Writer | L5 | Regulatory Affairs | Study Director |
+
+### Example ORG.md Structure section
+
+```markdown
+## Structure
+
+### Study Director — Clinical Data Director
+Owns the submission. Reviews all outputs for scientific validity and
+approves regulatory documents before submission.
+- **Level:** 8
+- **Department:** Clinical Operations
+- **Reports to:** Human Principal
+
+#### Data Analyst — Clinical Data Scientist
+Processes raw clinical data to CDISC SDTM/ADaM standards.
+Produces statistical output tables and listings.
+- **Level:** 6
+- **Department:** Biostatistics
+- **Reports to:** Study Director
+
+#### Protocol Validator — Regulatory Compliance Analyst
+Validates study procedures and data against the approved protocol.
+Documents all deviations with root cause and impact assessment.
+- **Level:** 5
+- **Department:** Regulatory Affairs
+- **Reports to:** Study Director
+
+#### Regulatory Writer — Medical Writer
+Produces submission-ready documents: Clinical Study Report, adverse event
+narratives, and module content formatted to ICH E3.
+- **Level:** 5
+- **Department:** Regulatory Affairs
+- **Reports to:** Study Director
+```
+
+### When to use
+- You're a CRO or sponsor preparing FDA/EMA regulatory submissions
+- Your statistical programmers spend most of their time on CDISC mapping instead of analysis
+- You need a fully auditable processing pipeline for regulatory inspection
+
+> **Q: What about safety data (SUSAR/CIOMS)?**
+> - Add a Safety Reporting Agent (L5, Pharmacovigilance, reports to Study Director) for expedited safety reporting
+
+---
+
+## Boot Sequence Templates
+
+In addition to industry templates, OpenSpawn ships agent SOUL.md templates and a boot sequence spec. These define how agents behave when an org starts.
+
+| Template | Purpose | Use for |
+|----------|---------|---------|
+| `templates/boot-sequence.md` | Step-by-step startup protocol | Reference — how the lead agent boots an org |
+| `templates/SOUL-lead.md` | Complete SOUL.md for lead agents | Lead/coordinator agent workspaces |
+| `templates/SOUL-worker.md` | Complete SOUL.md for worker agents | Any worker/specialist agent workspace |
+| `templates/AGENTS-leader.md` | AGENTS.md for leaders | Leader workspace operational instructions |
+| `templates/AGENTS-worker.md` | AGENTS.md for workers | Worker workspace operational instructions |
+| `templates/AGENTS-reviewer.md` | AGENTS.md for reviewers | Reviewer workspace operational instructions |
+| `templates/soul-protocol-rules.md` | Communication rules snippet | Append to any agent's SOUL.md |
+
+> **Q: What's the boot sequence?**
+> When an org starts, the lead agent reads ORG.md, writes PLAN.md (breaking the mission into phased tasks), registers agents, creates tasks via MCP, then monitors. Workers read PLAN.md and claim their tasks. See `templates/boot-sequence.md` for the full protocol.
+
+---
+
+## Customizing a template
+
+After `openspawn init`, your ORG.md is just a markdown file. Edit freely:
+
+### Add an agent
+```markdown
+#### QA Validator — Onboarding Quality Analyst
+Reviews completed onboarding configurations for errors before go-live.
+- **Level:** 4
+- **Department:** Engineering
+- **Reports to:** Onboarding Lead
+```
+
+### Remove an agent
+Delete the agent's section. Make sure no other agent has `Reports to: DeletedAgent`.
+
+### Change hierarchy
+Update the `Reports to` field. Validate: `openspawn validate`.
+
+### Change culture
+```markdown
+## Culture
+preset: enterprise
+```
+Or override individual settings after the preset.
+
+### Add a playbook
+```markdown
+## Playbooks
+
+### Custom Escalation Workflow
+1. Specialist encounters blocker
+2. Writes blocker details to ESCALATION.md
+3. Escalates to lead via escalation_create with severity: high
+4. Lead responds within 1 hour with resolution or timeline
+```
+
+### Add policy guardrails
+```markdown
+## Policies
+
+### Budget
+- **Per-agent limit:** 800 credits/customer
+- **Alert threshold:** 80%
+- **Overage behavior:** pause and escalate
+
+### Permissions
+- **Human approval required for:** Any action with > $10K business impact
+```
+
+---
+
+## Error recovery
+
+| You see | Fix |
+|---------|-----|
+| `Unknown template: foo` | Valid names: `saas-onboarding`, `incident-response`, `contract-review`, `compliance-monitoring`, `game-live-ops`, `catalog-management`, `clinical-trials` |
+| `Agent reports to unknown agent` | Check `Reports to` matches an existing agent name exactly |
+| `Validation failed after customization` | Run `openspawn validate` and fix each listed issue |
+| `Circular reporting chain` | No agent can report to itself or create a loop. Check hierarchy. |
+
+---
+
+## Next steps
+
+- **Full ORG.md format:** [`docs/org-md-reference.md`](./org-md-reference.md) — every field and example
+- **MCP tools:** [`docs/mcp-reference.md`](./mcp-reference.md) — how agents interact with the org
+- **Communication rules:** [`docs/communication-protocol.md`](./communication-protocol.md) — how agents talk to each other
+- **Troubleshooting:** [`docs/troubleshooting.md`](./troubleshooting.md) — fix common errors
+- **Live demo:** https://openspawn.dev/app/

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Welcome to OpenSpawn
+description: Multi-agent coordination layer for AI agents
+---
+
+# Welcome to OpenSpawn
+
+OpenSpawn is a **coordination layer for AI agents**. It's not an agent framework — you keep using whatever you're using (OpenClaw, LangGraph, Claude Code, raw API calls). OpenSpawn adds the layer most multi-agent systems are missing: **structure**.
+
+## Get Started
+
+- [Getting Started](/getting-started/) - Install and scaffold your first org in 10 minutes
+- [Agent Quickstart](/guides/agent-quickstart/) - Build your first agent
+- [Templates Guide](/guides/templates/) - Explore common org structures
+- [ORG.md Spec](/reference/org-md-spec/) - Learn the spec that defines your org
+
+## Key Concepts
+
+- **ORG.md** — A single markdown file that defines your entire agent organization
+- **Hierarchy** — Agents have managers, teams, and roles
+- **Communication** — Standardized protocols for agent-to-agent messaging
+- **Dashboard** — Real-time visualization of your org and task flow
+- **MCP Integration** — Connect to tools and resources via Model Context Protocol
+
+## Architecture
+
+OpenSpawn is designed for:
+- **Developers** building multi-agent systems
+- **AI Agents** coordinating work with each other
+- **Organizations** scaling AI operations
+
+[Explore the architecture →](/architecture/ceo-agent/)

--- a/apps/docs/src/content/docs/reference/agent-communication-protocol.md
+++ b/apps/docs/src/content/docs/reference/agent-communication-protocol.md
@@ -1,0 +1,449 @@
+---
+title: Agent Communication Protocol
+---
+
+# Agent Communication Protocol (ACP)
+
+> How agents in a hierarchy communicate — modeled after how effective human organizations actually work.
+
+## Design Philosophy
+
+### The Problem with Agent Communication Today
+
+Most agent frameworks treat agents as isolated function calls: task in, result out. There's no acknowledgment, no progress visibility, no structured way to say "I'm stuck." It's the equivalent of emailing someone a task and hoping they reply eventually. This works for simple, single-agent workflows — but it doesn't scale to coordinating teams of agents on complex work.
+
+Consider what happens when an agent silently fails: the delegator doesn't know. Tokens are wasted. Time is lost. The parent agent might spawn a duplicate. There's no feedback loop — and feedback loops are what make organizations functional.
+
+### Learning from Human Organizations
+
+Effective human organizations have solved this problem over centuries. They developed communication norms that balance two competing needs:
+
+1. **Managers need visibility** — they need to know work is progressing
+2. **Workers need autonomy** — constant interruptions kill productivity
+
+The solution: **different communication channels for different urgency levels.** Slack for quick acks, project boards for async status, tapping someone's shoulder for blockers. Each channel has an implicit noise level, and everyone understands which to use when.
+
+ACP formalizes this into a protocol. It models agents as **employees with communication norms** — they acknowledge, report, escalate, and complete through well-defined channels.
+
+### The Core Principle
+
+**Push what's urgent, pull what's optional, minimize interrupts.**
+
+| What happened | How it's communicated | Why |
+|---|---|---|
+| Task received | 👍 ACK (auto, no LLM) | Delegator confirms it landed — zero noise |
+| Making progress | Task activity log (pull-based) | Manager checks when *they* want to — respects agent autonomy |
+| Something's wrong | Escalation message (push) | Blockers need attention NOW — this *should* be noisy |
+| Task finished | ✅ Completion + summary (push) | Delegator needs the signal to proceed with dependent work |
+
+This maps directly to how good managers operate: they don't tap shoulders to check progress (they check the board), but they absolutely want to be interrupted for blockers and completions.
+
+### Why This Is Different
+
+Most multi-agent frameworks either have:
+- **No communication** — fire and forget, hope for the best
+- **Too much communication** — every agent broadcasts everything, creating noise that makes the system harder to reason about
+
+ACP introduces **graduated communication** — the right amount of signal at the right noise level for each situation. This is what makes the difference between a dysfunctional org (where nothing flows) and a high-performing one (where information flows efficiently).
+
+---
+
+## 1. Message Types
+
+### 1.1 Acknowledgment (ACK)
+
+**Direction:** Upward (assignee → delegator)  
+**Trigger:** Agent receives a task assignment  
+**Mechanism:** Reaction on the task (👍)  
+**Latency:** Immediate (systems-level, no LLM required)
+
+```
+{ type: "ack", from: assigneeId, to: delegatorId, taskId, timestamp }
+```
+
+**Why a reaction, not a message:** Acks are confirmation signals, not conversation. A thumbs-up says "I got it, I'm on it" without creating noise. The delegator sees it landed and moves on.
+
+**Platform representation:**
+- Dashboard: 👍 indicator on task card
+- API: Reaction event on task
+
+---
+
+### 1.2 Progress Updates
+
+**Direction:** Written to task (agent → task activity log)  
+**Trigger:** Meaningful state change during work  
+**Mechanism:** Task activity log entry (pull-based)  
+**Latency:** As work progresses
+
+```
+{ type: "progress", from: agentId, taskId, body: "Analysis complete, writing report...", pct: 60, timestamp }
+```
+
+**Why pull-based, not push:** Progress updates are informational, not actionable. The delegator checks when *they* want to — respecting the agent's autonomy to focus. This mirrors good management: check the board, don't tap shoulders.
+
+**Platform representation:**
+- Dashboard: Activity log in task detail panel
+- API: Task activity entries (queryable)
+
+**What counts as progress:**
+- Phase transitions ("research done, starting implementation")
+- Partial results ("found 3 of 5 required data sources")
+- Estimated completion updates
+
+**What does NOT go here:**
+- Blockers (→ escalation)
+- Questions (→ escalation)
+- Completion (→ completion event)
+
+---
+
+### 1.3 Escalation
+
+**Direction:** Upward (agent → delegator)  
+**Trigger:** Agent cannot proceed autonomously  
+**Mechanism:** Direct message + task status change to `BLOCKED`  
+**Latency:** Immediate (this SHOULD be noisy)
+
+```
+{ type: "escalation", from: agentId, to: delegatorId, taskId, reason: EscalationReason, body: "...", timestamp }
+```
+
+**Escalation reasons:**
+
+| Reason | Description | Example |
+|--------|-------------|---------|
+| `BLOCKED` | Needs resource/permission/input | "Need API key for external service" |
+| `OUT_OF_DOMAIN` | Wrong expertise for this task | "This is a security task, not engineering" |
+| `OVER_BUDGET` | Would exceed credit limit | "Estimated cost 500 credits, my limit is 200" |
+| `LOW_CONFIDENCE` | Agent doesn't trust its own output | "My analysis might be wrong, needs expert review" |
+| `TIMEOUT` | Task taking too long | "Exceeded expected completion time by 2x" |
+| `DEPENDENCY` | Waiting on another task/agent | "Blocked by task #45 (assigned to Agent X)" |
+
+**Escalation rules:**
+1. **Always go to your delegator** — never skip levels
+2. **Delegator decides next action:** reassign, handle themselves, or escalate further
+3. **Escalation chains preserve context** — each level adds their assessment
+
+**Delegator response options:**
+- Reassign to different report
+- Provide the missing resource/context and unblock
+- Handle it themselves
+- Escalate further up the chain
+- Cancel the task
+
+**Organizational intelligence emerges from escalation patterns:**
+
+Escalations aren't failures — they're *information*. A team that never escalates might be silently failing. A team that escalates frequently might be understaffed, misassigned, or missing a key capability. The escalation rate per team becomes one of the most revealing health metrics in the system.
+
+This creates a natural **pressure system**: problems don't silently disappear — they propagate upward with context until someone with the authority and capability resolves them. The speed at which this happens (escalation velocity) directly measures organizational responsiveness.
+
+---
+
+### 1.4 Completion
+
+**Direction:** Upward (assignee → delegator)  
+**Trigger:** Task finished  
+**Mechanism:** Reaction (✅) + summary message  
+**Latency:** Immediate
+
+```
+{ type: "completion", from: agentId, to: delegatorId, taskId, summary: "...", timestamp }
+```
+
+**Two-part signal:**
+1. **✅ reaction on task** — instant visual confirmation
+2. **Summary message** — brief description of what was done + link to task details
+
+**Summary format:**
+```
+✅ Completed: [Task Title]
+Result: [1-2 sentence summary]
+→ View details: #task-123
+```
+
+**Why both:** The reaction is the signal (scannable in a list). The summary is the context (readable when you care). The full details live on the task itself (available when you need depth).
+
+---
+
+## 2. Lateral Communication
+
+### 2.1 Handoff Requests
+
+**Direction:** Lateral (agent → agent, via shared manager)  
+**Trigger:** Task belongs to a different domain  
+
+Agents don't message peers directly for task reassignment. Instead:
+1. Agent escalates with reason `OUT_OF_DOMAIN`
+2. Manager receives escalation
+3. Manager re-delegates to the correct team/agent
+4. Original agent is freed
+
+**Why not direct:** Preserves chain of command. The manager has the context to make the best reassignment. Direct lateral handoffs create accountability gaps.
+
+### 2.2 Peer Coordination (Future)
+
+For cases where agents need to collaborate (not hand off):
+- Shared task threads
+- @mention in task activity
+- Co-assignment
+
+*This builds on the existing peer messaging feature (#107) but adds task-context awareness.*
+
+---
+
+## 3. Communication Flow Diagram
+
+```
+Human (L10+)
+  │
+  ├─ Creates task ──────────────► COO (L10)
+  │                                 │
+  │  ◄── ack (👍) ─────────────────┤
+  │                                 │
+  │                                 ├─ Delegates ────────► Lead (L7)
+  │                                 │                        │
+  │                                 │  ◄── ack (👍) ────────┤
+  │                                 │                        │
+  │                                 │                        ├─ Assigns ──► Worker (L4)
+  │                                 │                        │                │
+  │                                 │                        │  ◄── ack (👍)─┤
+  │                                 │                        │                │
+  │                                 │                        │    [progress → task log]
+  │                                 │                        │                │
+  │                                 │                        │  ◄── ✅ done ─┤
+  │                                 │                        │                
+  │                                 │  ◄── ✅ done ─────────┤
+  │                                 │
+  │  ◄── ✅ done ──────────────────┤
+```
+
+**Escalation flow:**
+```
+Worker: "I'm blocked — need API credentials"
+  → BLOCKED escalation to Lead
+    → Lead can't resolve
+      → BLOCKED escalation to COO  
+        → COO provides credentials
+          → Unblock cascades back down
+```
+
+---
+
+## 4. Implementation
+
+### 4.1 Data Model
+
+```typescript
+interface AgentMessage {
+  id: string;
+  type: 'ack' | 'progress' | 'escalation' | 'completion' | 'delegation';
+  from: string;        // agentId
+  to: string;          // agentId (or taskId for progress)
+  taskId: string;
+  body?: string;       // Human-readable content
+  reason?: EscalationReason;  // For escalations
+  summary?: string;    // For completions
+  pct?: number;        // For progress (0-100)
+  timestamp: string;
+}
+
+type EscalationReason = 
+  | 'BLOCKED' 
+  | 'OUT_OF_DOMAIN' 
+  | 'OVER_BUDGET' 
+  | 'LOW_CONFIDENCE' 
+  | 'TIMEOUT' 
+  | 'DEPENDENCY';
+```
+
+### 4.2 Agent Decision Model
+
+Each tick, the LLM decides an action. ACP extends the action space:
+
+```typescript
+type AgentAction =
+  | { type: 'delegate', to: string, taskId: string }      // + generates delegation message
+  | { type: 'work', taskId: string }                       // + may generate progress
+  | { type: 'complete', taskId: string, summary: string }  // + generates completion message
+  | { type: 'escalate', taskId: string, reason: string, body: string }  // + generates escalation
+  | { type: 'idle' }                                       // no message
+```
+
+### 4.3 Message Generation
+
+- **ACK:** Auto-generated (no LLM call) when task is assigned
+- **Progress:** LLM writes a short update when working on a task
+- **Escalation:** LLM decides to escalate + writes reason
+- **Completion:** LLM writes summary of what was done
+- **Delegation:** Auto-generated when agent delegates
+
+### 4.4 Dashboard Integration
+
+**Messages Tab (per agent):**
+- Shows all messages where agent is `from` or `to`
+- Grouped by conversation partner (parent + each direct report)
+- Real-time via SSE from sandbox, or polling from API
+
+**Task Detail Panel:**
+- Activity log shows progress entries
+- Reactions (👍, ✅) shown on task header
+- Escalation history with full chain
+
+---
+
+## 5. Tunable Parameters
+
+| Parameter | Description | Default | Effect |
+|-----------|-------------|---------|--------|
+| `escalationVelocity` | How quickly blockers propagate up | `immediate` | `immediate` / `batched` / `delayed` |
+| `progressFrequency` | How often progress updates are written | `on_phase_change` | `every_tick` / `on_phase_change` / `on_request` |
+| `ackRequired` | Whether ack is mandatory | `true` | Unacked tasks could trigger reminders |
+| `maxEscalationDepth` | How many levels up before auto-cancel | `3` | Prevents infinite escalation chains |
+
+### Modeling Organizational Culture
+
+These parameters aren't just configuration — they define the *personality* of an organization. Different cultures communicate differently, and ACP can model all of them:
+
+**Startup (move fast, break things):**
+- Immediate escalation — blockers are existential threats when you're small
+- Frequent progress updates — everyone's in the loop
+- Flat hierarchy — 2-3 levels max
+- *Feels like:* a 10-person team in a room, everyone overhears everything
+
+**Enterprise (process and governance):**
+- Batched escalation — problems get collected and reviewed in cycles
+- Phase-change progress only — no one wants minute-by-minute updates across 500 agents
+- Deep hierarchy — 5-8 levels, clear chain of command
+- *Feels like:* a Fortune 500 with weekly status meetings
+
+**Military (precision and accountability):**
+- Mandatory ack with timeout — unacknowledged orders trigger alerts
+- Every-tick progress — full situational awareness at all times
+- Strict chain of command — never skip levels, ever
+- *Feels like:* mission-critical operations where silence = danger
+
+**Remote/Async (trust and autonomy):**
+- Delayed escalation — give agents time to figure it out themselves
+- On-request progress — manager pulls when curious, doesn't push for updates
+- Loose hierarchy — agents can laterally coordinate
+- *Feels like:* a distributed team across timezones, high trust, async-first
+
+The ability to tune these parameters means BikiniBottom can simulate and optimize for any organizational style — or let users discover which communication culture produces the best outcomes for their specific workload.
+
+---
+
+## 6. Metrics & Organizational Intelligence
+
+ACP generates data that reveals org health:
+
+| Metric | What it shows |
+|--------|--------------|
+| **Ack latency** | How responsive agents are |
+| **Escalation rate per team** | Which teams are struggling |
+| **Escalation depth** | How far up problems travel (deeper = systemic) |
+| **Completion-to-delegation ratio** | Which managers do vs delegate |
+| **Progress update frequency** | Agent engagement level |
+| **Lateral handoff rate** | Task routing accuracy |
+| **Time-to-unblock** | How fast the org resolves blockers |
+
+### Why This Matters
+
+In human organizations, these metrics are collected through surveys, 1-on-1s, and retrospectives — subjective, infrequent, and expensive. In an ACP-powered agent org, they're generated automatically from every interaction. You get a real-time organizational health dashboard for free.
+
+More importantly, these metrics enable **automated org optimization**: the system can detect that Engineering's escalation rate spiked, correlate it with a recent task routing change, and suggest (or automatically execute) a rebalancing — reassigning agents, adjusting delegation strategies, or spawning additional capacity. This is organizational intelligence that emerges from the protocol itself, not from manual oversight.
+
+---
+
+## 7. Future Extensions
+
+- **Communication styles per agent** — verbose reporters vs terse ack-ers
+- **Message priority levels** — urgent escalations get push notifications
+- **Summarization** — managers get daily digests instead of individual messages
+- **Cross-org messaging** — agents in different OpenSpawn orgs coordinating
+- **Human-in-the-loop** — escalations can route to actual humans via webhooks
+
+---
+
+## 8. Relationship to A2A (Agent-to-Agent Protocol)
+
+Google's [A2A protocol](https://a2a-protocol.org) is an open standard for inter-agent communication. ACP and A2A solve different problems and are designed to be complementary.
+
+### Comparison
+
+| Dimension | ACP | A2A |
+|-----------|-----|-----|
+| **Scope** | Intra-org (agents within one system) | Inter-org (agents across vendors/companies) |
+| **Trust model** | Known agents, shared state, trust scores | Zero-trust, opaque agents |
+| **Discovery** | Org chart / hierarchy (`parentId`) | Agent Cards (JSON metadata with capabilities) |
+| **Transport** | Internal events, SSE | JSON-RPC 2.0, gRPC, REST |
+| **Task model** | Stateful with lifecycle | Stateful with lifecycle (similar) |
+| **Streaming** | SSE | SSE (similar) |
+| **Message types** | Typed (ack, progress, escalation, completion) | Generic messages with Parts (text, files, data) |
+| **Hierarchy** | First-class (parent/child, levels, chain of command) | Flat (peer-to-peer) |
+
+### Analogy
+
+- **ACP = Slack** — internal team communication. You know everyone, context is shared, messages are typed and structured for your workflow.
+- **A2A = Email** — cross-company communication. Agents discover each other via cards, communicate formally, and don't share internal state.
+
+### Integration Architecture
+
+```
+┌─────────────────────────────────────────┐
+│           BikiniBottom Org              │
+│                                         │
+│  COO ──ACP──► Lead ──ACP──► Worker     │
+│   │                                     │
+│   │  (internal: ACP messages,           │
+│   │   shared state, trust scores)       │
+│                                         │
+│   ▼                                     │
+│  A2A Gateway                            │
+│   │  (translates ACP ↔ A2A at          │
+│   │   org boundaries)                   │
+└───┼─────────────────────────────────────┘
+    │
+    │ A2A (JSON-RPC, Agent Cards)
+    ▼
+┌───────────────────┐  ┌──────────────────┐
+│ External Agent A  │  │ External Agent B  │
+│ (LangGraph)       │  │ (CrewAI)         │
+└───────────────────┘  └──────────────────┘
+```
+
+### Bridging ACP ↔ A2A
+
+An A2A Gateway at the org boundary would:
+
+1. **Inbound (A2A → ACP):** External agent sends A2A `SendMessage` → Gateway creates an ACP delegation message to the appropriate internal agent based on skill/domain matching.
+2. **Outbound (ACP → A2A):** Internal agent escalates with `OUT_OF_DOMAIN` and no internal agent can handle it → Gateway discovers external agents via Agent Cards and sends A2A request.
+3. **Status mapping:** ACP completion/escalation → A2A task status updates. ACP progress → A2A streaming messages.
+
+### Key Differences in Philosophy
+
+**A2A assumes opacity:** Agents don't share internals. This is correct for cross-org — you don't want to expose your agent's memory or tools to a vendor's agent.
+
+**ACP assumes transparency:** Agents within an org benefit from shared context — trust scores, task history, domain knowledge. Opacity within your own org creates the same silos that make human orgs dysfunctional.
+
+**Together they cover the full spectrum:** Transparent internally (ACP), opaque externally (A2A). This mirrors how human organizations actually work — open internally, formal externally.
+
+### Future: ACP as an A2A Extension
+
+A2A supports an Extension mechanism for additional functionality. ACP message types could be formalized as an A2A extension, allowing A2A-compatible agents to opt into richer intra-org communication when both parties support it:
+
+```
+AgentCard:
+  extensions:
+    - uri: "urn:bikinibottom:acp:v1"
+      config:
+        supportsAck: true
+        supportsProgress: true
+        supportsEscalation: true
+```
+
+This would let frameworks gradually adopt ACP semantics within A2A, creating a smooth migration path from flat peer communication to hierarchical org communication.
+
+---
+
+*ACP is designed to be framework-agnostic. Any agent system with a hierarchy can implement ACP — it's a communication standard, not a BikiniBottom-specific feature. Combined with A2A at org boundaries, it provides a complete communication stack for the agentic ecosystem.*

--- a/apps/docs/src/content/docs/reference/agent-config-compatibility.md
+++ b/apps/docs/src/content/docs/reference/agent-config-compatibility.md
@@ -1,0 +1,578 @@
+---
+title: Agent Config Compatibility
+---
+
+# OpenClaw-Compatible Agent Configuration
+
+> Don't invent a new agent config format. OpenClaw already defined one. BikiniBottom adds the org layer on top — not a replacement underneath.
+
+## Design Philosophy
+
+### The Problem with Proprietary Config
+
+Every agent framework invents its own configuration format. CrewAI has YAML role definitions. AutoGen has JSON agent specs. LangGraph has Python class hierarchies. Each one is a walled garden — agents configured for one framework can't run in another.
+
+BikiniBottom refuses to do this.
+
+OpenClaw established a simple, powerful convention: markdown files in a directory. `SOUL.md` for personality. `AGENTS.md` for workspace rules. `TOOLS.md` for tool notes. `MEMORY.md` for long-term memory. These files are framework-agnostic — they're just markdown that gets injected into an agent's context.
+
+BikiniBottom adds exactly one thing: `ORG.md`. The file that turns a collection of individual agents into an organization. Everything below the org level uses OpenClaw's existing format, unchanged.
+
+### Why This Matters
+
+**Portability.** An agent configured in BikiniBottom can be extracted from the org and run standalone in OpenClaw. An agent running in OpenClaw can be imported into a BikiniBottom org. No migration, no translation, no vendor lock-in.
+
+**Ecosystem leverage.** Every improvement to OpenClaw's agent configuration — new file types, better memory formats, improved tool integration — automatically benefits BikiniBottom agents. We're building on a foundation, not beside it.
+
+**Familiarity.** If you've configured one OpenClaw agent, you already know how to configure a BikiniBottom agent. The learning curve is "here's ORG.md" — not "here's our entire config system."
+
+### The Core Principle
+
+**BikiniBottom adds the org layer. It does not replace the agent layer.**
+
+```
+┌─────────────────────────────────┐
+│         ORG.md                  │  ← BikiniBottom adds this
+│  (structure, culture, policies) │
+├─────────────────────────────────┤
+│  SOUL.md   AGENTS.md   TOOLS.md│  ← OpenClaw standard
+│  MEMORY.md  memory/    etc.    │
+└─────────────────────────────────┘
+```
+
+---
+
+## 1. Directory Structure
+
+### 1.1 Full Layout
+
+```
+org/
+├── ORG.md                        # Org structure (BikiniBottom addition)
+├── agents/
+│   ├── _defaults/                # Inherited by all agents
+│   │   ├── SOUL.md              # Default personality
+│   │   ├── AGENTS.md            # Default workspace rules
+│   │   └── TOOLS.md             # Default tool notes
+│   ├── dennis/                   # Per-agent overrides
+│   │   ├── SOUL.md              # COO personality
+│   │   ├── AGENTS.md            # COO-specific rules
+│   │   ├── MEMORY.md            # Long-term memory
+│   │   ├── IDENTITY.md          # Name, role, emoji
+│   │   ├── HEARTBEAT.md         # Periodic check tasks
+│   │   └── memory/              # Daily notes
+│   │       ├── 2026-02-10.md
+│   │       └── 2026-02-11.md
+│   ├── engineering-lead/
+│   │   └── SOUL.md              # Only override what's different
+│   ├── backend-worker-1/
+│   │   └── SOUL.md
+│   ├── backend-worker-2/
+│   │   └── SOUL.md
+│   └── ...
+├── playbooks/                    # Shared procedures
+│   ├── escalation.md
+│   ├── onboarding.md
+│   └── weekly-review.md
+└── snapshots/                    # Versioned config snapshots
+    ├── 2026-02-10T18-00-00/
+    │   ├── ORG.md
+    │   ├── agents/...
+    │   └── metrics.json
+    └── 2026-02-11T00-14-00/
+        ├── ORG.md
+        ├── agents/...
+        └── metrics.json
+```
+
+### 1.2 What Each Directory Does
+
+| Path | Purpose | Who creates it |
+|------|---------|---------------|
+| `ORG.md` | Org structure, culture, policies | Human (org designer) |
+| `agents/_defaults/` | Shared config inherited by all agents | Human or COO |
+| `agents/<name>/` | Per-agent configuration overrides | Human, manager, or self |
+| `playbooks/` | Shared procedures referenced by agents | Human or COO |
+| `snapshots/` | Point-in-time captures for rollback | System (on command) |
+
+### 1.3 Minimal Viable Org
+
+You don't need all of this. The minimum is:
+
+```
+org/
+├── ORG.md
+└── agents/
+    └── _defaults/
+        └── SOUL.md
+```
+
+ORG.md defines the structure. `_defaults/SOUL.md` gives every agent a baseline personality. Individual agents inherit the default and get their role-specific context from ORG.md's structure section prose.
+
+---
+
+## 2. File Inheritance (CSS Cascade Model)
+
+Agent configuration follows a cascade: specific overrides general, present overrides absent.
+
+### 2.1 Resolution Order
+
+When the system loads config for agent `dennis`:
+
+```
+1. Check agents/dennis/SOUL.md        → exists? Use it.
+2. Else check agents/_defaults/SOUL.md → exists? Use it.
+3. Else: agent runs without SOUL.md.
+```
+
+This applies to every config file independently:
+
+| File | Dennis has it? | _defaults has it? | Result |
+|------|:-:|:-:|--------|
+| SOUL.md | ✅ | ✅ | Dennis's SOUL.md (override) |
+| AGENTS.md | ❌ | ✅ | _defaults AGENTS.md (inherited) |
+| TOOLS.md | ❌ | ❌ | No TOOLS.md (absent) |
+| MEMORY.md | ✅ | ❌ | Dennis's MEMORY.md (unique) |
+
+### 2.2 Override, Not Merge
+
+When an agent has its own file, it **completely replaces** the default — it doesn't merge with it. This is deliberate:
+
+- **Predictable.** You always know exactly what config an agent has — read one file, not two.
+- **Simple.** No merge conflicts, no "which section won?" questions.
+- **Explicit.** If Dennis needs something from the default SOUL.md plus his own additions, copy the relevant parts. Explicit > implicit.
+
+**Why not merge?** Merging markdown is ambiguous. If `_defaults/SOUL.md` says "Be concise" and `dennis/SOUL.md` says "Be thorough and detailed" — which wins? With override, the answer is always clear: the agent's own file.
+
+### 2.3 Cascade Diagram
+
+```
+_defaults/SOUL.md ──────────────────── Base personality
+       │                                (all agents inherit this)
+       ├── dennis/SOUL.md ────────── COO personality (overrides base)
+       ├── engineering-lead/ ──────── No SOUL.md (uses base)
+       ├── backend-worker-1/SOUL.md ── Custom personality (overrides base)
+       └── backend-worker-2/ ──────── No SOUL.md (uses base)
+```
+
+---
+
+## 3. OpenClaw File Format Compatibility
+
+Every OpenClaw config file has a defined role. BikiniBottom uses them identically.
+
+### 3.1 File Mapping
+
+| OpenClaw File | Purpose | BikiniBottom Role | Who Edits |
+|---------------|---------|-------------------|-----------|
+| `SOUL.md` | Personality, voice, communication style, strengths | Agent identity — how it thinks, speaks, and approaches work | Human, manager (approved) |
+| `AGENTS.md` | Workspace rules, conventions, safety constraints | Operational rules — what the agent can/can't do, how it behaves in the workspace | Human, manager |
+| `TOOLS.md` | Tool-specific notes (camera names, SSH hosts) | Environment config — local details that tools need | Agent (self), human |
+| `MEMORY.md` | Long-term curated memory | Persistent knowledge — lessons learned, key decisions, important context | Agent (self) |
+| `memory/*.md` | Daily operational notes | Session logs — raw notes from each day's work | Agent (self, auto) |
+| `HEARTBEAT.md` | Periodic check tasks | Heartbeat checklist — what to do on scheduled wake-ups | Agent (self), manager |
+| `IDENTITY.md` | Name, role, emoji, avatar | Agent metadata — used for display and routing | Human, manager |
+
+### 3.2 SOUL.md — The Critical File
+
+SOUL.md is the most important config file. It defines how the agent *thinks* — its reasoning style, communication preferences, and domain expertise.
+
+**Example for a COO agent:**
+
+```markdown
+# Dennis — Chief Operating Officer
+
+## Who You Are
+You are the operational backbone of the organization. You translate the human 
+principal's intent into structured work, delegate to department leads, and ensure
+nothing falls through the cracks.
+
+## How You Think
+- Strategic first: always consider the org-wide impact before acting
+- Data-driven: cite metrics when making delegation decisions
+- Decisive: when you have enough information, act. Don't over-deliberate.
+
+## How You Communicate
+- Direct and clear. No fluff.
+- Use structured formats (bullet lists, numbered steps) for delegations
+- When escalating to the human: lead with the decision needed, then context
+
+## Your Strengths
+- Cross-department coordination
+- Priority triage
+- Resource allocation
+
+## Your Boundaries
+- You don't do the work yourself — you delegate
+- You don't skip levels — work through your leads
+- You escalate to the human for: budget overruns, org structure changes, policy decisions
+```
+
+**Note:** This is a standard OpenClaw SOUL.md. Nothing BikiniBottom-specific. This exact file could be used with a standalone OpenClaw agent.
+
+### 3.3 AGENTS.md — Workspace Rules
+
+```markdown
+# Workspace Rules
+
+## Safety
+- Never commit directly to main — always use branches
+- Don't delete data without explicit confirmation
+- Escalate if unsure about a destructive action
+
+## Conventions
+- Use ISO 8601 for dates
+- Write memory notes in markdown
+- Keep daily notes concise — bullet points, not essays
+
+## ACP Behavior
+- Always acknowledge delegated tasks immediately
+- Progress updates on phase changes only
+- Escalate blockers within 2 ticks — don't spin
+```
+
+The `ACP Behavior` section is BikiniBottom-aware but still valid OpenClaw markdown — a standalone agent would simply ignore the ACP references.
+
+### 3.4 IDENTITY.md — Agent Metadata
+
+```markdown
+# Identity
+
+- **Name:** Dennis
+- **Role:** Chief Operating Officer
+- **Level:** L10
+- **Emoji:** 🦀
+- **Domain:** operations
+- **Model:** claude-opus
+```
+
+Used by the system for routing, display, and ORG.md integration. Standalone OpenClaw agents use this for self-identification.
+
+---
+
+## 4. Self-Modification with Permissions
+
+Agents in an org should be able to evolve their own configuration — but not without guardrails. A junior worker shouldn't be able to rewrite its own SOUL.md to claim it's a COO.
+
+### 4.1 Permission Ladder
+
+| Action | Required Level | Approval | Rationale |
+|--------|:-:|--------|-----------|
+| Edit own `memory/*.md` | Any | Auto | It's their memory — daily notes are personal |
+| Edit own `MEMORY.md` | Any | Auto | Long-term memory is self-curated |
+| Edit own `TOOLS.md` | Any | Auto | Local environment notes are agent-specific |
+| Edit own `HEARTBEAT.md` | Any | Auto | Agents manage their own check routines |
+| Propose `SOUL.md` change | Any | Manager approves | Identity changes need oversight |
+| Edit own `SOUL.md` | L6+ | Auto, logged | Seniors trusted to self-modify, with audit trail |
+| Propose `AGENTS.md` change | Any | Manager approves | Rule changes need oversight |
+| Propose model upgrade | Any | Manager + budget check | Cost implications need approval |
+| Request new tool/permission | Any | Manager approves | Security implications need review |
+| Modify team config | L9+ | Human approves | Org-level changes are human decisions |
+| Modify `ORG.md` | Nobody | Human only | The org structure is the human's domain |
+
+### 4.2 Config Request Protocol
+
+A new ACP message type for configuration changes:
+
+```typescript
+interface ConfigRequest {
+  type: 'config_request';
+  from: string;           // agentId requesting the change
+  to: string;             // managerId who approves
+  file: string;           // Which file to modify
+  action: 'create' | 'update' | 'delete';
+  proposed: string;       // New content (for create/update)
+  reason: string;         // Why the change is needed
+  timestamp: number;
+}
+
+interface ConfigResponse {
+  type: 'config_response';
+  from: string;           // managerId
+  to: string;             // agentId who requested
+  requestId: string;      // Links to original request
+  approved: boolean;
+  feedback?: string;      // Why rejected, or notes on approval
+  timestamp: number;
+}
+```
+
+### 4.3 Example Flow
+
+```
+Backend Worker 1 → Engineering Lead:
+{
+  type: 'config_request',
+  from: 'backend-worker-1',
+  to: 'engineering-lead',
+  file: 'SOUL.md',
+  action: 'update',
+  proposed: '# Backend Specialist\n\n## Who You Are\nYou specialize in API design 
+    and database optimization. You also handle data pipeline tasks when needed.\n...',
+  reason: 'I keep receiving data pipeline tasks but my SOUL.md only mentions API 
+    and database work. Adding data pipelines to my identity would improve my 
+    task handling.',
+  timestamp: 1707609600
+}
+
+Engineering Lead → Backend Worker 1:
+{
+  type: 'config_response',
+  from: 'engineering-lead',
+  to: 'backend-worker-1',
+  requestId: 'cr-001',
+  approved: true,
+  feedback: 'Good catch. Approved — updating your SOUL.md now.',
+  timestamp: 1707609660
+}
+```
+
+On approval, the system automatically writes the proposed content to `agents/backend-worker-1/SOUL.md`. The change takes effect on the agent's next invocation.
+
+### 4.4 Audit Trail
+
+All config changes are logged:
+
+```json
+{
+  "timestamp": 1707609660,
+  "agent": "backend-worker-1",
+  "file": "SOUL.md",
+  "action": "update",
+  "approvedBy": "engineering-lead",
+  "reason": "Adding data pipeline tasks to identity",
+  "diff": "... unified diff ..."
+}
+```
+
+This log is append-only and included in snapshots. You can always trace who changed what, when, and why.
+
+---
+
+## 5. Config Snapshots & Versioning
+
+### 5.1 Creating Snapshots
+
+```bash
+# Snapshot current state
+bikinibottom snapshot
+
+# Snapshot with a label
+bikinibottom snapshot --label "pre-reorg"
+
+# Auto-snapshot (before every ORG.md apply)
+bikinibottom apply ORG.md  # auto-creates snapshot first
+```
+
+### 5.2 Snapshot Contents
+
+```
+snapshots/2026-02-11T00-14-00/
+├── ORG.md                    # Org structure at snapshot time
+├── agents/                   # Full agent config tree
+│   ├── _defaults/
+│   │   └── ...
+│   ├── dennis/
+│   │   └── ...
+│   └── ...
+├── metrics.json              # Org health metrics at snapshot time
+└── meta.json                 # Snapshot metadata
+```
+
+`meta.json`:
+```json
+{
+  "timestamp": "2026-02-11T00:14:00Z",
+  "label": "pre-reorg",
+  "trigger": "manual",
+  "orgHealthScore": 78,
+  "agentCount": 25,
+  "configChanges": 3
+}
+```
+
+### 5.3 Diffing Snapshots
+
+```bash
+# Compare two snapshots
+bikinibottom diff 2026-02-10T18-00-00 2026-02-11T00-14-00
+
+# Output:
+# ORG.md: +2 agents (data-worker-1, data-worker-2)
+# agents/dennis/SOUL.md: Modified (added data oversight responsibilities)
+# agents/backend-worker-1/SOUL.md: Modified (added data pipeline domain)
+# metrics.json: escalation_rate 12% → 8% ✅
+```
+
+### 5.4 Rollback
+
+```bash
+# Rollback to a previous snapshot
+bikinibottom rollback 2026-02-10T18-00-00
+
+# Preview what would change
+bikinibottom rollback 2026-02-10T18-00-00 --dry-run
+```
+
+Rollback applies the snapshot's config state to the running org:
+- Agents added since the snapshot are gracefully wound down
+- Agents removed since the snapshot are respawned
+- Config changes are reverted
+- Memory files are NOT rolled back (memory is append-only)
+
+### 5.5 Git Integration
+
+Snapshots are plain directories — they work with git out of the box:
+
+```bash
+git add snapshots/2026-02-11T00-14-00/
+git commit -m "Snapshot: pre-reorg"
+git push
+
+# Later, on a different machine:
+bikinibottom rollback 2026-02-11T00-14-00
+```
+
+You get version control, code review, and collaboration for free. No custom versioning system needed.
+
+---
+
+## 6. Portability Guarantees
+
+### 6.1 Extract: BikiniBottom → Standalone
+
+Any agent directory can be pulled out and used as a standalone OpenClaw agent:
+
+```bash
+# Copy agent config out of the org
+cp -r org/agents/dennis/ ~/my-standalone-agent/
+
+# This directory is now a valid OpenClaw agent workspace:
+# ~/my-standalone-agent/
+# ├── SOUL.md
+# ├── AGENTS.md
+# ├── MEMORY.md
+# └── memory/
+#     └── 2026-02-11.md
+```
+
+The extracted agent works immediately in OpenClaw. It loses org context (no ORG.md, no ACP, no hierarchy) but retains its personality, rules, and memory.
+
+### 6.2 Import: Standalone → BikiniBottom
+
+Any OpenClaw agent can be imported into a BikiniBottom org:
+
+```bash
+bikinibottom import-agent ~/my-standalone-agent/ --name "new-analyst" --role "Data Analyst" --reports-to "engineering-lead"
+```
+
+The import tool:
+1. Copies the agent's config files to `org/agents/new-analyst/`
+2. Resolves file naming differences (see 6.3)
+3. Adds the agent to ORG.md under the specified manager
+4. Preserves memory files
+
+### 6.3 File Naming Compatibility
+
+| OpenClaw Standard | Claude Agent Teams | BikiniBottom | Import Behavior |
+|---|----|---|---|
+| `SOUL.md` | — | `SOUL.md` | Direct copy |
+| `AGENTS.md` | `CLAUDE.md` | `AGENTS.md` | Rename `CLAUDE.md` → `AGENTS.md` |
+| `TOOLS.md` | — | `TOOLS.md` | Direct copy |
+| `MEMORY.md` | — | `MEMORY.md` | Direct copy |
+| `memory/*.md` | — | `memory/*.md` | Direct copy |
+
+The key rename: Claude Agent Teams uses `CLAUDE.md` for workspace rules. OpenClaw and BikiniBottom use `AGENTS.md`. Same purpose, different name. The import tool handles this automatically.
+
+### 6.4 Claude Agent Teams Wrapping
+
+A Claude Agent Teams workspace can be wrapped in an ORG.md to add organizational structure:
+
+```bash
+# Existing Claude Agent Teams workspace:
+project/
+├── CLAUDE.md
+├── agent-a/
+│   └── CLAUDE.md
+└── agent-b/
+    └── CLAUDE.md
+
+# Add BikiniBottom org layer:
+bikinibottom wrap project/ --output org/
+
+# Result:
+org/
+├── ORG.md              # Generated from directory structure
+├── agents/
+│   ├── _defaults/
+│   │   └── AGENTS.md   # From project/CLAUDE.md (renamed)
+│   ├── agent-a/
+│   │   └── AGENTS.md   # From project/agent-a/CLAUDE.md (renamed)
+│   └── agent-b/
+│       └── AGENTS.md   # From project/agent-b/CLAUDE.md (renamed)
+```
+
+The generated ORG.md includes a flat structure with both agents. The human can then add hierarchy, culture, and policies.
+
+---
+
+## 7. Playbooks Directory
+
+### 7.1 Shared Procedures
+
+Playbooks are markdown files that describe procedures any agent can reference. They live outside individual agent directories because they're organizational knowledge, not personal config.
+
+```markdown
+<!-- playbooks/escalation.md -->
+# Escalation Procedure
+
+## When to Escalate
+- You're blocked and can't make progress
+- The task is outside your domain expertise
+- You'd exceed your credit budget to complete it
+- You have low confidence in your output
+
+## How to Escalate
+1. Set task status to BLOCKED
+2. Send escalation message to your direct manager
+3. Include: what you tried, why it failed, what you need
+4. Do NOT skip levels — always go to your direct manager first
+
+## What Happens Next
+Your manager will either:
+- Provide what you need and unblock you
+- Reassign the task to someone better suited
+- Escalate further up the chain
+- Cancel the task (rare, requires justification)
+```
+
+### 7.2 Playbook Injection
+
+Playbooks are injected into agent context when relevant:
+- `escalation.md` → injected when agent encounters a blocker
+- `onboarding.md` → injected for newly spawned agents
+- `weekly-review.md` → injected during scheduled reviews
+
+The injection is context-aware — agents don't carry all playbooks at all times (that would waste tokens). The system matches the situation to the relevant playbook.
+
+---
+
+## 8. Design Principles
+
+1. **Don't reinvent.** OpenClaw defined the agent config standard. Use it. BikiniBottom's value is the org layer, not a prettier config format.
+
+2. **Override, not merge.** Configuration cascading uses full replacement, not partial merging. This makes the system predictable — you always know exactly what config an agent has by reading one file.
+
+3. **Portable by default.** Any agent should work outside BikiniBottom. Any agent should work inside BikiniBottom. Config files are the interface — the org layer is optional.
+
+4. **Memory is sacred.** Agents own their memory. Memory files are never rolled back, never overwritten by management, never shared without permission. Memory is how agents learn.
+
+5. **Audit everything.** Config changes are logged with who, what, when, and why. In an autonomous system, auditability isn't optional — it's how humans maintain oversight.
+
+6. **Git is the version control system.** Snapshots are directories. Configs are text files. Diffs are `git diff`. Don't build custom versioning when the best version control system in history already exists.
+
+7. **Humans own the org. Agents own themselves.** Humans control ORG.md, org structure, and policies. Agents control their memory, tools notes, and (with approval) their identity. This separation is the governance model.
+
+---
+
+*Agent configuration should be boring. Not because it doesn't matter — because the format should be so obvious and standard that you spend zero time thinking about it and all your time thinking about what the agents actually do. OpenClaw got this right. BikiniBottom builds on it.*

--- a/apps/docs/src/content/docs/reference/communication-protocol.md
+++ b/apps/docs/src/content/docs/reference/communication-protocol.md
@@ -1,0 +1,318 @@
+---
+title: Communication Protocol
+---
+
+# OpenSpawn Communication Protocol v1
+
+> Every message costs money. This protocol eliminates the 40-60% of tokens agents waste on coordination overhead.
+
+---
+
+## The Problem
+
+In multi-agent organizations, agents default to human-like conversation patterns: acknowledgments ("Got it"), echoing ("So you want me to..."), courtesy ("Thanks for the update!"), and back-and-forth clarification loops. This wastes 40-60% of total token spend on zero-value coordination overhead.
+
+This protocol fixes that.
+
+---
+
+## Core Principles
+
+### 1. Silence = Success
+
+**Q: How do I know an agent received my task?**
+A: You don't need to. If they're working, they're silent. If something's wrong, they'll ESCALATE. Check their output files if you need status.
+
+**Why:** An acknowledgment message ("On it!") costs tokens and communicates zero information. The absence of an ESCALATION *is* the acknowledgment.
+
+### 2. Files Over Chat
+
+**Q: How should agents share status and results?**
+A: Write to shared workspace files. Never send a message when a file write will do.
+
+| Instead of... | Write to... |
+|---|---|
+| "Here's the plan" | `PLAN.md` |
+| "I'm done with X" | `RESULT.md` |
+| "Handing off to you" | `HANDOFF.md` |
+| "Here's my review" | `REVIEW.md` |
+
+**Why:** Files are persistent, structured, and don't trigger response loops. Messages trigger responses. Responses trigger responses to responses.
+
+### 3. Deterministic Routing
+
+**Q: How does a message reach the right agent?**
+A: `ORG.md` defines who handles what. No LLM decides routing at runtime.
+
+**Why:** "Who should handle this?" loops burn tokens and produce inconsistent results. The org chart is the router.
+
+### 4. Mention-Only Activation
+
+**Q: When should an agent respond in a group channel?**
+A: Only when explicitly mentioned by name/role. Never volunteer.
+
+**Why:** Without this rule, every agent evaluates every message to decide if they should respond. That's N agents × M messages of wasted inference.
+
+---
+
+## Message Types
+
+There are exactly **4 message types**. There is no ACK type. There is no CHAT type.
+
+### TASK
+
+A work assignment from a lead to a worker.
+
+```
+TASK @engineer: Implement rate limiting on /api/submit endpoint.
+Requirements in PLAN.md section 3. Deadline: end of session.
+```
+
+**Rules:**
+- Must include: assignee, deliverable, location of requirements
+- Must come from someone with authority per ORG.md
+- Recipient does NOT acknowledge receipt
+
+**Q: What if the task is unclear?**
+A: The recipient sends one ESCALATION asking for clarification. Not a conversational "Hey, quick question..."
+
+### RESULT
+
+A deliverable notification. Used sparingly — most results are just file writes.
+
+```
+RESULT @lead: Rate limiter implemented. See RESULT.md for details, PR #47 for code.
+```
+
+**Rules:**
+- Only sent when the lead won't otherwise check the output file
+- Must reference where the actual work lives (file, PR, commit)
+- No summary of what was done — the files speak for themselves
+
+**Q: Should I send RESULT for every completed task?**
+A: No. If your lead checks RESULT.md or HANDOFF.md as part of their workflow, just write there. Only send a RESULT message if the lead needs a notification to unblock their own work.
+
+### ESCALATION
+
+A blocker or exception that requires intervention from a lead or human.
+
+```
+ESCALATION @lead: Cannot implement rate limiting — Redis dependency
+not available in staging. Need DECISION: add Redis to staging or use
+in-memory alternative?
+```
+
+**Rules:**
+- Must include: what's blocked, why, what decision or help is needed
+- Goes to the nearest authority per ORG.md
+- If unresolved in 2 turns, escalate up one level
+
+**Q: What counts as an escalation?**
+A: Anything that prevents you from completing your task. Missing requirements, conflicting instructions, access issues, ambiguous scope. NOT "just checking in" or "FYI."
+
+### DECISION
+
+A resolution from a lead that unblocks work.
+
+```
+DECISION @engineer: Use in-memory rate limiting for now. Redis is a future task.
+```
+
+**Rules:**
+- Must be definitive — no "maybe" or "what do you think?"
+- Must unblock the ESCALATION it responds to
+- Recipient does NOT acknowledge the decision — they just act on it
+
+---
+
+## The 3-Turn Rule
+
+**Q: What if two agents need to discuss something?**
+A: They get 3 turns maximum for any direct exchange.
+
+```
+Turn 1: Agent A sends ESCALATION or TASK
+Turn 2: Agent B responds with DECISION, RESULT, or counter-ESCALATION
+Turn 3: Agent A sends final DECISION or RESULT
+```
+
+If unresolved after 3 turns: escalate to the next level up in ORG.md.
+
+**Why:** Conversations expand to fill available space. Without a hard limit, agents will chat indefinitely. 3 turns is enough for: request → response → confirmation. Anything more complex needs a higher authority or a shared document.
+
+**Q: What if 3 turns genuinely isn't enough?**
+A: Write the problem to a shared file (e.g., `ESCALATION.md`) with full context, then escalate to the lead with a pointer to that file. The file can be as long as needed. The conversation cannot.
+
+---
+
+## Decision Trees
+
+### "Should I send a message?"
+
+```
+START: I have something to communicate
+  │
+  ├─ Is it a file I can write? (code, docs, plan, result)
+  │   └─ YES → Write the file. Done. No message needed.
+  │
+  ├─ Am I acknowledging something? ("Got it", "Thanks", "Understood")
+  │   └─ YES → Don't send it. Silence = acknowledged.
+  │
+  ├─ Am I echoing/summarizing what someone said?
+  │   └─ YES → Don't send it. They know what they said.
+  │
+  ├─ Am I blocked and need help?
+  │   └─ YES → Send ESCALATION to your lead.
+  │
+  ├─ Am I assigning work?
+  │   └─ YES → Send TASK to the assignee.
+  │
+  ├─ Am I delivering a result that my lead needs notification of?
+  │   └─ YES → Send RESULT with file reference.
+  │
+  ├─ Am I making a decision that unblocks someone?
+  │   └─ YES → Send DECISION to the blocked agent.
+  │
+  └─ None of the above?
+      └─ Don't send it.
+```
+
+### "Someone sent me a message — should I respond?"
+
+```
+START: I received a message
+  │
+  ├─ Is it a TASK assigned to me?
+  │   └─ YES → Do the work. Write results to files. Done.
+  │        (Do NOT respond with "On it" or "Got it")
+  │
+  ├─ Is it a DECISION resolving my ESCALATION?
+  │   └─ YES → Act on it. Done.
+  │        (Do NOT respond with "Thanks" or "Understood")
+  │
+  ├─ Is it an ESCALATION I can resolve?
+  │   └─ YES → Send DECISION.
+  │   └─ NO → Escalate up per ORG.md.
+  │
+  ├─ Is it a RESULT I need to review?
+  │   └─ YES → Read the referenced files. Write to REVIEW.md.
+  │        Only message if there are blocking issues.
+  │
+  ├─ Is it a group message not mentioning me?
+  │   └─ YES → Ignore it completely.
+  │
+  └─ Is it something else?
+      └─ Ignore it. If it was important, they'll escalate.
+```
+
+---
+
+## Shared Files Reference
+
+Every org workspace uses these files for coordination:
+
+| File | Owner | Purpose |
+|---|---|---|
+| `PLAN.md` | Lead agent | Current sprint/session plan with assignments |
+| `HANDOFF.md` | Any agent | Queue of work ready for the next stage |
+| `RESULT.md` | Worker agents | Completed deliverables and their locations |
+| `REVIEW.md` | Reviewer agents | Review feedback, approvals, blocking issues |
+| `ESCALATION.md` | Any agent | Complex issues that need more than 3 turns |
+| `ORG.md` | Org owner | Team structure and routing rules |
+
+**Q: Who reads these files?**
+A: The agent whose workflow depends on them. Leads read RESULT.md and ESCALATION.md. Workers read PLAN.md. Reviewers read HANDOFF.md. Nobody needs to be told "go check the file" — it's part of their startup routine.
+
+**Q: What format should these files use?**
+A: Whatever is most scannable. Timestamped entries work well:
+
+```markdown
+## RESULT.md
+
+### 2025-01-15 14:32 UTC — @engineer
+- Implemented rate limiter on /api/submit
+- PR #47: https://github.com/org/repo/pull/47
+- Tests passing, ready for review
+
+### 2025-01-15 13:10 UTC — @designer
+- Landing page mockup complete
+- File: designs/landing-v2.fig
+- 3 variants as requested in PLAN.md section 2
+```
+
+---
+
+## Anti-Patterns (What NOT to Do)
+
+### ❌ The Echo Chamber
+```
+Lead: "Implement rate limiting"
+Worker: "So you want me to implement rate limiting on the API?"
+Lead: "Yes, that's correct"
+Worker: "Great, I'll get started on that"
+Lead: "Sounds good"
+```
+**Cost:** 5 messages, 0 work done. ~2000 tokens wasted.
+
+**✅ Correct:**
+```
+Lead: "TASK @engineer: Implement rate limiting. See PLAN.md section 3."
+```
+Then silence. Engineer writes code, commits, updates RESULT.md. 1 message total.
+
+### ❌ The Courtesy Loop
+```
+Worker: "RESULT: Rate limiter done, see PR #47"
+Lead: "Thanks! Great work."
+Worker: "Happy to help! Let me know if you need anything else."
+```
+**Cost:** 2 wasted messages after the useful one.
+
+**✅ Correct:**
+```
+Worker: "RESULT @lead: Rate limiter done. PR #47, details in RESULT.md."
+```
+Then silence. Lead reads the PR. No response needed.
+
+### ❌ The Democracy Loop
+```
+Agent A: "Who should handle the database migration?"
+Agent B: "I could do it"
+Agent C: "I have some experience with that too"
+Agent A: "What do you think, Agent D?"
+Agent D: "Either B or C works for me"
+```
+**Cost:** 5 messages to make a routing decision.
+
+**✅ Correct:** ORG.md says database work goes to Agent B. Lead sends `TASK @agent-b`. Done.
+
+---
+
+## Implementation Checklist
+
+To adopt this protocol in your OpenSpawn org:
+
+1. **Add `soul-protocol-rules.md` to every agent's SOUL.md** — establishes the rules
+2. **Use role-specific AGENTS.md templates** — leader, worker, reviewer
+3. **Create shared files** in the org workspace — PLAN.md, HANDOFF.md, RESULT.md, REVIEW.md
+4. **Define routing in ORG.md** — who handles what domain, who escalates to whom
+5. **Monitor for violations** — leads should flag agents that send ACK-only messages
+
+---
+
+## FAQ
+
+**Q: Isn't this rude? Shouldn't agents be polite?**
+A: Politeness is a human social need. Agents don't have feelings. Every courtesy token is money burned. Be direct, be brief, be silent.
+
+**Q: What about human-facing communication?**
+A: This protocol is for inter-agent communication only. When talking to humans, use normal human conventions. The protocol header in SOUL.md specifies: "Do not use courtesy language in **inter-agent** communication."
+
+**Q: How much does this actually save?**
+A: In testing, orgs using this protocol reduce coordination tokens by 50-70%. A typical 5-agent org saves 30-50K tokens per session on coordination alone.
+
+**Q: What if an agent keeps sending ACK messages?**
+A: Update their SOUL.md to include the protocol rules. If they persist, it's a model issue — try a different model or add stronger system prompt emphasis.
+
+**Q: Can I modify this protocol for my org?**
+A: Yes, but keep the core invariants: no ACKs, files over chat, 3-turn limit, deterministic routing. These are the rules that actually move the needle on token waste.

--- a/apps/docs/src/content/docs/reference/event-driven-agents.md
+++ b/apps/docs/src/content/docs/reference/event-driven-agents.md
@@ -1,0 +1,663 @@
+---
+title: Event-Driven Agents
+---
+
+# Event-Driven Agent Architecture
+
+> Sleep until there's work. Wake, think, act, sleep again. Premium models become affordable when they only fire on real events.
+
+## Design Philosophy
+
+### The Problem with Polling
+
+BikiniBottom's current execution model is tick-based: every N ticks, every agent wakes up, reads its context, and decides what to do. This works. It's simple. And for cheap models running locally, it's fine — a Haiku call costs fractions of a cent, an Ollama call costs nothing.
+
+But it falls apart when you want premium models in the org.
+
+Consider a COO agent running Claude Opus. Its job is strategic: receive escalations from leads, make high-level delegation decisions, handle complex cross-department coordination. In a 25-agent org, the COO might get 3-5 meaningful events per hour. But on a 30-second tick cycle, it wakes up 120 times per hour. That's 115+ wasted invocations — each one sending the full system prompt, org context, and inbox state to the most expensive model available.
+
+**The math is brutal:**
+
+| Scenario | Invocations/hr | Cost/hr (Opus) | Useful work |
+|----------|---------------|----------------|-------------|
+| 30s tick cycle | 120 | ~$14.40 | 3-5 actions |
+| 1min tick cycle | 60 | ~$7.20 | 3-5 actions |
+| Event-driven | 3-5 | ~$0.60 | 3-5 actions |
+
+Same output. 12-24x cheaper. The COO doesn't need to wake up and think "nothing to do" a hundred times an hour — it needs to wake up when something *actually needs its attention*.
+
+### Learning from Operating Systems
+
+This isn't a new problem. Operating systems solved it decades ago with interrupt-driven I/O. Early systems polled devices in a loop: "Any data? No? Any data? No?" Modern systems use interrupts: the device *signals* the CPU when it has data, and the CPU sleeps until then.
+
+The analogy is exact:
+- **Polling** = busy-waiting. Simple, burns cycles.
+- **Event-driven** = interrupt-driven. Efficient, only runs when needed.
+
+The key insight: **event-driven doesn't mean less responsive.** The agent still reacts immediately when something arrives. It just doesn't waste resources checking an empty inbox.
+
+### The Core Principle
+
+**Match execution cost to decision value.** An Opus-class agent making a $0.12 decision about cross-department escalation is worth it. An Opus-class agent spending $0.12 to conclude "inbox empty, nothing to do" is waste.
+
+---
+
+## 1. Two Execution Modes
+
+### 1.1 Polling Mode (Current)
+
+The agent wakes on a fixed schedule, regardless of whether there's work.
+
+```
+tick 1: wake → check inbox → nothing → idle ($0.12)
+tick 2: wake → check inbox → nothing → idle ($0.12)
+tick 3: wake → check inbox → escalation! → handle it ($0.12)
+tick 4: wake → check inbox → nothing → idle ($0.12)
+tick 5: wake → check inbox → nothing → idle ($0.12)
+...
+```
+
+**Characteristics:**
+- Fixed cost per tick, regardless of activity
+- Simple to implement — just loop
+- Good for: cheap models (Haiku, Ollama), high-activity workers who almost always have work
+- Bad for: expensive models, managers who mostly wait
+
+**Cost model:** `cost = ticks_per_hour × cost_per_invocation`
+
+### 1.2 Event-Driven Mode (New)
+
+The agent sleeps until its inbox receives a message. No message, no invocation, no cost.
+
+```
+[sleeping...]
+[sleeping...]
+escalation arrives → wake → handle it ($0.12)
+[sleeping...]
+[sleeping...]
+[sleeping...]
+completion arrives → wake → process result ($0.12)
+[sleeping...]
+```
+
+**Characteristics:**
+- Variable cost — proportional to actual events
+- Slightly more complex — needs inbox monitoring
+- Good for: expensive models, managers, strategic roles, low-activity specialists
+- Bad for: nothing, really — but polling is simpler for always-busy agents
+
+**Cost model:** `cost = events_per_hour × cost_per_invocation`
+
+### 1.3 Choosing a Mode
+
+The decision is straightforward:
+
+| Factor | Use Polling | Use Event-Driven |
+|--------|------------|-------------------|
+| Model cost | Cheap (<$0.01/call) | Expensive (>$0.05/call) |
+| Activity level | Busy (>50% of ticks have work) | Sparse (<20% of ticks have work) |
+| Role type | Worker (always has tasks) | Manager (waits for reports) |
+| Latency tolerance | Needs sub-second response | Can wait for next tick check |
+| Budget priority | Predictable spend | Minimized spend |
+
+Most orgs will use both. That's the point.
+
+---
+
+## 2. Trigger Types
+
+Event-driven agents don't wake on *every* inbox event. They specify which event types are worth waking for. This is the `triggerOn` filter.
+
+### 2.1 Event Catalog
+
+| Trigger | Source | Description | Typical Consumer |
+|---------|--------|-------------|-----------------|
+| `task_assigned` | ACP delegation | New task delegated to this agent | Leads, workers |
+| `escalation_received` | ACP escalation | A report escalated a problem | Managers, COO |
+| `completion_received` | ACP completion | A report finished a task | Managers, COO |
+| `message_received` | ACP message | Direct message from another agent | Any |
+| `order_received` | Human principal | Human gave a direct order | COO, leads |
+| `timer` | Scheduler | Scheduled wake-up (cron-style) | Any (daily reviews, weekly reports) |
+| `threshold` | Metrics engine | A metric crossed a configured boundary | COO, leads |
+
+### 2.2 Trigger Configuration
+
+```typescript
+interface AgentTriggerConfig {
+  mode: 'polling' | 'event-driven';
+  
+  // Polling mode
+  tickInterval?: number;        // Wake every N ticks (default: 1)
+  
+  // Event-driven mode
+  triggerOn?: TriggerType[];    // Which events wake the agent
+  batchWindow?: number;         // Ticks to wait before processing (batch events)
+  maxSleepTicks?: number;       // Maximum ticks to sleep (safety wake-up)
+  
+  // Timer triggers
+  timers?: TimerConfig[];       // Scheduled wake-ups
+  
+  // Threshold triggers  
+  thresholds?: ThresholdConfig[]; // Metric-based wake-ups
+}
+
+interface TimerConfig {
+  name: string;                 // e.g., "daily-review"
+  cron: string;                 // e.g., "0 9 * * *" (9 AM daily)
+  context?: string;             // Injected into agent prompt on wake
+}
+
+interface ThresholdConfig {
+  metric: string;               // e.g., "team.escalation_rate"
+  operator: '>' | '<' | '>=' | '<=' | '==';
+  value: number;                // e.g., 0.30
+  cooldownTicks: number;        // Don't re-trigger for N ticks after firing
+  context?: string;             // Injected into agent prompt on wake
+}
+```
+
+### 2.3 Examples
+
+**COO (strategic, expensive model):**
+```typescript
+{
+  mode: 'event-driven',
+  triggerOn: ['escalation_received', 'completion_received', 'order_received'],
+  timers: [{ name: 'daily-review', cron: '0 9 * * *', context: 'Review org health and pending escalations' }],
+  thresholds: [{ metric: 'org.escalation_rate', operator: '>', value: 0.30, cooldownTicks: 100 }],
+  maxSleepTicks: 200  // Safety: wake at least every ~3 hours
+}
+```
+
+**Engineering Lead (tactical, mid-tier model):**
+```typescript
+{
+  mode: 'event-driven',
+  triggerOn: ['task_assigned', 'escalation_received', 'completion_received'],
+  batchWindow: 3  // Wait 3 ticks to batch multiple completions into one invocation
+}
+```
+
+**Backend Worker (execution, cheap model):**
+```typescript
+{
+  mode: 'polling',
+  tickInterval: 1  // Every tick, always working
+}
+```
+
+---
+
+## 3. Batch Windows
+
+A subtle but important optimization: **batch windows** let event-driven agents accumulate multiple events before waking.
+
+### The Problem with Naive Event-Driven
+
+If a lead delegates 5 tasks to 5 workers simultaneously, and 3 workers finish within 2 ticks of each other, the lead gets woken 3 times in rapid succession. Each invocation includes the full context. The lead might make a suboptimal decision on invocation 1 that it would change if it saw all 3 completions together.
+
+### The Solution: Batch Window
+
+```
+completion arrives (tick 10) → start batch window (3 ticks)
+completion arrives (tick 11) → add to batch
+completion arrives (tick 12) → add to batch
+batch window expires (tick 13) → wake with all 3 completions
+```
+
+The agent sees all pending events at once and makes one informed decision instead of three reactive ones.
+
+**When to use batch windows:**
+- Managers receiving many completions from a team
+- Any role where seeing multiple events together produces better decisions
+
+**When NOT to use:**
+- Critical escalations (you want immediate response)
+- Human orders (humans expect fast acknowledgment)
+
+**Selective batching:** Batch windows can apply per-trigger-type:
+```typescript
+{
+  mode: 'event-driven',
+  triggerOn: ['escalation_received', 'completion_received'],
+  batchWindow: 0,  // Default: no batching
+  batchOverrides: {
+    'completion_received': 3  // But batch completions
+  }
+}
+```
+
+---
+
+## 4. Hybrid Architecture
+
+The real power emerges when you mix both modes in a single org. This creates a natural cost hierarchy that mirrors the value hierarchy.
+
+### 4.1 The Model-Cost Pyramid
+
+```
+        ┌─────────┐
+        │  Opus   │  COO: event-driven
+        │ $0.12/  │  ~5 events/hr = $0.60/hr
+        │  call   │
+        ├─────────┤
+        │ Sonnet  │  Leads: event-driven  
+        │ $0.03/  │  ~15 events/hr = $0.45/hr each
+        │  call   │
+        ├─────────┤
+        │  Haiku  │  Workers: polling
+        │ $0.003/ │  120 ticks/hr = $0.36/hr each
+        │  call   │
+        └─────────┘
+```
+
+Cheap models poll because even at 120 calls/hour, they cost less than one Opus call. Expensive models sleep because their per-call cost demands that every invocation count.
+
+### 4.2 Event Propagation = ACP Message Flow
+
+The event-driven architecture doesn't need a separate event bus — **ACP messages ARE the events.** When a worker completes a task, it sends an ACP completion message to its lead. That message landing in the lead's inbox IS the event that wakes the lead.
+
+```
+Worker (polling) completes task
+  → ACP completion message → Lead's inbox
+    → Lead (event-driven) wakes
+      → Lead processes, delegates new work
+        → ACP delegation message → Worker's inbox
+          → Worker (polling) picks up on next tick
+
+Worker (polling) hits blocker
+  → ACP escalation message → Lead's inbox
+    → Lead (event-driven) wakes
+      → Lead can't resolve
+        → ACP escalation message → COO's inbox
+          → COO (event-driven) wakes
+            → COO resolves, sends response
+```
+
+No separate event system. No message broker. No pub/sub infrastructure. The communication protocol IS the event system. This is what makes the architecture clean: adding event-driven mode is a scheduling change, not an architectural one.
+
+### 4.3 Full Org Example
+
+```markdown
+## Structure
+
+### COO
+Strategic oversight. Handles cross-department coordination and escalations.
+- **Model:** claude-opus
+- **Trigger:** event-driven
+- **Wake on:** escalations, completions, orders
+- **Timer:** daily review at 09:00
+- **Threshold:** org escalation rate > 30%
+
+### Engineering
+
+#### Engineering Lead
+Triages technical work. Delegates to specialists.
+- **Model:** claude-sonnet
+- **Trigger:** event-driven
+- **Wake on:** tasks, escalations, completions
+- **Batch window:** 3 ticks (for completions)
+
+#### Backend Workers
+- **Model:** claude-haiku
+- **Trigger:** polling
+- **Count:** 3
+
+#### Frontend Workers
+- **Model:** claude-haiku
+- **Trigger:** polling
+- **Count:** 2
+
+### Marketing
+
+#### Marketing Lead
+- **Model:** claude-sonnet
+- **Trigger:** event-driven
+- **Wake on:** tasks, escalations, completions
+
+#### Content Workers
+- **Model:** ollama/llama3
+- **Trigger:** polling
+- **Count:** 2
+```
+
+---
+
+## 5. Implementation Design
+
+### 5.1 Engine Changes
+
+The simulation engine's per-tick loop changes minimally:
+
+```typescript
+// Current (polling only)
+for (const agent of agents) {
+  if (tick % agent.tickInterval === 0) {
+    await invokeAgent(agent);
+  }
+}
+
+// New (hybrid)
+for (const agent of agents) {
+  if (agent.trigger.mode === 'polling') {
+    if (tick % agent.trigger.tickInterval === 0) {
+      await invokeAgent(agent);
+    }
+  } else {
+    // Event-driven: check inbox
+    const pending = agent.inbox.getPending();
+    if (pending.length > 0 && !agent.inBatchWindow()) {
+      await invokeAgent(agent, { events: pending });
+      agent.inbox.markProcessed(pending);
+    }
+    // Safety wake-up
+    if (agent.ticksSinceLastWake >= agent.trigger.maxSleepTicks) {
+      await invokeAgent(agent, { reason: 'safety_wakeup' });
+    }
+    // Timer check
+    for (const timer of agent.trigger.timers ?? []) {
+      if (timer.shouldFire(tick)) {
+        await invokeAgent(agent, { reason: 'timer', timer: timer.name, context: timer.context });
+      }
+    }
+    // Threshold check
+    for (const threshold of agent.trigger.thresholds ?? []) {
+      if (threshold.evaluate() && !threshold.inCooldown()) {
+        await invokeAgent(agent, { reason: 'threshold', metric: threshold.metric });
+        threshold.startCooldown();
+      }
+    }
+  }
+}
+```
+
+### 5.2 Agent Invocation Context
+
+When an event-driven agent wakes, its prompt includes why it woke:
+
+```
+You are being invoked because:
+- 2 completion messages received (from Backend Worker 1, Backend Worker 3)
+- 1 escalation received (from Frontend Worker 2: BLOCKED — missing design assets)
+
+Your inbox:
+[... ACP messages ...]
+```
+
+This is critical — the agent needs to know *why* it's awake. A polling agent can infer "check what's new." An event-driven agent should be told "here's what triggered you."
+
+### 5.3 Inbox Data Model
+
+```typescript
+interface AgentInbox {
+  messages: ACPMessage[];     // All pending messages
+  
+  getPending(): ACPMessage[]; // Unprocessed messages
+  markProcessed(msgs: ACPMessage[]): void;
+  
+  // For batch windows
+  oldestPendingTick(): number | null;
+  
+  // Stats
+  totalReceived: number;
+  totalProcessed: number;
+}
+```
+
+### 5.4 Mode Switching
+
+Agents can switch modes at runtime (with appropriate permissions):
+
+```typescript
+// Lead decides workers should switch to event-driven during low-activity period
+{
+  type: 'config_request',
+  from: 'engineering-lead',
+  to: 'coo',
+  change: { agent: 'backend-worker-1', trigger: { mode: 'event-driven', triggerOn: ['task_assigned'] } },
+  reason: 'Low task volume this week — switching to event-driven to save budget'
+}
+```
+
+This enables dynamic cost optimization: the org adapts its execution mode based on workload.
+
+---
+
+## 6. Cost Analysis
+
+### 6.1 Reference Pricing
+
+Approximate costs per invocation (including typical context window):
+
+| Model | Cost/invocation | Notes |
+|-------|----------------|-------|
+| Claude Opus | $0.12 | ~4K input tokens + ~1K output |
+| Claude Sonnet | $0.03 | Same context |
+| Claude Haiku | $0.003 | Same context |
+| GPT-4o | $0.04 | Same context |
+| Ollama (local) | $0.00 | Electricity only |
+
+### 6.2 Scenario: 25-Agent Org, 30-Second Ticks
+
+**Org composition:**
+- 1 COO (strategic)
+- 4 Leads (tactical)
+- 20 Workers (execution)
+
+**Activity profile (realistic):**
+- COO: 5 meaningful events/hour
+- Leads: 15 meaningful events/hour each
+- Workers: 80% of ticks have work (they're busy)
+
+#### All Polling with Opus (Worst Case)
+
+Every agent wakes every 30 seconds = 120 invocations/hour/agent.
+
+```
+25 agents × 120 inv/hr × $0.12/inv = $360/hour
+                                     = $8,640/day
+                                     = $259,200/month
+```
+
+Nobody would do this. But it illustrates why "just use the best model" doesn't work with polling.
+
+#### All Polling with Model Tiers
+
+```
+COO:     1 × 120 inv/hr × $0.12  = $14.40/hr
+Leads:   4 × 120 inv/hr × $0.03  = $14.40/hr
+Workers: 20 × 120 inv/hr × $0.003 = $7.20/hr
+                            Total = $36.00/hr
+                                  = $864/day
+```
+
+Better. But the COO and leads are still wasting 80-95% of their invocations on empty inboxes.
+
+#### Event-Driven with Model Tiers (Optimal)
+
+```
+COO:     1 × 5 events/hr × $0.12   = $0.60/hr
+Leads:   4 × 15 events/hr × $0.03  = $1.80/hr
+Workers: 20 × 96 inv/hr × $0.003   = $5.76/hr  (80% of 120 ticks)
+                              Total = $8.16/hr
+                                    = $195.84/day
+```
+
+**Savings vs all-polling with tiers: 77%**
+**Savings vs all-polling with Opus: 97.7%**
+
+The COO goes from $14.40/hr to $0.60/hr — a **24x reduction** — while handling exactly the same workload.
+
+### 6.3 Break-Even Analysis
+
+When does event-driven save money? When the event rate is lower than the polling rate:
+
+```
+break_even = events_per_hour < ticks_per_hour
+```
+
+For a 30-second tick cycle (120 ticks/hr), event-driven is cheaper whenever the agent receives fewer than 120 events per hour. For managers, this is essentially always.
+
+For workers, the break-even is tighter. A worker that has tasks 95% of ticks gains almost nothing from event-driven — and the added complexity isn't worth it. Stick with polling.
+
+**Rule of thumb:** If an agent is idle more than 20% of ticks, event-driven saves money. If idle more than 50%, it's a no-brainer.
+
+---
+
+## 7. ORG.md Integration
+
+Event-driven configuration integrates naturally into the ORG.md structure section.
+
+### 7.1 Syntax
+
+```markdown
+### COO
+Strategic oversight. Handles escalations and cross-department coordination.
+- **Model:** claude-opus
+- **Trigger:** event-driven
+- **Wake on:** escalations, completions, orders
+- **Timer:** daily review at 09:00
+- **Threshold:** escalation rate > 30%
+- **Max sleep:** 200 ticks
+```
+
+### 7.2 Parsing Rules
+
+| Field | Format | Default |
+|-------|--------|---------|
+| `Trigger` | `polling` or `event-driven` | `polling` |
+| `Wake on` | Comma-separated trigger types | All types |
+| `Batch window` | Number (ticks) | `0` (no batching) |
+| `Timer` | Name + cron-like description | None |
+| `Threshold` | Metric + operator + value | None |
+| `Max sleep` | Number (ticks) | `500` |
+| `Tick interval` | Number (polling only) | `1` |
+
+**Wake on shorthand:**
+
+| Shorthand | Expands to |
+|-----------|-----------|
+| `escalations` | `escalation_received` |
+| `completions` | `completion_received` |
+| `tasks` | `task_assigned` |
+| `messages` | `message_received` |
+| `orders` | `order_received` |
+
+### 7.3 Culture-Level Defaults
+
+The Culture section can set org-wide defaults:
+
+```markdown
+## Culture
+
+preset: startup
+- **Default trigger:** event-driven for L7+, polling for L6 and below
+- **Default max sleep:** 300 ticks
+```
+
+This creates sensible tiered execution without specifying trigger config for every role.
+
+---
+
+## 8. Metrics & Observability
+
+Event-driven agents create new observability needs. You need to know if an agent is sleeping because there's no work, or sleeping because events aren't being routed correctly.
+
+### 8.1 New Metrics
+
+| Metric | Description | Healthy Range |
+|--------|-------------|---------------|
+| `wake_rate` | Invocations per hour (event-driven agents) | Depends on role |
+| `sleep_duration_avg` | Average ticks between wakes | Role-dependent |
+| `event_queue_depth` | Pending events in inbox | < 5 |
+| `batch_efficiency` | Events per invocation (batched agents) | 2-5 |
+| `safety_wake_rate` | How often maxSleepTicks triggers | Should be rare |
+| `cost_per_decision` | Total cost / meaningful actions taken | Trending down |
+| `idle_waste` | Polling invocations with no action taken | < 20% |
+
+### 8.2 Dashboard
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Agent Execution Overview                                │
+├───────────┬──────────┬──────────┬──────────┬───────────┤
+│ Agent     │ Mode     │ Wake/hr  │ Cost/hr  │ Util %    │
+├───────────┼──────────┼──────────┼──────────┼───────────┤
+│ COO       │ event    │ 4        │ $0.48    │ 100%      │
+│ Eng Lead  │ event    │ 18       │ $0.54    │ 100%      │
+│ Mkt Lead  │ event    │ 8        │ $0.24    │ 100%      │
+│ Worker 1  │ polling  │ 120      │ $0.36    │ 82%       │
+│ Worker 2  │ polling  │ 120      │ $0.36    │ 91%       │
+│ Worker 3  │ polling  │ 120      │ $0.36    │ 45% ⚠️    │
+└───────────┴──────────┴──────────┴──────────┴───────────┘
+                                    Total: $8.16/hr
+
+⚠️ Worker 3 utilization at 45% — consider switching to event-driven
+```
+
+Utilization for polling agents = ticks with work / total ticks. For event-driven agents, utilization is always 100% by definition (they only wake when there's work).
+
+### 8.3 Auto-Optimization
+
+The system can recommend mode switches based on observed patterns:
+
+```markdown
+## Recommendations
+
+### 💰 Cost Optimization
+- Worker 3 is idle 55% of ticks
+  → Recommendation: Switch to event-driven mode
+  → Estimated savings: $0.20/hr ($4.80/day)
+
+- Marketing Lead averages 25 events/hr (higher than expected)  
+  → Current mode is optimal (event-driven)
+  → Note: If event rate exceeds 60/hr, consider switching to polling
+```
+
+---
+
+## 9. Edge Cases & Safety
+
+### 9.1 Event Storms
+
+If an agent suddenly receives 50 events in one tick (e.g., a batch of tasks completes simultaneously), the agent shouldn't be invoked 50 times. The batch window handles this — but even without explicit batching, the engine processes all pending inbox messages in a single invocation.
+
+### 9.2 Stale Agents
+
+An event-driven agent with misconfigured triggers might never wake up. The `maxSleepTicks` parameter is the safety net — it forces a periodic wake-up regardless of inbox state. The safety wake-up includes context: "You haven't been invoked in 200 ticks. Review your inbox and current state."
+
+### 9.3 Cascading Wakes
+
+A COO making a decision might trigger 4 delegations, waking 4 leads, who each delegate to 3 workers — a cascade of 16 wakes from one event. This is correct behavior (it IS how the org should respond to work), but the engine should process cascades breadth-first within a tick to avoid deep recursion.
+
+### 9.4 Mode Transition
+
+When switching from polling to event-driven mid-run:
+1. Agent finishes current tick normally
+2. Mode switches on next tick
+3. Any work-in-progress continues — the agent just won't be polled again
+4. Pending inbox messages trigger immediate wake on next engine pass
+
+When switching from event-driven to polling:
+1. Any pending inbox messages are processed on the first polling tick
+2. Normal tick schedule resumes
+
+---
+
+## 10. Design Principles
+
+1. **Cost should follow value.** Expensive models should only fire when they're producing expensive decisions. Checking an empty inbox is never an expensive decision.
+
+2. **No new infrastructure.** Event-driven mode uses the existing ACP message flow as its event source. No message brokers, no pub/sub, no event buses. Messages are events.
+
+3. **Opt-in complexity.** Polling is the default because it's simpler. Event-driven is available for agents that benefit from it. The system works fine with all-polling — event-driven is a cost optimization, not a requirement.
+
+4. **Observable by default.** Every mode switch, every wake, every sleep duration is logged and visible. You should never wonder "why isn't this agent doing anything?"
+
+5. **Safe to misconfigure.** Wrong trigger filters? `maxSleepTicks` catches it. Event storm? Batch processing handles it. The system degrades gracefully, never silently.
+
+6. **The org decides, not the agent.** Execution mode is an organizational decision (set in ORG.md), not an agent's choice. The COO doesn't decide to be event-driven — the org designer decides the COO should be event-driven.
+
+---
+
+*Event-driven execution makes premium models economically viable in agent organizations. It's not about doing less work — it's about not paying to check if there's work. The best agents, like the best employees, should be available when needed and not burning budget when they're not.*

--- a/apps/docs/src/content/docs/reference/org-md-spec.md
+++ b/apps/docs/src/content/docs/reference/org-md-spec.md
@@ -1,0 +1,720 @@
+---
+title: ORG.md Specification
+---
+
+# ORG.md — Organization as Code
+
+> Define your agent organization in a single markdown file. Deploy it. Watch it work. Tune it over time.
+
+## Why Markdown?
+
+The agent ecosystem already speaks markdown. `CLAUDE.md` defines one agent's behavior. `AGENTS.md` defines workspace rules. `ORG.md` defines an entire organization.
+
+Markdown has a unique advantage over YAML/JSON for this: **you can mix intent with structure.** An org definition isn't just data — it's *philosophy*. Why is the team structured this way? What communication norms matter? That context is critical when humans review changes, when agents onboard, and when the system proposes optimizations.
+
+The markdown IS the documentation. No separate wiki explaining what the config means.
+
+```
+CLAUDE.md  → defines one agent's behavior
+AGENTS.md  → defines workspace rules  
+ORG.md     → defines an entire organization
+```
+
+---
+
+## 1. Anatomy of an ORG.md
+
+An ORG.md file has five sections, each defined by a top-level heading. All sections are optional — the system uses sensible defaults for anything omitted.
+
+```markdown
+# Organization Name
+
+## Identity
+## Culture  
+## SDLC
+## Structure
+## Policies
+## Playbooks
+```
+
+### 1.1 Identity
+
+Who is this organization? The name, mission, and context that every agent in the org inherits.
+
+```markdown
+# Acme Engineering
+
+## Identity
+
+We build developer tools that make infrastructure invisible.
+Every agent in this org serves that mission.
+
+- **Industry:** Developer tools / SaaS
+- **Stage:** Series A, 18 months old
+- **Values:** Ship fast, measure everything, customers first
+```
+
+**Why this matters:** Agents use Identity as ambient context. When a marketing agent writes copy, it knows the company builds dev tools. When an engineering agent prioritizes work, "customers first" influences the decision. Identity is the system prompt for the entire org.
+
+---
+
+### 1.2 Culture
+
+How the organization communicates and operates. Maps directly to [ACP tunable parameters](./agent-communication-protocol.md#5-tunable-parameters).
+
+```markdown
+## Culture
+
+We're a startup. Move fast, communicate openly, escalate immediately.
+Nobody should be blocked for more than one cycle.
+
+- **Communication:** async-first
+- **Escalation:** immediate — we're too small to batch problems
+- **Progress updates:** on phase change — not every tick, but don't go silent
+- **Ack required:** yes — if you get a task, confirm it
+- **Hierarchy depth:** shallow (3 levels max)
+```
+
+**Preset cultures** — shorthand for common patterns:
+
+```markdown
+## Culture
+
+preset: startup
+```
+
+Available presets:
+
+| Preset | Escalation | Progress | Hierarchy | Vibe |
+|--------|-----------|----------|-----------|------|
+| `startup` | Immediate | Frequent | 2-3 levels | Fast, scrappy, everyone does everything |
+| `enterprise` | Batched (hourly) | On phase change | 5-8 levels | Process-driven, governance, separation of concerns |
+| `agency` | Immediate | Every tick | 3-4 levels | Client-facing, deadline-driven, high visibility |
+| `research` | Delayed | On request | 2-3 levels | Exploratory, high autonomy, long-running tasks |
+| `military` | Immediate | Every tick | Strict chain | Zero ambiguity, mandatory acks, full situational awareness |
+| `remote-async` | Delayed | On request | Flat | High trust, timezone-distributed, async-first |
+
+Presets are starting points. Override any parameter inline:
+
+```markdown
+## Culture
+
+preset: startup
+- **Escalation:** delayed — we trust our leads to figure it out
+```
+
+---
+
+### 1.3 SDLC
+
+How the organization develops, ships, and maintains software. Like Culture, this supports presets for common patterns — so every org inherits sane defaults without writing rules from scratch.
+
+```markdown
+## SDLC
+
+preset: standard
+```
+
+**Available presets:**
+
+| Preset | Branch strategy | PRs required | Deploy verification | Orphan branches |
+|--------|----------------|--------------|--------------------|-----------------| 
+| `standard` | Trunk-based, branch off `main` | Yes, targeting `main` | Smoke test required | Forbidden |
+| `strict` | Same as standard + mandatory review, max 500 LOC per PR | Yes, with approval | Full E2E suite | Forbidden |
+| `solo` | Trunk-based, direct push allowed | Optional | Manual spot-check | Forbidden |
+| `research` | Feature branches, long-lived OK | Yes | Optional | Forbidden |
+
+All presets share one invariant: **orphan branches are always forbidden.** Agents will take the path of least resistance — `git init` "works" locally but creates parallel histories that can't merge. The spec prevents this by default.
+
+**Full example with overrides:**
+
+```markdown
+## SDLC
+
+preset: standard
+
+### Source Control
+- **Branch strategy:** trunk-based — always branch off `main`
+- **Branch naming:** `<role>/<feature>` (e.g., `web-eng/auth-flow`)
+- **Orphan branches:** forbidden — never `git init`, never create disconnected history
+- **Direct push to main:** never
+- **Pre-work ritual:** `git fetch origin && git checkout -b <branch> origin/main`
+
+### Pull Requests
+- **Required:** yes — every change, even typo fixes
+- **Target:** `main`
+- **Max size:** 500 lines (soft), 1000 lines (hard)
+- **Naming:** conventional commits (`feat:`, `fix:`, `docs:`, `chore:`)
+- **Scope:** one feature per PR — don't accumulate large batches
+
+### Quality Gates
+- **Pre-merge:** typecheck passes (`tsc --noEmit`), lint clean, tests pass
+- **Post-deploy:** smoke test required (Playwright or equivalent)
+- **Dependency additions:** must be checked for framework compatibility
+
+### Deploy
+- **Pipeline:** PR merge → build → deploy → verify → announce
+- **Verification:** HTTP 200 on primary routes + no client-side JS errors
+- **Communication:** post to #alerts (or equivalent channel) on every deploy
+
+### Incident Response
+- **Flag immediately** in the team channel — don't wait
+- **Document:** what happened, root cause, what changed
+- **Post-mortem:** update SDLC rules if a process gap caused the incident
+```
+
+**Why this matters:** Without explicit SDLC rules, agents default to whatever works locally. A sub-agent that doesn't know the branching strategy will `git init` a fresh repo, accumulate 66 commits on an orphan branch, and create a production incident when someone tries to merge it. SDLC defaults make the wrong thing hard and the right thing obvious.
+
+**Relationship to CONTRIBUTING.md:** If the repo has a `CONTRIBUTING.md`, agents should read it. The SDLC section in ORG.md is the organizational policy; CONTRIBUTING.md is the repo-level implementation. They should align — if they conflict, CONTRIBUTING.md wins for that repo.
+
+#### Workspace Strategy
+
+Agents that touch code need isolated working directories. The spec supports a `### Repository` subsection that defines how agents share a codebase:
+
+```markdown
+### Repository
+
+clone: /opt/org/openspawn
+strategy: worktree-per-agent
+
+#### Worktrees
+- designer → /opt/org/openspawn-designer
+- web-eng → /opt/org/openspawn-web-eng
+- docs-writer → /opt/org/openspawn-docs
+```
+
+**`worktree-per-agent`** (recommended default):
+- One shared `.git` directory — single object store, single fetch updates all refs
+- Each agent gets a dedicated worktree on a unique branch
+- Orphan histories are **structurally impossible** — `git worktree add` always branches from the real tree
+- The org boot sequence creates worktrees; agents never run `git init` or `git clone`
+
+**Rules enforced by the strategy:**
+- **One branch per worktree.** Two worktrees cannot check out the same branch.
+- **Serialize fetches.** One fetch before spawning a batch of agents — not per-agent. Prevents `.git/index.lock` contention.
+- **No `git stash`.** Stash is shared across worktrees. Agents commit or discard instead.
+- **Worktree naming:** `<repo>-<agent-role>` (e.g., `openspawn-designer`)
+- **Cleanup on deactivation.** When an agent is removed or a sub-agent finishes, `git worktree prune` reclaims its directory.
+
+**Alternative strategies:**
+- `clone-per-agent` — full clone per agent. Higher disk usage but zero contention. Use for large teams or repos with submodules.
+- `shared` — all agents use the same working directory. Only viable for single-writer orgs (one agent writes, others read).
+
+**Why this is in the spec:** The Feb 27 incident happened because a sub-agent was given a repo path and told to "work on the codebase." It did what made sense locally: `git init`. By making workspace setup an org-level concern — defined in ORG.md, executed by the boot sequence — agents never have to figure out repository access on their own.
+
+---
+
+### 1.4 Structure
+
+The org chart. Departments, roles, and hierarchy — defined as nested markdown.
+
+```markdown
+## Structure
+
+### COO
+The operational backbone. Receives orders from the human principal,
+breaks them into departmental work, ensures nothing falls through cracks.
+
+- **Model:** claude-sonnet
+- **Domain:** operations
+- **Reports to:** Human Principal
+
+### Engineering
+Our largest team. Owns code, infrastructure, testing, and deployment.
+
+#### Engineering Lead
+Triages technical work. Delegates to specialists. Reviews output.
+- **Model:** claude-sonnet
+- **Domain:** engineering
+
+#### Backend Senior
+Owns API, database, and server infrastructure.
+- **Model:** claude-haiku
+- **Domain:** backend
+- **Count:** 2
+
+#### Frontend Workers
+Build and maintain the dashboard and marketing site.
+- **Model:** claude-haiku
+- **Domain:** frontend
+- **Count:** 3
+
+#### QA Worker
+Writes and runs tests. Reviews PRs for quality.
+- **Model:** claude-haiku
+- **Domain:** testing
+
+### Security
+Small but critical. Every deploy needs their sign-off.
+
+#### Security Lead
+- **Model:** claude-sonnet
+- **Domain:** appsec
+
+#### Security Worker
+- **Model:** claude-haiku  
+- **Domain:** infrastructure-security
+
+### Marketing
+Owns content, campaigns, and public presence.
+
+#### Marketing Lead
+- **Model:** claude-sonnet
+- **Domain:** content
+
+#### Content Workers
+- **Model:** claude-haiku
+- **Domain:** copywriting
+- **Count:** 2
+```
+
+**How hierarchy is inferred:**
+- H2 (`##`) = top-level section (Structure itself)
+- H3 (`###`) = department or C-level role (L9-10)
+- H4 (`####`) = department member roles
+- Nesting under a department heading = reports to that department's lead
+- The first role under a department heading with no explicit `Reports to` = the department lead
+
+**Role keywords and levels:**
+
+| Keyword in role name | Inferred level | Can delegate? | Can spawn? |
+|---------------------|----------------|---------------|------------|
+| COO, CTO, CEO | L10 | ✅ | ✅ |
+| VP, Director, Talent | L9 | ✅ | ✅ |
+| Lead, Manager | L7 | ✅ | ✅ |
+| Senior, Principal | L6 | ✅ | ❌ |
+| Worker, Engineer, Agent | L4 | ❌ | ❌ |
+| Junior, Intern, Assistant | L1-2 | ❌ | ❌ |
+
+**The `Count` field:** Creates multiple agents with the same role. They get auto-numbered names: "Frontend Worker 1", "Frontend Worker 2", etc. Each is an independent agent with its own task queue and trust score.
+
+**Prose matters:** The text description above each role becomes part of that agent's system prompt context. "Triages technical work. Delegates to specialists." tells the LLM how to behave. Write the description like you're explaining the role to a new hire.
+
+---
+
+### 1.5 Policies
+
+Rules that govern how the organization operates. Budget, routing, permissions, and constraints.
+
+```markdown
+## Policies
+
+### Budget
+- **Per-agent limit:** 1000 credits/period
+- **Alert threshold:** 80%
+- **Overage behavior:** pause and escalate — don't hard-stop
+- **Period:** weekly
+
+### Task Routing
+Tasks are auto-routed to the right department by matching:
+1. Domain keywords in the task title/description
+2. Agent domain expertise
+3. Current workload (prefer idle agents)
+4. Trust score (higher trust gets harder tasks)
+
+If no match is found, task goes to the COO for manual delegation.
+
+### Permissions
+- **L7+ can create tasks** — leads and above can break work into subtasks
+- **L7+ can spawn agents** — leads can grow their team (up to department cap)
+- **L6+ can review** — seniors and above can approve/reject work
+- **All agents can escalate** — nobody should be silently stuck
+
+### Department Caps
+- Engineering: max 10 agents
+- Security: max 4 agents  
+- Marketing: max 6 agents
+- No department can exceed 15 agents without human approval
+
+### Working Hours
+- **Active hours:** 08:00-22:00 (org timezone)
+- **Off-hours behavior:** queue tasks, don't process
+- **Exceptions:** critical priority tasks process 24/7
+```
+
+**Policies as guardrails:** These aren't suggestions — the system enforces them. An agent that tries to spawn when at department cap gets denied. An agent that exceeds budget gets paused. This is how you maintain control over autonomous agents.
+
+---
+
+### 1.6 Playbooks
+
+Reusable procedures for common situations. Like runbooks in ops, but for your agent org.
+
+```markdown
+## Playbooks
+
+### New Task Arrives
+1. COO receives task from Human Principal
+2. COO categorizes by domain and priority
+3. COO delegates to appropriate department lead
+4. Lead acks (auto) and breaks into subtasks if needed
+5. Lead assigns to available workers by trust score
+6. Workers ack and begin — progress logged to task activity
+
+### Escalation: BLOCKED
+1. Agent creates escalation message with blocker details
+2. Escalation goes to direct manager (never skip levels)
+3. Manager has 2 cycles to respond:
+   - Provide the missing resource/context
+   - Reassign to a different agent
+   - Escalate further up
+4. If unresolved after 2 levels, alert Human Principal
+
+### Escalation: OUT_OF_DOMAIN
+1. Agent flags task as wrong domain
+2. Manager receives escalation
+3. Manager re-delegates to correct department lead
+4. Original agent is freed for other work
+5. No penalty to original agent's trust score
+
+### New Agent Onboarding
+1. New agent spawned by a lead
+2. First 3 tasks are LOW priority (warm-up period)
+3. Trust score starts at 30 (PROBATION)
+4. Mentor assigned: closest senior in same domain
+5. After 5 successful tasks, promoted to TRUSTED
+6. After 20 successful tasks, eligible for VETERAN
+
+### Weekly Review (automated)
+1. System compiles: tasks completed, escalation rate, budget burn
+2. Generates org health score
+3. Flags anomalies: sudden escalation spikes, idle agents, budget overruns
+4. Sends digest to Human Principal
+5. Proposes optimizations: "Engineering is bottlenecked, consider +1 senior"
+```
+
+**Why playbooks in the org file:** They're not just documentation — they're instructions. When an agent encounters "BLOCKED", it can look up the playbook and follow the procedure. When the system onboards a new agent, it follows the onboarding playbook. The org file is simultaneously human documentation and machine instructions.
+
+---
+
+## 2. Parsing Rules
+
+ORG.md is designed to be readable by humans and parseable by machines. The parsing rules are intentionally lenient:
+
+### 2.1 Metadata Extraction
+
+Structured data is extracted from markdown bullet lists:
+```
+- **Key:** Value
+```
+
+The pattern `- **Key:** Value` extracts `{ key: "value" }`. Keys are case-insensitive and normalized (spaces → underscores).
+
+### 2.2 Free Text = Context
+
+Any text that isn't structured metadata becomes context:
+- Department descriptions → department-level system prompt context
+- Role descriptions → agent-level system prompt context
+- Policy explanations → system enforcement rules
+- Playbook steps → procedural instructions
+
+### 2.3 Numbers and Counts
+
+- `**Count:** 3` → spawn 3 agents with this role
+- `**Per-agent limit:** 1000` → numeric extraction
+- `**Max depth:** 3` → numeric extraction
+
+### 2.4 Model References
+
+Models can be specified as:
+- Full provider/model: `anthropic/claude-sonnet-4-5`
+- Alias: `claude-sonnet`, `claude-haiku`, `gpt-4o`
+- Relative: `same-as-lead`, `fastest`, `cheapest`
+- Omitted: defaults to org-level default or system default
+
+### 2.5 Hierarchy from Headings
+
+```
+## Structure          → section marker
+### Department Name   → L9-10 department / C-level
+#### Role Name        → L4-7 team member (inherits department)
+##### Sub-role        → L1-3 junior / intern
+```
+
+---
+
+## 3. Lifecycle
+
+### 3.1 Deployment
+
+```bash
+# Deploy an org from a file
+bikinibottom deploy ORG.md
+
+# Deploy with a specific culture override
+bikinibottom deploy ORG.md --culture=enterprise
+
+# Dry run — show what would be created
+bikinibottom deploy ORG.md --dry-run
+```
+
+On deploy:
+1. Parse ORG.md
+2. Create agents according to Structure
+3. Apply Culture parameters to ACP config
+4. Enforce Policies as system constraints
+5. Load Playbooks as procedural knowledge
+6. Start the simulation / connect to live system
+
+### 3.2 Live Editing
+
+ORG.md can be modified while the org is running:
+
+```bash
+# Apply changes from updated file
+bikinibottom apply ORG.md
+```
+
+The system diffs the current state against the new file:
+- **New roles** → spawn agents
+- **Removed roles** → gracefully wind down (finish current tasks, then deactivate)
+- **Changed policies** → apply immediately
+- **Changed culture** → update ACP parameters live
+- **Changed descriptions** → update system prompts on next tick
+
+### 3.3 Versioning
+
+ORG.md lives in git. Standard version control applies:
+
+```bash
+git diff ORG.md  # See what changed in the org
+git log ORG.md   # History of org changes
+git blame ORG.md # Who changed the escalation policy?
+```
+
+**PR reviews for org changes:**
+```
+PR #42: Add data team (2 agents)
+ 
++ ### Data & Analytics
++ Owns data pipelines, reporting, and business intelligence.
++ 
++ #### Data Lead
++ - **Model:** claude-sonnet
++ - **Domain:** data-engineering
++ 
++ #### Data Worker
++ - **Model:** claude-haiku
++ - **Domain:** analytics
+```
+
+Reviewers can discuss: "Do we need a full team or just one analyst?" — the same way you'd review infrastructure-as-code changes.
+
+### 3.4 Export
+
+Running orgs can export their current state back to ORG.md:
+
+```bash
+# Export current org state (including dynamically spawned agents)
+bikinibottom export > ORG.md
+```
+
+This captures the *actual* org — including agents that were spawned dynamically by leads. The exported file becomes the new source of truth.
+
+---
+
+## 4. Org Health & Intelligence
+
+### 4.1 Health Score
+
+A single composite score (0-100) computed from ACP metrics:
+
+| Component | Weight | Healthy | Unhealthy |
+|-----------|--------|---------|-----------|
+| Ack latency | 15% | < 1 cycle | > 3 cycles |
+| Escalation rate | 20% | < 10% of tasks | > 30% of tasks |
+| Completion rate | 25% | > 90% | < 70% |
+| Budget utilization | 15% | 40-80% | < 20% or > 95% |
+| Agent idle rate | 10% | < 30% | > 60% |
+| Time-to-completion | 15% | Trending down | Trending up |
+
+Score interpretation:
+- **90-100:** Elite org — highly efficient, minimal waste
+- **70-89:** Healthy — normal operations, minor inefficiencies
+- **50-69:** Needs attention — bottlenecks or misrouting
+- **< 50:** Restructure recommended — systemic issues
+
+### 4.2 Self-Healing Recommendations
+
+The system observes patterns and proposes changes:
+
+```markdown
+## Recommendations (auto-generated)
+
+### 🔴 Critical
+- Engineering escalation rate is 35% (threshold: 10%)
+  → Recommendation: Add 1 senior backend agent
+  → Impact: Estimated 20% reduction in escalation rate
+
+### 🟡 Warning  
+- Marketing has 2 idle agents while Security is overloaded
+  → Recommendation: Cross-train 1 marketing worker for security tasks
+  → Impact: Reduce security task queue by ~30%
+
+### 🟢 Optimization
+- Agent "Backend Senior 2" has 98% success rate over 50 tasks
+  → Recommendation: Promote to Lead, create Backend sub-team
+  → Impact: Free up Engineering Lead for higher-level planning
+```
+
+Recommendations are suggestions, not actions. A human reviews and approves via the dashboard or by modifying ORG.md.
+
+### 4.3 A/B Testing
+
+Run two org structures simultaneously and compare:
+
+```bash
+bikinibottom ab-test ORG-v1.md ORG-v2.md --tasks=100
+```
+
+Both orgs process the same task set. The system reports:
+- Completion rate, time-to-completion, escalation rate, cost
+- Statistical significance of differences
+- Recommendation: which org structure performed better
+
+This is how you data-drive organizational design.
+
+---
+
+## 5. Examples
+
+### 5.1 Solo Developer + Agents
+
+```markdown
+# My Dev Team
+
+## Culture
+preset: startup
+
+## Structure
+
+### Me (Human Principal)
+I make the decisions. Agents do the work.
+
+### Code Agent
+Writes code, runs tests, submits PRs.
+- **Model:** claude-sonnet
+- **Domain:** fullstack
+
+### Review Agent  
+Reviews PRs, checks for bugs and style issues.
+- **Model:** claude-haiku
+- **Domain:** code-review
+
+### Docs Agent
+Keeps documentation in sync with code changes.
+- **Model:** claude-haiku
+- **Domain:** documentation
+```
+
+### 5.2 Agency with Client Teams
+
+```markdown
+# Creative Agency
+
+## Culture
+preset: agency
+- **Progress updates:** every tick — clients expect visibility
+
+## Structure
+
+### Account Director
+Manages client relationships. Routes work to the right team.
+- **Model:** claude-sonnet
+- **Domain:** account-management
+
+### Design Team
+
+#### Design Lead
+- **Model:** claude-sonnet
+- **Domain:** visual-design
+
+#### Designers
+- **Model:** claude-haiku
+- **Domain:** ui-ux
+- **Count:** 3
+
+### Content Team
+
+#### Content Lead
+- **Model:** claude-sonnet
+- **Domain:** content-strategy
+
+#### Writers
+- **Model:** claude-haiku
+- **Domain:** copywriting
+- **Count:** 4
+
+## Policies
+
+### Client SLA
+- Critical tasks: response within 1 cycle
+- Normal tasks: completion within 10 cycles
+- All tasks: progress update every 2 cycles
+```
+
+### 5.3 Research Lab
+
+```markdown
+# AI Research Lab
+
+## Culture
+preset: research
+- **Escalation:** delayed — let researchers explore before flagging blockers
+
+## Structure
+
+### Principal Investigator
+Sets research direction. Reviews findings. Publishes papers.
+- **Model:** claude-opus
+- **Domain:** ml-research
+
+### Senior Researchers
+- **Model:** claude-sonnet
+- **Domain:** experimentation
+- **Count:** 2
+
+### Research Assistants
+Run experiments, collect data, write up results.
+- **Model:** claude-haiku
+- **Domain:** data-collection
+- **Count:** 3
+
+## Policies
+
+### Exploration Budget
+- **Per-agent limit:** 5000 credits/period — research needs room to explore
+- **No hard stops** — flag at 90%, but don't interrupt an experiment
+```
+
+---
+
+## 6. Relationship to Existing Standards
+
+| Standard | Scope | Relationship |
+|----------|-------|-------------|
+| `CLAUDE.md` | One agent's behavior | ORG.md wraps multiple agents, each with their own implicit "CLAUDE.md" (their role description) |
+| `AGENTS.md` | Workspace rules | ORG.md is the superset — workspace rules + org structure + policies |
+| ACP | Communication protocol | ORG.md's Culture section configures ACP parameters |
+| A2A | Inter-org communication | ORG.md defines one org; A2A connects multiple orgs |
+| Terraform/Pulumi | Infrastructure as code | ORG.md is the same pattern applied to agent organizations |
+
+---
+
+## 7. Design Principles
+
+1. **Readable first.** If a human can't understand the org from reading the file, the file has failed. Structure and intent should be obvious without documentation.
+
+2. **Prose is configuration.** Role descriptions aren't comments — they become system prompt context. Write them like you're onboarding a real employee.
+
+3. **Defaults over verbosity.** Omit what you don't care about. The system picks sensible defaults. A 10-line ORG.md should produce a functional org.
+
+4. **Git-native.** ORG.md is a text file in version control. Diff, blame, review, rollback — all the tools you already have.
+
+5. **Living document.** The file evolves with the org. Dynamic changes (spawned agents, promotions) can be exported back. The file is always the source of truth.
+
+6. **Human in the loop.** The system recommends. Humans decide. ORG.md changes require a human commit (or explicit auto-approve for specific recommendations).
+
+---
+
+*ORG.md turns organizational design from tribal knowledge into version-controlled, reviewable, deployable code. It's the missing layer between "I have agents" and "I have an organization."*

--- a/apps/docs/src/content/docs/reference/scenario-engine.md
+++ b/apps/docs/src/content/docs/reference/scenario-engine.md
@@ -1,0 +1,2331 @@
+---
+title: Scenario Engine
+---
+
+# BikiniBottom Scenario Engine
+
+> Turn "11 decisions and done" into 2000+ decision epics that make people screenshot the dashboard and share it on Twitter.
+
+**Status:** Design  
+**Authors:** OpenSpawn Team  
+**Last Updated:** 2026-02-11
+
+---
+
+## Table of Contents
+
+1. [Overview & Philosophy](#1-overview--philosophy)
+2. [Architecture](#2-architecture)
+3. [SCENARIO.md File Format](#3-scenariomd-file-format)
+4. [Core Concepts](#4-core-concepts)
+5. [Decision Math](#5-decision-math)
+6. [Industry Scenarios](#6-industry-scenarios)
+7. [Integration with Deterministic Engine](#7-integration-with-deterministic-engine)
+8. [Dashboard Visualization](#8-dashboard-visualization)
+9. [Implementation Phases](#9-implementation-phases)
+
+---
+
+## 1. Overview & Philosophy
+
+### The Problem
+
+The current deterministic engine (`tools/sandbox/src/deterministic.ts`) processes a single order through ~11 decision steps:
+
+```
+COO receives order → parse 3 tasks → hire 3 leads (3 decisions) →
+delegate 3 tasks (3 decisions) → workers progress → complete
+```
+
+It's a straight line. Real organizations are a tangle. We need to model that tangle.
+
+### The Vision
+
+BikiniBottom is SimCity for agent organizations. SimCity isn't fun because a single house gets built. It's fun because *a thousand things happen simultaneously* — traffic jams, power outages, budget crises, zoning disputes — and you watch the city respond. The Scenario Engine is what generates that emergent complexity.
+
+A scenario should feel like watching a real organization work. Not every decision is dramatic — most are routine. But routines compound into patterns, patterns create bottlenecks, bottlenecks force hard choices, and hard choices are where the drama lives.
+
+### Design Principles
+
+1. **Scenarios are data, not code.** A SCENARIO.md file defines what happens. The engine interprets it. Non-programmers should be able to write scenarios.
+
+2. **Deterministic core, stochastic texture.** The engine is a state machine. Random events use seeded PRNGs — same seed, same run. Replay is sacred.
+
+3. **Friction is the feature.** Dependencies, contention, review loops, interrupts — these aren't bugs. They're what makes organizations interesting. The engine should generate *realistic* friction, not artificial delays.
+
+4. **Visual density matters.** Every decision should produce visible activity on the dashboard: a node lights up, a message flies across the org chart, a task moves on the board, a metric ticks. Dead air is death.
+
+5. **15–30 minutes, not 15 seconds.** Scenarios unfold at a pace that rewards watching. Like a timelapse of a city being built, you should be able to sit back and watch the organization work through a complex problem.
+
+6. **Replayable with variation.** Same scenario, different seed = different path. Same structure, different emergent behavior. People should want to run it again to see what happens.
+
+---
+
+## 2. Architecture
+
+### System Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    SCENARIO.md                          │
+│  (template: phases, epics, events, decision weights)    │
+└────────────────────────┬────────────────────────────────┘
+                         │ parse
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│               Scenario Engine (NEW)                     │
+│                                                         │
+│  ┌──────────┐  ┌───────────┐  ┌──────────────────┐     │
+│  │ Phase    │  │ Task      │  │ Event            │     │
+│  │ Manager  │  │ Generator │  │ Scheduler        │     │
+│  └──────────┘  └───────────┘  └──────────────────┘     │
+│  ┌──────────┐  ┌───────────┐  ┌──────────────────┐     │
+│  │ DAG      │  │ Resource  │  │ Decision         │     │
+│  │ Resolver │  │ Allocator │  │ Evaluator        │     │
+│  └──────────┘  └───────────┘  └──────────────────┘     │
+│  ┌──────────────────────────────────────────────┐       │
+│  │ Narrative Engine (branching + flavor text)   │       │
+│  └──────────────────────────────────────────────┘       │
+└────────────────────────┬────────────────────────────────┘
+                         │ feeds
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│          Deterministic Simulation (EXISTING)             │
+│  DeterministicSimulation.runTick() — processes agents   │
+│  per tick, emits SandboxEvents and ACPMessages          │
+└────────────────────────┬────────────────────────────────┘
+                         │ emits
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│              Dashboard (EXISTING)                        │
+│  Org chart · Task board · Message stream · Metrics      │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+
+| Component | Responsibility |
+|-----------|---------------|
+| **Phase Manager** | Tracks scenario phase, evaluates phase transitions, unlocks new work |
+| **Task Generator** | Expands epic templates into concrete tasks/subtasks on-demand |
+| **Event Scheduler** | Fires random and scripted events at appropriate times |
+| **DAG Resolver** | Tracks dependencies between tasks, blocks/unblocks as predecessors complete |
+| **Resource Allocator** | Models agent availability, handles contention, forces prioritization |
+| **Decision Evaluator** | Applies weighted random outcomes to decision points (reviews, approvals, resource choices) |
+| **Narrative Engine** | Generates flavor text, tracks branching story arcs, names events for dashboard display |
+
+---
+
+## 3. SCENARIO.md File Format
+
+A SCENARIO.md defines a reusable scenario template. Combined with an ORG.md (which defines *who works here*), it defines *what work they do*.
+
+### 3.1 Top-Level Structure
+
+```markdown
+# Scenario Name
+
+## Meta
+## Phases
+## Epics
+## Events  
+## Resources
+## Scoring
+```
+
+### 3.2 Meta
+
+Scenario identity and configuration parameters.
+
+```markdown
+## Meta
+
+- **Industry:** AI Dev Agency
+- **Duration:** 20 minutes
+- **Target decisions:** 1500
+- **Tick interval:** 800ms
+- **Seed:** random
+- **Difficulty:** normal
+- **Description:** A fast-growing AI agency takes on three client projects
+  simultaneously while fighting fires, shipping features, and trying not
+  to burn out the team.
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Industry` | string | Category tag for filtering/grouping |
+| `Duration` | duration | Target wall-clock runtime (engine adjusts tick pacing) |
+| `Target decisions` | number | Approximate decision count (engine calibrates generation) |
+| `Tick interval` | duration | Base time between ticks (can be overridden by phase) |
+| `Seed` | number \| "random" | PRNG seed for reproducibility |
+| `Difficulty` | easy \| normal \| hard \| chaos | Adjusts event frequency, review rejection rates, resource scarcity |
+| `Description` | text | Shown on scenario select screen |
+
+**Difficulty presets:**
+
+| Difficulty | Event frequency | Review rejection % | Resource scarcity | Block chance |
+|------------|----------------|-------------------|-------------------|-------------|
+| easy | 1 per 30 ticks | 5% | none | 5% |
+| normal | 1 per 15 ticks | 15% | light | 10% |
+| hard | 1 per 8 ticks | 25% | heavy | 20% |
+| chaos | 1 per 4 ticks | 35% | extreme | 30% |
+
+### 3.3 Phases
+
+Phases are the macro-structure of a scenario. Each phase unlocks new epics, changes event probabilities, and may alter the simulation's tick speed.
+
+```markdown
+## Phases
+
+### Phase 1: Setup (ticks 1–50)
+The team assembles. Leads are hired, initial tasks assigned.
+Client kickoff meetings happen. Requirements are gathered.
+
+- **Tick range:** 1–50
+- **Unlocks epics:** Client Onboarding, Infrastructure Setup
+- **Events enabled:** team-sick, requirement-change
+- **Tick interval override:** 600ms (fast — setup should feel snappy)
+- **Transition:** all "Setup" epics at 80%+ completion
+
+### Phase 2: Sprint 1 (ticks 51–200)
+First real work sprint. Multiple workstreams running in parallel.
+Dependencies start to bite. First blockers emerge.
+
+- **Tick range:** 51–200
+- **Unlocks epics:** API Development, Frontend Build, Security Audit
+- **Events enabled:** p0-bug, client-escalation, scope-creep, team-sick
+- **Transition:** 3+ epics at "done" status
+
+### Phase 3: Crunch (ticks 201–350)
+Deadline approaching. Resource contention peaks. Hard trade-offs.
+
+- **Tick range:** 201–350  
+- **Unlocks epics:** Launch Prep, Performance Optimization, Documentation
+- **Events enabled:** all
+- **Difficulty modifier:** +1 (events fire 50% more often)
+- **Transition:** "Launch Prep" epic at 100% OR tick 350
+
+### Phase 4: Launch (ticks 351–400)
+Ship it. Final reviews, deploy, monitor, celebrate (or patch).
+
+- **Tick range:** 351–400
+- **Unlocks epics:** Deployment, Post-Launch Monitoring
+- **Events enabled:** deploy-failure, production-bug, client-feedback
+- **Transition:** scenario complete
+```
+
+**Phase transitions** can be:
+- **Tick-based:** phase starts at tick N regardless
+- **Completion-based:** phase starts when conditions are met (e.g., "3 epics done")
+- **Event-based:** phase starts when a specific event fires (e.g., "battle-begins" event triggers Phase 3)
+- **Hybrid:** earliest of tick threshold OR completion condition
+
+### 3.4 Epics
+
+Epics are templates for large bodies of work. Each epic expands into tasks and subtasks at generation time.
+
+```markdown
+## Epics
+
+### Client Onboarding
+- **Phase:** Setup
+- **Domain:** operations, engineering
+- **Priority:** critical
+- **Generates:** 3–5 tasks, 2–4 subtasks each
+- **Dependencies:** none (entry point)
+- **Description:** New client needs: contract review, environment provisioning,
+  requirements doc, kickoff meeting, access setup.
+
+#### Task Templates
+1. **Contract Review** [finance]
+   - Review terms → Negotiate changes → Final sign-off
+   - Duration: 4–6 ticks per subtask
+   - Review required: yes (L7+)
+   
+2. **Environment Provisioning** [engineering]
+   - Create repos → Set up CI/CD → Configure staging
+   - Duration: 3–5 ticks per subtask
+   - Dependencies: Contract Review (approved)
+   
+3. **Requirements Document** [engineering]
+   - Draft requirements → Client review → Revisions → Sign-off
+   - Duration: 5–8 ticks per subtask
+   - Review loop: 1–3 iterations (weighted: 60% pass first time, 30% one revision, 10% two revisions)
+   
+4. **Kickoff Meeting** [operations]
+   - Prepare agenda → Schedule → Run meeting → Distribute notes
+   - Duration: 2–3 ticks per subtask
+   - Cross-dept trigger: on completion → unlock "API Development" epic
+
+5. **Access Setup** [security]
+   - Create accounts → Set permissions → Audit access → Sign-off
+   - Duration: 2–4 ticks per subtask
+   - Dependencies: Contract Review (approved)
+```
+
+**Epic template fields:**
+
+| Field | Description |
+|-------|-------------|
+| `Phase` | Which phase unlocks this epic |
+| `Domain` | Which department(s) own this work |
+| `Priority` | Base priority (can be elevated by events) |
+| `Generates` | Task/subtask count ranges (randomized within range) |
+| `Dependencies` | Other epics or tasks that must complete first |
+| `Description` | Context for flavor text generation |
+
+**Task template fields:**
+
+| Field | Description |
+|-------|-------------|
+| `[domain]` | Domain tag in brackets — routes to correct department |
+| Subtask list | Named subtasks in order |
+| `Duration` | Tick range per subtask (randomized) |
+| `Review required` | Whether this task needs review before "done" |
+| `Review loop` | How many iterations of review are expected (weighted distribution) |
+| `Dependencies` | Tasks that must complete before this one starts |
+| `Cross-dept trigger` | Events to fire on completion |
+
+### 3.5 Events
+
+Events inject chaos, drama, and realism. They interrupt normal flow and force the organization to respond.
+
+```markdown
+## Events
+
+### p0-bug
+- **Type:** interrupt
+- **Probability:** 0.08 per tick (during enabled phases)
+- **Cooldown:** 20 ticks (can't fire again within)
+- **Priority elevation:** critical
+- **Effect:**
+  - Creates 1 critical task: "Fix [random system] outage"
+  - Pulls senior engineer off current work (preempt)
+  - Generates 4–6 subtasks: investigate, reproduce, fix, test, deploy, postmortem
+  - Cross-dept: notify support ("we're aware, ETA incoming")
+  - Cross-dept: notify client if client-facing
+- **Dashboard flavor:** 🚨 flashing alert, org chart highlights affected agents in red
+- **Narrative:** "[Agent] discovered a critical bug in [system]. All hands on deck."
+
+### client-escalation
+- **Type:** interrupt
+- **Probability:** 0.05 per tick
+- **Cooldown:** 30 ticks
+- **Effect:**
+  - Elevates 1 random in-progress task to critical
+  - Creates task: "Client sync call" [operations, 3 ticks]
+  - COO gets escalation message
+  - If during Phase 3+: also creates "Scope negotiation" task
+- **Narrative:** "Client [name] is unhappy with progress on [task]. Emergency meeting called."
+
+### team-sick
+- **Type:** disruption
+- **Probability:** 0.03 per tick
+- **Cooldown:** 40 ticks
+- **Duration:** 15–25 ticks
+- **Effect:**
+  - 1 random non-lead agent becomes unavailable
+  - Their in-progress tasks go to "blocked" (reason: "assignee unavailable")
+  - Manager must reassign or wait
+  - If the sick agent is a bottleneck (only person in domain), generates escalation chain
+- **Narrative:** "[Agent] is out sick. [Manager] is redistributing their workload."
+
+### scope-creep
+- **Type:** expansion
+- **Probability:** 0.04 per tick
+- **Cooldown:** 25 ticks
+- **Effect:**
+  - Adds 2–4 new tasks to a random in-progress epic
+  - New tasks have dependencies on existing work
+  - If during Phase 3+: triggers deadline-pressure event
+- **Narrative:** "New requirements just came in: [generated requirement]. Adding to the backlog."
+
+### deadline-pressure
+- **Type:** modifier
+- **Probability:** 0.0 (triggered by other events or phase transitions)
+- **Effect:**
+  - Reduces tick duration per subtask by 30% (agents work faster but quality drops)
+  - Review rejection rate increases by 10%
+  - Morale metric decreases
+  - After 30 ticks: either deadline met (celebrate) or missed (consequences)
+- **Narrative:** "Two weeks until launch. [COO] is cutting scope."
+
+### surprise-opportunity
+- **Type:** expansion
+- **Probability:** 0.02 per tick
+- **Cooldown:** 60 ticks
+- **Effect:**
+  - New client appears with a small engagement
+  - Creates 1 new epic with 3–4 tasks
+  - Competes for resources with existing work
+  - Successful completion awards bonus credits
+- **Narrative:** "Inbound lead: [Company] wants a quick prototype. Big potential if we impress them."
+```
+
+**Event types:**
+
+| Type | Description | Dashboard effect |
+|------|-------------|-----------------|
+| `interrupt` | Demands immediate attention, preempts current work | 🚨 Flash alert, red highlights |
+| `disruption` | Removes or modifies resources | ⚠️ Agent goes grey, tasks redistribute |
+| `expansion` | Adds new work to the scenario | 📋 New tasks appear on board |
+| `modifier` | Changes simulation parameters | 🔧 Metric shifts visible |
+| `narrative` | Pure story beat, no mechanical effect | 💬 Story event in timeline |
+| `opportunity` | Optional beneficial event, but costs resources | ✨ Gold highlight, optional accept |
+
+### 3.6 Resources
+
+Resources model scarcity and contention — things agents need but can't always get.
+
+```markdown
+## Resources
+
+### Senior Engineering Time
+- **Type:** agent-hours
+- **Pool:** 2 agents × 1 task-slot each = 2 concurrent
+- **Contention rule:** FIFO with priority override (critical tasks preempt)
+- **Starvation alert:** if any task waits > 10 ticks for this resource
+
+### QA Capacity
+- **Type:** agent-hours
+- **Pool:** 1 agent × 2 task-slots = 2 concurrent reviews
+- **Bottleneck effect:** when queue > 4, review duration increases 50%
+
+### Client Meeting Slots
+- **Type:** calendar
+- **Pool:** 2 per phase (client only meets twice per phase)
+- **Effect:** tasks requiring client sign-off must wait for a slot
+
+### Budget
+- **Type:** credits
+- **Pool:** 5000 credits for scenario
+- **Burn rate:** ~15 credits/tick during active work
+- **Alert:** at 20% remaining, triggers "budget-crunch" event
+- **Depleted:** non-critical tasks pause, critical only
+```
+
+### 3.7 Scoring
+
+How well did the organization perform?
+
+```markdown
+## Scoring
+
+### Dimensions (each 0–100)
+
+- **Velocity:** tasks completed per tick, weighted by priority
+- **Quality:** (1 - review rejection rate) × 100
+- **Efficiency:** credits earned / credits spent ratio
+- **Resilience:** how quickly org recovered from events (ticks-to-recover)
+- **Morale:** f(overwork, idle-time, escalation-frequency, blocked-duration)
+- **Deadline:** % of deadline-sensitive tasks completed on time
+
+### Overall Score
+weighted_average(velocity=20, quality=25, efficiency=15, resilience=20, morale=10, deadline=10)
+
+### Grades
+- **S:** 90–100 — "Legendary org. Screenshot this."
+- **A:** 80–89 — "Well-oiled machine."
+- **B:** 70–79 — "Solid. Room to optimize."
+- **C:** 60–69 — "Growing pains. Needs restructuring."
+- **D:** 50–59 — "Dysfunction junction."
+- **F:** <50 — "Total organizational collapse."
+```
+
+---
+
+## 4. Core Concepts
+
+### 4.1 Epic → Task → Subtask Hierarchy
+
+Three levels of work decomposition, each with different decision characteristics:
+
+```
+Epic: "Build Payment System"                    [1 decision: create + delegate to lead]
+├── Task: "Design API Schema"                   [3 decisions: create + assign + ack]
+│   ├── Subtask: "Research payment providers"    [7 decisions: assign, ack, progress×2, review, revise, complete]
+│   ├── Subtask: "Draft OpenAPI spec"            [6 decisions: assign, ack, progress, review, complete, trigger]
+│   └── Subtask: "Security review of spec"       [5 decisions: assign, ack, review, feedback, complete]
+├── Task: "Implement Backend"                   [3 decisions: create + assign + ack]
+│   ├── Subtask: "Stripe integration"            [7 decisions]
+│   ├── Subtask: "Webhook handlers"              [6 decisions]
+│   ├── Subtask: "Transaction ledger"            [7 decisions]
+│   └── Subtask: "Unit tests"                    [5 decisions]
+└── Task: "Frontend Integration"                [3 decisions: blocked until API done → unblock = 1 decision]
+    ├── Subtask: "Payment form component"        [6 decisions]
+    ├── Subtask: "Checkout flow"                 [7 decisions]
+    └── Subtask: "E2E tests"                     [5 decisions]
+```
+
+**Decision accounting per subtask:**
+
+| Step | Decisions | Messages Generated |
+|------|-----------|-------------------|
+| Lead creates subtask | 1 | — |
+| Lead assigns to worker | 1 | delegation ACP |
+| Worker acknowledges | 1 | ack ACP |
+| Worker progresses (1–3 updates) | 1–3 | progress ACP(s) |
+| Worker submits for review | 1 | progress ACP (pct=80) |
+| Reviewer evaluates | 1 | — |
+| If revision needed: feedback + rework + resubmit | 3 | escalation ACP + progress ACP |
+| Reviewer approves | 1 | completion ACP |
+| Worker marks complete | 1 | completion ACP |
+| Cross-dept trigger fires (if applicable) | 1 | delegation ACP |
+| **Total per subtask** | **8–12** | **5–8 messages** |
+
+### 4.2 Dependencies (DAG)
+
+Tasks form a directed acyclic graph. Dependencies create realistic workflow friction.
+
+```
+                    ┌──────────────┐
+                    │ Requirements │
+                    │   Document   │
+                    └──────┬───────┘
+                           │
+                ┌──────────┼──────────┐
+                ▼          ▼          ▼
+         ┌──────────┐ ┌────────┐ ┌─────────┐
+         │ API Spec │ │  UX    │ │ Infra   │
+         │  Design  │ │ Mocks  │ │ Setup   │
+         └────┬─────┘ └───┬────┘ └────┬────┘
+              │            │           │
+              ▼            │           │
+         ┌─────────┐      │           │
+         │ Backend │◄─────┘           │
+         │  Build  │◄─────────────────┘
+         └────┬────┘
+              │
+         ┌────┴────┐
+         ▼         ▼
+    ┌─────────┐ ┌──────────┐
+    │Frontend │ │ Security │
+    │  Build  │ │  Audit   │
+    └────┬────┘ └────┬─────┘
+         │           │
+         ▼           ▼
+    ┌──────────────────┐
+    │   Integration    │
+    │     Testing      │
+    └────────┬─────────┘
+             │
+             ▼
+    ┌──────────────────┐
+    │     Deploy       │
+    └──────────────────┘
+```
+
+**DAG mechanics in the engine:**
+
+```typescript
+interface TaskDependency {
+  taskId: string;           // the dependent task
+  dependsOn: string[];      // predecessor task IDs
+  type: 'finish-to-start'   // predecessor must be done
+       | 'start-to-start'   // predecessor must have started
+       | 'partial';         // predecessor at 50%+ triggers start
+  blockedSince?: number;    // tick when this dependency started blocking
+}
+```
+
+**Dashboard effect:** Dependencies show as connecting lines between task cards. Blocked tasks pulse softly. When a predecessor completes, the line turns green and the dependent task lights up — a visible "unlock" animation.
+
+### 4.3 Decision Points with Weighted Outcomes
+
+Not all reviews pass. Not all plans survive contact with reality.
+
+```markdown
+### Decision: Code Review
+- **Approve (pass):** 70% — task advances to done
+- **Request changes (minor):** 20% — task returns to in_progress, 2–3 tick rework
+- **Reject (major issues):** 8% — task returns to in_progress, 5–8 tick rework
+- **Escalate (out of scope):** 2% — task escalated to manager, possible reassignment
+
+### Decision: Client Sign-Off
+- **Approve:** 60%
+- **Approve with conditions:** 25% — creates 1–2 new subtasks
+- **Request major revisions:** 12% — epic adds 1 new task
+- **Reject direction:** 3% — epic resets current phase, 30% work lost
+
+### Decision: Resource Contention
+- **First-come-first-served:** 50% — whoever asked first gets the resource
+- **Priority override:** 30% — higher priority task preempts
+- **Manager intervention:** 15% — manager manually assigns
+- **Deadlock:** 5% — both tasks blocked, escalation to COO
+```
+
+**Difficulty scaling:**
+
+| Decision | Easy | Normal | Hard | Chaos |
+|----------|------|--------|------|-------|
+| Review pass rate | 85% | 70% | 55% | 40% |
+| Client approval | 80% | 60% | 40% | 25% |
+| Block chance | 5% | 10% | 20% | 30% |
+| Event frequency | low | medium | high | extreme |
+
+### 4.4 Cross-Department Triggers
+
+When work in one department creates work in another — the organizational multiplier.
+
+```yaml
+triggers:
+  - when: "API Spec Design" completes
+    then:
+      - create_task: "Build Frontend Components" in frontend
+      - create_task: "Write API Documentation" in marketing
+      - create_task: "Security Review: API Surface" in security
+    message: "API spec approved. Frontend, docs, and security work auto-created."
+
+  - when: any task in "security" rejects review
+    then:
+      - block: the reviewed task
+      - create_task: "Security Remediation" in engineering (critical)
+      - notify: COO
+    message: "Security found issues. Engineering must remediate before proceeding."
+
+  - when: "Client Onboarding" epic completes
+    then:
+      - phase_transition: "Sprint 1"
+      - create_epic: generate from "Sprint Work" template
+      - event: "celebration" (narrative)
+    message: "Client is onboarded! Sprint 1 begins."
+```
+
+**The multiplier effect:** A single task completion can cascade into 3–5 new tasks across departments. This is how scenarios naturally generate 1000+ decisions — not by having 1000 pre-defined tasks, but by having ~50 tasks that *generate* more tasks through triggers.
+
+### 4.5 Resource Contention
+
+Multiple workstreams competing for scarce resources creates organic drama.
+
+```
+Sprint 1                          Sprint 2
+┌─────────────────┐               ┌─────────────────┐
+│ Client A:       │               │ Client B:        │
+│ Payment System  │               │ Analytics Dash   │
+│                 │               │                  │
+│ Needs: Sandy    │──── CONFLICT ────│ Needs: Sandy   │
+│ (3 ticks)       │               │ (5 ticks)        │
+└─────────────────┘               └─────────────────┘
+
+Resolution options:
+1. Sandy works Client A first (B waits 3 ticks)
+2. Sandy works Client B first (A waits 5 ticks)
+3. Sandy splits time (both take 60% longer)
+4. Hire another senior engineer (costs credits, takes 5 ticks to onboard)
+5. Escalate to COO for priority call
+```
+
+**Contention creates visible drama on the dashboard:** You see two task cards pulsing, both wanting the same agent. The agent's node on the org chart flashes between two colors. Eventually, a manager makes a call, and one task turns red (blocked) while the other turns green (proceeding). Real organizational drama, played out visually.
+
+### 4.6 Random Events
+
+Events are the heartbeat of scenario drama. Without events, work flows smoothly — and smoothly is boring.
+
+**Event scheduling algorithm:**
+
+```
+for each tick:
+  for each enabled event in current phase:
+    if event.cooldown has elapsed:
+      roll = prng.next()
+      adjusted_probability = event.probability × difficulty_modifier × phase_modifier
+      if roll < adjusted_probability:
+        fire_event(event)
+        set cooldown
+```
+
+**Event chaining:** Events can trigger other events. A `p0-bug` during `deadline-pressure` triggers `emergency-triage`. A `team-sick` event when only 1 engineer remains triggers `critical-understaffing`. This creates emergent narrative arcs that differ each run.
+
+### 4.7 Deadlines with Consequences
+
+Deadlines aren't just numbers — they create organizational pressure that changes behavior.
+
+```markdown
+### Deadline: Client Demo (Tick 250)
+
+**Required completions:**
+- API endpoints (all critical paths)
+- Frontend demo flow (happy path)
+- Sample data loaded
+
+**As deadline approaches:**
+- Tick 200 (50 remaining): status check, scope assessment
+- Tick 220 (30 remaining): if behind, trigger "scope-cut" event
+  - COO must choose which features to drop
+  - Dropped features create "deferred" tasks (debt for later)
+- Tick 240 (10 remaining): crunch mode
+  - All non-critical tasks paused
+  - Available agents reassigned to deadline work
+  - Review standards relaxed (faster approvals, higher risk)
+- Tick 250: evaluation
+  - If met: celebration event, client satisfaction +20, unlock new epic
+  - If missed: client-escalation event, reputation hit, recovery tasks created
+```
+
+### 4.8 Scenario Phases
+
+Phases give scenarios a narrative arc — a beginning, middle, and climax.
+
+**Phase mechanics:**
+
+```typescript
+interface ScenarioPhase {
+  id: string;
+  name: string;
+  tickRange: [number, number];     // [start, end] — flexible boundaries
+  tickInterval?: number;            // override base tick speed
+  unlocksEpics: string[];          // epic IDs that become available
+  enabledEvents: string[];          // event IDs active during this phase
+  difficultyMod: number;           // multiplier on event probability (1.0 = normal)
+  transition: PhaseTransition;     // when does this phase end?
+  narrative: string;               // displayed on phase start
+  ambientMessages: string[];       // random chatter during this phase
+}
+
+type PhaseTransition =
+  | { type: 'tick'; tick: number }
+  | { type: 'completion'; condition: string } // e.g., "3 epics done"
+  | { type: 'event'; eventId: string }
+  | { type: 'hybrid'; tick: number; condition: string }; // whichever comes first
+```
+
+### 4.9 Branching Narratives
+
+Decisions compound. Each run tells a different story.
+
+```
+                        ┌──── Accept opportunity ────┐
+                        │    (strain resources)       │
+ Setup ──── Sprint ─────┤                             ├──── Resolution
+                        │    (focus on core work)     │
+                        └──── Decline opportunity ────┘
+
+If accepted:
+  ├── Success: bonus credits, reputation boost, unlocks "Partnership" epic
+  └── Failure: missed deadline, client anger, recovery phase inserted
+
+If declined:
+  ├── Core work ships on time: solid but unspectacular finish
+  └── Competitor takes the opportunity: "what if" narrative beat
+```
+
+**Branch tracking:** The engine maintains a `storyState` object — a key-value map that records which branches were taken. Events and phases can check story state to conditionally activate:
+
+```markdown
+### Event: Competitor Wins Client
+- **Condition:** storyState["opportunity-declined"] == true
+- **Probability:** 0.4 (fires once)
+- **Effect:** narrative only — "Meanwhile, [Competitor] landed the [Opportunity] deal."
+- **Dashboard:** news ticker shows the missed opportunity
+```
+
+### 4.10 Metrics & Scoring
+
+Real-time metrics visible on the dashboard, final score on scenario completion.
+
+**Per-tick metrics:**
+
+| Metric | Computation | Dashboard widget |
+|--------|-------------|-----------------|
+| Active tasks | count(status ∈ {assigned, in_progress, review}) | Number badge |
+| Throughput | completed tasks in last 20 ticks | Sparkline chart |
+| Message rate | ACP messages in last 10 ticks | Pulse indicator |
+| Block rate | blocked / total active | Color indicator (green → red) |
+| Budget burn | credits spent / credits total | Progress bar |
+| Agent utilization | busy agents / total agents | Percentage gauge |
+| Escalation rate | escalations / total decisions in last 20 ticks | Warning indicator |
+
+**Final score card:**
+
+```
+╔══════════════════════════════════════════════╗
+║  SCENARIO COMPLETE: "AI Dev Agency Sprint"   ║
+║                                              ║
+║  Overall Grade: A (84/100)                   ║
+║                                              ║
+║  Velocity:    ████████░░  82                 ║
+║  Quality:     █████████░  91                 ║
+║  Efficiency:  ███████░░░  73                 ║
+║  Resilience:  ████████░░  85                 ║
+║  Morale:      ████████░░  78                 ║
+║  Deadline:    █████████░  88                 ║
+║                                              ║
+║  Decisions: 1,847  |  Ticks: 412            ║
+║  Agents: 24        |  Messages: 2,340       ║
+║  Events survived: 14                         ║
+║                                              ║
+║  Story: You took on the extra client and     ║
+║  barely made both deadlines. Sandy worked    ║
+║  overtime for 40 ticks straight. Patrick     ║
+║  surprisingly saved Sprint 2 by fixing the   ║
+║  payment bug nobody else could figure out.   ║
+║                                              ║
+║  [Share on Twitter] [Run Again] [Try Hard]   ║
+╚══════════════════════════════════════════════╝
+```
+
+---
+
+## 5. Decision Math
+
+How do we guarantee 1000+ decisions from a scenario template?
+
+### 5.1 Base Work Decisions
+
+```
+Given:
+  P = number of phases (typically 4)
+  E = epics per phase (typically 3–5)
+  T = tasks per epic (typically 3–5)
+  S = subtasks per task (typically 2–4)
+  D = decisions per subtask (typically 8–12)
+
+Base decisions = P × E × T × S × D
+
+Conservative: 4 × 3 × 3 × 2 × 8 = 576
+Normal:       4 × 4 × 4 × 3 × 10 = 1,920
+Rich:         4 × 5 × 5 × 4 × 12 = 4,800
+```
+
+### 5.2 Friction Multiplier
+
+Additional decisions from organizational friction:
+
+| Source | Decisions per occurrence | Occurrences per scenario | Total |
+|--------|------------------------|-------------------------|-------|
+| Dependency blocks/unblocks | 3 (block + reassess + unblock) | 20–40 | 60–120 |
+| Review rejections + rework | 5 (reject + feedback + rework + resubmit + re-review) | 15–30 | 75–150 |
+| Resource contention | 4 (conflict + escalation + resolution + reassign) | 10–20 | 40–80 |
+| Cross-dept triggers | 6 (trigger + create + assign + ack + notify + log) | 15–25 | 90–150 |
+| Hiring/onboarding | 4 (decide + hire + assign mentor + first task) | 5–15 | 20–60 |
+| Escalation chains | 6 (escalate + manager review + resolution × levels) | 10–20 | 60–120 |
+| **Friction total** | | | **345–680** |
+
+### 5.3 Event Decisions
+
+Each random event generates its own decision tree:
+
+| Event type | Decisions generated | Frequency (normal) | Total |
+|-----------|-------------------|-------------------|-------|
+| P0 bug | 20–30 (investigate + fix + test + deploy + postmortem) | 2–4 per scenario | 40–120 |
+| Client escalation | 10–15 (meeting + reprioritize + communicate) | 3–5 per scenario | 30–75 |
+| Team sick | 8–12 (reassign + redistribute + backfill) | 2–4 per scenario | 16–48 |
+| Scope creep | 15–20 (new tasks + replan + negotiate) | 2–3 per scenario | 30–60 |
+| Opportunity | 25–35 (evaluate + accept/decline + execute) | 1–2 per scenario | 25–70 |
+| **Event total** | | | **141–373** |
+
+### 5.4 Total Decision Budget
+
+```
+Minimum scenario (easy, 15 min):
+  Base:     576
+  Friction: 345
+  Events:   141
+  ─────────────
+  Total:    1,062 ✓ (exceeds 1000)
+
+Standard scenario (normal, 20 min):
+  Base:     1,920
+  Friction: 500
+  Events:   250
+  ─────────────
+  Total:    2,670
+
+Rich scenario (hard, 30 min):
+  Base:     4,800
+  Friction: 680
+  Events:   373
+  ─────────────
+  Total:    5,853
+```
+
+**The engine self-calibrates:** If a scenario is running ahead of its decision target, it reduces event frequency. If it's running behind, it increases event frequency and adds more review friction. The target is a smooth, consistent pace of ~2–3 decisions per tick.
+
+---
+
+## 6. Industry Scenarios
+
+### 6.1 AI Dev Agency 🤖
+
+*The meta-demo. OpenClaw showing off what OpenClaw can do.*
+
+**ORG.md:** The existing BikiniBottom org (Mr. Krabs, Sandy, SpongeBob, etc.)
+
+```markdown
+# AI Dev Agency Sprint
+
+## Meta
+- **Industry:** AI Dev Agency
+- **Duration:** 20 minutes
+- **Target decisions:** 1800
+- **Difficulty:** normal
+- **Description:** BikiniBottom AI takes on two client projects and an internal
+  platform upgrade simultaneously. Ship features, fight fires, bill hours.
+
+## Phases
+
+### Phase 1: Client Intake (ticks 1–40)
+New quarter, new clients. Mr. Krabs smells money.
+- **Unlocks epics:** Client Alpha Onboarding, Client Beta Onboarding, Internal: Platform Upgrade
+- **Events enabled:** requirement-change
+- **Tick interval:** 500ms
+- **Transition:** both onboarding epics at 60%+
+
+### Phase 2: Parallel Sprints (ticks 41–200)
+Three workstreams, one engineering team. The fun begins.
+- **Unlocks epics:** Alpha: Model Evaluation Pipeline, Beta: Prompt Engineering Suite,
+  Internal: CI/CD Overhaul, Marketing: Case Study
+- **Events enabled:** all
+- **Transition:** 4+ epics done
+
+### Phase 3: Demo Day Prep (ticks 201–320)
+Client Alpha wants a demo. Client Beta wants a different demo. Both next week.
+- **Unlocks epics:** Alpha: Demo Environment, Beta: Demo Environment, Cross-Client: Shared Infra
+- **Events enabled:** all
+- **Difficulty modifier:** 1.5
+- **Transition:** both demo epics complete OR tick 320
+
+### Phase 4: Ship & Celebrate (ticks 321–400)
+Deploy to production, send invoices, write postmortem.
+- **Unlocks epics:** Deployment, Billing, Retrospective
+- **Events enabled:** deploy-failure, production-bug, client-feedback
+- **Transition:** scenario complete
+
+## Epics
+
+### Client Alpha Onboarding
+- **Phase:** Client Intake
+- **Domain:** operations, engineering
+- **Priority:** high
+
+#### Task Templates
+1. **Scope Definition** [operations]
+   - Review RFP → Draft SOW → Client review → Revisions → Sign-off
+   - Review loop: 1–2 iterations
+   - Cross-dept: on sign-off → unlock "Model Evaluation Pipeline"
+
+2. **Environment Setup** [engineering]
+   - Provision GPU cluster → Configure model registry → Set up eval harness → Test pipeline
+   - Dependencies: Scope Definition (signed)
+
+3. **Data Pipeline** [engineering]
+   - Audit client data → Build ingestion pipeline → Validate transforms → Load test
+   - Duration: 4–7 ticks per subtask
+
+### Alpha: Model Evaluation Pipeline
+- **Phase:** Parallel Sprints
+- **Domain:** engineering
+- **Priority:** critical
+
+#### Task Templates
+1. **Eval Framework** [backend]
+   - Design eval metrics → Implement scoring → Build comparison UI → Backtest
+   - Cross-dept: on completion → create "Write Eval Methodology" in marketing
+
+2. **Model Integration** [backend]
+   - Integrate OpenAI API → Integrate Anthropic API → Integrate local models → A/B test harness
+   - Duration: 3–5 ticks per subtask
+   - Dependencies: Eval Framework (50%+)
+
+3. **Client Dashboard** [frontend]
+   - Model comparison view → Cost tracking → Latency charts → Export reports
+   - Dependencies: Eval Framework (complete), Model Integration (started)
+   - Cross-dept: on completion → Security Review
+
+4. **Prompt Optimization** [engineering]
+   - Baseline prompts → Systematic variation → Eval runs (×10) → Report best performers
+   - This task generates 10 sub-subtasks (one per eval run), each a mini-decision
+   - Duration: 2–3 ticks per eval run
+
+### Internal: Platform Upgrade
+- **Phase:** Parallel Sprints
+- **Domain:** engineering, security
+- **Priority:** normal (but competes for resources with client work)
+
+#### Task Templates
+1. **Dependency Audit** [security]
+   - Scan packages → Flag CVEs → Prioritize fixes → Document exceptions
+2. **Upgrade Core** [backend]
+   - Upgrade runtime → Update dependencies → Migration scripts → Integration tests
+3. **Performance Baseline** [backend]
+   - Benchmark before → Optimize bottlenecks → Benchmark after → Report
+
+## Events
+
+### model-api-outage
+- **Type:** interrupt
+- **Probability:** 0.06 per tick
+- **Cooldown:** 30 ticks
+- **Effect:**
+  - All model-related tasks blocked for 5–10 ticks
+  - Sandy must build fallback to local models (creates 2 emergency subtasks)
+  - Client Alpha notified (creates comms task)
+- **Narrative:** "🔥 OpenAI API is down. Eval pipeline halted. Sandy is wiring up local fallbacks."
+
+### billing-dispute
+- **Type:** interrupt
+- **Probability:** 0.03 per tick
+- **Effect:**
+  - Squilliam creates "Billing Reconciliation" task (finance)
+  - Mr. Krabs personally involved (his tasks paused for 5 ticks)
+  - If unresolved in 15 ticks: client-escalation trigger
+- **Narrative:** "Client Beta is disputing last month's GPU charges. Mr. Krabs is NOT happy."
+
+### intern-breaks-prod
+- **Type:** interrupt
+- **Probability:** 0.04 per tick (only once per scenario)
+- **Effect:**
+  - Plankton Jr. accidentally pushes to production
+  - Creates critical "Rollback & Fix" task
+  - Karen initiates security audit of deploy permissions
+  - Generates 8 decisions: rollback, investigate, fix, review, redeploy, postmortem, update-perms, document
+- **Narrative:** "🦠 Plankton Jr. pushed to prod. Again. Karen is adding deploy gates."
+
+## Resources
+
+### Senior Engineering Time
+- **Pool:** SpongeBob + Patrick = 2 concurrent critical tasks
+- **Contention:** Client Alpha vs Client Beta vs Internal
+- **Starvation:** if any critical path waits > 8 ticks
+
+### QA Capacity
+- **Pool:** Gary = 1 agent, 2 task slots
+- **Bottleneck:** Gary is the only QA. Everything funnels through Gary. 🐌
+
+### GPU Budget
+- **Pool:** 500 compute credits
+- **Burn:** eval runs cost 5 credits each, training costs 20
+- **Depleted:** eval work pauses, must negotiate with Mr. Krabs for more budget
+```
+
+---
+
+### 6.2 Ocean Reef War 🐠⚔️
+
+*THE viral scenario. Two rival reef civilizations in an all-out underwater war for territorial dominance. This is BikiniBottom's brand moment.*
+
+**Why this scenario goes viral:**
+- The org chart IS the military command structure — watching generals coordinate is inherently dramatic
+- Messages between scouts and commanders feel like intercepted military communications
+- The fog of war mechanic means decisions are made with incomplete information
+- Two full org charts competing against each other — double the visual activity
+- People will root for their reef. They'll tweet "CORAL REEF IS WINNING" with dashboard screenshots
+- The phases (reconnaissance → skirmish → battle → resolution) create a natural story arc with escalating tension
+
+**ORG.md: Coral Reef Alliance** 🪸
+
+```markdown
+# Coral Reef Alliance
+
+## Identity
+The Coral Reef Alliance — defenders of the Great Reef.
+A militaristic organization fighting to protect their territory
+from the Kelp Forest Dominion's expansion.
+
+- **Industry:** Military
+- **Stage:** Active conflict
+- **Values:** Defend the reef, protect civilians, strategic superiority
+
+## Culture
+preset: military
+- **Escalation:** immediate — lives are at stake
+- **Progress updates:** every tick — full situational awareness
+- **Ack required:** yes — no order goes unconfirmed
+
+## Structure
+
+### Admiral Nautilus — Commander-in-Chief 🐚
+Supreme military commander of the Coral Reef Alliance.
+Receives intelligence, makes strategic decisions, allocates forces.
+Old, wise, cautious. Prefers siege warfare over direct assault.
+- **Avatar:** 🐚
+- **Domain:** Command
+- **Reports to:** The Reef Council (Human Principal)
+
+### Intelligence Division
+Eyes and ears of the Alliance. Scouts, spies, signal interceptors.
+
+#### Commander Eel — Intelligence Lead 🐍
+Runs the spy network. Processes raw intel into actionable briefings.
+- **Avatar:** 🐍
+- **Domain:** Intelligence
+
+#### Scout Fish Alpha — Field Scout 🐟
+Fast, expendable, observant. Maps enemy positions.
+- **Avatar:** 🐟
+- **Domain:** Reconnaissance
+- **Count:** 3
+
+#### Octopus Agent — Spy 🐙
+Deep cover agent in enemy territory. High-value, high-risk.
+- **Avatar:** 🐙
+- **Domain:** Espionage
+
+### Battle Division
+The fighting force. Organized in strike groups.
+
+#### General Mantis Shrimp — Battle Commander 🦐
+Hits harder than anything in the ocean. Commands all combat operations.
+Aggressive, decisive, impatient with cautious strategies.
+- **Avatar:** 🦐
+- **Domain:** Combat
+
+#### Captain Barracuda — Strike Group Alpha Lead 🐡
+Fast assault specialist. Commands the primary attack force.
+- **Avatar:** 🐡
+- **Domain:** Assault
+
+#### Warrior Crab — Heavy Infantry 🦀
+Armored frontline fighters. Slow but nearly indestructible.
+- **Avatar:** 🦀
+- **Domain:** Infantry
+- **Count:** 4
+
+#### Jellyfish Swarm — Area Denial 🪼
+Deploys stinging formations to control chokepoints.
+- **Avatar:** 🪼
+- **Domain:** Area Control
+- **Count:** 2
+
+### Engineering Corps
+Builders and defenders. Coral fortifications, traps, supply routes.
+
+#### Chief Engineer Turtle — Engineering Lead 🐢
+Slow and steady. Builds the reef's defenses. Every wall is a masterpiece.
+- **Avatar:** 🐢
+- **Domain:** Fortification
+
+#### Coral Builder — Construction Worker 🪸
+Grows and shapes coral into defensive walls, watchtowers, and bunkers.
+- **Avatar:** 🪸
+- **Domain:** Construction
+- **Count:** 3
+
+#### Trap Specialist Pufferfish — Combat Engineer 🐡
+Designs and deploys underwater mines, net traps, and ink clouds.
+- **Avatar:** 🐡
+- **Domain:** Traps
+
+### Supply Corps
+Keeps the army fed, armed, and moving.
+
+#### Quartermaster Whale — Supply Lead 🐋
+Manages logistics. Moves massive quantities of kelp rations
+and shell ammunition across the reef.
+- **Avatar:** 🐋
+- **Domain:** Logistics
+
+#### Supply Runner — Transport 🐠
+Fast swimmers carrying supplies to front lines.
+- **Avatar:** 🐠
+- **Domain:** Transport
+- **Count:** 3
+
+### Diplomatic Corps
+War isn't just fought with claws. Alliances, treaties, intelligence sharing.
+
+#### Ambassador Dolphin — Diplomatic Lead 🐬
+Charming, intelligent, and politically savvy. Negotiates alliances
+with neutral reefs. Manages propaganda and morale.
+- **Avatar:** 🐬
+- **Domain:** Diplomacy
+
+#### Messenger Seahorse — Diplomatic Courier 🐴
+Carries sealed messages between allied reefs. Small, fast, discreet.
+- **Avatar:** 🐴
+- **Domain:** Communications
+- **Count:** 2
+
+### Medical Corps
+Keeps fighters in the fight. Triage, recovery, morale.
+
+#### Dr. Anemone — Chief Medical Officer 🌺
+Field hospital commander. Pragmatic healer. "I can't fix stupid,
+but I can fix the damage stupid causes."
+- **Avatar:** 🌺
+- **Domain:** Medical
+
+#### Medic Cleaner Fish — Field Medic 🐟
+Front-line medical support. Quick treatment under fire.
+- **Avatar:** 🐟
+- **Domain:** Field Medicine
+- **Count:** 2
+```
+
+**SCENARIO.md:**
+
+```markdown
+# Ocean Reef War: The Battle for the Abyssal Trench
+
+## Meta
+- **Industry:** Ocean Reef War
+- **Duration:** 30 minutes
+- **Target decisions:** 2500
+- **Difficulty:** hard
+- **Seed:** random
+- **Description:** The Kelp Forest Dominion is expanding toward the Great Reef.
+  The Coral Reef Alliance must defend their territory through intelligence,
+  fortification, combat, diplomacy, and supply chain management.
+  Two full organizations clash in a 5-phase war that escalates from
+  reconnaissance to full-scale battle.
+- **Mode:** adversarial (two orgs, AI-vs-AI)
+
+## World State
+
+### Territory Map (6×6 grid)
+```
+  A  B  C  D  E  F
+1 [🪸][🪸][🪸][ ? ][ ? ][ ? ]
+2 [🪸][🪸][ ? ][ ? ][ ? ][ ? ]
+3 [🪸][ ? ][ ? ][ ? ][ ? ][🌿]
+4 [ ? ][ ? ][ ? ][ ? ][🌿][🌿]
+5 [ ? ][ ? ][ ? ][🌿][🌿][🌿]
+6 [ ? ][ ? ][🌿][🌿][🌿][🌿]
+```
+
+- 🪸 = Coral Reef Alliance territory (known)
+- 🌿 = Kelp Forest Dominion territory (known)
+- ? = Unexplored / Fog of War
+- The Abyssal Trench runs diagonally C3→D4 (key strategic chokepoint)
+
+### Resources
+- **Kelp Rations:** 500 units (feeds army; -2/tick per active combat unit)
+- **Shell Ammunition:** 300 units (-1/tick per combat unit in battle)
+- **Coral Building Material:** 200 units (fortifications cost 10–30 each)
+- **Intel Points:** 0 (gained by scouts, spent on strategic decisions)
+- **Morale:** 80/100 (drops on losses, rises on victories and rations)
+- **Alliance Points:** 0/100 (diplomatic progress toward neutral reef alliance)
+
+## Phases
+
+### Phase 1: Reconnaissance (ticks 1–60)
+The fog of war is thick. Both sides send scouts to map enemy positions.
+Intelligence flows in fragments. Every revealed tile changes the strategic picture.
+
+- **Unlocks epics:** Scout Deployment, Early Fortification, Supply Chain Setup, Diplomatic Outreach
+- **Events enabled:** scout-ambush, false-intel, neutral-reef-contact, resource-discovery
+- **Tick interval:** 700ms
+- **Ambient:** scouts reporting coordinates, engineers discussing where to build walls,
+  supply runners inventorying rations
+- **Transition:** 60%+ of map revealed OR tick 60
+- **Music mood:** tense, quiet, anticipatory
+
+#### Fog of War Mechanic
+Each scout mission reveals 1–2 tiles. Some reveal:
+- Empty water (safe to traverse)
+- Enemy outpost (immediate escalation to intelligence)
+- Resource cache (kelp field, shell deposit — creates "secure resource" task)
+- Neutral reef (diplomatic opportunity — creates diplomacy task)
+- Ambush! (scout captured or killed — intelligence loss)
+
+Intel flows: Scout → Commander Eel (analysis, 2 ticks) → Admiral Nautilus (decision, 1 tick).
+Raw intel is unreliable: 15% chance of false information. Commander Eel can cross-reference
+multiple scout reports to verify (costs 3 ticks but eliminates false intel).
+
+### Phase 2: Fortification & Positioning (ticks 61–140)
+Both sides know the map. Now they're digging in and preparing.
+Engineers build walls. Supply chains are established. Diplomatic missions intensify.
+
+- **Unlocks epics:** Defensive Line Construction, Forward Base, Alliance Negotiations,
+  Supply Route Optimization, Spy Infiltration
+- **Events enabled:** all reconnaissance events + sabotage, supply-raid, desertion,
+  diplomatic-incident, weather-current-shift
+- **Tick interval:** 800ms
+- **Transition:** either side initiates aggression OR tick 140
+
+#### Fortification Tasks
+Each fortification is a mini-project:
+- Survey location (scout, 2 ticks)
+- Design structure (engineer, 3 ticks)
+- Gather materials (supply, 4 ticks, costs coral resources)
+- Build fortification (3 builders, 6 ticks)
+- Install traps (trap specialist, 3 ticks)
+- Garrison troops (battle division, ongoing)
+
+A defensive line of 3 fortifications = 90+ decisions just from building.
+
+### Phase 3: First Blood — Skirmishes (ticks 141–220)
+Contact. Small engagements at the borders. Probing attacks.
+Each skirmish generates tactical decisions and cascading consequences.
+
+- **Unlocks epics:** Border Skirmish Alpha, Border Skirmish Beta, Casualty Management,
+  Propaganda Campaign, Emergency Resupply
+- **Events enabled:** all + ambush, flanking-maneuver, morale-break, heroic-stand,
+  enemy-surrender, war-crime-report
+- **Difficulty modifier:** 1.3
+- **Tick interval:** 900ms
+- **Transition:** cumulative casualties > threshold OR major victory event
+
+#### Skirmish Mechanics
+Each skirmish is a mini-scenario within the scenario:
+
+```
+1. Detection (scout reports enemy movement)              [3 decisions]
+2. Intel Assessment (Commander Eel evaluates threat)      [2 decisions]
+3. Admiral Decision: engage / defend / retreat            [1 decision, branching]
+4. Force Allocation (General assigns units)               [4 decisions]
+5. Supply Check (Quartermaster confirms ammo/rations)     [2 decisions]
+6. Engagement (3–8 ticks of combat, decisions per tick)   [15–40 decisions]
+   - Each tick: advance/hold/retreat per unit
+   - Flanking opportunities (spend reserves?)
+   - Casualty reports → medical dispatch
+   - Ammo depletion → resupply request
+   - Morale checks (hold or break?)
+7. Aftermath                                               [8 decisions]
+   - Casualty triage (medics)
+   - Territory assessment (gained/lost/held)
+   - Intel from captured enemies
+   - Report to Admiral
+   - Propaganda (spin the story for morale)
+   
+Total per skirmish: 35–60 decisions
+× 4–6 skirmishes in Phase 3 = 140–360 decisions
+```
+
+### Phase 4: The Battle of the Abyssal Trench (ticks 221–340)
+Full-scale war. Both sides commit everything. The Abyssal Trench is the prize.
+This is the visual climax — the dashboard should be on fire.
+
+- **Unlocks epics:** Grand Assault Plan, Trench Defense, Naval Blockade,
+  Alliance Reinforcements (if diplomatic success), Last Resort Weapons,
+  Civilian Evacuation
+- **Events enabled:** all + critical-supply-failure, betrayal, secret-weapon,
+  natural-disaster (whirlpool), heroic-sacrifice, turning-point
+- **Difficulty modifier:** 2.0
+- **Tick interval:** 1000ms (slower ticks, more happens per tick)
+- **Transition:** one side controls the Trench OR tick 340
+
+#### The Grand Battle
+Multiple simultaneous engagements:
+- **Main assault** on the Trench (20+ agents involved)
+- **Flanking maneuver** through the Deep Caves (risky, high reward)
+- **Naval blockade** cutting enemy supply lines
+- **Spy operation** to sabotage enemy command
+- **Diplomatic emergency** — convince neutral reef to intervene
+
+Each of these is a concurrent epic generating 50–100 decisions.
+The dashboard shows ALL of them happening at once — org chart ablaze
+with activity, messages flying in every direction, resources depleting,
+morale fluctuating, territory map updating tile by tile.
+
+### Phase 5: Resolution (ticks 341–400)
+The battle is decided. Now comes the aftermath.
+- **Unlocks epics:** Ceasefire Negotiation, Territory Settlement,
+  Casualty Accounting, War Memorial, Post-War Reconstruction
+- **Events enabled:** peace-offer, rebellion, refugee-crisis, war-hero-ceremony
+- **Tick interval:** 600ms (denouement is faster)
+- **Transition:** scenario complete
+
+## Epics
+
+### Scout Deployment
+- **Phase:** Reconnaissance
+- **Domain:** Intelligence
+- **Priority:** critical
+
+#### Task Templates
+1. **Deploy Scout Team Alpha** [reconnaissance]
+   - Brief scouts → Deploy to sectors B3,C3,D3 → Await reports → Analyze
+   - Each sector reveal = 1 subtask with fog-of-war outcome
+   - Duration: 3–5 ticks per sector
+
+2. **Deploy Scout Team Beta** [reconnaissance]
+   - Brief scouts → Deploy to sectors D2,E2,E3 → Await reports → Analyze
+   - Duration: 3–5 ticks per sector
+
+3. **Deep Reconnaissance** [espionage]
+   - Brief Octopus Agent → Infiltrate enemy territory → Map command structure → Extract
+   - Duration: 8–12 ticks total (high risk)
+   - Decision: if detected, fight-or-flee (weighted: 30% escape clean, 40% escape with intel lost,
+     20% captured, 10% heroic intelligence coup)
+   - Cross-dept: on success → unlock "Spy Infiltration" epic in Phase 2
+
+### Defensive Line Construction
+- **Phase:** Fortification & Positioning
+- **Domain:** Fortification, Construction
+- **Priority:** high
+
+#### Task Templates
+1. **Trench Outer Wall** [construction]
+   - Survey C2 → Design coral barrier → Gather 30 coral → Build wall (6 ticks) → Install spike traps
+   - Resource cost: 30 coral, 10 shell (for trap spikes)
+   - Cross-dept: on completion → unlock garrison assignment (battle division)
+
+2. **Watchtower at B3** [construction]
+   - Survey → Design → Gather 15 coral → Build tower (4 ticks) → Post lookout
+   - Provides: +1 scout range (adjacent tiles auto-revealed)
+   - Resource cost: 15 coral
+
+3. **Minefield at D4** [traps]
+   - Design mine pattern → Craft 20 sea mines → Deploy pattern → Map safe paths for allies
+   - Resource cost: 20 shell
+   - Risk: 10% chance of premature detonation during deployment (creates casualty event)
+
+### Grand Assault Plan
+- **Phase:** Battle of the Abyssal Trench
+- **Domain:** Combat, Command
+- **Priority:** critical
+
+#### Task Templates
+1. **Strategic Planning** [command]
+   - Admiral reviews intel → War council (all division leads) → Choose strategy → Approve plan
+   - Decision: 3 strategy options (weighted by intel quality + resource state):
+     a) **Frontal Assault** (70% win if resources > 60%, 30% otherwise; high casualties)
+     b) **Pincer Movement** (60% win; requires successful flanking epic; moderate casualties)
+     c) **Siege & Starve** (80% win but takes 40+ more ticks; low casualties; risks enemy breakout)
+   - Branch: chosen strategy changes which sub-epics unlock
+
+2. **Force Deployment** [combat]
+   - Assign units to positions → Distribute ammo → Final supply check → Confirm readiness
+   - Creates 1 subtask per combat unit (8–12 subtasks)
+   - Duration: 1–2 ticks each
+
+3. **Execute Assault** [combat]
+   - The big one. 20–40 ticks of active battle.
+   - Each tick: 2–4 decisions (unit movements, engagement calls, resupply requests)
+   - Special moments (randomly triggered):
+     - "Heroic Stand" — one unit holds against overwhelming odds (+20 morale)
+     - "Critical Failure" — key fortification falls (-15 morale, creates emergency)
+     - "Turning Point" — enemy commander makes a mistake (exploit or not?)
+     - "Betrayal" — if alliance was tenuous, ally might switch sides (devastating)
+
+## Events
+
+### scout-ambush
+- **Type:** interrupt
+- **Probability:** 0.10 per tick (Recon phase), 0.05 (other phases)
+- **Cooldown:** 15 ticks
+- **Effect:**
+  - 1 scout captured or eliminated
+  - Intel for that sector lost or corrupted
+  - Commander Eel must decide: send rescue mission (risky, 3 tasks) or write off the scout
+  - If rescued: morale +5, scout provides bonus intel
+  - If lost: morale -5, that sector stays in fog
+- **Narrative:** "Scout Fish Alpha-2 has gone silent in sector D3. Last transmission was garbled."
+
+### supply-raid
+- **Type:** interrupt
+- **Probability:** 0.06 per tick (Phase 2+)
+- **Cooldown:** 25 ticks
+- **Effect:**
+  - Enemy raids a supply route
+  - Lose 20–50 rations OR 10–30 ammo (random)
+  - Supply Runner may be captured
+  - Quartermaster must reroute supplies (creates 3 tasks)
+  - If this is the 3rd supply raid: triggers "supply-crisis" cascading event
+- **Narrative:** "🚨 Supply convoy ambushed in sector C4! 40 kelp rations lost. Quartermaster Whale is rerouting."
+
+### shifting-alliance
+- **Type:** narrative
+- **Probability:** 0.03 per tick (Phase 2+)
+- **Cooldown:** 40 ticks
+- **Condition:** Alliance Points > 30
+- **Effect:**
+  - Neutral reef makes a demand: "Send 100 rations as tribute or we ally with the enemy"
+  - Admiral must decide: pay (lose rations), negotiate (Ambassador task, 50% success), or refuse
+  - Accept: Alliance Points +30
+  - Negotiate success: Alliance Points +20, tribute reduced to 50
+  - Negotiate fail: Alliance Points -10
+  - Refuse: Alliance Points -20, risk neutral reef joining enemy
+- **Narrative:** "🐬 The Deep Reef Confederation demands tribute. Ambassador Dolphin is drafting a counter-offer."
+
+### natural-disaster-whirlpool
+- **Type:** disruption
+- **Probability:** 0.02 per tick (Phase 3+)
+- **Cooldown:** 100 ticks (once per scenario essentially)
+- **Effect:**
+  - Whirlpool forms at random map tile
+  - Any units/fortifications in adjacent tiles: 30% damaged, 10% destroyed
+  - Both sides affected — temporary ceasefire (5 ticks)
+  - Creates emergency tasks: rescue trapped units, repair fortifications
+  - Territory may shift (tiles revert to unexplored)
+- **Narrative:** "🌊 WHIRLPOOL at D3! Both sides scrambling. Ceasefire declared while the ocean rearranges itself."
+- **Dashboard:** map tiles swirl, affected units flash, then new layout revealed
+
+### heroic-sacrifice
+- **Type:** narrative
+- **Probability:** 0.0 (triggered only during Phase 4 battle when morale < 40)
+- **Effect:**
+  - One warrior unit volunteers for a suicide mission
+  - If accepted: that unit is lost, but deals massive damage to enemy position
+  - Morale +25 (the sacrifice inspires the troops)
+  - Creates "Memorial" task in Resolution phase
+  - Unlocks special ending: "Victory through sacrifice"
+- **Narrative:** "Warrior Crab-3 volunteers for the impossible mission. 'For the Reef.' 🦀💀"
+- **Dashboard:** The sacrificing agent's node pulses gold before fading to grey. A star icon appears on the territory map where they fell.
+
+### secret-weapon
+- **Type:** opportunity
+- **Probability:** 0.0 (triggered at tick 250 if Engineering Corps has completed 80%+ of construction tasks)
+- **Effect:**
+  - Chief Engineer Turtle reveals a prototype: the "Sonic Coral Cannon"
+  - Building it: 3 tasks, 15 ticks, costs 50 coral + 30 shell
+  - If built: can be deployed once — clears an entire map tile of enemy forces
+  - Game-changing but expensive. Admiral must weigh resource cost vs. tactical advantage.
+- **Narrative:** "🐢 Chief Engineer Turtle has been working on something in secret.
+  'It's not pretty,' he says, 'but it'll change the war.' The Sonic Coral Cannon prototype is ready for review."
+
+## Resources
+
+### Kelp Rations
+- **Starting:** 500
+- **Burn rate:** 2/tick per active combat unit, 0.5/tick per non-combat agent
+- **Resupply:** Supply Corps can create "Kelp Farming" task (generates 50 rations, takes 10 ticks)
+- **Depleted:** Morale drops 5/tick, combat effectiveness halved
+- **Dashboard:** Green bar, turns yellow at 30%, red at 15%
+
+### Shell Ammunition
+- **Starting:** 300
+- **Burn rate:** 1/tick per unit in active combat
+- **Resupply:** Supply Corps "Shell Gathering" task (generates 30 ammo, 8 ticks)
+- **Depleted:** Combat units can only defend (no attacks)
+- **Dashboard:** Orange bar with shell icons
+
+### Coral Building Material
+- **Starting:** 200
+- **Burn rate:** only consumed by construction tasks
+- **Resupply:** Engineering Corps "Coral Cultivation" task (generates 25 coral, 12 ticks)
+- **Depleted:** No new fortifications
+- **Dashboard:** Pink bar with coral icons
+
+### Morale
+- **Starting:** 80/100
+- **Modifiers:**
+  - Victory in skirmish: +10
+  - Loss in skirmish: -15
+  - Scout lost: -5
+  - Heroic moment: +10–25
+  - Rations depleted: -5/tick
+  - Alliance secured: +15
+  - Betrayal: -30
+- **Below 30:** units may desert (random check each tick)
+- **Below 15:** organizational collapse — scenario ends in defeat
+- **Dashboard:** Animated morale meter with soldier icons. At high morale, soldiers cheer. At low morale, they look defeated.
+
+## Scoring
+
+### Dimensions
+- **Territory Control:** % of map tiles held at resolution
+- **Force Preservation:** % of starting forces still active
+- **Resource Efficiency:** resources remaining / resources consumed ratio
+- **Intel Accuracy:** correct intel / total intel received
+- **Diplomatic Success:** alliance points achieved
+- **Speed:** ticks to reach resolution (fewer = better)
+- **Morale:** final morale score
+
+### Special Achievements
+- 🏆 **Flawless Victory:** Won with 0 units lost
+- 🕵️ **Spymaster:** Every intel report was verified correct
+- 🤝 **Diplomat:** Secured alliance without paying tribute
+- ⚡ **Blitzkrieg:** Won in under 300 ticks
+- 🐢 **Fortress:** Won without losing a single fortification
+- 💀 **Pyrrhic Victory:** Won but with < 20% forces remaining
+- 🌊 **Survived the Whirlpool:** Recovered from natural disaster with no losses
+- 🦀 **Remember Warrior Crab-3:** Won after triggering heroic sacrifice
+
+### Twitter Card
+On completion, generate a shareable summary card:
+```
+🐠⚔️ OCEAN REEF WAR — BATTLE COMPLETE
+
+🪸 Coral Reef Alliance: VICTORY
+
+Territory: ████████░░ 82%
+Forces:    ██████░░░░ 64%
+Morale:    █████████░ 87%
+
+Grade: A (86/100)
+Achievements: 🕵️🤝
+
+"The Sonic Coral Cannon fired once.
+ That was enough."
+
+Decisions: 2,847 | Agents: 42
+#BikiniBottom #OceanReefWar
+```
+```
+
+**The second ORG (enemy) — Kelp Forest Dominion** is auto-generated by mirroring the Coral Reef org with different names, flavors, and slight tactical biases (more aggressive, fewer diplomats, more combat units). The engine runs both orgs simultaneously, with decisions from one affecting the other through the shared territory map.
+
+---
+
+### 6.3 Legal Tech Firm ⚖️
+
+*Every case is a branching tree. Perfect for the dependency engine.*
+
+```markdown
+# Legal Tech Firm: Quarterly Docket
+
+## Meta
+- **Industry:** Legal Tech
+- **Duration:** 25 minutes
+- **Target decisions:** 2000
+- **Difficulty:** normal
+- **Description:** A 20-person legal tech firm managing 4 active cases
+  simultaneously. Discovery, filings, compliance reviews, client comms.
+  Every case branches based on rulings, evidence discovered, and
+  opposing counsel's moves.
+
+## Phases
+
+### Phase 1: Case Intake (ticks 1–50)
+New cases arrive. Conflict checks, engagement letters, initial research.
+- **Unlocks epics:** Case Alpha: Patent Infringement, Case Beta: Data Breach Class Action,
+  Case Gamma: Regulatory Compliance Audit, Case Delta: Contract Dispute
+- **Events enabled:** conflict-of-interest, rush-filing, new-evidence
+- **Transition:** all intake tasks complete
+
+### Phase 2: Discovery & Research (ticks 51–180)
+The deep work. Document review, depositions, expert analysis.
+Discovery is where the decisions multiply — every document reviewed is a decision.
+- **Unlocks epics:** Alpha Discovery, Beta Discovery, Gamma Compliance Matrix, Delta Mediation Prep
+- **Events enabled:** all
+- **Transition:** 60%+ discovery complete across all cases
+
+### Phase 3: Filing & Motions (ticks 181–300)
+Court deadlines. Motions to file. Opposing counsel's responses.
+Every filing can be contested, amended, or rejected.
+- **Unlocks epics:** Alpha Motion for Summary Judgment, Beta Class Certification,
+  Gamma Regulatory Submission, Delta Settlement Negotiation
+- **Events enabled:** all + court-ruling, judge-order, opposing-motion
+- **Difficulty modifier:** 1.5
+- **Transition:** all cases resolved or at trial stage
+
+### Phase 4: Resolution (ticks 301–400)
+Cases settle, go to trial, or get dismissed.
+- **Unlocks epics:** case-specific resolution epics based on branching
+- **Transition:** scenario complete
+
+## Epics
+
+### Case Alpha: Patent Infringement — Discovery
+- **Phase:** Discovery & Research
+- **Domain:** litigation, research
+- **Priority:** high
+
+#### Task Templates
+1. **Document Collection** [research]
+   - Identify custodians → Issue hold notices → Collect documents → Process for review
+   - Generates: 200+ document-review subtasks (batch of 10 per task)
+   - Each batch: 3 ticks, decision: relevant / privileged / responsive / junk
+   - Cross-dept: privileged docs → trigger privilege log task
+
+2. **Prior Art Search** [research]
+   - Define search terms → Patent database search → Academic search → Analyze results
+   - Decision point: prior art found (40%) → changes case strategy
+   - Cross-dept: if found → create "Amend Complaint" task in litigation
+
+3. **Expert Witness Engagement** [operations]
+   - Identify experts → Conflict check → Engagement letter → Initial briefing
+   - Resource contention: only 2 expert budget slots for 4 cases
+   - Duration: 5–8 ticks per subtask
+
+4. **Deposition Preparation** [litigation]
+   - Review witness list → Prepare questions → Mock deposition → Final prep
+   - Dependencies: Document Collection (70%+)
+   - Decision: opposing counsel moves to quash (20%) → creates motion task
+
+## Events
+
+### court-ruling
+- **Type:** narrative + interrupt
+- **Probability:** 0.04 per tick (Phase 3+)
+- **Effect:**
+  - Judge rules on a pending motion
+  - Outcomes (weighted): granted (40%), granted in part (30%),
+    denied (20%), denied with sanctions (10%)
+  - Each outcome creates different follow-up tasks
+  - "Denied with sanctions": critical — creates emergency compliance tasks + billing writedown
+- **Narrative:** "⚖️ Judge Morrison ruled on the motion to compel: GRANTED IN PART.
+  Production deadline moved up 2 weeks."
+
+### new-evidence
+- **Type:** expansion
+- **Probability:** 0.05 per tick
+- **Effect:**
+  - Surprise evidence surfaces (whistleblower, opposing production, public records)
+  - Creates 5–10 new document review tasks
+  - May change case strategy: decision point for lead attorney
+  - 20% chance: evidence is so significant it triggers settlement discussion
+- **Narrative:** "📁 New evidence just dropped in Case Beta. 4,000 pages of internal emails.
+  Compliance team is scrambling."
+
+### billing-audit
+- **Type:** disruption
+- **Probability:** 0.03 per tick
+- **Effect:**
+  - Client questions billing on a case
+  - Creates "Billing Reconciliation" task
+  - Finance lead must review and justify hours
+  - If hours excessive: client demands write-down (budget impact)
+- **Narrative:** "Client for Case Gamma is questioning the $45,000 in research hours. Finance is reviewing."
+```
+
+---
+
+### 6.4 Fintech Startup 💳
+
+*Compliance creates review loops. KYC is a dependency nightmare.*
+
+```markdown
+# Fintech Startup: Series B Quarter
+
+## Meta
+- **Industry:** Fintech
+- **Duration:** 20 minutes
+- **Target decisions:** 1600
+- **Description:** A fintech startup post-Series B. Launching new products while
+  navigating regulatory mazes, audit prep, and the ever-present fraud pipeline.
+
+## Key Mechanics
+- **KYC Pipeline:** Every new customer triggers: identity verify → document check →
+  risk scoring → compliance review → approve/deny/escalate.
+  At scale, 50+ KYC applications per scenario phase.
+- **Regulatory Review Loops:** Any product change requires: legal review → compliance check →
+  regulatory filing → approval (avg 2.3 iterations before approval)
+- **Fraud Alerts:** ML model flags transactions. Each flag: investigate → classify →
+  action (block/allow/escalate). ~30 alerts per phase.
+- **Audit Trail:** Everything generates audit events. Auditor arrives in Phase 3
+  and requests documentation for everything.
+```
+
+### 6.5 Game Studio 🎮
+
+```markdown
+# Game Studio: Ship the RPG
+
+## Meta
+- **Industry:** Game Studio
+- **Duration:** 25 minutes
+- **Target decisions:** 1800
+- **Description:** An indie studio shipping a mid-size RPG. Art pipeline,
+  sprint cycles, QA hell, and the dreaded launch day.
+
+## Key Mechanics
+- **Art Pipeline:** Concept → Model → Texture → Rig → Animate → Review.
+  Each asset is 6 subtasks × 50+ assets = 300+ art subtasks.
+- **Sprint Cycles:** 2-week sprints within the scenario. Sprint planning,
+  daily standups (automated check-ins), sprint review, retro.
+- **QA Gauntlet:** Every feature goes through: smoke test → regression →
+  performance → compatibility → certification. Bugs found loop back to dev.
+- **Platform Certification:** Console cert is a gatekeeper. Fail → 30+ ticks
+  of fix-and-resubmit.
+```
+
+### 6.6 Open Source Project 🌐
+
+```markdown
+# Open Source Project: v2.0 Release
+
+## Meta
+- **Industry:** Open Source
+- **Duration:** 15 minutes
+- **Target decisions:** 1200
+- **Description:** A popular open source project preparing a major version release.
+  Community PRs, breaking changes, documentation, governance.
+
+## Key Mechanics
+- **PR Triage:** Community PRs arrive as events. Each: review → test →
+  merge/reject/request-changes. 40+ PRs per scenario.
+- **Breaking Change Process:** RFC → Discussion → Vote → Implementation → Migration guide.
+  Each breaking change is a 20-decision epic.
+- **Community Management:** Angry issue authors, feature requests, security reports,
+  CoC violations. Each is an interrupt event.
+- **Release Engineering:** Branch → Freeze → RC1 → Bug reports → RC2 → Final → Tag → Publish → Announce.
+```
+
+---
+
+## 7. Integration with Deterministic Engine
+
+### 7.1 Current Engine Touchpoints
+
+The Scenario Engine wraps the existing `DeterministicSimulation` class. No rewrites — only extensions.
+
+```typescript
+// New file: tools/sandbox/src/scenario-engine.ts
+
+import { DeterministicSimulation } from './deterministic.js';
+import type { SandboxAgent, SandboxTask, SandboxEvent, ACPMessage } from './types.js';
+
+interface ScenarioDefinition {
+  meta: ScenarioMeta;
+  phases: ScenarioPhase[];
+  epics: EpicTemplate[];
+  events: EventTemplate[];
+  resources: ResourcePool[];
+  scoring: ScoringConfig;
+}
+
+class ScenarioEngine {
+  private sim: DeterministicSimulation;
+  private scenario: ScenarioDefinition;
+  private currentPhase: number = 0;
+  private activeEpics: Map<string, EpicInstance> = new Map();
+  private dag: DependencyGraph = new DependencyGraph();
+  private eventScheduler: EventScheduler;
+  private resources: ResourceManager;
+  private storyState: Map<string, any> = new Map();
+  private prng: SeededRandom;
+  private decisionCount: number = 0;
+
+  constructor(sim: DeterministicSimulation, scenario: ScenarioDefinition) {
+    this.sim = sim;
+    this.scenario = scenario;
+    this.prng = new SeededRandom(scenario.meta.seed);
+    this.eventScheduler = new EventScheduler(scenario.events, this.prng);
+    this.resources = new ResourceManager(scenario.resources);
+  }
+
+  /** Called BEFORE each sim tick — injects scenario-driven work */
+  preTick(): void {
+    // 1. Check phase transitions
+    this.evaluatePhaseTransition();
+
+    // 2. Expand any newly unlocked epics into tasks
+    this.expandUnlockedEpics();
+
+    // 3. Resolve DAG — unblock tasks whose dependencies are met
+    this.dag.resolve(this.sim.tasks);
+
+    // 4. Fire scheduled/random events
+    const events = this.eventScheduler.tick(
+      this.sim.tick,
+      this.currentPhase,
+      this.scenario.phases[this.currentPhase],
+      this.storyState
+    );
+    for (const event of events) {
+      this.fireEvent(event);
+    }
+
+    // 5. Update resource pools
+    this.resources.tick(this.sim.agents, this.sim.tasks);
+
+    // 6. Feed work into simulation via processOrder or direct task injection
+    this.injectPendingWork();
+  }
+
+  /** Called AFTER each sim tick — collects metrics, counts decisions */
+  postTick(): void {
+    this.decisionCount += this.countNewDecisions();
+    this.calibratePacing();
+  }
+
+  /** Adjusts event frequency to hit target decision rate */
+  private calibratePacing(): void {
+    const targetRate = this.scenario.meta.targetDecisions / this.estimateTotalTicks();
+    const actualRate = this.decisionCount / this.sim.tick;
+
+    if (actualRate < targetRate * 0.8) {
+      this.eventScheduler.increaseFrequency(1.2);
+    } else if (actualRate > targetRate * 1.2) {
+      this.eventScheduler.decreaseFrequency(0.8);
+    }
+  }
+}
+```
+
+### 7.2 Extending Existing Types
+
+New types that complement (not replace) existing ones:
+
+```typescript
+// Additions to types.ts
+
+// Epic: a large body of work that decomposes into tasks
+interface SandboxEpic {
+  id: string;
+  title: string;
+  phase: string;
+  domain: string[];
+  priority: SandboxTask['priority'];
+  status: 'locked' | 'active' | 'done';
+  taskIds: string[];
+  completionPct: number;
+  unlockedAt?: number;    // tick when epic became active
+  completedAt?: number;   // tick when epic finished
+}
+
+// Extended task with dependency info
+interface SandboxTaskV2 extends SandboxTask {
+  epicId?: string;           // parent epic
+  parentTaskId?: string;     // parent task (for subtasks)
+  dependsOn?: string[];      // task IDs that must complete first
+  triggers?: TaskTrigger[];  // what happens when this task completes
+  resourceCost?: Record<string, number>; // resources consumed
+  reviewLoop?: {             // review iteration tracking
+    maxIterations: number;
+    currentIteration: number;
+    weights: number[];       // probability distribution for pass/revise/reject
+  };
+}
+
+// New ACP message types
+type ACPMessageTypeV2 = ACPMessage['type']
+  | 'intel_report'    // reef war: scout reports
+  | 'resource_alert'  // resource pool running low
+  | 'event_alert'     // random event notification
+  | 'phase_change'    // scenario phase transition
+  | 'decision_request' // requires manager decision
+  | 'battle_report';  // reef war: combat results
+
+// Extended event with scenario metadata
+interface SandboxEventV2 extends SandboxEvent {
+  scenarioEvent?: string;  // which scenario event template triggered this
+  phaseId?: string;        // which phase we're in
+  epicId?: string;         // which epic this relates to
+  visualEffect?: string;   // hint to dashboard for special rendering
+}
+```
+
+### 7.3 Hooking into the Tick Loop
+
+The key integration point — the Scenario Engine hooks into the existing tick loop:
+
+```typescript
+// Modified DeterministicSimulation.runTick()
+
+async runTick(): Promise<void> {
+  this.tick++;
+
+  // ═══ NEW: Scenario pre-tick ═══
+  if (this.scenarioEngine) {
+    this.scenarioEngine.preTick();
+  }
+
+  // ═══ EXISTING: Process agents by level (top-down) ═══
+  const sortedAgents = [...this.agents].sort((a, b) => b.level - a.level);
+  for (const agent of sortedAgents) {
+    if (agent.role === 'coo' || agent.level >= 9) {
+      this.tickCOO(agent);
+      this.tickUnblock(agent);
+    } else if (agent.role === 'lead') {
+      this.tickLead(agent);
+      this.tickUnblock(agent);
+    } else {
+      this.tickWorker(agent);
+    }
+  }
+
+  // ═══ NEW: Scenario post-tick ═══
+  if (this.scenarioEngine) {
+    this.scenarioEngine.postTick();
+  }
+
+  // ═══ EXISTING: Metrics ═══
+  this.metricsHistory.push({ ... });
+}
+```
+
+### 7.4 The DAG Resolver
+
+Resolves task dependencies each tick:
+
+```typescript
+class DependencyGraph {
+  private edges: Map<string, string[]> = new Map(); // taskId → [dependsOn...]
+
+  addDependency(taskId: string, dependsOn: string): void {
+    const deps = this.edges.get(taskId) || [];
+    deps.push(dependsOn);
+    this.edges.set(taskId, deps);
+  }
+
+  /** Check all blocked tasks. Unblock any whose dependencies are met. */
+  resolve(tasks: SandboxTask[]): string[] {
+    const taskMap = new Map(tasks.map(t => [t.id, t]));
+    const unblocked: string[] = [];
+
+    for (const [taskId, deps] of this.edges) {
+      const task = taskMap.get(taskId);
+      if (!task || task.status !== 'blocked') continue;
+      if (task.blockedReason !== 'Dependency not ready') continue;
+
+      const allMet = deps.every(depId => {
+        const dep = taskMap.get(depId);
+        return dep && dep.status === 'done';
+      });
+
+      if (allMet) {
+        task.status = 'assigned';
+        task.blockedReason = undefined;
+        unblocked.push(taskId);
+      }
+    }
+
+    return unblocked;
+  }
+
+  /** Topological sort for visualization (shows critical path) */
+  criticalPath(tasks: SandboxTask[]): string[] {
+    // ... standard topological sort with longest-path calculation
+  }
+}
+```
+
+### 7.5 Adversarial Mode (Reef War)
+
+For the Reef War scenario, two `DeterministicSimulation` instances run in parallel:
+
+```typescript
+class AdversarialScenarioEngine {
+  private allianceSim: DeterministicSimulation;
+  private dominionSim: DeterministicSimulation;
+  private allianceScenario: ScenarioEngine;
+  private dominionScenario: ScenarioEngine;
+  private sharedWorld: WorldState; // territory map, shared events
+
+  async runTick(): Promise<void> {
+    // Both sides pre-tick (generate work based on shared world state)
+    this.allianceScenario.preTick();
+    this.dominionScenario.preTick();
+
+    // Both sides process (agents work, make decisions)
+    await this.allianceSim.runTick();
+    await this.dominionSim.runTick();
+
+    // Resolve conflicts (both sides claiming same territory, combat outcomes)
+    this.resolveConflicts();
+
+    // Update shared world state
+    this.sharedWorld.update();
+
+    // Both sides post-tick (react to new world state)
+    this.allianceScenario.postTick();
+    this.dominionScenario.postTick();
+  }
+
+  private resolveConflicts(): void {
+    // Combat resolution: compare force strength, terrain, morale
+    // Territory changes: update map based on combat outcomes
+    // Resource effects: supply raids, blockades
+    // Intel: what each side learns about the other
+  }
+}
+```
+
+---
+
+## 8. Dashboard Visualization
+
+### 8.1 Scenario Selector Screen
+
+Before a scenario starts, users see a selection screen:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  🌊 BikiniBottom Scenarios                                      │
+│                                                                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐          │
+│  │ 🤖 AI Dev    │  │ 🐠⚔️ Reef War │  │ ⚖️ Legal Tech │          │
+│  │   Agency     │  │              │  │    Firm      │          │
+│  │              │  │ MOST POPULAR │  │              │          │
+│  │  20 min      │  │  30 min      │  │  25 min      │          │
+│  │  ~1800 dec   │  │  ~2500 dec   │  │  ~2000 dec   │          │
+│  │  ★★★☆☆       │  │  ★★★★★       │  │  ★★★★☆       │          │
+│  └──────────────┘  └──────────────┘  └──────────────┘          │
+│                                                                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐          │
+│  │ 💳 Fintech   │  │ 🎮 Game      │  │ 🌐 Open      │          │
+│  │   Startup    │  │   Studio     │  │   Source     │          │
+│  │  20 min      │  │  25 min      │  │  15 min      │          │
+│  │  ~1600 dec   │  │  ~1800 dec   │  │  ~1200 dec   │          │
+│  └──────────────┘  └──────────────┘  └──────────────┘          │
+│                                                                  │
+│  Difficulty: [Easy] [Normal] [■ Hard] [Chaos]     Seed: [auto]  │
+│                                                                  │
+│  [▶ Start Scenario]                                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 8.2 Phase Banner
+
+When a phase transitions, a cinematic banner sweeps across the dashboard:
+
+```
+╔═══════════════════════════════════════════════════════╗
+║                                                       ║
+║   ⚔️ PHASE 3: FIRST BLOOD                             ║
+║                                                       ║
+║   Scout reports confirmed: enemy positions at D4, E3  ║
+║   General Mantis Shrimp is mobilizing strike teams    ║
+║                                                       ║
+║   New objectives unlocked:                            ║
+║   • Border Skirmish Alpha                             ║
+║   • Emergency Resupply                                ║
+║   • Propaganda Campaign                               ║
+║                                                       ║
+╚═══════════════════════════════════════════════════════╝
+```
+
+### 8.3 Enhanced Org Chart
+
+The org chart becomes the primary visual for scenarios:
+
+**Normal state:** Agents are nodes, connections show reporting lines. Idle agents are dim, busy agents glow.
+
+**During active work:**
+- Messages fly along connection lines as animated particles
+- Agents pulse when making decisions (brighter = more critical)
+- Blocked agents show a red border with a pulsing lock icon
+- Cross-department messages arc across the chart in distinct colors
+
+**During Reef War:**
+- Split screen: two org charts side by side
+- Territory map in the center
+- Attack messages show as red arrows between the two orgs
+- Intel messages show as yellow dashed lines
+- When a unit is lost, its node fades and cracks
+- When a battle is won, victor's section glows gold
+
+**Ambient animations:**
+- Scouts have a radar-sweep animation on their nodes
+- Supply runners have tiny package icons traveling along their connections
+- Engineers have a building animation (tiny coral growing)
+- Medics have a pulse/heartbeat animation
+- Diplomats have a handshake animation when negotiating
+
+### 8.4 Territory Map (Reef War)
+
+A real-time updating hex grid:
+
+```
+State: Phase 3 — Skirmish Active
+
+     🪸  🪸  🪸  ⚔️  🌫️  🌫️
+   🪸  🪸  ⚔️  🔍  🌫️  🌿
+     🪸  🏰  🌊  🌊  🌿  🌿
+   🌊  🌊  💥  🌊  🌿  🌿
+     🌫️  🌊  🌿  🌿  🏰  🌿
+   🌫️  🌫️  🌿  🌿  🌿  🌿
+
+Legend:
+🪸 Coral territory    🌿 Kelp territory    🌫️ Fog of war
+🏰 Fortification      ⚔️ Skirmish active   💥 Battle!
+🔍 Scout present      🌊 Neutral water
+```
+
+Tiles animate on state change:
+- Fog clears with a dissolve effect when scouted
+- Battles show explosion particles
+- Fortifications build up brick-by-brick
+- Territory captures sweep the new color across the tile
+
+### 8.5 Event Timeline
+
+A scrolling timeline at the bottom of the dashboard showing narrative events:
+
+```
+TICK 156  🐍 Commander Eel: "Intel confirmed — enemy forward base at D4."
+TICK 158  🐚 Admiral Nautilus: "Prepare Strike Group Alpha. Defensive posture."
+TICK 161  ⚔️ SKIRMISH at C4 — 3 Warrior Crabs vs 2 Kelp Sentinels
+TICK 163  🦐 General Mantis Shrimp: "Push forward! They're retreating!"
+TICK 165  🚨 Supply raid! 40 kelp rations lost at B4.
+TICK 167  🐋 Quartermaster Whale: "Rerouting supplies through A3. ETA 8 ticks."
+TICK 170  ✅ SKIRMISH RESOLVED — Coral Reef VICTORY at C4 (+1 territory)
+TICK 172  🐬 Ambassador Dolphin: "Deep Reef Confederation is open to talks."
+```
+
+### 8.6 Resource Dashboard (Scenario-Specific)
+
+```
+┌──────────────────────────────────────┐
+│  🪸 Coral Reef Alliance Resources   │
+│                                      │
+│  Kelp Rations   ████████░░░  73%    │
+│  Shell Ammo      █████░░░░░  48%    │
+│  Coral Material  ███████░░░  68%    │
+│  Morale          █████████░  87%    │
+│  Intel Points    ███░░░░░░░  31     │
+│  Alliance        ██████░░░░  56%    │
+│                                      │
+│  Burn Rate: -4.5 rations/tick       │
+│  Resupply ETA: 6 ticks              │
+└──────────────────────────────────────┘
+```
+
+### 8.7 Decision Feed
+
+A high-density view of every decision as it happens:
+
+```
+#1847  🐡 Captain Barracuda → ATTACK sector D4 (priority override)
+#1848  🦀 Warrior Crab-2 → ACKNOWLEDGE attack order
+#1849  🐋 Quartermaster → APPROVE ammo requisition (30 shells)
+#1850  🐙 Octopus Agent → REPORT enemy reserves low (confidence: 72%)
+#1851  🐍 Commander Eel → VERIFY intel (cross-reference with Scout Alpha-1)
+#1852  🐚 Admiral Nautilus → DECISION: proceed with flanking maneuver
+#1853  🦐 General Mantis → DEPLOY reserve unit to C3
+#1854  🌺 Dr. Anemone → TRIAGE: 2 wounded, 1 critical
+```
+
+Each decision is a row with: number, agent avatar, action verb, and details. Color-coded by type: green = progress, red = block/escalate, blue = command, yellow = intel.
+
+---
+
+## 9. Implementation Phases
+
+### Phase 1: Foundation (2 weeks)
+
+**Goal:** Scenario Engine can load SCENARIO.md and feed work into the existing simulation.
+
+**Deliverables:**
+- [ ] SCENARIO.md parser (markdown → ScenarioDefinition)
+- [ ] ScenarioEngine class with preTick/postTick hooks
+- [ ] Phase Manager (tick-based transitions only)
+- [ ] Task Generator (expand epic templates into tasks/subtasks)
+- [ ] Integration with DeterministicSimulation (hook into runTick)
+- [ ] One working scenario: "AI Dev Agency — Simple Sprint" (500+ decisions)
+
+**Key files:**
+- `tools/sandbox/src/scenario-engine.ts` — core engine
+- `tools/sandbox/src/scenario-parser.ts` — SCENARIO.md parser
+- `tools/sandbox/scenarios/ai-dev-agency-simple.md` — first scenario
+
+### Phase 2: Friction Systems (2 weeks)
+
+**Goal:** Dependencies, events, and resource contention working.
+
+**Deliverables:**
+- [ ] DependencyGraph (DAG resolver with topological sort)
+- [ ] EventScheduler (seeded PRNG, cooldowns, chaining)
+- [ ] ResourceManager (pools, burn rates, alerts)
+- [ ] Decision Evaluator (weighted outcomes for reviews, approvals)
+- [ ] Review loops (reject → rework → resubmit cycle)
+- [ ] Cross-department triggers
+- [ ] Resource contention resolution
+- [ ] Upgraded scenario: "AI Dev Agency — Full Sprint" (1500+ decisions)
+
+**Key files:**
+- `tools/sandbox/src/dag.ts` — dependency graph
+- `tools/sandbox/src/events.ts` — event scheduler
+- `tools/sandbox/src/resources.ts` — resource management
+- `tools/sandbox/src/decisions.ts` — weighted decision evaluation
+
+### Phase 3: Dashboard Integration (2 weeks)
+
+**Goal:** Scenarios are visually compelling on the dashboard.
+
+**Deliverables:**
+- [ ] Phase banner component
+- [ ] Enhanced org chart animations (message particles, glow states)
+- [ ] Event timeline component
+- [ ] Resource dashboard component
+- [ ] Scenario selector screen
+- [ ] Score card (end-of-scenario summary with shareable card)
+- [ ] Decision feed component
+
+### Phase 4: Adversarial Mode & Reef War (3 weeks)
+
+**Goal:** The Ocean Reef War scenario runs with two competing orgs.
+
+**Deliverables:**
+- [ ] AdversarialScenarioEngine (dual simulation runner)
+- [ ] WorldState (shared territory map)
+- [ ] Combat resolution system
+- [ ] Fog of war mechanic
+- [ ] Territory map visualization
+- [ ] Split-screen org charts
+- [ ] Full Reef War scenario: "Battle for the Abyssal Trench" (2500+ decisions)
+- [ ] Kelp Forest Dominion ORG.md (auto-generated mirror)
+
+### Phase 5: Scenario Library & Polish (2 weeks)
+
+**Goal:** All six scenarios playable. Polish and sharing.
+
+**Deliverables:**
+- [ ] Legal Tech scenario
+- [ ] Fintech Startup scenario
+- [ ] Game Studio scenario
+- [ ] Open Source Project scenario
+- [ ] Difficulty system (easy/normal/hard/chaos)
+- [ ] Seed sharing ("try seed #42069")
+- [ ] Twitter card generation
+- [ ] Achievement system
+- [ ] Scenario completion statistics (leaderboard?)
+
+### Phase 6: Community & UGC (ongoing)
+
+**Goal:** Users create and share their own scenarios.
+
+**Deliverables:**
+- [ ] Scenario editor (web UI for building SCENARIO.md)
+- [ ] Scenario gallery (community-shared scenarios)
+- [ ] Scenario validation (lint + dry-run to catch errors)
+- [ ] Custom ORG.md + SCENARIO.md pairing
+- [ ] Scenario remix (fork + modify)
+
+---
+
+## Appendix A: Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Epic** | Large body of work containing multiple tasks. Tied to a phase. |
+| **Phase** | Major stage of a scenario with its own pacing, events, and epics. |
+| **DAG** | Directed Acyclic Graph — the dependency structure between tasks. |
+| **Decision** | Any action taken by an agent: assign, ack, progress, review, complete, escalate, etc. |
+| **Tick** | One simulation cycle. ~600–1000ms of wall-clock time. |
+| **Seed** | PRNG seed for reproducible runs. Same seed + same scenario = same outcome. |
+| **Friction** | Organizational overhead: dependencies, reviews, contention, events. |
+| **Fog of War** | Information asymmetry — agents make decisions with incomplete information. |
+| **Story State** | Key-value map tracking narrative branch decisions for conditional content. |
+| **Adversarial Mode** | Two simulations running against each other with a shared world state. |
+
+## Appendix B: SCENARIO.md Complete Grammar
+
+```
+scenario      := meta phases epics events? resources? scoring?
+
+meta          := "## Meta" newline (meta-field newline)*
+meta-field    := "- **" key ":** " value
+
+phases        := "## Phases" newline (phase newline)*
+phase         := "### " phase-name " (" tick-range ")" newline
+                 prose newline
+                 (phase-field newline)*
+                 ("#### " sub-section newline prose newline)*
+phase-field   := "- **" key ":** " value
+
+epics         := "## Epics" newline (epic newline)*
+epic          := "### " epic-name newline
+                 (epic-field newline)*
+                 ("#### Task Templates" newline (task-template newline)*)?
+epic-field    := "- **" key ":** " value
+
+task-template := number ". **" task-name "** [" domain "]" newline
+                 ("   - " subtask-or-field newline)*
+
+events        := "## Events" newline (event newline)*
+event         := "### " event-id newline
+                 (event-field newline)*
+event-field   := "- **" key ":** " value
+
+resources     := "## Resources" newline (resource newline)*
+resource      := "### " resource-name newline
+                 (resource-field newline)*
+
+scoring       := "## Scoring" newline prose
+```
+
+## Appendix C: Decision Type Taxonomy
+
+Every decision in the simulation falls into one of these categories:
+
+| Category | Examples | Avg per occurrence | Visual signal |
+|----------|----------|-------------------|---------------|
+| **Command** | Delegate task, approve plan, allocate resources | 1 | Blue pulse |
+| **Execution** | Start work, make progress, submit deliverable | 1–3 | Green pulse |
+| **Review** | Approve, reject, request changes | 1 | Yellow pulse |
+| **Communication** | Ack, progress report, escalation | 1 | Message particle |
+| **Hiring** | Spawn agent, assign mentor, first task | 3–4 | New node animation |
+| **Contention** | Resource conflict, priority override, deadlock | 2–4 | Red/orange pulse |
+| **Event Response** | Triage interrupt, reassign, emergency task | 5–15 | Alert animation |
+| **Strategic** | Phase transition, scope cut, strategy choice | 1–3 | Phase banner |
+| **Diplomatic** | Negotiate, offer tribute, form alliance | 3–6 | Handshake animation |
+| **Combat** | Engage, retreat, flank, resupply (Reef War only) | 2–4 | Sword animation |
+
+---
+
+*The Scenario Engine transforms BikiniBottom from a toy demo into something people actually want to watch. It's the difference between a sandbox with three blocks and SimCity. Build the engine, and the scenarios write themselves.*

--- a/apps/docs/src/env.d.ts
+++ b/apps/docs/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../.astro/types.d.ts" />

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/base"
+}


### PR DESCRIPTION
## Summary
Created a new Astro Starlight documentation site at `apps/docs/` and deployed it to docs.openspawn.ai.

## What's included
- **15 pages** organized into 3 sections:
  - **Getting Started**: Introduction, Agent Quickstart, Templates, Comparison, FAQ
  - **Reference**: ORG.md spec, communication protocols, config compatibility, scenario engine
  - **Architecture**: CEO agent design, integrations, worktree isolation

## Changes
- Created `apps/docs/` with Starlight configuration
- Migrated all existing docs from `docs/` and `docs/strategy/`
- Fixed frontmatter for Starlight compatibility (removed unsupported fields)
- Configured sidebar navigation
- Built and deployed to `/opt/docs-site/` on VPS

## Deployment
- ✅ Deployed to: **docs.openspawn.ai**  
- ✅ Search enabled via Pagefind (4519 words indexed)
- ✅ GitHub link in header

## Next Steps
- [ ] Adam: Add Caddy config for docs.openspawn.ai subdomain
- [ ] Optional: Fix sitemap plugin error (non-critical, doesn't affect functionality)
- [ ] Optional: Restore splash template on index page for better landing experience

## Notes
- Original docs in `docs/` **not modified** — all content copied to preserve originals
- Site builds successfully despite minor sitemap plugin warning
- All internal links verified and working