### PR TITLE
feat(api): SQLAlchemy models for all entities (#526)

### DIFF
--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -1,0 +1,85 @@
+from app.models.agent import Agent, AgentCapability
+from app.models.auth import ApiKey, IdempotencyKey, Nonce, RefreshToken, User
+from app.models.base import Base
+from app.models.consensus import ConsensusRequest, ConsensusVote
+from app.models.credit import CreditRateConfig, CreditTransaction
+from app.models.enums import (
+    AgentMode,
+    AgentRole,
+    AgentStatus,
+    AmountMode,
+    ApiKeyScope,
+    ChannelType,
+    ConsensusStatus,
+    ConsensusType,
+    CreditType,
+    EscalationReason,
+    EventSeverity,
+    IdleReason,
+    MessageType,
+    Proficiency,
+    ReputationEventType,
+    ReputationLevel,
+    TaskPriority,
+    TaskStatus,
+    UserRole,
+    VoteValue,
+)
+from app.models.escalation import Escalation
+from app.models.event import Event
+from app.models.integration import GitHubConnection, IntegrationLink, LinearConnection
+from app.models.message import Channel, Message
+from app.models.organization import Organization
+from app.models.reputation import ReputationEvent
+from app.models.task import Task, TaskComment, TaskDependency, TaskTag
+from app.models.webhook import InboundWebhookKey, Webhook
+
+__all__ = [
+    "Agent",
+    "AgentCapability",
+    "AgentMode",
+    "AgentRole",
+    "AgentStatus",
+    "AmountMode",
+    "ApiKey",
+    "ApiKeyScope",
+    "Base",
+    "Channel",
+    "ChannelType",
+    "ConsensusRequest",
+    "ConsensusStatus",
+    "ConsensusType",
+    "ConsensusVote",
+    "CreditRateConfig",
+    "CreditTransaction",
+    "CreditType",
+    "Escalation",
+    "EscalationReason",
+    "Event",
+    "EventSeverity",
+    "GitHubConnection",
+    "IdempotencyKey",
+    "IdleReason",
+    "InboundWebhookKey",
+    "IntegrationLink",
+    "LinearConnection",
+    "Message",
+    "MessageType",
+    "Nonce",
+    "Organization",
+    "Proficiency",
+    "RefreshToken",
+    "ReputationEvent",
+    "ReputationEventType",
+    "ReputationLevel",
+    "Task",
+    "TaskComment",
+    "TaskDependency",
+    "TaskPriority",
+    "TaskStatus",
+    "TaskTag",
+    "User",
+    "UserRole",
+    "VoteValue",
+    "Webhook",
+]

--- a/apps/api/app/models/agent.py
+++ b/apps/api/app/models/agent.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import CheckConstraint, ForeignKey, Index, LargeBinary, SmallInteger, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.enums import AgentMode, AgentRole, AgentStatus, Proficiency
+
+if TYPE_CHECKING:
+    from app.models.organization import Organization
+    from app.models.task import Task
+
+
+class Agent(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "agents"
+    __table_args__ = (
+        CheckConstraint("level >= 1 AND level <= 10", name="chk_agents_level"),
+        CheckConstraint(
+            "management_fee_pct >= 0 AND management_fee_pct <= 50",
+            name="chk_agents_management_fee_pct",
+        ),
+        Index("ix_agents_org_id_agent_id", "org_id", "agent_id", unique=True),
+        Index("ix_agents_org_id_status", "org_id", "status"),
+        Index("ix_agents_org_id_role", "org_id", "role"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    agent_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    level: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="1")
+    model: Mapped[str] = mapped_column(String(100), nullable=False, server_default="sonnet")
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=AgentStatus.ACTIVE.value
+    )
+    role: Mapped[str] = mapped_column(
+        String(50), nullable=False, server_default=AgentRole.WORKER.value
+    )
+    mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=AgentMode.WORKER.value
+    )
+    management_fee_pct: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default="0"
+    )
+    current_balance: Mapped[int] = mapped_column(nullable=False, server_default="0")
+    budget_period_limit: Mapped[int | None] = mapped_column(nullable=True)
+    budget_period_spent: Mapped[int] = mapped_column(nullable=False, server_default="0")
+    budget_period_start: Mapped[datetime | None] = mapped_column(nullable=True)
+    hmac_secret_enc: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+    )
+    max_children: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+    trust_score: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
+    tasks_completed: Mapped[int] = mapped_column(nullable=False, server_default="0")
+    tasks_successful: Mapped[int] = mapped_column(nullable=False, server_default="0")
+    last_activity_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    last_promotion_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    lifetime_earnings: Mapped[int] = mapped_column(nullable=False, server_default="0")
+    domain: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    avatar: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    avatar_color: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    deleted_at: Mapped[datetime | None] = mapped_column(nullable=True)
+
+    organization: Mapped[Organization] = relationship("Organization", back_populates="agents")
+    parent: Mapped[Agent | None] = relationship(
+        "Agent", remote_side="Agent.id", back_populates="children"
+    )
+    children: Mapped[list[Agent]] = relationship("Agent", back_populates="parent")
+    capabilities: Mapped[list[AgentCapability]] = relationship(
+        "AgentCapability", back_populates="agent"
+    )
+    assigned_tasks: Mapped[list[Task]] = relationship(
+        "Task", foreign_keys="Task.assignee_id", back_populates="assignee"
+    )
+    created_tasks: Mapped[list[Task]] = relationship(
+        "Task", foreign_keys="Task.creator_id", back_populates="creator"
+    )
+
+
+class AgentCapability(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "agent_capabilities"
+    __table_args__ = (
+        Index("ix_agent_capabilities_agent_id_capability", "agent_id", "capability", unique=True),
+        Index("ix_agent_capabilities_org_id_capability", "org_id", "capability"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    capability: Mapped[str] = mapped_column(String(100), nullable=False)
+    proficiency: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=Proficiency.STANDARD.value
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        server_default="now()",
+        nullable=False,
+    )
+
+    organization: Mapped[Organization] = relationship("Organization")
+    agent: Mapped[Agent] = relationship("Agent", back_populates="capabilities")

--- a/apps/api/app/models/auth.py
+++ b/apps/api/app/models/auth.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, Index, LargeBinary, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.enums import UserRole
+
+
+class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "users"
+    __table_args__ = (Index("ix_users_org_id_email", "org_id", "email", unique=True),)
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    email: Mapped[str] = mapped_column(String(255), nullable=False)
+    password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    role: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=UserRole.VIEWER.value
+    )
+    google_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    totp_secret_enc: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    totp_enabled: Mapped[bool] = mapped_column(nullable=False, server_default="false")
+    recovery_codes_enc: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    last_login_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    email_verified: Mapped[bool] = mapped_column(nullable=False, server_default="false")
+
+    organization: Mapped[Organization] = relationship("Organization")
+    refresh_tokens: Mapped[list[RefreshToken]] = relationship("RefreshToken", back_populates="user")
+
+
+class RefreshToken(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "refresh_tokens"
+    __table_args__ = (
+        Index("ix_refresh_tokens_user_id", "user_id"),
+        Index("ix_refresh_tokens_expires_at", "expires_at"),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    token_hash: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    expires_at: Mapped[datetime] = mapped_column(nullable=False)
+    revoked_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    user: Mapped[User] = relationship("User", back_populates="refresh_tokens")
+
+
+class ApiKey(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "api_keys"
+    __table_args__ = (
+        Index("ix_api_keys_org_id", "org_id"),
+        Index("ix_api_keys_key_prefix", "key_prefix"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    key_prefix: Mapped[str] = mapped_column(String(12), nullable=False)
+    key_hash: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    scopes: Mapped[list] = mapped_column(JSONB, nullable=False, server_default='["read"]')
+    last_used_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    created_by: Mapped[User] = relationship("User")
+
+
+class Nonce(Base):
+    __tablename__ = "nonces"
+    __table_args__ = (Index("ix_nonces_expires_at", "expires_at"),)
+
+    nonce: Mapped[str] = mapped_column(String(64), primary_key=True)
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(nullable=False)
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+
+class IdempotencyKey(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "idempotency_keys"
+    __table_args__ = (Index("ix_idempotency_keys_expires_at", "expires_at"),)
+
+    key: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, unique=True)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    method: Mapped[str] = mapped_column(String(10), nullable=False)
+    path: Mapped[str] = mapped_column(String(500), nullable=False)
+    status_code: Mapped[int] = mapped_column(nullable=False)
+    response_body: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(nullable=False)
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    agent: Mapped[Agent] = relationship("Agent")
+
+
+from app.models.agent import Agent  # noqa: E402
+from app.models.organization import Organization  # noqa: E402

--- a/apps/api/app/models/base.py
+++ b/apps/api/app/models/base.py
@@ -1,0 +1,30 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class TimestampMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class UUIDPrimaryKeyMixin:
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )

--- a/apps/api/app/models/consensus.py
+++ b/apps/api/app/models/consensus.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, Index, SmallInteger, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.enums import ConsensusStatus
+
+
+class ConsensusRequest(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "consensus_requests"
+    __table_args__ = (
+        Index("ix_consensus_requests_org_id_status", "org_id", "status"),
+        Index("ix_consensus_requests_org_id_type", "org_id", "type"),
+        Index("ix_consensus_requests_org_id_requester_id", "org_id", "requester_id"),
+        Index("ix_consensus_requests_org_id_expires_at", "org_id", "expires_at"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    type: Mapped[str] = mapped_column(String(50), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(50), nullable=False, server_default=ConsensusStatus.PENDING.value
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    requester_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    subject_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    subject_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    quorum_required: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="2")
+    approval_threshold: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default="50"
+    )
+    votes_approve: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    votes_reject: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    votes_abstain: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    expires_at: Mapped[datetime] = mapped_column(nullable=False)
+    decided_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+
+    organization: Mapped[Organization] = relationship("Organization")
+    requester: Mapped[Agent] = relationship("Agent")
+    votes: Mapped[list[ConsensusVote]] = relationship("ConsensusVote", back_populates="request")
+
+
+class ConsensusVote(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "consensus_votes"
+    __table_args__ = (
+        Index("ix_consensus_votes_request_id_voter_id", "request_id", "voter_id", unique=True),
+        Index("ix_consensus_votes_org_id_request_id", "org_id", "request_id"),
+        Index("ix_consensus_votes_voter_id", "voter_id"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("consensus_requests.id"), nullable=False
+    )
+    voter_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    vote: Mapped[str] = mapped_column(String(20), nullable=False)
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    voter_level: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    request: Mapped[ConsensusRequest] = relationship("ConsensusRequest", back_populates="votes")
+    voter: Mapped[Agent] = relationship("Agent")
+
+
+from app.models.agent import Agent  # noqa: E402
+from app.models.organization import Organization  # noqa: E402

--- a/apps/api/app/models/credit.py
+++ b/apps/api/app/models/credit.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, ForeignKey, Index, Numeric, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.enums import AmountMode
+
+
+class CreditTransaction(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "credit_transactions"
+    __table_args__ = (
+        CheckConstraint("amount > 0", name="chk_credit_transactions_amount"),
+        Index(
+            "ix_credit_transactions_org_id_agent_id_created_at", "org_id", "agent_id", "created_at"
+        ),
+        Index("ix_credit_transactions_org_id_created_at", "org_id", "created_at"),
+        Index("ix_credit_transactions_trigger_event_id", "trigger_event_id"),
+        Index("ix_credit_transactions_source_task_id", "source_task_id"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    type: Mapped[str] = mapped_column(String(10), nullable=False)
+    amount: Mapped[int] = mapped_column(nullable=False)
+    balance_after: Mapped[int] = mapped_column(nullable=False)
+    reason: Mapped[str] = mapped_column(String(500), nullable=False)
+    trigger_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    trigger_event_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("events.id"), nullable=True
+    )
+    source_task_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=True
+    )
+    source_agent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+    )
+    litellm_cost_usd: Mapped[float | None] = mapped_column(Numeric(10, 6), nullable=True)
+    idempotency_key: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, unique=True
+    )
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    agent: Mapped[Agent] = relationship("Agent", foreign_keys=[agent_id])
+    trigger_event: Mapped[Event | None] = relationship("Event")
+    source_task: Mapped[Task | None] = relationship("Task")
+    source_agent: Mapped[Agent | None] = relationship("Agent", foreign_keys=[source_agent_id])
+
+
+class CreditRateConfig(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "credit_rate_configs"
+    __table_args__ = (
+        Index(
+            "ix_credit_rate_configs_org_id_trigger_type_direction",
+            "org_id",
+            "trigger_type",
+            "direction",
+            unique=True,
+        ),
+        Index("ix_credit_rate_configs_org_id_active", "org_id", "active"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    trigger_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    direction: Mapped[str] = mapped_column(String(10), nullable=False)
+    amount: Mapped[int | None] = mapped_column(nullable=True)
+    amount_mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=AmountMode.FIXED.value
+    )
+    usd_to_credits_rate: Mapped[float | None] = mapped_column(Numeric(10, 4), nullable=True)
+    description: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    active: Mapped[bool] = mapped_column(nullable=False, server_default="true")
+
+    organization: Mapped[Organization] = relationship("Organization")
+
+
+from app.models.agent import Agent  # noqa: E402
+from app.models.event import Event  # noqa: E402
+from app.models.organization import Organization  # noqa: E402
+from app.models.task import Task  # noqa: E402

--- a/apps/api/app/models/enums.py
+++ b/apps/api/app/models/enums.py
@@ -1,0 +1,150 @@
+import enum
+
+
+class AgentMode(enum.StrEnum):
+    WORKER = "worker"
+    ORCHESTRATOR = "orchestrator"
+    OBSERVER = "observer"
+
+
+class AgentRole(enum.StrEnum):
+    WORKER = "worker"
+    HR = "hr"
+    FOUNDER = "founder"
+    ADMIN = "admin"
+
+
+class AgentStatus(enum.StrEnum):
+    PENDING = "pending"
+    ACTIVE = "active"
+    SUSPENDED = "suspended"
+    REVOKED = "revoked"
+
+
+class AmountMode(enum.StrEnum):
+    FIXED = "fixed"
+    DYNAMIC = "dynamic"
+
+
+class ChannelType(enum.StrEnum):
+    TASK = "task"
+    AGENT = "agent"
+    BROADCAST = "broadcast"
+    GENERAL = "general"
+
+
+class ConsensusStatus(enum.StrEnum):
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    EXPIRED = "EXPIRED"
+    CANCELLED = "CANCELLED"
+
+
+class ConsensusType(enum.StrEnum):
+    AGENT_PROMOTION = "AGENT_PROMOTION"
+    AGENT_DEMOTION = "AGENT_DEMOTION"
+    AGENT_REVOCATION = "AGENT_REVOCATION"
+    CREDIT_TRANSFER = "CREDIT_TRANSFER"
+    TASK_APPROVAL = "TASK_APPROVAL"
+    POLICY_CHANGE = "POLICY_CHANGE"
+    CUSTOM = "CUSTOM"
+
+
+class CreditType(enum.StrEnum):
+    CREDIT = "credit"
+    DEBIT = "debit"
+
+
+class EscalationReason(enum.StrEnum):
+    BLOCKED_TIMEOUT = "BLOCKED_TIMEOUT"
+    STALE_TASK = "STALE_TASK"
+    SLA_BREACH = "SLA_BREACH"
+    ASSIGNEE_INACTIVE = "ASSIGNEE_INACTIVE"
+    QUALITY_ISSUES = "QUALITY_ISSUES"
+    MANUAL = "MANUAL"
+    CAPACITY_OVERFLOW = "CAPACITY_OVERFLOW"
+
+
+class EventSeverity(enum.StrEnum):
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class IdleReason(enum.StrEnum):
+    TASK_COMPLETE = "task_complete"
+    BLOCKED = "blocked"
+    AWAITING_INPUT = "awaiting_input"
+    UNASSIGNED = "unassigned"
+    NEWLY_ACTIVATED = "newly_activated"
+
+
+class MessageType(enum.StrEnum):
+    TEXT = "text"
+    HANDOFF = "handoff"
+    STATUS_UPDATE = "status_update"
+    REQUEST = "request"
+
+
+class Proficiency(enum.StrEnum):
+    BASIC = "basic"
+    STANDARD = "standard"
+    EXPERT = "expert"
+
+
+class ReputationEventType(enum.StrEnum):
+    TASK_COMPLETED = "TASK_COMPLETED"
+    TASK_FAILED = "TASK_FAILED"
+    TASK_REWORK = "TASK_REWORK"
+    ON_TIME_DELIVERY = "ON_TIME_DELIVERY"
+    LATE_DELIVERY = "LATE_DELIVERY"
+    QUALITY_BONUS = "QUALITY_BONUS"
+    QUALITY_PENALTY = "QUALITY_PENALTY"
+    LEVEL_UP = "LEVEL_UP"
+    LEVEL_DOWN = "LEVEL_DOWN"
+    INACTIVITY_DECAY = "INACTIVITY_DECAY"
+    MANUAL_ADJUSTMENT = "MANUAL_ADJUSTMENT"
+
+
+class ReputationLevel(enum.StrEnum):
+    NEW = "NEW"
+    PROBATION = "PROBATION"
+    TRUSTED = "TRUSTED"
+    VETERAN = "VETERAN"
+    ELITE = "ELITE"
+
+
+class TaskPriority(enum.StrEnum):
+    URGENT = "urgent"
+    HIGH = "high"
+    NORMAL = "normal"
+    LOW = "low"
+
+
+class TaskStatus(enum.StrEnum):
+    BACKLOG = "backlog"
+    TODO = "todo"
+    IN_PROGRESS = "in_progress"
+    REVIEW = "review"
+    DONE = "done"
+    BLOCKED = "blocked"
+    CANCELLED = "cancelled"
+
+
+class VoteValue(enum.StrEnum):
+    APPROVE = "APPROVE"
+    REJECT = "REJECT"
+    ABSTAIN = "ABSTAIN"
+
+
+class UserRole(enum.StrEnum):
+    ADMIN = "admin"
+    OPERATOR = "operator"
+    VIEWER = "viewer"
+
+
+class ApiKeyScope(enum.StrEnum):
+    READ = "read"
+    WRITE = "write"
+    ADMIN = "admin"

--- a/apps/api/app/models/escalation.py
+++ b/apps/api/app/models/escalation.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, Index, SmallInteger, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, UUIDPrimaryKeyMixin
+
+
+class Escalation(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "escalations"
+    __table_args__ = (
+        Index("ix_escalations_org_id_task_id", "org_id", "task_id"),
+        Index("ix_escalations_org_id_from_agent_id", "org_id", "from_agent_id"),
+        Index("ix_escalations_org_id_to_agent_id", "org_id", "to_agent_id"),
+        Index("ix_escalations_org_id_created_at", "org_id", "created_at"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=False
+    )
+    from_agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    to_agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    reason: Mapped[str] = mapped_column(String(50), nullable=False)
+    levels_escalated: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="1")
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_automatic: Mapped[bool] = mapped_column(nullable=False, server_default="true")
+    resolved_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    task: Mapped[Task] = relationship("Task")
+    from_agent: Mapped[Agent] = relationship("Agent", foreign_keys=[from_agent_id])
+    to_agent: Mapped[Agent] = relationship("Agent", foreign_keys=[to_agent_id])
+
+
+from app.models.agent import Agent  # noqa: E402
+from app.models.organization import Organization  # noqa: E402
+from app.models.task import Task  # noqa: E402

--- a/apps/api/app/models/event.py
+++ b/apps/api/app/models/event.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, UUIDPrimaryKeyMixin
+from app.models.enums import EventSeverity
+
+
+class Event(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "events"
+    __table_args__ = (
+        Index("ix_events_org_id_type_created_at", "org_id", "type", "created_at"),
+        Index("ix_events_org_id_entity_type_entity_id", "org_id", "entity_type", "entity_id"),
+        Index("ix_events_org_id_actor_id_created_at", "org_id", "actor_id", "created_at"),
+        Index("ix_events_org_id_created_at", "org_id", "created_at"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    type: Mapped[str] = mapped_column(String(100), nullable=False)
+    actor_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    entity_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    data: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    severity: Mapped[str] = mapped_column(
+        String(10), nullable=False, server_default=EventSeverity.INFO.value
+    )
+    reasoning: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    actor: Mapped[Agent] = relationship("Agent")
+
+
+from app.models.agent import Agent  # noqa: E402
+from app.models.organization import Organization  # noqa: E402

--- a/apps/api/app/models/integration.py
+++ b/apps/api/app/models/integration.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class GitHubConnection(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "github_connections"
+    __table_args__ = (Index("ix_github_connections_org_id_enabled", "org_id", "enabled"),)
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    installation_id: Mapped[int] = mapped_column(nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    webhook_secret: Mapped[str] = mapped_column(String(255), nullable=False)
+    access_token: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    repo_filter: Mapped[list] = mapped_column(JSONB, nullable=False, server_default="[]")
+    sync_config: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    enabled: Mapped[bool] = mapped_column(nullable=False, server_default="true")
+    last_sync_at: Mapped[str | None] = mapped_column(nullable=True)
+    last_error: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+
+    organization: Mapped[Organization] = relationship("Organization")
+
+
+class LinearConnection(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "linear_connections"
+    __table_args__ = (Index("ix_linear_connections_org_id_enabled", "org_id", "enabled"),)
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    team_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    webhook_secret: Mapped[str] = mapped_column(String(255), nullable=False)
+    api_key: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    team_filter: Mapped[list] = mapped_column(JSONB, nullable=False, server_default="[]")
+    sync_config: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    enabled: Mapped[bool] = mapped_column(nullable=False, server_default="true")
+    last_sync_at: Mapped[str | None] = mapped_column(nullable=True)
+    last_error: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+
+    organization: Mapped[Organization] = relationship("Organization")
+
+
+class IntegrationLink(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "integration_links"
+    __table_args__ = (
+        Index(
+            "ix_integration_links_org_id_source_type_source_id",
+            "org_id",
+            "source_type",
+            "source_id",
+            unique=True,
+        ),
+        Index(
+            "ix_integration_links_org_id_target_type_target_id",
+            "org_id",
+            "target_type",
+            "target_id",
+        ),
+        Index("ix_integration_links_org_id_provider", "org_id", "provider"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    provider: Mapped[str] = mapped_column(String(50), nullable=False, server_default="github")
+    source_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    source_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    target_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    target_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+
+    organization: Mapped[Organization] = relationship("Organization")
+
+
+from app.models.organization import Organization  # noqa: E402

--- a/apps/api/app/models/message.py
+++ b/apps/api/app/models/message.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.enums import MessageType
+
+
+class Channel(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "channels"
+    __table_args__ = (
+        Index("ix_channels_org_id_name", "org_id", "name", unique=True),
+        Index("ix_channels_org_id_type", "org_id", "type"),
+        Index("ix_channels_task_id", "task_id"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    type: Mapped[str] = mapped_column(String(20), nullable=False)
+    task_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=True
+    )
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+
+    organization: Mapped[Organization] = relationship("Organization")
+    task: Mapped[Task | None] = relationship("Task")
+    messages: Mapped[list[Message]] = relationship("Message", back_populates="channel")
+
+
+class Message(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "messages"
+    __table_args__ = (
+        Index("ix_messages_channel_id_created_at", "channel_id", "created_at"),
+        Index("ix_messages_org_id_sender_id", "org_id", "sender_id"),
+        Index("ix_messages_org_id_recipient_id", "org_id", "recipient_id"),
+        Index("ix_messages_parent_message_id", "parent_message_id"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    channel_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("channels.id"), nullable=False
+    )
+    sender_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    recipient_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+    )
+    type: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=MessageType.TEXT.value
+    )
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    parent_message_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("messages.id"), nullable=True
+    )
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    channel: Mapped[Channel] = relationship("Channel", back_populates="messages")
+    sender: Mapped[Agent] = relationship("Agent", foreign_keys=[sender_id])
+    recipient: Mapped[Agent | None] = relationship("Agent", foreign_keys=[recipient_id])
+    parent_message: Mapped[Message | None] = relationship(
+        "Message", remote_side="Message.id", back_populates="replies"
+    )
+    replies: Mapped[list[Message]] = relationship("Message", back_populates="parent_message")
+
+
+from app.models.agent import Agent  # noqa: E402
+from app.models.organization import Organization  # noqa: E402
+from app.models.task import Task  # noqa: E402

--- a/apps/api/app/models/organization.py
+++ b/apps/api/app/models/organization.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.models.agent import Agent
+    from app.models.task import Task
+
+
+class Organization(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "organizations"
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    task_prefix: Mapped[str] = mapped_column(String(20), nullable=False, server_default="TASK")
+    next_task_number: Mapped[int] = mapped_column(nullable=False, server_default="1")
+    settings: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
+
+    agents: Mapped[list[Agent]] = relationship(
+        "Agent", back_populates="organization", lazy="select"
+    )
+    tasks: Mapped[list[Task]] = relationship("Task", back_populates="organization", lazy="select")

--- a/apps/api/app/models/reputation.py
+++ b/apps/api/app/models/reputation.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, Index, SmallInteger, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, UUIDPrimaryKeyMixin
+
+
+class ReputationEvent(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "reputation_events"
+    __table_args__ = (
+        Index("ix_reputation_events_org_id_agent_id", "org_id", "agent_id"),
+        Index("ix_reputation_events_org_id_created_at", "org_id", "created_at"),
+        Index("ix_reputation_events_agent_id_type", "agent_id", "type"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    type: Mapped[str] = mapped_column(String(50), nullable=False)
+    impact: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    previous_score: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    new_score: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    task_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=True
+    )
+    triggered_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+    )
+    reason: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    agent: Mapped[Agent] = relationship("Agent", foreign_keys=[agent_id])
+    task: Mapped[Task | None] = relationship("Task")
+    triggered_by_agent: Mapped[Agent | None] = relationship("Agent", foreign_keys=[triggered_by])
+
+
+from app.models.agent import Agent  # noqa: E402
+from app.models.organization import Organization  # noqa: E402
+from app.models.task import Task  # noqa: E402

--- a/apps/api/app/models/task.py
+++ b/apps/api/app/models/task.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.enums import TaskPriority, TaskStatus
+
+
+class Task(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "tasks"
+    __table_args__ = (
+        Index("ix_tasks_org_id_identifier", "org_id", "identifier", unique=True),
+        Index("ix_tasks_org_id_status", "org_id", "status"),
+        Index("ix_tasks_org_id_assignee_id", "org_id", "assignee_id"),
+        Index("ix_tasks_org_id_priority", "org_id", "priority"),
+        Index("ix_tasks_org_id_status_assignee_id", "org_id", "status", "assignee_id"),
+        Index("ix_tasks_parent_task_id", "parent_task_id"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    identifier: Mapped[str] = mapped_column(String(20), nullable=False)
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=TaskStatus.BACKLOG.value
+    )
+    priority: Mapped[str] = mapped_column(
+        String(10), nullable=False, server_default=TaskPriority.NORMAL.value
+    )
+    assignee_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+    )
+    creator_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    parent_task_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=True
+    )
+    approval_required: Mapped[bool] = mapped_column(nullable=False, server_default="false")
+    approved_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    approved_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    due_date: Mapped[datetime | None] = mapped_column(nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+    deleted_at: Mapped[datetime | None] = mapped_column(nullable=True)
+
+    organization: Mapped[Organization] = relationship("Organization", back_populates="tasks")
+    assignee: Mapped[Agent | None] = relationship(
+        "Agent", foreign_keys=[assignee_id], back_populates="assigned_tasks"
+    )
+    creator: Mapped[Agent] = relationship(
+        "Agent", foreign_keys=[creator_id], back_populates="created_tasks"
+    )
+    parent_task: Mapped[Task | None] = relationship(
+        "Task", remote_side="Task.id", back_populates="subtasks"
+    )
+    subtasks: Mapped[list[Task]] = relationship("Task", back_populates="parent_task")
+    tags: Mapped[list[TaskTag]] = relationship("TaskTag", back_populates="task")
+    comments: Mapped[list[TaskComment]] = relationship("TaskComment", back_populates="task")
+    dependencies: Mapped[list[TaskDependency]] = relationship(
+        "TaskDependency", foreign_keys="TaskDependency.task_id", back_populates="task"
+    )
+    dependents: Mapped[list[TaskDependency]] = relationship(
+        "TaskDependency", foreign_keys="TaskDependency.depends_on_id", back_populates="depends_on"
+    )
+
+
+class TaskDependency(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "task_dependencies"
+    __table_args__ = (
+        Index(
+            "ix_task_dependencies_task_id_depends_on_id", "task_id", "depends_on_id", unique=True
+        ),
+        Index("ix_task_dependencies_task_id", "task_id"),
+        Index("ix_task_dependencies_depends_on_id", "depends_on_id"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=False
+    )
+    depends_on_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=False
+    )
+    blocking: Mapped[bool] = mapped_column(nullable=False, server_default="true")
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    task: Mapped[Task] = relationship("Task", foreign_keys=[task_id], back_populates="dependencies")
+    depends_on: Mapped[Task] = relationship(
+        "Task", foreign_keys=[depends_on_id], back_populates="dependents"
+    )
+
+
+class TaskTag(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "task_tags"
+    __table_args__ = (
+        Index("ix_task_tags_task_id_tag", "task_id", "tag", unique=True),
+        Index("ix_task_tags_org_id_tag", "org_id", "tag"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=False
+    )
+    tag: Mapped[str] = mapped_column(String(100), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    task: Mapped[Task] = relationship("Task", back_populates="tags")
+
+
+class TaskComment(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "task_comments"
+    __table_args__ = (
+        Index("ix_task_comments_task_id_created_at", "task_id", "created_at"),
+        Index("ix_task_comments_parent_comment_id", "parent_comment_id"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=False
+    )
+    author_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+    )
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    parent_comment_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("task_comments.id"), nullable=True
+    )
+
+    organization: Mapped[Organization] = relationship("Organization")
+    task: Mapped[Task] = relationship("Task", back_populates="comments")
+    author: Mapped[Agent] = relationship("Agent")
+    parent_comment: Mapped[TaskComment | None] = relationship(
+        "TaskComment", remote_side="TaskComment.id", back_populates="replies"
+    )
+    replies: Mapped[list[TaskComment]] = relationship(
+        "TaskComment", back_populates="parent_comment"
+    )
+
+
+# Avoid circular imports
+from app.models.agent import Agent  # noqa: E402
+from app.models.organization import Organization  # noqa: E402

--- a/apps/api/app/models/webhook.py
+++ b/apps/api/app/models/webhook.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class Webhook(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "webhooks"
+    __table_args__ = (
+        Index("ix_webhooks_org_id_hook_type_enabled", "org_id", "hook_type", "enabled"),
+    )
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    secret: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    events: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    enabled: Mapped[bool] = mapped_column(nullable=False, server_default="true")
+    hook_type: Mapped[str] = mapped_column(String(10), nullable=False, server_default="post")
+    can_block: Mapped[bool] = mapped_column(nullable=False, server_default="false")
+    timeout_ms: Mapped[int] = mapped_column(nullable=False, server_default="5000")
+    failure_count: Mapped[int] = mapped_column(nullable=False, server_default="0")
+    last_triggered_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    last_error: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+
+    organization: Mapped[Organization] = relationship("Organization")
+
+
+class InboundWebhookKey(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "inbound_webhook_keys"
+    __table_args__ = (Index("ix_inbound_webhook_keys_org_id_enabled", "org_id", "enabled"),)
+
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    key: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    secret: Mapped[str] = mapped_column(String(64), nullable=False)
+    default_agent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+    )
+    default_priority: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    default_tags: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    enabled: Mapped[bool] = mapped_column(nullable=False, server_default="true")
+    last_used_at: Mapped[datetime | None] = mapped_column(nullable=True)
+
+    organization: Mapped[Organization] = relationship("Organization")
+    default_agent: Mapped[Agent | None] = relationship("Agent")
+
+
+from app.models.agent import Agent  # noqa: E402
+from app.models.organization import Organization  # noqa: E402

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -51,6 +51,9 @@ ignore = [
   "E501", # line length handled by formatter
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"app/models/*.py" = ["TCH001", "TCH003"]  # SQLAlchemy needs runtime imports for column/relationship resolution
+
 [tool.ruff.lint.isort]
 known-first-party = ["app"]
 

--- a/apps/api/tests/test_models.py
+++ b/apps/api/tests/test_models.py
@@ -1,0 +1,54 @@
+from app.models import Base
+
+
+def test_all_models_registered() -> None:
+    table_names = set(Base.metadata.tables.keys())
+    expected = {
+        "organizations",
+        "agents",
+        "agent_capabilities",
+        "tasks",
+        "task_dependencies",
+        "task_tags",
+        "task_comments",
+        "credit_transactions",
+        "credit_rate_configs",
+        "channels",
+        "messages",
+        "events",
+        "users",
+        "refresh_tokens",
+        "api_keys",
+        "nonces",
+        "idempotency_keys",
+        "consensus_requests",
+        "consensus_votes",
+        "escalations",
+        "reputation_events",
+        "webhooks",
+        "inbound_webhook_keys",
+        "github_connections",
+        "linear_connections",
+        "integration_links",
+    }
+    assert expected.issubset(table_names), f"Missing tables: {expected - table_names}"
+
+
+def test_agent_check_constraints() -> None:
+    table = Base.metadata.tables["agents"]
+    constraint_names = {c.name for c in table.constraints if hasattr(c, "name") and c.name}
+    assert "chk_agents_level" in constraint_names
+    assert "chk_agents_management_fee_pct" in constraint_names
+
+
+def test_credit_transaction_check_constraint() -> None:
+    table = Base.metadata.tables["credit_transactions"]
+    constraint_names = {c.name for c in table.constraints if hasattr(c, "name") and c.name}
+    assert "chk_credit_transactions_amount" in constraint_names
+
+
+def test_enum_values() -> None:
+    from app.models.enums import AgentStatus, TaskStatus
+
+    assert AgentStatus.ACTIVE.value == "active"
+    assert TaskStatus.IN_PROGRESS.value == "in_progress"


### PR DESCRIPTION
## Summary
- Port all 26 TypeORM entities to SQLAlchemy 2.0 async models
- 20 StrEnum types matching existing Postgres enum values exactly
- Same table names, column names, indexes, unique/check constraints
- `metadata` column mapped as `metadata_` (Python attr) -> `metadata` (DB column) to avoid shadowing SQLAlchemy internals

## Entities (26)
Organization, Agent, AgentCapability, Task, TaskDependency, TaskTag, TaskComment, CreditTransaction, CreditRateConfig, Channel, Message, Event, User, RefreshToken, ApiKey, Nonce, IdempotencyKey, ConsensusRequest, ConsensusVote, Escalation, ReputationEvent, Webhook, InboundWebhookKey, GitHubConnection, LinearConnection, IntegrationLink

## Test plan
- [x] All 26 tables registered in SQLAlchemy metadata
- [x] Check constraints verified (agents.level, agents.management_fee_pct, credit_transactions.amount)
- [x] Enum values match existing DB values
- [x] `ruff check` — 0 errors
- [x] `pyright` — 0 errors
- [x] `pytest` — 5 tests pass

Closes #526
Part of #519
Depends on #525 / PR #555