### PR TITLE
feat(api): core CRUD endpoints for agents, tasks, credits, messages, events

### DIFF
--- a/apps/api/app/agents/router.py
+++ b/apps/api/app/agents/router.py
@@ -1,0 +1,892 @@
+from __future__ import annotations
+
+import os
+import uuid
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agents.schemas import (
+    AddCapabilityDto,
+    AgentRegistrationResponse,
+    AgentResponse,
+    BalanceResponse,
+    BudgetResponse,
+    CapabilityResponse,
+    HierarchyNode,
+    LeaderboardEntry,
+    ReputationBonusPenaltyDto,
+    ReputationEventResponse,
+    ReputationSummary,
+    SetBudgetDto,
+    SpawnAgentDto,
+    TransferCreditsDto,
+    UpdateAgentDto,
+    UpdateCapabilityDto,
+)
+from app.auth.dependencies import AuthContext, require_auth
+from app.auth.schemas import AuthenticatedAgent
+from app.database import get_db
+from app.models.agent import Agent, AgentCapability
+from app.models.credit import CreditTransaction
+from app.models.enums import AgentRole, AgentStatus, CreditType, Proficiency
+from app.models.reputation import ReputationEvent
+from app.schemas import DataMessageResponse, DataResponse, PaginatedResponse, PaginationMeta
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+
+
+def _encrypt_secret(plaintext: str) -> bytes:
+    key = os.environ.get("ENCRYPTION_KEY")
+    if not key:
+        raise RuntimeError("ENCRYPTION_KEY not configured")
+    key_bytes = bytes.fromhex(key)
+    aesgcm = AESGCM(key_bytes)
+    nonce = os.urandom(12)
+    ct = aesgcm.encrypt(nonce, plaintext.encode("utf-8"), None)
+    return nonce + ct
+
+
+def _generate_hmac_secret() -> str:
+    return os.urandom(32).hex()
+
+
+# --- Registration ---
+
+
+@router.post("/register", status_code=status.HTTP_201_CREATED)
+async def register_agent(
+    dto: dict,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[AgentRegistrationResponse]:
+    from app.agents.schemas import CreateAgentDto
+
+    body = CreateAgentDto.model_validate(dto)
+
+    # Only HR or ADMIN can register
+    if isinstance(auth, AuthenticatedAgent) and auth.role not in (
+        AgentRole.HR,
+        AgentRole.ADMIN,
+        AgentRole.FOUNDER,
+    ):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="HR role required")
+
+    # Check duplicate agent_id
+    existing = await db.execute(
+        select(Agent).where(Agent.org_id == auth.org_id, Agent.agent_id == body.agent_id)
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Agent ID already exists")
+
+    hmac_secret = _generate_hmac_secret()
+    hmac_enc = _encrypt_secret(hmac_secret)
+
+    agent = Agent(
+        org_id=auth.org_id,
+        agent_id=body.agent_id,
+        name=body.name,
+        level=body.level,
+        model=body.model,
+        status=AgentStatus.ACTIVE,
+        role=body.role.value,
+        mode=body.mode.value,
+        management_fee_pct=body.management_fee_pct,
+        budget_period_limit=body.budget_period_limit,
+        hmac_secret_enc=hmac_enc,
+        metadata_=body.metadata,
+    )
+    db.add(agent)
+    await db.flush()
+
+    # Add capabilities
+    if body.capabilities:
+        for cap in body.capabilities:
+            db.add(
+                AgentCapability(
+                    org_id=auth.org_id,
+                    agent_id=agent.id,
+                    capability=cap.capability,
+                    proficiency=cap.proficiency.value,
+                )
+            )
+
+    await db.commit()
+    await db.refresh(agent)
+
+    return DataMessageResponse(
+        data=AgentRegistrationResponse(
+            agent=AgentResponse.model_validate(agent),
+            hmac_secret=hmac_secret,
+        ),
+        message="Agent registered. Save the HMAC secret — it will not be shown again.",
+    )
+
+
+# --- CRUD ---
+
+
+@router.get("")
+async def list_agents(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+    status_filter: AgentStatus | None = Query(None, alias="status"),
+    role: AgentRole | None = None,
+) -> DataResponse[list[AgentResponse]]:
+    q = select(Agent).where(Agent.org_id == auth.org_id, Agent.deleted_at.is_(None))
+    if status_filter:
+        q = q.where(Agent.status == status_filter.value)
+    if role:
+        q = q.where(Agent.role == role.value)
+    result = await db.execute(q.order_by(Agent.created_at))
+    agents = result.scalars().all()
+    return DataResponse(data=[AgentResponse.model_validate(a) for a in agents])
+
+
+@router.get("/{agent_id}")
+async def get_agent(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[AgentResponse]:
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    return DataResponse(data=AgentResponse.model_validate(agent))
+
+
+@router.patch("/{agent_id}")
+async def update_agent(
+    agent_id: uuid.UUID,
+    dto: UpdateAgentDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[AgentResponse]:
+    if isinstance(auth, AuthenticatedAgent) and auth.role not in (
+        AgentRole.HR,
+        AgentRole.ADMIN,
+        AgentRole.FOUNDER,
+    ):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="HR role required")
+
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    update_data = dto.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        if field == "mode" and value is not None:
+            setattr(agent, field, value.value)
+        else:
+            setattr(agent, field, value)
+
+    await db.commit()
+    await db.refresh(agent)
+    return DataResponse(data=AgentResponse.model_validate(agent))
+
+
+@router.post("/{agent_id}/revoke")
+async def revoke_agent(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[AgentResponse]:
+    if isinstance(auth, AuthenticatedAgent) and auth.role not in (
+        AgentRole.HR,
+        AgentRole.ADMIN,
+        AgentRole.FOUNDER,
+    ):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="HR role required")
+
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    agent.status = AgentStatus.REVOKED.value
+    await db.commit()
+    await db.refresh(agent)
+    return DataMessageResponse(data=AgentResponse.model_validate(agent), message="Agent revoked")
+
+
+# --- Onboarding ---
+
+
+@router.post("/spawn", status_code=status.HTTP_201_CREATED)
+async def spawn_agent(
+    dto: SpawnAgentDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[AgentRegistrationResponse]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+
+    # Child level must be < parent level
+    if dto.level >= auth.level:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Child level must be lower than parent level",
+        )
+
+    # Check max children
+    parent = await _get_agent_or_404(db, auth.id, auth.org_id)
+    children_count = await db.scalar(select(func.count()).where(Agent.parent_id == parent.id))
+    if children_count is not None and children_count >= parent.max_children > 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Maximum children limit reached"
+        )
+
+    hmac_secret = _generate_hmac_secret()
+    hmac_enc = _encrypt_secret(hmac_secret)
+
+    child = Agent(
+        org_id=auth.org_id,
+        agent_id=dto.agent_id,
+        name=dto.name,
+        level=dto.level,
+        model=dto.model,
+        status=AgentStatus.PENDING.value,
+        role=AgentRole.WORKER.value,
+        mode="worker",
+        parent_id=parent.id,
+        budget_period_limit=dto.budget_period_limit,
+        hmac_secret_enc=hmac_enc,
+        metadata_={},
+    )
+    db.add(child)
+    await db.flush()
+
+    if dto.capabilities:
+        for cap in dto.capabilities:
+            db.add(
+                AgentCapability(
+                    org_id=auth.org_id,
+                    agent_id=child.id,
+                    capability=cap.capability,
+                    proficiency=cap.proficiency.value,
+                )
+            )
+
+    await db.commit()
+    await db.refresh(child)
+
+    return DataMessageResponse(
+        data=AgentRegistrationResponse(
+            agent=AgentResponse.model_validate(child),
+            hmac_secret=hmac_secret,
+        ),
+        message="Agent spawned in PENDING status. Requires activation.",
+    )
+
+
+@router.get("/capacity", name="get_capacity")
+async def get_capacity(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[dict]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+    parent = await _get_agent_or_404(db, auth.id, auth.org_id)
+    children_count = await db.scalar(select(func.count()).where(Agent.parent_id == parent.id)) or 0
+    return DataResponse(
+        data={
+            "max_children": parent.max_children,
+            "current_children": children_count,
+            "can_spawn": parent.max_children == 0 or children_count < parent.max_children,
+        }
+    )
+
+
+@router.get("/pending")
+async def get_pending_agents(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[AgentResponse]]:
+    result = await db.execute(
+        select(Agent).where(
+            Agent.org_id == auth.org_id,
+            Agent.status == AgentStatus.PENDING.value,
+        )
+    )
+    return DataResponse(data=[AgentResponse.model_validate(a) for a in result.scalars().all()])
+
+
+@router.post("/{agent_id}/activate")
+async def activate_agent(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[AgentResponse]:
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    if agent.status != AgentStatus.PENDING.value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Agent is not in PENDING status"
+        )
+
+    # Must be parent or L10+
+    if isinstance(auth, AuthenticatedAgent):
+        is_parent = agent.parent_id == auth.id
+        is_high_level = auth.level >= 10
+        if not (is_parent or is_high_level):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only parent agent or L10+ can activate",
+            )
+
+    agent.status = AgentStatus.ACTIVE.value
+    await db.commit()
+    await db.refresh(agent)
+    return DataMessageResponse(data=AgentResponse.model_validate(agent), message="Agent activated")
+
+
+@router.delete("/{agent_id}/reject")
+async def reject_agent(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[AgentResponse]:
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    if agent.status != AgentStatus.PENDING.value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Agent is not in PENDING status"
+        )
+
+    agent.status = AgentStatus.REVOKED.value
+    await db.commit()
+    await db.refresh(agent)
+    return DataMessageResponse(data=AgentResponse.model_validate(agent), message="Agent rejected")
+
+
+@router.get("/{agent_id}/hierarchy")
+async def get_hierarchy(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+    depth: int = Query(default=3, ge=1, le=10),
+) -> DataResponse[HierarchyNode]:
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    tree = await _build_hierarchy(db, agent, depth)
+    return DataResponse(data=tree)
+
+
+# --- Budget & Credits ---
+
+
+@router.get("/{agent_id}/credits/balance")
+async def get_balance(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[BalanceResponse]:
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    return DataResponse(data=BalanceResponse(balance=agent.current_balance))
+
+
+@router.get("/{agent_id}/budget")
+async def get_budget(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[BudgetResponse]:
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    remaining = None
+    can_spend = True
+    limit_val = agent.budget_period_limit
+    if limit_val is not None:
+        remaining = limit_val - agent.budget_period_spent
+        can_spend = remaining > 0
+    return DataResponse(
+        data=BudgetResponse(
+            budget_period_limit=agent.budget_period_limit,
+            budget_period_spent=agent.budget_period_spent,
+            budget_period_start=agent.budget_period_start,
+            can_spend=can_spend,
+            remaining=remaining,
+        )
+    )
+
+
+@router.patch("/{agent_id}/budget")
+async def set_budget(
+    agent_id: uuid.UUID,
+    dto: SetBudgetDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[BudgetResponse]:
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    agent.budget_period_limit = dto.budget_period_limit
+    if dto.reset_current_period:
+        agent.budget_period_spent = 0
+        import pendulum
+
+        agent.budget_period_start = pendulum.now("UTC")
+    await db.commit()
+    await db.refresh(agent)
+    remaining = None
+    can_spend = True
+    limit_val = agent.budget_period_limit
+    if limit_val is not None:
+        remaining = limit_val - agent.budget_period_spent
+        can_spend = remaining > 0
+    return DataResponse(
+        data=BudgetResponse(
+            budget_period_limit=agent.budget_period_limit,
+            budget_period_spent=agent.budget_period_spent,
+            budget_period_start=agent.budget_period_start,
+            can_spend=can_spend,
+            remaining=remaining,
+        )
+    )
+
+
+@router.post("/credits/transfer")
+async def transfer_credits(
+    dto: TransferCreditsDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[dict]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+
+    from_agent = await _get_agent_or_404(db, auth.id, auth.org_id)
+    to_agent = await _get_agent_or_404(db, dto.to_agent_id, auth.org_id)
+
+    if from_agent.current_balance < dto.amount:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Insufficient balance")
+
+    # Apply management fee
+    fee = 0
+    if to_agent.parent_id and to_agent.parent_id != from_agent.id:
+        fee = int(dto.amount * from_agent.management_fee_pct / 100)
+
+    net_amount = dto.amount - fee
+
+    # Debit sender
+    from_agent.current_balance -= dto.amount
+    db.add(
+        CreditTransaction(
+            org_id=auth.org_id,
+            agent_id=from_agent.id,
+            type=CreditType.DEBIT.value,
+            amount=dto.amount,
+            balance_after=from_agent.current_balance,
+            reason=f"Transfer to {to_agent.agent_id}: {dto.reason}",
+        )
+    )
+
+    # Credit receiver
+    to_agent.current_balance += net_amount
+    db.add(
+        CreditTransaction(
+            org_id=auth.org_id,
+            agent_id=to_agent.id,
+            type=CreditType.CREDIT.value,
+            amount=net_amount,
+            balance_after=to_agent.current_balance,
+            reason=f"Transfer from {from_agent.agent_id}: {dto.reason}",
+            source_agent_id=from_agent.id,
+        )
+    )
+
+    await db.commit()
+    return DataMessageResponse(
+        data={"transferred": dto.amount, "fee": fee, "net": net_amount},
+        message=f"Transferred {net_amount} credits",
+    )
+
+
+@router.get("/{agent_id}/budget/can-spend")
+async def can_spend(
+    agent_id: uuid.UUID,
+    amount: int = Query(gt=0),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[dict]:
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    has_balance = agent.current_balance >= amount
+    within_budget = True
+    if agent.budget_period_limit is not None:
+        within_budget = (agent.budget_period_spent + amount) <= agent.budget_period_limit
+    return DataResponse(
+        data={"can_spend": has_balance and within_budget, "balance": agent.current_balance}
+    )
+
+
+@router.get("/budget/alerts")
+async def budget_alerts(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[dict]]:
+    result = await db.execute(
+        select(Agent).where(
+            Agent.org_id == auth.org_id,
+            Agent.budget_period_limit.isnot(None),
+            Agent.status == AgentStatus.ACTIVE.value,
+        )
+    )
+    alerts = []
+    for agent in result.scalars().all():
+        if agent.budget_period_limit and agent.budget_period_limit > 0:
+            pct = agent.budget_period_spent / agent.budget_period_limit * 100
+            if pct >= 80:
+                alerts.append(
+                    {
+                        "agent_id": agent.agent_id,
+                        "name": agent.name,
+                        "budget_period_limit": agent.budget_period_limit,
+                        "budget_period_spent": agent.budget_period_spent,
+                        "percentage_used": round(pct, 1),
+                    }
+                )
+    return DataResponse(data=alerts)
+
+
+# --- Capabilities ---
+
+
+@router.get("/capabilities")
+async def list_org_capabilities(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[str]]:
+    result = await db.execute(
+        select(AgentCapability.capability).where(AgentCapability.org_id == auth.org_id).distinct()
+    )
+    return DataResponse(data=list(result.scalars().all()))
+
+
+@router.get("/capabilities/match")
+async def match_capabilities(
+    capabilities: str = Query(description="Comma-separated capabilities"),
+    min_proficiency: Proficiency = Query(default=Proficiency.BASIC),
+    only_active: bool = Query(default=True),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[AgentResponse]]:
+    caps = [c.strip() for c in capabilities.split(",")]
+    proficiency_order = [Proficiency.BASIC, Proficiency.STANDARD, Proficiency.EXPERT]
+    min_idx = proficiency_order.index(min_proficiency)
+    valid_profs = [p.value for p in proficiency_order[min_idx:]]
+
+    q = (
+        select(Agent)
+        .join(AgentCapability, Agent.id == AgentCapability.agent_id)
+        .where(
+            Agent.org_id == auth.org_id,
+            AgentCapability.capability.in_(caps),
+            AgentCapability.proficiency.in_(valid_profs),
+        )
+    )
+    if only_active:
+        q = q.where(Agent.status == AgentStatus.ACTIVE.value)
+    q = q.distinct()
+    result = await db.execute(q)
+    return DataResponse(data=[AgentResponse.model_validate(a) for a in result.scalars().all()])
+
+
+@router.get("/{agent_id}/capabilities")
+async def get_agent_capabilities(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[CapabilityResponse]]:
+    await _get_agent_or_404(db, agent_id, auth.org_id)
+    result = await db.execute(select(AgentCapability).where(AgentCapability.agent_id == agent_id))
+    return DataResponse(data=[CapabilityResponse.model_validate(c) for c in result.scalars().all()])
+
+
+@router.post("/{agent_id}/capabilities", status_code=status.HTTP_201_CREATED)
+async def add_capability(
+    agent_id: uuid.UUID,
+    dto: AddCapabilityDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[CapabilityResponse]:
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+
+    # Check duplicate
+    existing = await db.execute(
+        select(AgentCapability).where(
+            AgentCapability.agent_id == agent.id,
+            AgentCapability.capability == dto.capability,
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Capability already exists"
+        )
+
+    cap = AgentCapability(
+        org_id=auth.org_id,
+        agent_id=agent.id,
+        capability=dto.capability,
+        proficiency=dto.proficiency.value,
+    )
+    db.add(cap)
+    await db.commit()
+    await db.refresh(cap)
+    return DataResponse(data=CapabilityResponse.model_validate(cap))
+
+
+@router.patch("/capabilities/{capability_id}")
+async def update_capability(
+    capability_id: uuid.UUID,
+    dto: UpdateCapabilityDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[CapabilityResponse]:
+    result = await db.execute(
+        select(AgentCapability).where(
+            AgentCapability.id == capability_id, AgentCapability.org_id == auth.org_id
+        )
+    )
+    cap = result.scalar_one_or_none()
+    if not cap:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Capability not found")
+    cap.proficiency = dto.proficiency.value
+    await db.commit()
+    await db.refresh(cap)
+    return DataResponse(data=CapabilityResponse.model_validate(cap))
+
+
+@router.delete("/capabilities/{capability_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_capability(
+    capability_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> None:
+    result = await db.execute(
+        select(AgentCapability).where(
+            AgentCapability.id == capability_id, AgentCapability.org_id == auth.org_id
+        )
+    )
+    cap = result.scalar_one_or_none()
+    if not cap:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Capability not found")
+    await db.delete(cap)
+    await db.commit()
+
+
+# --- Trust & Reputation ---
+
+
+@router.get("/{agent_id}/reputation")
+async def get_reputation(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[ReputationSummary]:
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    success_rate = (
+        agent.tasks_successful / agent.tasks_completed if agent.tasks_completed > 0 else 0.0
+    )
+    level = "NEW"
+    if agent.trust_score >= 90:
+        level = "ELITE"
+    elif agent.trust_score >= 75:
+        level = "VETERAN"
+    elif agent.trust_score >= 50:
+        level = "TRUSTED"
+    elif agent.trust_score >= 25:
+        level = "PROBATION"
+
+    return DataResponse(
+        data=ReputationSummary(
+            trust_score=agent.trust_score,
+            tasks_completed=agent.tasks_completed,
+            tasks_successful=agent.tasks_successful,
+            success_rate=round(success_rate, 4),
+            level=level,
+        )
+    )
+
+
+@router.get("/{agent_id}/reputation/history")
+async def get_reputation_history(
+    agent_id: uuid.UUID,
+    limit: int = Query(default=50, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> PaginatedResponse[ReputationEventResponse]:
+    await _get_agent_or_404(db, agent_id, auth.org_id)
+
+    total = (
+        await db.scalar(
+            select(func.count()).where(
+                ReputationEvent.agent_id == agent_id, ReputationEvent.org_id == auth.org_id
+            )
+        )
+        or 0
+    )
+
+    result = await db.execute(
+        select(ReputationEvent)
+        .where(ReputationEvent.agent_id == agent_id, ReputationEvent.org_id == auth.org_id)
+        .order_by(ReputationEvent.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    events = [ReputationEventResponse.model_validate(e) for e in result.scalars().all()]
+    return PaginatedResponse(
+        data=events, meta=PaginationMeta(total=total, page=(offset // limit) + 1, limit=limit)
+    )
+
+
+@router.post("/{agent_id}/reputation/bonus")
+async def award_bonus(
+    agent_id: uuid.UUID,
+    dto: ReputationBonusPenaltyDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[ReputationSummary]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+    if auth.level < 7:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="L7+ required for reputation changes"
+        )
+
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    prev_score = agent.trust_score
+    agent.trust_score = min(100, agent.trust_score + dto.impact)
+
+    db.add(
+        ReputationEvent(
+            org_id=auth.org_id,
+            agent_id=agent.id,
+            type="QUALITY_BONUS",
+            impact=dto.impact,
+            previous_score=prev_score,
+            new_score=agent.trust_score,
+            triggered_by=auth.id,
+            reason=dto.reason,
+        )
+    )
+
+    await db.commit()
+    await db.refresh(agent)
+
+    success_rate = (
+        agent.tasks_successful / agent.tasks_completed if agent.tasks_completed > 0 else 0.0
+    )
+    return DataMessageResponse(
+        data=ReputationSummary(
+            trust_score=agent.trust_score,
+            tasks_completed=agent.tasks_completed,
+            tasks_successful=agent.tasks_successful,
+            success_rate=round(success_rate, 4),
+            level="TRUSTED",
+        ),
+        message="Bonus awarded",
+    )
+
+
+@router.post("/{agent_id}/reputation/penalty")
+async def apply_penalty(
+    agent_id: uuid.UUID,
+    dto: ReputationBonusPenaltyDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[ReputationSummary]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+    if auth.level < 7:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="L7+ required for reputation changes"
+        )
+
+    agent = await _get_agent_or_404(db, agent_id, auth.org_id)
+    prev_score = agent.trust_score
+    agent.trust_score = max(0, agent.trust_score - dto.impact)
+
+    db.add(
+        ReputationEvent(
+            org_id=auth.org_id,
+            agent_id=agent.id,
+            type="QUALITY_PENALTY",
+            impact=-dto.impact,
+            previous_score=prev_score,
+            new_score=agent.trust_score,
+            triggered_by=auth.id,
+            reason=dto.reason,
+        )
+    )
+
+    await db.commit()
+    await db.refresh(agent)
+
+    success_rate = (
+        agent.tasks_successful / agent.tasks_completed if agent.tasks_completed > 0 else 0.0
+    )
+    return DataMessageResponse(
+        data=ReputationSummary(
+            trust_score=agent.trust_score,
+            tasks_completed=agent.tasks_completed,
+            tasks_successful=agent.tasks_successful,
+            success_rate=round(success_rate, 4),
+            level="TRUSTED",
+        ),
+        message="Penalty applied",
+    )
+
+
+@router.get("/leaderboard/trust")
+async def trust_leaderboard(
+    limit: int = Query(default=10, le=100),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[LeaderboardEntry]]:
+    result = await db.execute(
+        select(Agent)
+        .where(Agent.org_id == auth.org_id, Agent.status == AgentStatus.ACTIVE.value)
+        .order_by(Agent.trust_score.desc())
+        .limit(limit)
+    )
+    entries = []
+    for a in result.scalars().all():
+        rate = a.tasks_successful / a.tasks_completed if a.tasks_completed > 0 else 0.0
+        entries.append(
+            LeaderboardEntry(
+                agent_id=a.agent_id,
+                name=a.name,
+                trust_score=a.trust_score,
+                tasks_completed=a.tasks_completed,
+                success_rate=round(rate, 4),
+            )
+        )
+    return DataResponse(data=entries)
+
+
+# --- Helpers ---
+
+
+async def _get_agent_or_404(db: AsyncSession, agent_id: uuid.UUID, org_id: uuid.UUID) -> Agent:
+    result = await db.execute(select(Agent).where(Agent.id == agent_id, Agent.org_id == org_id))
+    agent = result.scalar_one_or_none()
+    if not agent:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+    return agent
+
+
+async def _build_hierarchy(db: AsyncSession, agent: Agent, depth: int) -> HierarchyNode:
+    children_list: list[HierarchyNode] = []
+    if depth > 0:
+        result = await db.execute(
+            select(Agent).where(Agent.parent_id == agent.id, Agent.deleted_at.is_(None))
+        )
+        for child in result.scalars().all():
+            children_list.append(await _build_hierarchy(db, child, depth - 1))
+
+    return HierarchyNode(
+        id=agent.id,
+        agent_id=agent.agent_id,
+        name=agent.name,
+        level=agent.level,
+        status=AgentStatus(agent.status),
+        role=AgentRole(agent.role),
+        children=children_list,
+    )

--- a/apps/api/app/agents/schemas.py
+++ b/apps/api/app/agents/schemas.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.models.enums import AgentMode, AgentRole, AgentStatus, Proficiency
+
+# --- Request schemas ---
+
+
+class CreateAgentDto(BaseModel):
+    agent_id: str = Field(max_length=100)
+    name: str = Field(max_length=255)
+    level: int = Field(default=1, ge=1, le=10)
+    model: str = Field(default="sonnet", max_length=100)
+    role: AgentRole = AgentRole.WORKER
+    mode: AgentMode = AgentMode.WORKER
+    management_fee_pct: int = Field(default=0, ge=0, le=50)
+    budget_period_limit: int | None = None
+    capabilities: list[AddCapabilityDto] | None = None
+    metadata: dict = Field(default_factory=dict)
+
+
+class UpdateAgentDto(BaseModel):
+    name: str | None = Field(default=None, max_length=255)
+    level: int | None = Field(default=None, ge=1, le=10)
+    model: str | None = Field(default=None, max_length=100)
+    mode: AgentMode | None = None
+    management_fee_pct: int | None = Field(default=None, ge=0, le=50)
+    budget_period_limit: int | None = None
+    metadata: dict | None = None
+
+
+class SpawnAgentDto(BaseModel):
+    agent_id: str = Field(max_length=100)
+    name: str = Field(max_length=255)
+    level: int = Field(default=1, ge=1, le=10)
+    model: str = Field(default="sonnet", max_length=100)
+    budget_period_limit: int | None = None
+    capabilities: list[AddCapabilityDto] | None = None
+
+
+class SetBudgetDto(BaseModel):
+    budget_period_limit: int | None = None
+    reset_current_period: bool = False
+
+
+class TransferCreditsDto(BaseModel):
+    to_agent_id: uuid.UUID
+    amount: int = Field(gt=0)
+    reason: str = Field(max_length=500)
+
+
+class AddCapabilityDto(BaseModel):
+    capability: str = Field(max_length=100)
+    proficiency: Proficiency = Proficiency.STANDARD
+
+
+class UpdateCapabilityDto(BaseModel):
+    proficiency: Proficiency
+
+
+class ReputationBonusPenaltyDto(BaseModel):
+    reason: str = Field(max_length=500)
+    impact: int = Field(ge=1, le=20)
+
+
+# --- Response schemas ---
+
+
+class AgentResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    agent_id: str
+    name: str
+    level: int
+    model: str
+    status: AgentStatus
+    role: AgentRole
+    mode: AgentMode
+    management_fee_pct: int
+    current_balance: int
+    budget_period_limit: int | None
+    budget_period_spent: int
+    budget_period_start: datetime | None
+    parent_id: uuid.UUID | None
+    max_children: int
+    metadata: dict = Field(alias="metadata_")
+    trust_score: int
+    tasks_completed: int
+    tasks_successful: int
+    last_activity_at: datetime | None
+    last_promotion_at: datetime | None
+    lifetime_earnings: int
+    domain: str | None
+    avatar: str | None
+    avatar_color: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AgentRegistrationResponse(BaseModel):
+    agent: AgentResponse
+    hmac_secret: str
+
+
+class CapabilityResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    agent_id: uuid.UUID
+    capability: str
+    proficiency: Proficiency
+    created_at: datetime
+
+
+class BalanceResponse(BaseModel):
+    balance: int
+
+
+class BudgetResponse(BaseModel):
+    budget_period_limit: int | None
+    budget_period_spent: int
+    budget_period_start: datetime | None
+    can_spend: bool
+    remaining: int | None
+
+
+class HierarchyNode(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    agent_id: str
+    name: str
+    level: int
+    status: AgentStatus
+    role: AgentRole
+    children: list[HierarchyNode] = []
+
+
+class ReputationSummary(BaseModel):
+    trust_score: int
+    tasks_completed: int
+    tasks_successful: int
+    success_rate: float
+    level: str
+
+
+class ReputationEventResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    type: str
+    impact: int
+    previous_score: int
+    new_score: int
+    task_id: uuid.UUID | None
+    triggered_by: uuid.UUID | None
+    reason: str | None
+    created_at: datetime
+
+
+class LeaderboardEntry(BaseModel):
+    agent_id: str
+    name: str
+    trust_score: int
+    tasks_completed: int
+    success_rate: float
+
+
+# Forward ref resolution
+CreateAgentDto.model_rebuild()
+SpawnAgentDto.model_rebuild()
+HierarchyNode.model_rebuild()

--- a/apps/api/app/credits/router.py
+++ b/apps/api/app/credits/router.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import uuid
+
+import pendulum
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import AuthContext, require_auth
+from app.auth.schemas import AuthenticatedAgent
+from app.credits.schemas import (
+    AdjustCreditsDto,
+    AgentSpendingResponse,
+    CreditStatsResponse,
+    CreditTransactionResponse,
+    SpendCreditsDto,
+    SpendingTrendPoint,
+)
+from app.database import get_db
+from app.models.agent import Agent
+from app.models.credit import CreditTransaction
+from app.models.enums import AgentRole, CreditType
+from app.schemas import DataMessageResponse, DataResponse, PaginatedResponse, PaginationMeta
+
+router = APIRouter(prefix="/credits", tags=["credits"])
+
+
+# --- Core operations ---
+
+
+@router.get("/balance")
+async def get_balance(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[dict]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+    agent = await db.get(Agent, auth.id)
+    if not agent:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+    return DataResponse(data={"balance": agent.current_balance})
+
+
+@router.post("/spend")
+async def spend_credits(
+    dto: SpendCreditsDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[CreditTransactionResponse]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+
+    agent = await db.get(Agent, auth.id)
+    if not agent:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+
+    if agent.current_balance < dto.amount:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Insufficient balance")
+
+    # Check budget
+    if (
+        agent.budget_period_limit is not None
+        and (agent.budget_period_spent + dto.amount) > agent.budget_period_limit
+    ):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Budget limit exceeded")
+
+    agent.current_balance -= dto.amount
+    agent.budget_period_spent += dto.amount
+
+    txn = CreditTransaction(
+        org_id=auth.org_id,
+        agent_id=agent.id,
+        type=CreditType.DEBIT.value,
+        amount=dto.amount,
+        balance_after=agent.current_balance,
+        reason=dto.reason,
+        trigger_type=dto.trigger_type,
+        source_task_id=dto.source_task_id,
+        source_agent_id=dto.source_agent_id,
+    )
+    db.add(txn)
+    await db.commit()
+    await db.refresh(txn)
+    return DataMessageResponse(
+        data=CreditTransactionResponse.model_validate(txn),
+        message=f"Spent {dto.amount} credits",
+    )
+
+
+@router.get("/history")
+async def get_history(
+    limit: int = Query(default=50, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> PaginatedResponse[CreditTransactionResponse]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+
+    total = (
+        await db.scalar(
+            select(func.count()).where(
+                CreditTransaction.agent_id == auth.id, CreditTransaction.org_id == auth.org_id
+            )
+        )
+        or 0
+    )
+
+    result = await db.execute(
+        select(CreditTransaction)
+        .where(CreditTransaction.agent_id == auth.id, CreditTransaction.org_id == auth.org_id)
+        .order_by(CreditTransaction.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    txns = [CreditTransactionResponse.model_validate(t) for t in result.scalars().all()]
+    return PaginatedResponse(
+        data=txns, meta=PaginationMeta(total=total, page=(offset // limit) + 1, limit=limit)
+    )
+
+
+@router.post("/adjust")
+async def adjust_credits(
+    dto: AdjustCreditsDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[CreditTransactionResponse]:
+    # Admin/HR only
+    if isinstance(auth, AuthenticatedAgent) and auth.role not in (
+        AgentRole.HR,
+        AgentRole.ADMIN,
+        AgentRole.FOUNDER,
+    ):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin/HR role required")
+
+    agent = await db.get(Agent, dto.agent_id)
+    if not agent or agent.org_id != auth.org_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+
+    if dto.type == CreditType.CREDIT:
+        agent.current_balance += dto.amount
+    else:
+        agent.current_balance -= dto.amount
+
+    txn = CreditTransaction(
+        org_id=auth.org_id,
+        agent_id=agent.id,
+        type=dto.type.value,
+        amount=dto.amount,
+        balance_after=agent.current_balance,
+        reason=f"Admin adjustment: {dto.reason}",
+    )
+    db.add(txn)
+    await db.commit()
+    await db.refresh(txn)
+    return DataMessageResponse(
+        data=CreditTransactionResponse.model_validate(txn), message="Credits adjusted"
+    )
+
+
+# --- Analytics ---
+
+
+@router.get("/analytics/stats")
+async def get_stats(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[CreditStatsResponse]:
+    credits_sum = (
+        await db.scalar(
+            select(func.coalesce(func.sum(CreditTransaction.amount), 0)).where(
+                CreditTransaction.org_id == auth.org_id,
+                CreditTransaction.type == CreditType.CREDIT.value,
+            )
+        )
+        or 0
+    )
+
+    debits_sum = (
+        await db.scalar(
+            select(func.coalesce(func.sum(CreditTransaction.amount), 0)).where(
+                CreditTransaction.org_id == auth.org_id,
+                CreditTransaction.type == CreditType.DEBIT.value,
+            )
+        )
+        or 0
+    )
+
+    count = (
+        await db.scalar(select(func.count()).where(CreditTransaction.org_id == auth.org_id)) or 0
+    )
+
+    return DataResponse(
+        data=CreditStatsResponse(
+            total_credits=credits_sum,
+            total_debits=debits_sum,
+            net=credits_sum - debits_sum,
+            transaction_count=count,
+        )
+    )
+
+
+@router.get("/analytics/trends")
+async def get_trends(
+    days: int = Query(default=30, ge=1, le=365),
+    agent_id: uuid.UUID | None = None,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[SpendingTrendPoint]]:
+    since = pendulum.now("UTC").subtract(days=days)
+    q = select(
+        func.date(CreditTransaction.created_at).label("date"),
+        func.sum(CreditTransaction.amount).label("amount"),
+    ).where(
+        CreditTransaction.org_id == auth.org_id,
+        CreditTransaction.type == CreditType.DEBIT.value,
+        CreditTransaction.created_at >= since,
+    )
+    if agent_id:
+        q = q.where(CreditTransaction.agent_id == agent_id)
+    q = q.group_by(func.date(CreditTransaction.created_at)).order_by("date")
+
+    result = await db.execute(q)
+    trends = [SpendingTrendPoint(date=str(row.date), amount=row.amount) for row in result.all()]
+    return DataResponse(data=trends)
+
+
+@router.get("/analytics/agents")
+async def get_spending_by_agent(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[AgentSpendingResponse]]:
+    result = await db.execute(
+        select(
+            Agent.agent_id,
+            Agent.name,
+            func.coalesce(func.sum(CreditTransaction.amount), 0).label("total_spent"),
+            func.count(CreditTransaction.id).label("txn_count"),
+        )
+        .join(CreditTransaction, Agent.id == CreditTransaction.agent_id)
+        .where(
+            Agent.org_id == auth.org_id,
+            CreditTransaction.type == CreditType.DEBIT.value,
+        )
+        .group_by(Agent.agent_id, Agent.name)
+        .order_by(func.sum(CreditTransaction.amount).desc())
+    )
+    data = [
+        AgentSpendingResponse(
+            agent_id=row.agent_id,
+            name=row.name,
+            total_spent=row.total_spent,
+            transaction_count=row.txn_count,
+        )
+        for row in result.all()
+    ]
+    return DataResponse(data=data)
+
+
+@router.get("/analytics/top-spenders")
+async def get_top_spenders(
+    days: int = Query(default=30, ge=1, le=365),
+    limit: int = Query(default=10, le=100),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[AgentSpendingResponse]]:
+    since = pendulum.now("UTC").subtract(days=days)
+    result = await db.execute(
+        select(
+            Agent.agent_id,
+            Agent.name,
+            func.sum(CreditTransaction.amount).label("total_spent"),
+            func.count(CreditTransaction.id).label("txn_count"),
+        )
+        .join(CreditTransaction, Agent.id == CreditTransaction.agent_id)
+        .where(
+            Agent.org_id == auth.org_id,
+            CreditTransaction.type == CreditType.DEBIT.value,
+            CreditTransaction.created_at >= since,
+        )
+        .group_by(Agent.agent_id, Agent.name)
+        .order_by(func.sum(CreditTransaction.amount).desc())
+        .limit(limit)
+    )
+    data = [
+        AgentSpendingResponse(
+            agent_id=row.agent_id,
+            name=row.name,
+            total_spent=row.total_spent,
+            transaction_count=row.txn_count,
+        )
+        for row in result.all()
+    ]
+    return DataResponse(data=data)

--- a/apps/api/app/credits/schemas.py
+++ b/apps/api/app/credits/schemas.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.models.enums import CreditType
+
+# --- Request schemas ---
+
+
+class SpendCreditsDto(BaseModel):
+    amount: int = Field(gt=0)
+    reason: str = Field(max_length=500)
+    trigger_type: str | None = None
+    source_task_id: uuid.UUID | None = None
+    source_agent_id: uuid.UUID | None = None
+
+
+class AdjustCreditsDto(BaseModel):
+    agent_id: uuid.UUID
+    amount: int = Field(gt=0)
+    type: CreditType
+    reason: str = Field(max_length=500)
+
+
+class LiteLLMCallbackDto(BaseModel):
+    agent_id: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    call_id: str | None = None
+
+
+# --- Response schemas ---
+
+
+class CreditTransactionResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    agent_id: uuid.UUID
+    type: CreditType
+    amount: int
+    balance_after: int
+    reason: str
+    trigger_type: str | None
+    source_task_id: uuid.UUID | None
+    source_agent_id: uuid.UUID | None
+    litellm_cost_usd: float | None
+    created_at: datetime
+
+
+class CreditStatsResponse(BaseModel):
+    total_credits: int
+    total_debits: int
+    net: int
+    transaction_count: int
+
+
+class SpendingTrendPoint(BaseModel):
+    date: str
+    amount: int
+
+
+class AgentSpendingResponse(BaseModel):
+    agent_id: str
+    name: str
+    total_spent: int
+    transaction_count: int

--- a/apps/api/app/events/router.py
+++ b/apps/api/app/events/router.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import AuthContext, require_auth
+from app.database import get_db
+from app.events.schemas import EventResponse
+from app.models.event import Event
+from app.schemas import DataResponse, PaginatedResponse, PaginationMeta
+
+router = APIRouter(prefix="/events", tags=["events"])
+
+
+@router.get("")
+async def list_events(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+    type: str | None = None,
+    actor_id: uuid.UUID | None = None,
+    entity_type: str | None = None,
+    entity_id: uuid.UUID | None = None,
+    severity: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=50, le=200),
+) -> PaginatedResponse[EventResponse]:
+    q = select(Event).where(Event.org_id == auth.org_id)
+
+    if type:
+        q = q.where(Event.type == type)
+    if actor_id:
+        q = q.where(Event.actor_id == actor_id)
+    if entity_type:
+        q = q.where(Event.entity_type == entity_type)
+    if entity_id:
+        q = q.where(Event.entity_id == entity_id)
+    if severity:
+        q = q.where(Event.severity == severity)
+    if start_date:
+        q = q.where(Event.created_at >= start_date)
+    if end_date:
+        q = q.where(Event.created_at <= end_date)
+
+    total = await db.scalar(select(func.count()).select_from(q.subquery())) or 0
+    offset = (page - 1) * limit
+    result = await db.execute(q.order_by(Event.created_at.desc()).offset(offset).limit(limit))
+    events = [EventResponse.model_validate(e) for e in result.scalars().all()]
+    return PaginatedResponse(data=events, meta=PaginationMeta(total=total, page=page, limit=limit))
+
+
+@router.get("/{event_id}")
+async def get_event(
+    event_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[EventResponse]:
+    result = await db.execute(
+        select(Event).where(Event.id == event_id, Event.org_id == auth.org_id)
+    )
+    event = result.scalar_one_or_none()
+    if not event:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+    return DataResponse(data=EventResponse.model_validate(event))

--- a/apps/api/app/events/schemas.py
+++ b/apps/api/app/events/schemas.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from app.models.enums import EventSeverity
+
+
+class EventResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    type: str
+    actor_id: uuid.UUID
+    entity_type: str
+    entity_id: uuid.UUID
+    data: dict
+    severity: EventSeverity
+    reasoning: str | None
+    created_at: datetime

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -5,9 +5,14 @@ import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.agents.router import router as agents_router
 from app.config import settings
+from app.credits.router import router as credits_router
 from app.database import engine
+from app.events.router import router as events_router
 from app.logging import setup_logging
+from app.messages.router import router as messages_router
+from app.tasks.router import router as tasks_router
 
 logger = structlog.stdlib.get_logger()
 
@@ -35,6 +40,12 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(agents_router)
+app.include_router(tasks_router)
+app.include_router(credits_router)
+app.include_router(messages_router)
+app.include_router(events_router)
 
 
 @app.get("/health")

--- a/apps/api/app/messages/router.py
+++ b/apps/api/app/messages/router.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import AuthContext, require_auth
+from app.auth.schemas import AuthenticatedAgent
+from app.database import get_db
+from app.messages.schemas import (
+    ChannelResponse,
+    CreateChannelDto,
+    MessageResponse,
+    SendDirectMessageDto,
+    SendMessageDto,
+)
+from app.models.agent import Agent
+from app.models.enums import ChannelType
+from app.models.message import Channel, Message
+from app.schemas import DataResponse
+
+router = APIRouter(tags=["messages"])
+
+
+# --- Channels ---
+
+
+@router.post("/channels", status_code=status.HTTP_201_CREATED)
+async def create_channel(
+    dto: CreateChannelDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[ChannelResponse]:
+    # Check duplicate name
+    existing = await db.execute(
+        select(Channel).where(Channel.org_id == auth.org_id, Channel.name == dto.name)
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Channel name already exists"
+        )
+
+    channel = Channel(
+        org_id=auth.org_id,
+        name=dto.name,
+        type=dto.type.value,
+        task_id=dto.task_id,
+        metadata_=dto.metadata,
+    )
+    db.add(channel)
+    await db.commit()
+    await db.refresh(channel)
+    return DataResponse(data=ChannelResponse.model_validate(channel))
+
+
+@router.get("/channels")
+async def list_channels(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[ChannelResponse]]:
+    result = await db.execute(
+        select(Channel).where(Channel.org_id == auth.org_id).order_by(Channel.created_at)
+    )
+    return DataResponse(data=[ChannelResponse.model_validate(c) for c in result.scalars().all()])
+
+
+@router.get("/channels/{channel_id}")
+async def get_channel(
+    channel_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[ChannelResponse]:
+    result = await db.execute(
+        select(Channel).where(Channel.id == channel_id, Channel.org_id == auth.org_id)
+    )
+    channel = result.scalar_one_or_none()
+    if not channel:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Channel not found")
+    return DataResponse(data=ChannelResponse.model_validate(channel))
+
+
+# --- Messages ---
+
+
+@router.post("/messages", status_code=status.HTTP_201_CREATED)
+async def send_message(
+    dto: SendMessageDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[MessageResponse]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+
+    # Validate channel
+    channel = await db.execute(
+        select(Channel).where(Channel.id == dto.channel_id, Channel.org_id == auth.org_id)
+    )
+    if not channel.scalar_one_or_none():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Channel not found")
+
+    msg = Message(
+        org_id=auth.org_id,
+        channel_id=dto.channel_id,
+        sender_id=auth.id,
+        type=dto.type.value,
+        body=dto.body,
+        parent_message_id=dto.parent_message_id,
+        metadata_=dto.metadata,
+    )
+    db.add(msg)
+    await db.commit()
+    await db.refresh(msg)
+    return DataResponse(data=MessageResponse.model_validate(msg))
+
+
+@router.get("/messages")
+async def list_messages(
+    channel_id: uuid.UUID = Query(),
+    limit: int = Query(default=50, le=200),
+    before: uuid.UUID | None = None,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[MessageResponse]]:
+    q = select(Message).where(Message.channel_id == channel_id, Message.org_id == auth.org_id)
+    if before:
+        # Get the created_at of the "before" message for cursor pagination
+        ref = await db.execute(select(Message.created_at).where(Message.id == before))
+        ref_time = ref.scalar_one_or_none()
+        if ref_time:
+            q = q.where(Message.created_at < ref_time)
+
+    result = await db.execute(q.order_by(Message.created_at.desc()).limit(limit))
+    messages = [MessageResponse.model_validate(m) for m in result.scalars().all()]
+    return DataResponse(data=list(reversed(messages)))
+
+
+@router.get("/messages/{message_id}")
+async def get_message(
+    message_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[MessageResponse]:
+    result = await db.execute(
+        select(Message).where(Message.id == message_id, Message.org_id == auth.org_id)
+    )
+    msg = result.scalar_one_or_none()
+    if not msg:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Message not found")
+    return DataResponse(data=MessageResponse.model_validate(msg))
+
+
+@router.get("/messages/{message_id}/thread")
+async def get_thread(
+    message_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[MessageResponse]]:
+    # Get parent + replies
+    result = await db.execute(
+        select(Message)
+        .where(
+            Message.org_id == auth.org_id,
+            (Message.id == message_id) | (Message.parent_message_id == message_id),
+        )
+        .order_by(Message.created_at)
+    )
+    return DataResponse(data=[MessageResponse.model_validate(m) for m in result.scalars().all()])
+
+
+# --- Direct Messages ---
+
+
+@router.post("/dm", status_code=status.HTTP_201_CREATED)
+async def send_dm(
+    dto: SendDirectMessageDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[MessageResponse]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+
+    # Validate recipient
+    recipient = await db.execute(
+        select(Agent).where(Agent.id == dto.recipient_id, Agent.org_id == auth.org_id)
+    )
+    if not recipient.scalar_one_or_none():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Recipient not found")
+
+    # Find or create DM channel
+    dm_name = _dm_channel_name(auth.id, dto.recipient_id)
+    result = await db.execute(
+        select(Channel).where(Channel.org_id == auth.org_id, Channel.name == dm_name)
+    )
+    channel = result.scalar_one_or_none()
+    if not channel:
+        channel = Channel(
+            org_id=auth.org_id,
+            name=dm_name,
+            type=ChannelType.AGENT.value,
+            metadata_={},
+        )
+        db.add(channel)
+        await db.flush()
+
+    msg = Message(
+        org_id=auth.org_id,
+        channel_id=channel.id,
+        sender_id=auth.id,
+        recipient_id=dto.recipient_id,
+        type="text",
+        body=dto.body,
+        metadata_=dto.metadata,
+    )
+    db.add(msg)
+    await db.commit()
+    await db.refresh(msg)
+    return DataResponse(data=MessageResponse.model_validate(msg))
+
+
+@router.get("/dm/{agent_id}")
+async def get_dm_history(
+    agent_id: uuid.UUID,
+    limit: int = Query(default=50, le=200),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[MessageResponse]]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+
+    dm_name = _dm_channel_name(auth.id, agent_id)
+    channel_result = await db.execute(
+        select(Channel).where(Channel.org_id == auth.org_id, Channel.name == dm_name)
+    )
+    channel = channel_result.scalar_one_or_none()
+    if not channel:
+        return DataResponse(data=[])
+
+    result = await db.execute(
+        select(Message)
+        .where(Message.channel_id == channel.id)
+        .order_by(Message.created_at.desc())
+        .limit(limit)
+    )
+    messages = [MessageResponse.model_validate(m) for m in result.scalars().all()]
+    return DataResponse(data=list(reversed(messages)))
+
+
+def _dm_channel_name(a: uuid.UUID, b: uuid.UUID) -> str:
+    ids = sorted([str(a), str(b)])
+    return f"dm:{ids[0]}:{ids[1]}"

--- a/apps/api/app/messages/schemas.py
+++ b/apps/api/app/messages/schemas.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.models.enums import ChannelType, MessageType
+
+# --- Request schemas ---
+
+
+class CreateChannelDto(BaseModel):
+    name: str = Field(max_length=255)
+    type: ChannelType
+    task_id: uuid.UUID | None = None
+    metadata: dict = Field(default_factory=dict)
+
+
+class SendMessageDto(BaseModel):
+    channel_id: uuid.UUID
+    type: MessageType = MessageType.TEXT
+    body: str
+    parent_message_id: uuid.UUID | None = None
+    metadata: dict = Field(default_factory=dict)
+
+
+class SendDirectMessageDto(BaseModel):
+    recipient_id: uuid.UUID
+    body: str
+    metadata: dict = Field(default_factory=dict)
+
+
+# --- Response schemas ---
+
+
+class ChannelResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    name: str
+    type: ChannelType
+    task_id: uuid.UUID | None
+    metadata: dict = Field(alias="metadata_")
+    created_at: datetime
+    updated_at: datetime
+
+
+class MessageResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    channel_id: uuid.UUID
+    sender_id: uuid.UUID
+    recipient_id: uuid.UUID | None
+    type: MessageType
+    body: str
+    parent_message_id: uuid.UUID | None
+    metadata: dict = Field(alias="metadata_")
+    created_at: datetime
+
+
+class ConversationResponse(BaseModel):
+    agent_id: uuid.UUID
+    agent_name: str
+    last_message: str
+    last_message_at: datetime
+    unread_count: int

--- a/apps/api/app/schemas/__init__.py
+++ b/apps/api/app/schemas/__init__.py
@@ -1,0 +1,21 @@
+from app.schemas.common import (
+    DEFAULT_LIMIT,
+    DEFAULT_PAGE,
+    MAX_LIMIT,
+    DataMessageResponse,
+    DataResponse,
+    MessageResponse,
+    PaginatedResponse,
+    PaginationMeta,
+)
+
+__all__ = [
+    "DEFAULT_LIMIT",
+    "DEFAULT_PAGE",
+    "MAX_LIMIT",
+    "DataMessageResponse",
+    "DataResponse",
+    "MessageResponse",
+    "PaginatedResponse",
+    "PaginationMeta",
+]

--- a/apps/api/app/schemas/common.py
+++ b/apps/api/app/schemas/common.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T")
+
+
+class PaginationMeta(BaseModel):
+    total: int
+    page: int
+    limit: int
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    data: list[T]
+    meta: PaginationMeta
+
+
+class DataResponse(BaseModel, Generic[T]):
+    data: T
+
+
+class MessageResponse(BaseModel):
+    message: str
+    success: bool = True
+
+
+class DataMessageResponse(BaseModel, Generic[T]):
+    data: T
+    message: str
+    success: bool = True
+
+
+# Common query param defaults
+DEFAULT_PAGE = 1
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 200
+
+
+# Reusable base schemas
+class OrgScopedBase(BaseModel):
+    org_id: uuid.UUID
+
+
+class TimestampBase(BaseModel):
+    created_at: datetime
+    updated_at: datetime
+
+
+class TimestampCreatedBase(BaseModel):
+    created_at: datetime

--- a/apps/api/app/tasks/router.py
+++ b/apps/api/app/tasks/router.py
@@ -1,0 +1,623 @@
+from __future__ import annotations
+
+import uuid
+
+import pendulum
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import AuthContext, require_auth
+from app.auth.schemas import AuthenticatedAgent
+from app.database import get_db
+from app.models.agent import Agent
+from app.models.consensus import ConsensusRequest, ConsensusVote
+from app.models.enums import ConsensusStatus, TaskStatus
+from app.models.escalation import Escalation
+from app.models.organization import Organization
+from app.models.task import Task, TaskComment, TaskDependency, TaskTag
+from app.schemas import DataMessageResponse, DataResponse, PaginatedResponse, PaginationMeta
+from app.tasks.schemas import (
+    AddCommentDto,
+    AddDependencyDto,
+    AssignTaskDto,
+    CastVoteDto,
+    ConsensusRequestResponse,
+    ConsensusVoteResponse,
+    CreateConsensusDto,
+    CreateTaskDto,
+    EscalateTaskDto,
+    EscalationResponse,
+    ResolveEscalationDto,
+    TaskCommentResponse,
+    TaskDependencyResponse,
+    TaskResponse,
+    TransitionTaskDto,
+)
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+# Valid status transitions
+VALID_TRANSITIONS: dict[str, list[str]] = {
+    TaskStatus.BACKLOG.value: [TaskStatus.TODO.value, TaskStatus.CANCELLED.value],
+    TaskStatus.TODO.value: [
+        TaskStatus.IN_PROGRESS.value,
+        TaskStatus.BACKLOG.value,
+        TaskStatus.CANCELLED.value,
+    ],
+    TaskStatus.IN_PROGRESS.value: [
+        TaskStatus.REVIEW.value,
+        TaskStatus.BLOCKED.value,
+        TaskStatus.CANCELLED.value,
+    ],
+    TaskStatus.REVIEW.value: [
+        TaskStatus.DONE.value,
+        TaskStatus.IN_PROGRESS.value,
+        TaskStatus.CANCELLED.value,
+    ],
+    TaskStatus.BLOCKED.value: [TaskStatus.TODO.value, TaskStatus.CANCELLED.value],
+    TaskStatus.DONE.value: [TaskStatus.IN_PROGRESS.value],
+    TaskStatus.CANCELLED.value: [TaskStatus.BACKLOG.value],
+}
+
+
+# --- Core CRUD ---
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_task(
+    dto: CreateTaskDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[TaskResponse]:
+    # Generate identifier
+    org = await db.get(Organization, auth.org_id)
+    if not org:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+
+    identifier = f"{org.task_prefix}-{org.next_task_number}"
+    org.next_task_number += 1
+
+    creator_id = auth.id
+
+    task = Task(
+        org_id=auth.org_id,
+        identifier=identifier,
+        title=dto.title,
+        description=dto.description,
+        status=TaskStatus.BACKLOG.value,
+        priority=dto.priority.value,
+        assignee_id=dto.assignee_id,
+        creator_id=creator_id,
+        parent_task_id=dto.parent_task_id,
+        approval_required=dto.approval_required,
+        due_date=dto.due_at,
+        metadata_=dto.metadata,
+    )
+    db.add(task)
+    await db.flush()
+
+    # Add tags
+    for tag_str in dto.tags:
+        db.add(TaskTag(org_id=auth.org_id, task_id=task.id, tag=tag_str))
+
+    await db.commit()
+    await db.refresh(task)
+    return DataResponse(data=TaskResponse.model_validate(task))
+
+
+@router.get("")
+async def list_tasks(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+    status_filter: TaskStatus | None = Query(None, alias="status"),
+    assignee_id: uuid.UUID | None = None,
+    creator_id: uuid.UUID | None = None,
+    parent_task_id: uuid.UUID | None = None,
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=50, le=200),
+) -> PaginatedResponse[TaskResponse]:
+    q = select(Task).where(Task.org_id == auth.org_id, Task.deleted_at.is_(None))
+    if status_filter:
+        q = q.where(Task.status == status_filter.value)
+    if assignee_id:
+        q = q.where(Task.assignee_id == assignee_id)
+    if creator_id:
+        q = q.where(Task.creator_id == creator_id)
+    if parent_task_id:
+        q = q.where(Task.parent_task_id == parent_task_id)
+
+    total = await db.scalar(select(func.count()).select_from(q.subquery())) or 0
+    offset = (page - 1) * limit
+    result = await db.execute(q.order_by(Task.created_at.desc()).offset(offset).limit(limit))
+    tasks = [TaskResponse.model_validate(t) for t in result.scalars().all()]
+    return PaginatedResponse(data=tasks, meta=PaginationMeta(total=total, page=page, limit=limit))
+
+
+@router.get("/{task_id}")
+async def get_task(
+    task_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[TaskResponse]:
+    task = await _get_task_or_404(db, task_id, auth.org_id)
+    return DataResponse(data=TaskResponse.model_validate(task))
+
+
+# --- Status transitions ---
+
+
+@router.post("/{task_id}/transition")
+async def transition_task(
+    task_id: uuid.UUID,
+    dto: TransitionTaskDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[TaskResponse]:
+    task = await _get_task_or_404(db, task_id, auth.org_id)
+
+    valid = VALID_TRANSITIONS.get(task.status, [])
+    if dto.status.value not in valid:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot transition from {task.status} to {dto.status.value}",
+        )
+
+    # Check approval requirement
+    if dto.status == TaskStatus.DONE and task.approval_required and not task.approved_at:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Task requires approval before completion",
+        )
+
+    task.status = dto.status.value
+
+    if dto.status == TaskStatus.DONE:
+        task.completed_at = pendulum.now("UTC")
+
+    await db.commit()
+    await db.refresh(task)
+    return DataResponse(data=TaskResponse.model_validate(task))
+
+
+@router.post("/{task_id}/approve")
+async def approve_task(
+    task_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[TaskResponse]:
+    task = await _get_task_or_404(db, task_id, auth.org_id)
+    if not task.approval_required:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Task does not require approval"
+        )
+    if task.approved_at:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Task already approved")
+
+    approver_name = auth.agent_id if isinstance(auth, AuthenticatedAgent) else auth.name
+    task.approved_by = approver_name
+    task.approved_at = pendulum.now("UTC")
+    await db.commit()
+    await db.refresh(task)
+    return DataMessageResponse(data=TaskResponse.model_validate(task), message="Task approved")
+
+
+@router.post("/{task_id}/assign")
+async def assign_task(
+    task_id: uuid.UUID,
+    dto: AssignTaskDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[TaskResponse]:
+    task = await _get_task_or_404(db, task_id, auth.org_id)
+
+    # Validate assignee exists in org
+    assignee = await db.execute(
+        select(Agent).where(Agent.id == dto.assignee_id, Agent.org_id == auth.org_id)
+    )
+    if not assignee.scalar_one_or_none():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Assignee not found")
+
+    task.assignee_id = dto.assignee_id
+    await db.commit()
+    await db.refresh(task)
+    return DataResponse(data=TaskResponse.model_validate(task))
+
+
+# --- Dependencies ---
+
+
+@router.post("/{task_id}/dependencies", status_code=status.HTTP_201_CREATED)
+async def add_dependency(
+    task_id: uuid.UUID,
+    dto: AddDependencyDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[TaskDependencyResponse]:
+    task = await _get_task_or_404(db, task_id, auth.org_id)
+    dep_task = await _get_task_or_404(db, dto.depends_on_id, auth.org_id)
+
+    if task_id == dto.depends_on_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Task cannot depend on itself"
+        )
+
+    # Check duplicate
+    existing = await db.execute(
+        select(TaskDependency).where(
+            TaskDependency.task_id == task_id,
+            TaskDependency.depends_on_id == dto.depends_on_id,
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Dependency already exists"
+        )
+
+    dep = TaskDependency(
+        org_id=auth.org_id,
+        task_id=task.id,
+        depends_on_id=dep_task.id,
+        blocking=dto.blocking,
+    )
+    db.add(dep)
+    await db.commit()
+    await db.refresh(dep)
+    return DataResponse(data=TaskDependencyResponse.model_validate(dep))
+
+
+@router.delete("/{task_id}/dependencies/{dep_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_dependency(
+    task_id: uuid.UUID,
+    dep_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> None:
+    result = await db.execute(
+        select(TaskDependency).where(
+            TaskDependency.id == dep_id,
+            TaskDependency.task_id == task_id,
+            TaskDependency.org_id == auth.org_id,
+        )
+    )
+    dep = result.scalar_one_or_none()
+    if not dep:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dependency not found")
+    await db.delete(dep)
+    await db.commit()
+
+
+# --- Comments ---
+
+
+@router.post("/{task_id}/comments", status_code=status.HTTP_201_CREATED)
+async def add_comment(
+    task_id: uuid.UUID,
+    dto: AddCommentDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[TaskCommentResponse]:
+    await _get_task_or_404(db, task_id, auth.org_id)
+
+    comment = TaskComment(
+        org_id=auth.org_id,
+        task_id=task_id,
+        author_id=auth.id,
+        body=dto.body,
+        parent_comment_id=dto.parent_comment_id,
+    )
+    db.add(comment)
+    await db.commit()
+    await db.refresh(comment)
+    return DataResponse(data=TaskCommentResponse.model_validate(comment))
+
+
+@router.get("/{task_id}/comments")
+async def list_comments(
+    task_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[TaskCommentResponse]]:
+    await _get_task_or_404(db, task_id, auth.org_id)
+    result = await db.execute(
+        select(TaskComment)
+        .where(TaskComment.task_id == task_id, TaskComment.org_id == auth.org_id)
+        .order_by(TaskComment.created_at)
+    )
+    return DataResponse(
+        data=[TaskCommentResponse.model_validate(c) for c in result.scalars().all()]
+    )
+
+
+# --- Escalations ---
+
+
+@router.post("/{task_id}/escalate", status_code=status.HTTP_201_CREATED)
+async def escalate_task(
+    task_id: uuid.UUID,
+    dto: EscalateTaskDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[EscalationResponse]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+
+    task = await _get_task_or_404(db, task_id, auth.org_id)
+
+    # Find escalation target (parent agent or higher-level agent)
+    from_agent = await db.get(Agent, auth.id)
+    if not from_agent:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+
+    to_agent_id = from_agent.parent_id
+    if not to_agent_id:
+        # Find any agent with higher level
+        result = await db.execute(
+            select(Agent)
+            .where(
+                Agent.org_id == auth.org_id,
+                Agent.level > from_agent.level,
+                Agent.status == "active",
+            )
+            .order_by(Agent.level)
+            .limit(1)
+        )
+        higher = result.scalar_one_or_none()
+        if not higher:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No escalation target available",
+            )
+        to_agent_id = higher.id
+
+    escalation = Escalation(
+        org_id=auth.org_id,
+        task_id=task.id,
+        from_agent_id=auth.id,
+        to_agent_id=to_agent_id,
+        reason=dto.reason.value,
+        notes=dto.notes,
+        is_automatic=False,
+    )
+    db.add(escalation)
+    await db.commit()
+    await db.refresh(escalation)
+    return DataResponse(data=EscalationResponse.model_validate(escalation))
+
+
+@router.get("/{task_id}/escalations")
+async def get_task_escalations(
+    task_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[EscalationResponse]]:
+    await _get_task_or_404(db, task_id, auth.org_id)
+    result = await db.execute(
+        select(Escalation)
+        .where(Escalation.task_id == task_id, Escalation.org_id == auth.org_id)
+        .order_by(Escalation.created_at.desc())
+    )
+    return DataResponse(data=[EscalationResponse.model_validate(e) for e in result.scalars().all()])
+
+
+@router.get("/escalations/open")
+async def list_open_escalations(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[EscalationResponse]]:
+    result = await db.execute(
+        select(Escalation)
+        .where(Escalation.org_id == auth.org_id, Escalation.resolved_at.is_(None))
+        .order_by(Escalation.created_at.desc())
+    )
+    return DataResponse(data=[EscalationResponse.model_validate(e) for e in result.scalars().all()])
+
+
+@router.post("/escalations/{escalation_id}/resolve")
+async def resolve_escalation(
+    escalation_id: uuid.UUID,
+    dto: ResolveEscalationDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[EscalationResponse]:
+    result = await db.execute(
+        select(Escalation).where(Escalation.id == escalation_id, Escalation.org_id == auth.org_id)
+    )
+    escalation = result.scalar_one_or_none()
+    if not escalation:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Escalation not found")
+    if escalation.resolved_at:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Escalation already resolved"
+        )
+
+    escalation.resolved_at = pendulum.now("UTC")
+    if dto.notes:
+        escalation.notes = dto.notes
+    await db.commit()
+    await db.refresh(escalation)
+    return DataMessageResponse(
+        data=EscalationResponse.model_validate(escalation), message="Escalation resolved"
+    )
+
+
+# --- Consensus ---
+
+
+@router.post("/consensus", status_code=status.HTTP_201_CREATED)
+async def create_consensus(
+    dto: CreateConsensusDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[ConsensusRequestResponse]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+
+    expires_at = pendulum.now("UTC").add(hours=dto.expires_in_hours)
+
+    consensus = ConsensusRequest(
+        org_id=auth.org_id,
+        type=dto.type.value,
+        status=ConsensusStatus.PENDING.value,
+        title=dto.title,
+        description=dto.description,
+        requester_id=auth.id,
+        subject_id=dto.subject_id,
+        subject_type=dto.subject_type,
+        quorum_required=dto.quorum_required,
+        approval_threshold=dto.approval_threshold,
+        expires_at=expires_at,
+    )
+    db.add(consensus)
+    await db.commit()
+    await db.refresh(consensus)
+    return DataResponse(data=ConsensusRequestResponse.model_validate(consensus))
+
+
+@router.get("/consensus/pending")
+async def get_pending_consensus(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[ConsensusRequestResponse]]:
+    result = await db.execute(
+        select(ConsensusRequest).where(
+            ConsensusRequest.org_id == auth.org_id,
+            ConsensusRequest.status == ConsensusStatus.PENDING.value,
+        )
+    )
+    return DataResponse(
+        data=[ConsensusRequestResponse.model_validate(c) for c in result.scalars().all()]
+    )
+
+
+@router.get("/consensus/{request_id}")
+async def get_consensus(
+    request_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[ConsensusRequestResponse]:
+    result = await db.execute(
+        select(ConsensusRequest).where(
+            ConsensusRequest.id == request_id, ConsensusRequest.org_id == auth.org_id
+        )
+    )
+    consensus = result.scalar_one_or_none()
+    if not consensus:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Consensus request not found"
+        )
+    return DataResponse(data=ConsensusRequestResponse.model_validate(consensus))
+
+
+@router.post("/consensus/{request_id}/vote")
+async def cast_vote(
+    request_id: uuid.UUID,
+    dto: CastVoteDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[ConsensusVoteResponse]:
+    if not isinstance(auth, AuthenticatedAgent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent authentication required"
+        )
+
+    result = await db.execute(
+        select(ConsensusRequest).where(
+            ConsensusRequest.id == request_id, ConsensusRequest.org_id == auth.org_id
+        )
+    )
+    consensus = result.scalar_one_or_none()
+    if not consensus:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Consensus request not found"
+        )
+    if consensus.status != ConsensusStatus.PENDING.value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Consensus request is not pending"
+        )
+
+    # Check for duplicate vote
+    existing = await db.execute(
+        select(ConsensusVote).where(
+            ConsensusVote.request_id == request_id, ConsensusVote.voter_id == auth.id
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Already voted")
+
+    vote = ConsensusVote(
+        org_id=auth.org_id,
+        request_id=request_id,
+        voter_id=auth.id,
+        vote=dto.vote.value,
+        reason=dto.reason,
+        voter_level=auth.level,
+    )
+    db.add(vote)
+
+    # Update vote counts
+    if dto.vote.value == "APPROVE":
+        consensus.votes_approve += 1
+    elif dto.vote.value == "REJECT":
+        consensus.votes_reject += 1
+    else:
+        consensus.votes_abstain += 1
+
+    # Check if quorum reached and decide
+    total_votes = consensus.votes_approve + consensus.votes_reject + consensus.votes_abstain
+    if total_votes >= consensus.quorum_required:
+        total_decisive = consensus.votes_approve + consensus.votes_reject
+        if total_decisive > 0:
+            approval_pct = consensus.votes_approve / total_decisive * 100
+            if approval_pct >= consensus.approval_threshold:
+                consensus.status = ConsensusStatus.APPROVED.value
+            else:
+                consensus.status = ConsensusStatus.REJECTED.value
+            consensus.decided_at = pendulum.now("UTC")
+
+    await db.commit()
+    await db.refresh(vote)
+    return DataMessageResponse(data=ConsensusVoteResponse.model_validate(vote), message="Vote cast")
+
+
+@router.delete("/consensus/{request_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def cancel_consensus(
+    request_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> None:
+    result = await db.execute(
+        select(ConsensusRequest).where(
+            ConsensusRequest.id == request_id, ConsensusRequest.org_id == auth.org_id
+        )
+    )
+    consensus = result.scalar_one_or_none()
+    if not consensus:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Consensus request not found"
+        )
+    if consensus.status != ConsensusStatus.PENDING.value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Can only cancel pending requests"
+        )
+
+    consensus.status = ConsensusStatus.CANCELLED.value
+    consensus.decided_at = pendulum.now("UTC")
+    await db.commit()
+
+
+# --- Helpers ---
+
+
+async def _get_task_or_404(db: AsyncSession, task_id: uuid.UUID, org_id: uuid.UUID) -> Task:
+    result = await db.execute(
+        select(Task).where(Task.id == task_id, Task.org_id == org_id, Task.deleted_at.is_(None))
+    )
+    task = result.scalar_one_or_none()
+    if not task:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+    return task

--- a/apps/api/app/tasks/schemas.py
+++ b/apps/api/app/tasks/schemas.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.models.enums import (
+    ConsensusStatus,
+    ConsensusType,
+    EscalationReason,
+    TaskPriority,
+    TaskStatus,
+    VoteValue,
+)
+
+# --- Request schemas ---
+
+
+class CreateTaskDto(BaseModel):
+    title: str = Field(max_length=500)
+    description: str | None = None
+    priority: TaskPriority = TaskPriority.NORMAL
+    assignee_id: uuid.UUID | None = None
+    parent_task_id: uuid.UUID | None = None
+    approval_required: bool = False
+    due_at: datetime | None = None
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict = Field(default_factory=dict)
+
+
+class TransitionTaskDto(BaseModel):
+    status: TaskStatus
+    reason: str | None = None
+
+
+class AssignTaskDto(BaseModel):
+    assignee_id: uuid.UUID
+
+
+class AddDependencyDto(BaseModel):
+    depends_on_id: uuid.UUID
+    blocking: bool = True
+
+
+class AddCommentDto(BaseModel):
+    body: str
+    parent_comment_id: uuid.UUID | None = None
+
+
+class EscalateTaskDto(BaseModel):
+    reason: EscalationReason
+    notes: str | None = None
+
+
+class ResolveEscalationDto(BaseModel):
+    notes: str | None = None
+
+
+class CreateConsensusDto(BaseModel):
+    type: ConsensusType
+    title: str = Field(max_length=255)
+    description: str | None = None
+    subject_id: uuid.UUID | None = None
+    subject_type: str | None = None
+    quorum_required: int = Field(default=2, ge=1)
+    approval_threshold: int = Field(default=50, ge=1, le=100)
+    expires_in_hours: int = Field(default=48, ge=1)
+
+
+class CastVoteDto(BaseModel):
+    vote: VoteValue
+    reason: str | None = None
+
+
+# --- Response schemas ---
+
+
+class TaskResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    identifier: str
+    title: str
+    description: str | None
+    status: TaskStatus
+    priority: TaskPriority
+    assignee_id: uuid.UUID | None
+    creator_id: uuid.UUID
+    parent_task_id: uuid.UUID | None
+    approval_required: bool
+    approved_by: str | None
+    approved_at: datetime | None
+    due_date: datetime | None
+    completed_at: datetime | None
+    metadata: dict = Field(alias="metadata_")
+    created_at: datetime
+    updated_at: datetime
+
+
+class TaskDependencyResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    task_id: uuid.UUID
+    depends_on_id: uuid.UUID
+    blocking: bool
+    created_at: datetime
+
+
+class TaskTagResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    task_id: uuid.UUID
+    tag: str
+    created_at: datetime
+
+
+class TaskCommentResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    task_id: uuid.UUID
+    author_id: uuid.UUID
+    body: str
+    parent_comment_id: uuid.UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class EscalationResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    task_id: uuid.UUID
+    from_agent_id: uuid.UUID
+    to_agent_id: uuid.UUID
+    reason: EscalationReason
+    levels_escalated: int
+    notes: str | None
+    is_automatic: bool
+    resolved_at: datetime | None
+    created_at: datetime
+
+
+class ConsensusRequestResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    type: ConsensusType
+    status: ConsensusStatus
+    title: str
+    description: str | None
+    requester_id: uuid.UUID
+    subject_id: uuid.UUID | None
+    subject_type: str | None
+    quorum_required: int
+    approval_threshold: int
+    votes_approve: int
+    votes_reject: int
+    votes_abstain: int
+    expires_at: datetime
+    decided_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ConsensusVoteResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    request_id: uuid.UUID
+    voter_id: uuid.UUID
+    vote: VoteValue
+    reason: str | None
+    voter_level: int
+    created_at: datetime

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -52,11 +52,15 @@ select = [
 ignore = [
   "E501", # line length handled by formatter
   "B008", # Depends() in function defaults is standard FastAPI pattern
+  "UP046", # Generic[T] required for Pydantic BaseModel generics
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"app/models/*.py" = ["TCH001", "TCH003"]  # SQLAlchemy needs runtime imports for column/relationship resolution
+"app/models/*.py" = ["TCH001", "TCH003"]  # SQLAlchemy needs runtime imports
 "app/auth/*.py" = ["TCH002"]  # FastAPI dependencies need runtime type annotations
+"app/*/schemas.py" = ["TCH001", "TCH002", "TCH003"]  # Pydantic needs runtime type imports
+"app/*/router.py" = ["TCH002", "TCH003"]  # FastAPI routes need runtime type imports
+"app/schemas/*.py" = ["TCH003"]  # Pydantic needs runtime type imports
 
 [tool.ruff.lint.isort]
 known-first-party = ["app"]

--- a/apps/api/tests/test_routes.py
+++ b/apps/api/tests/test_routes.py
@@ -1,0 +1,144 @@
+"""Smoke tests for all CRUD endpoint routes — verifies routing and auth gates."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.fixture
+def auth_headers() -> dict[str, str]:
+    """Headers that will fail auth but prove the route exists (401 vs 404)."""
+    return {"Authorization": "Bearer osp_invalid_key"}
+
+
+# --- Agents ---
+
+
+async def test_list_agents_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/agents")
+    assert r.status_code == 401
+
+
+async def test_register_agent_requires_auth(client: AsyncClient) -> None:
+    r = await client.post("/agents/register", json={"agent_id": "test", "name": "Test"})
+    assert r.status_code == 401
+
+
+async def test_get_agent_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/agents/00000000-0000-0000-0000-000000000001")
+    assert r.status_code == 401
+
+
+# --- Tasks ---
+
+
+async def test_list_tasks_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/tasks")
+    assert r.status_code == 401
+
+
+async def test_create_task_requires_auth(client: AsyncClient) -> None:
+    r = await client.post("/tasks", json={"title": "Test task"})
+    assert r.status_code == 401
+
+
+async def test_get_task_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/tasks/00000000-0000-0000-0000-000000000001")
+    assert r.status_code == 401
+
+
+# --- Credits ---
+
+
+async def test_credits_balance_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/credits/balance")
+    assert r.status_code == 401
+
+
+async def test_credits_spend_requires_auth(client: AsyncClient) -> None:
+    r = await client.post("/credits/spend", json={"amount": 10, "reason": "test"})
+    assert r.status_code == 401
+
+
+async def test_credits_history_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/credits/history")
+    assert r.status_code == 401
+
+
+async def test_credits_analytics_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/credits/analytics/stats")
+    assert r.status_code == 401
+
+
+# --- Messages ---
+
+
+async def test_list_channels_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/channels")
+    assert r.status_code == 401
+
+
+async def test_create_channel_requires_auth(client: AsyncClient) -> None:
+    r = await client.post("/channels", json={"name": "test", "type": "general"})
+    assert r.status_code == 401
+
+
+async def test_send_message_requires_auth(client: AsyncClient) -> None:
+    r = await client.post(
+        "/messages",
+        json={
+            "channel_id": "00000000-0000-0000-0000-000000000001",
+            "body": "hello",
+        },
+    )
+    assert r.status_code == 401
+
+
+# --- Events ---
+
+
+async def test_list_events_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/events")
+    assert r.status_code == 401
+
+
+async def test_get_event_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/events/00000000-0000-0000-0000-000000000001")
+    assert r.status_code == 401
+
+
+# --- Escalations ---
+
+
+async def test_open_escalations_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/tasks/escalations/open")
+    assert r.status_code == 401
+
+
+# --- Consensus ---
+
+
+async def test_pending_consensus_requires_auth(client: AsyncClient) -> None:
+    r = await client.get("/tasks/consensus/pending")
+    assert r.status_code == 401
+
+
+async def test_create_consensus_requires_auth(client: AsyncClient) -> None:
+    r = await client.post(
+        "/tasks/consensus",
+        json={"type": "CUSTOM", "title": "Test"},
+    )
+    assert r.status_code == 401
+
+
+# --- DM ---
+
+
+async def test_send_dm_requires_auth(client: AsyncClient) -> None:
+    r = await client.post(
+        "/dm",
+        json={
+            "recipient_id": "00000000-0000-0000-0000-000000000001",
+            "body": "hello",
+        },
+    )
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary
- **Agents**: registration, CRUD, hierarchy, capabilities, budget, trust/reputation, leaderboard
- **Tasks**: CRUD, status transitions, dependencies, comments, escalations, consensus voting
- **Credits**: balance, spend, history, admin adjust, analytics (stats, trends, top-spenders)
- **Messages**: channels, messages, threads, direct messages
- **Events**: paginated query with filters (type, actor, entity, severity, date range)
- Shared Pydantic response schemas (DataResponse, PaginatedResponse, DataMessageResponse)
- All endpoints auth-gated via `require_auth` dependency, org-scoped
- 29 tests passing (ruff, pyright, pytest all clean)

Closes #529