### PR TITLE
fix(api): resolve circular dependency crash

### DIFF
--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -1,16 +1,20 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { Webhook } from "@openspawn/database";
 import { WebhooksController } from "./webhooks.controller";
 import { DiscordWebhookController } from "./discord-webhook.controller";
 import { WebhooksService } from "./webhooks.service";
 import { AuthModule } from "../auth";
-
 import { TasksModule } from "../tasks";
 import { AgentsModule } from "../agents";
 
 @Module({
-  imports: [TasksModule, AgentsModule, TypeOrmModule.forFeature([Webhook]), AuthModule],
+  imports: [
+    forwardRef(() => TasksModule),
+    forwardRef(() => AgentsModule),
+    TypeOrmModule.forFeature([Webhook]),
+    AuthModule,
+  ],
   controllers: [WebhooksController, DiscordWebhookController],
   providers: [WebhooksService],
   exports: [WebhooksService],


### PR DESCRIPTION
API was crash-looping on VPS. WebhooksModule ↔ TasksModule circular import. Fixed with forwardRef().