### PR TITLE
fix: broken build — missing MCP exports + dead import

### DIFF
--- a/apps/dashboard/src/services/mcp-client.ts
+++ b/apps/dashboard/src/services/mcp-client.ts
@@ -1,1 +1,14 @@
-export { orgStatus, taskList, McpError } from "@openspawn/dashboard-data";
+export {
+  orgStatus,
+  taskList,
+  taskCreate,
+  taskClaim,
+  taskComplete,
+  agentList,
+  agentRegister,
+  agentUpdateStatus,
+  agentFire,
+  eventList,
+  escalate,
+  McpError,
+} from "@openspawn/dashboard-data";

--- a/apps/demo/src/components/index.ts
+++ b/apps/demo/src/components/index.ts
@@ -1,5 +1,4 @@
 export * from "./layout";
-export * from "./protected-route";
 export * from "./theme-provider";
 export * from "./theme-toggle";
 export * from "./theme-picker";

--- a/apps/demo/src/services/mcp-client.ts
+++ b/apps/demo/src/services/mcp-client.ts
@@ -1,1 +1,14 @@
-export { orgStatus, taskList, McpError } from "@openspawn/dashboard-data";
+export {
+  orgStatus,
+  taskList,
+  taskCreate,
+  taskClaim,
+  taskComplete,
+  agentList,
+  agentRegister,
+  agentUpdateStatus,
+  agentFire,
+  eventList,
+  escalate,
+  McpError,
+} from "@openspawn/dashboard-data";

--- a/libs/dashboard-data/src/index.ts
+++ b/libs/dashboard-data/src/index.ts
@@ -17,7 +17,7 @@ export { useTasks, type Task } from "./hooks/use-tasks";
 export { useTouchDevice } from "./hooks/use-touch-device";
 
 // Services
-export { orgStatus, taskList, McpError } from "./services/mcp-client";
+export { orgStatus, taskList, taskCreate, taskClaim, taskComplete, agentList, agentRegister, agentUpdateStatus, agentFire, eventList, escalate, McpError } from "./services/mcp-client";
 
 // Contexts
 export { AuthProvider, useAuth, useOAuthCallback, type User } from "./contexts/auth-context";


### PR DESCRIPTION
Dashboard and demo builds were failing due to incomplete re-exports from the monorepo restructure. Fixes barrel exports in dashboard-data and removes dead protected-route import from demo.