### PR TITLE
fix: mobile side panel transparency

### DIFF
--- a/apps/team/src/components/layout.tsx
+++ b/apps/team/src/components/layout.tsx
@@ -72,7 +72,7 @@ function SidePanelOverlay() {
   return (
     <>
       <div className="fixed inset-0 z-40 bg-black/30" onClick={closeSidePanel} />
-      <div className="fixed inset-y-0 right-0 z-50">
+      <div className="fixed inset-y-0 right-0 z-50 bg-[hsl(var(--background))]">
         <SidePanelShell title={title} onClose={closeSidePanel} width={width} onWidthChange={setWidth}>
           {content}
         </SidePanelShell>

--- a/libs/dashboard-ui/src/ui/side-panel.tsx
+++ b/libs/dashboard-ui/src/ui/side-panel.tsx
@@ -47,7 +47,7 @@ export function SidePanelShell({ children, title, onClose, width, onWidthChange 
   }, [width, onWidthChange]);
 
   return (
-    <div data-testid="side-panel" className="h-full flex flex-col bg-background relative overflow-x-hidden w-full md:w-auto">
+    <div data-testid="side-panel" className="h-full flex flex-col bg-[hsl(var(--background))] relative overflow-x-hidden w-full md:w-auto">
       {/* Drag handle on left edge */}
       <div
         onMouseDown={handleMouseDown}


### PR DESCRIPTION
Use explicit hsl(var(--background)) to fix transparent background on mobile browsers.