### PR TITLE
chore: add .pnpm-store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ __pycache__/
 # Production secrets
 .env.production
 node_modules
+.pnpm-store/


### PR DESCRIPTION
Prevents 1.2GB pnpm store from being committed by sub-agents.