### PR TITLE
fix(api): GraphQL production fixes — throttler guard + public queries

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -1,7 +1,8 @@
 import { MiddlewareConsumer, Module, NestModule } from "@nestjs/common";
 import { APP_GUARD } from "@nestjs/core";
 import { EventEmitterModule } from "@nestjs/event-emitter";
-import { ThrottlerGuard, ThrottlerModule } from "@nestjs/throttler";
+import { ThrottlerModule } from "@nestjs/throttler";
+import { GqlThrottlerGuard } from "../common/gql-throttler.guard";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { entities } from "@openspawn/database";
@@ -68,7 +69,7 @@ import { AppService } from "./app.service";
     AppService,
     {
       provide: APP_GUARD,
-      useClass: ThrottlerGuard,
+      useClass: GqlThrottlerGuard,
     },
   ],
 })

--- a/apps/api/src/common/gql-throttler.guard.ts
+++ b/apps/api/src/common/gql-throttler.guard.ts
@@ -1,0 +1,20 @@
+import { ExecutionContext, Injectable } from "@nestjs/common";
+import { ThrottlerGuard } from "@nestjs/throttler";
+import { GqlContextType, GqlExecutionContext } from "@nestjs/graphql";
+
+@Injectable()
+export class GqlThrottlerGuard extends ThrottlerGuard {
+  getRequestResponse(context: ExecutionContext) {
+    if (context.getType<GqlContextType>() === "graphql") {
+      const gqlCtx = GqlExecutionContext.create(context);
+      const ctx = gqlCtx.getContext();
+      const req = ctx.req;
+      // Ensure req exists with ip for throttler
+      if (req && !req.ip) {
+        req.ip = req.headers?.["x-forwarded-for"] || req.socket?.remoteAddress || "unknown";
+      }
+      return { req, res: ctx.res ?? req?.res ?? {} };
+    }
+    return super.getRequestResponse(context);
+  }
+}

--- a/apps/api/src/graphql/resolvers/agent.resolver.ts
+++ b/apps/api/src/graphql/resolvers/agent.resolver.ts
@@ -1,7 +1,7 @@
 import { Args, ID, Int, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 
 import { getReputationLevel, ReputationLevel } from "@openspawn/shared-types";
-import { OrgFromContext, validateOrgAccess } from "../../auth/decorators";
+import { OrgFromContext, validateOrgAccess, Public } from "../../auth/decorators";
 import { AgentsService, TrustService } from "../../agents";
 import {
   AgentType,
@@ -25,12 +25,13 @@ export class AgentResolver {
     private readonly trustService: TrustService,
   ) {}
 
+  @Public()
   @Query(() => [AgentType])
   async agents(
     @Args("orgId", { type: () => ID }) orgId: string,
     @OrgFromContext() authenticatedOrgId: string | undefined,
   ): Promise<AgentType[]> {
-    validateOrgAccess(orgId, authenticatedOrgId);
+    if (authenticatedOrgId) validateOrgAccess(orgId, authenticatedOrgId);
     return this.agentsService.findAll(orgId);
   }
 
@@ -40,7 +41,7 @@ export class AgentResolver {
     @Args("id", { type: () => ID }) id: string,
     @OrgFromContext() authenticatedOrgId: string | undefined,
   ): Promise<AgentType | null> {
-    validateOrgAccess(orgId, authenticatedOrgId);
+    if (authenticatedOrgId) validateOrgAccess(orgId, authenticatedOrgId);
     try {
       return await this.agentsService.findOne(orgId, id);
     } catch {
@@ -59,7 +60,7 @@ export class AgentResolver {
     @Args("agentId", { type: () => ID }) agentId: string,
     @OrgFromContext() authenticatedOrgId: string | undefined,
   ): Promise<AgentReputationType | null> {
-    validateOrgAccess(orgId, authenticatedOrgId);
+    if (authenticatedOrgId) validateOrgAccess(orgId, authenticatedOrgId);
     try {
       const summary = await this.trustService.getReputationSummary(agentId);
       return {
@@ -85,7 +86,7 @@ export class AgentResolver {
     @OrgFromContext() authenticatedOrgId: string | undefined,
     @Args("limit", { type: () => Int, nullable: true }) limit?: number,
   ): Promise<ReputationHistoryEntryType[]> {
-    validateOrgAccess(orgId, authenticatedOrgId);
+    if (authenticatedOrgId) validateOrgAccess(orgId, authenticatedOrgId);
     const result = await this.trustService.getReputationHistory(agentId, { limit });
     return result.events.map((e) => ({
       id: e.id,
@@ -104,7 +105,7 @@ export class AgentResolver {
     @OrgFromContext() authenticatedOrgId: string | undefined,
     @Args("limit", { type: () => Int, nullable: true }) limit?: number,
   ): Promise<LeaderboardEntryType[]> {
-    validateOrgAccess(orgId, authenticatedOrgId);
+    if (authenticatedOrgId) validateOrgAccess(orgId, authenticatedOrgId);
     return this.trustService.getLeaderboard(orgId, limit ?? 10);
   }
 }

--- a/apps/api/src/graphql/resolvers/event.resolver.ts
+++ b/apps/api/src/graphql/resolvers/event.resolver.ts
@@ -4,7 +4,7 @@ import { Repository } from "typeorm";
 
 import { Agent } from "@openspawn/database";
 
-import { OrgFromContext, validateOrgAccess } from "../../auth/decorators";
+import { OrgFromContext, validateOrgAccess, Public } from "../../auth/decorators";
 import { EventsService } from "../../events";
 import { EVENT_CREATED, PubSubProvider } from "../pubsub.provider";
 import { AgentType, EventType } from "../types";
@@ -26,6 +26,8 @@ export class EventResolver {
     private readonly agentRepository: Repository<Agent>,
   ) {}
 
+  @ Public()
+  @Public()
   @Query(() => [EventType])
   async events(
     @Args("orgId", { type: () => ID }) orgId: string,
@@ -33,7 +35,7 @@ export class EventResolver {
     @Args("page", { type: () => Int, defaultValue: 1 }) page: number,
     @OrgFromContext() authenticatedOrgId?: string,
   ): Promise<EventType[]> {
-    validateOrgAccess(orgId, authenticatedOrgId);
+    if (authenticatedOrgId) validateOrgAccess(orgId, authenticatedOrgId);
     const { events } = await this.eventsService.findAll(orgId, {}, page, limit);
     return events;
   }

--- a/apps/api/src/graphql/resolvers/task.resolver.ts
+++ b/apps/api/src/graphql/resolvers/task.resolver.ts
@@ -5,7 +5,7 @@ import { Repository } from "typeorm";
 import { Agent } from "@openspawn/database";
 import { TaskStatus } from "@openspawn/shared-types";
 
-import { OrgFromContext, validateOrgAccess } from "../../auth/decorators";
+import { OrgFromContext, validateOrgAccess, Public } from "../../auth/decorators";
 import { TasksService } from "../../tasks";
 import { PubSubProvider, TASK_UPDATED } from "../pubsub.provider";
 import { AgentType, ClaimTaskResultType, TaskRejectionType, TaskType } from "../types";
@@ -27,6 +27,8 @@ export class TaskResolver {
     private readonly agentRepository: Repository<Agent>,
   ) {}
 
+  @ Public()
+  @Public()
   @Query(() => [TaskType])
   async tasks(
     @Args("orgId", { type: () => ID }) orgId: string,
@@ -34,7 +36,7 @@ export class TaskResolver {
     @Args("assigneeId", { type: () => ID, nullable: true }) assigneeId?: string,
     @OrgFromContext() authenticatedOrgId?: string,
   ): Promise<TaskType[]> {
-    validateOrgAccess(orgId, authenticatedOrgId);
+    if (authenticatedOrgId) validateOrgAccess(orgId, authenticatedOrgId);
     return this.tasksService.findAll(orgId, { status, assigneeId });
   }
 
@@ -44,7 +46,7 @@ export class TaskResolver {
     @Args("id", { type: () => ID }) id: string,
     @OrgFromContext() authenticatedOrgId?: string,
   ): Promise<TaskType | null> {
-    validateOrgAccess(orgId, authenticatedOrgId);
+    if (authenticatedOrgId) validateOrgAccess(orgId, authenticatedOrgId);
     try {
       return await this.tasksService.findOne(orgId, id);
     } catch {
@@ -57,7 +59,7 @@ export class TaskResolver {
     @Args("orgId", { type: () => ID }) orgId: string,
     @OrgFromContext() authenticatedOrgId?: string,
   ): Promise<number> {
-    validateOrgAccess(orgId, authenticatedOrgId);
+    if (authenticatedOrgId) validateOrgAccess(orgId, authenticatedOrgId);
     return this.tasksService.getClaimableTaskCount(orgId);
   }
 
@@ -67,7 +69,7 @@ export class TaskResolver {
     @Args("agentId", { type: () => ID }) agentId: string,
     @OrgFromContext() authenticatedOrgId?: string,
   ): Promise<ClaimTaskResultType> {
-    validateOrgAccess(orgId, authenticatedOrgId);
+    if (authenticatedOrgId) validateOrgAccess(orgId, authenticatedOrgId);
     return this.tasksService.claimNextTask(orgId, agentId);
   }
 


### PR DESCRIPTION
## Changes
- Custom GqlThrottlerGuard handles GraphQL context (fixes `request.ip` crash in production)
- Read queries marked `@Public()` so team dashboard can fetch agent/task/event data without auth
- Org access validation skipped for unauthenticated requests (demo/dashboard mode)
- `formatError` still sanitizes internal errors in production mode

Fixes the 'Internal server error' on all GraphQL queries in production.