### PR TITLE
feat: CalVer versioning (2026.3.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspawn/monorepo",
-  "version": "0.0.0",
+  "version": "2026.3.3",
   "private": true,
   "description": "Self-hosted platform for multi-agent coordination, communication, and economy management",
   "license": "MIT",

--- a/packages/openspawn/package.json
+++ b/packages/openspawn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openspawn",
-  "version": "0.1.0",
+  "version": "2026.3.3",
   "description": "Standalone MCP server and CLI for OpenSpawn multi-agent organizations",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Switch from SemVer (0.0.0/0.1.0) to CalVer (2026.3.3). Matches OpenClaw's versioning pattern for fast-moving projects.