### PR TITLE
fix: Docker build — scripts copy + remove generate-md dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN pnpm install --frozen-lockfile
 COPY tools/sandbox/src/ ./tools/sandbox/src/
 COPY tools/sandbox/ORG.md ./tools/sandbox/
 COPY tools/sandbox/org/ ./tools/sandbox/org/
+COPY scripts/ ./scripts/
 
 ARG VITE_DASHBOARD_THEME=openspawn
 ENV VITE_SANDBOX_MODE=true

--- a/apps/website/project.json
+++ b/apps/website/project.json
@@ -17,9 +17,6 @@
       ],
       "outputs": [
         "{workspaceRoot}/dist/apps/website"
-      ],
-      "dependsOn": [
-        "generate-md"
       ]
     },
     "serve": {


### PR DESCRIPTION
Fix Docker build failure (exit code 130) by removing generate-md from build dependencies. .md files are pre-generated and committed to public/.