### PR TITLE
fix: blank screen on bikinibottom.ai

### DIFF
--- a/libs/dashboard-data/src/index.ts
+++ b/libs/dashboard-data/src/index.ts
@@ -42,3 +42,14 @@ export * from "./lib/resolve-avatar-url";
 export { SANDBOX_URL } from "./lib/sandbox-url";
 export * from "./lib/status-colors";
 export * from "./lib/toast";
+
+
+// Document node exports (used by demo mock-fetcher)
+export {
+  TasksDocument,
+  TaskDocument,
+  AgentsDocument,
+  CreditHistoryDocument,
+  EventsDocument,
+  MessagesDocument,
+} from "./graphql/generated/graphql";


### PR DESCRIPTION
Root cause: Document nodes (TasksDocument, AgentsDocument, etc.) weren't exported from `@openspawn/dashboard-data` barrel. The demo mock-fetcher imported them at module init, crashing before React mounted. Also fixes Dockerfile to build `demo` app instead of old `dashboard`.