### PR TITLE
fix: team dashboard org ID + configurable base path

### DIFF
--- a/apps/team/vite.config.mts
+++ b/apps/team/vite.config.mts
@@ -11,7 +11,7 @@ const commitSha = (() => {
 })();
 const buildTime = new Date().toISOString();
 
-const basePath = '/app/';
+const basePath = process.env.VITE_BASE_PATH || '/app/';
 
 function fixBaseHref(): Plugin {
   return {

--- a/libs/dashboard-data/src/lib/constants.ts
+++ b/libs/dashboard-data/src/lib/constants.ts
@@ -1,3 +1,3 @@
 // Default organization ID for single-org mode
 // TODO: Replace with org context when multi-org support is needed
-export const DEFAULT_ORG_ID = "4b5b1008-0640-42cf-b434-d6a01e423295";
+export const DEFAULT_ORG_ID = "f3a3fc0c-29e6-4d0d-b489-3c065d9230b6";


### PR DESCRIPTION
Dashboard was querying wrong org. Fixed DEFAULT_ORG_ID to match actual CEO org.