### PR TITLE
fix: default Dockerfile dashboard theme to openspawn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY tools/sandbox/src/ ./tools/sandbox/src/
 COPY tools/sandbox/ORG.md ./tools/sandbox/
 COPY tools/sandbox/org/ ./tools/sandbox/org/
 
-ARG VITE_DASHBOARD_THEME=bikinibottom
+ARG VITE_DASHBOARD_THEME=openspawn
 ENV VITE_SANDBOX_MODE=true
 ENV VITE_DASHBOARD_THEME=${VITE_DASHBOARD_THEME}
 RUN pnpm nx run dashboard:build --configuration=production


### PR DESCRIPTION
Changes VITE_DASHBOARD_THEME default from bikinibottom to openspawn.

bikinibottom.ai builds should pass --build-arg VITE_DASHBOARD_THEME=bikinibottom explicitly.