### PR TITLE
feat(dashboard): Memory page + demo fixtures

### DIFF
--- a/apps/demo/src/components/layout.tsx
+++ b/apps/demo/src/components/layout.tsx
@@ -29,6 +29,7 @@ import {
   Star,
   Layers,
   ClipboardList,
+  Brain,
 } from "lucide-react";
 import { AnimatePresence } from "motion/react";
 import { cn } from "../lib/utils";
@@ -86,6 +87,7 @@ const navigation: { name: string; href: string; icon: typeof LayoutDashboard; to
     { name: "Agents", href: "/agents", icon: Users, tourId: "agents" },
     { name: "Messages", href: "/messages", icon: MessageSquare },
     { name: "Model Router", href: "/router", icon: GitBranch },
+    { name: "Memory", href: "/memory", icon: Brain },
     { name: "Credits", href: "/credits", icon: Coins },
     { name: "Events", href: "/events", icon: Activity },
     { name: "Settings", href: "/settings", icon: Settings },

--- a/apps/demo/src/pages/memory.tsx
+++ b/apps/demo/src/pages/memory.tsx
@@ -1,0 +1,275 @@
+import { useMemo, useState } from "react";
+import { Brain, Search, Eye, EyeOff, Users, Shield, Database, TrendingUp } from "lucide-react";
+import { motion } from "motion/react";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
+import { StatCard } from "../components/ui/stat-card";
+import { PageHeader } from "../components/ui/page-header";
+import { Badge } from "../components/ui/badge";
+import { Input } from "../components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select";
+import { useAgents } from "../hooks";
+import { demoMemories, searchMemories } from "@openspawn/demo-data";
+import type { DemoMemory } from "@openspawn/demo-data";
+import { formatDate } from "../lib/date-format";
+
+const SOURCE_CONFIDENCE: Record<string, number> = {
+  task_completion: 90,
+  code_change: 85,
+  observation: 60,
+  inference: 40,
+  unknown: 50,
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  episodic: "bg-blue-500/10 text-blue-500 border-blue-500/20",
+  semantic: "bg-purple-500/10 text-purple-500 border-purple-500/20",
+  graph: "bg-emerald-500/10 text-emerald-500 border-emerald-500/20",
+};
+
+const VISIBILITY_ICONS: Record<string, typeof Eye> = {
+  shared: Users,
+  private: EyeOff,
+  targeted: Eye,
+};
+
+const SOURCE_COLORS: Record<string, string> = {
+  task_completion: "bg-emerald-500/10 text-emerald-500",
+  code_change: "bg-cyan-500/10 text-cyan-500",
+  observation: "bg-amber-500/10 text-amber-500",
+  inference: "bg-rose-500/10 text-rose-500",
+  unknown: "bg-gray-500/10 text-gray-500",
+};
+
+function ConfidenceBar({ value }: { value: number }) {
+  const color = value >= 80 ? "bg-emerald-500" : value >= 60 ? "bg-amber-500" : "bg-rose-500";
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-16 rounded-full bg-muted">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${value}%` }} />
+      </div>
+      <span className="text-xs text-muted-foreground tabular-nums">{value}%</span>
+    </div>
+  );
+}
+
+function MemoryCard({ memory, agentName }: { memory: DemoMemory; agentName: string }) {
+  const VisIcon = VISIBILITY_ICONS[memory.visibility] ?? Eye;
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+    >
+      <Card className="hover:border-primary/30 transition-colors">
+        <CardContent className="p-3 sm:p-4 space-y-3">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
+              <Badge variant="outline" className={TYPE_COLORS[memory.type]}>
+                {memory.type}
+              </Badge>
+              <Badge variant="outline" className={SOURCE_COLORS[memory.source]}>
+                {memory.source.replace("_", " ")}
+              </Badge>
+              <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                <VisIcon className="h-3 w-3" />
+                {memory.visibility}
+              </span>
+            </div>
+            <ConfidenceBar value={memory.confidence} />
+          </div>
+          <p className="text-sm leading-relaxed">{memory.content}</p>
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <div className="flex items-center gap-2 flex-wrap">
+              {memory.tags.map((tag) => (
+                <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+            <div className="flex items-center gap-3 text-xs text-muted-foreground">
+              <span>{agentName}</span>
+              <span>{memory.accessCount} accesses</span>
+              <span>{formatDate(memory.createdAt)}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}
+
+export function MemoryPage() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [sourceFilter, setSourceFilter] = useState("all");
+  const { agents } = useAgents();
+
+  const agentMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const agent of agents) {
+      map.set(agent.id, agent.name);
+    }
+    return map;
+  }, [agents]);
+
+  const filteredMemories = useMemo(() => {
+    let result: DemoMemory[] = searchQuery ? searchMemories(searchQuery) : [...demoMemories];
+
+    if (typeFilter !== "all") {
+      result = result.filter((m) => m.type === typeFilter);
+    }
+    if (sourceFilter !== "all") {
+      result = result.filter((m) => m.source === sourceFilter);
+    }
+
+    return result.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+  }, [searchQuery, typeFilter, sourceFilter]);
+
+  const stats = useMemo(() => {
+    const total = demoMemories.length;
+    const byType = { episodic: 0, semantic: 0, graph: 0 };
+    const bySource: Record<string, number> = {};
+    let totalAccess = 0;
+    let avgConfidence = 0;
+
+    for (const m of demoMemories) {
+      byType[m.type] = (byType[m.type] || 0) + 1;
+      bySource[m.source] = (bySource[m.source] || 0) + 1;
+      totalAccess += m.accessCount;
+      avgConfidence += m.confidence;
+    }
+
+    return {
+      total,
+      byType,
+      bySource,
+      avgAccess: Math.round(totalAccess / total),
+      avgConfidence: Math.round(avgConfidence / total),
+    };
+  }, []);
+
+  const typeSparkline = useMemo(
+    () => [stats.byType.episodic, stats.byType.semantic, stats.byType.graph],
+    [stats],
+  );
+
+  const handleChangeSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      <PageHeader
+        title="Memory"
+        description="Agent knowledge base — episodic and semantic memories with confidence scoring"
+      />
+
+      <div className="grid gap-3 sm:gap-4 grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          title="Total Memories"
+          value={stats.total}
+          icon={Database}
+          sparklineData={typeSparkline}
+          sparklineColor="#a855f7"
+        />
+        <StatCard
+          title="Avg Confidence"
+          value={`${stats.avgConfidence}%`}
+          icon={Shield}
+          description={`Source range: ${SOURCE_CONFIDENCE.inference}%-${SOURCE_CONFIDENCE.task_completion}%`}
+        />
+        <StatCard title="Avg Access Count" value={stats.avgAccess} icon={TrendingUp} />
+        <StatCard
+          title="Semantic"
+          value={stats.byType.semantic}
+          icon={Brain}
+          description={`${stats.byType.episodic} episodic, ${stats.byType.graph} graph`}
+        />
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Source Distribution</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+            {Object.entries(stats.bySource).map(([source, count]) => (
+              <div
+                key={source}
+                className="flex items-center justify-between rounded-lg border border-border p-2.5"
+              >
+                <div className="flex items-center gap-2">
+                  <div
+                    className={`h-2 w-2 rounded-full ${SOURCE_COLORS[source]?.split(" ")[0] ?? "bg-gray-500/10"}`}
+                  />
+                  <span className="text-xs capitalize">{source.replace("_", " ")}</span>
+                </div>
+                <span className="text-sm font-medium tabular-nums">{count}</span>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search memories..."
+            value={searchQuery}
+            onChange={handleChangeSearch}
+            className="pl-9"
+          />
+        </div>
+        <Select value={typeFilter} onValueChange={setTypeFilter}>
+          <SelectTrigger className="w-full sm:w-[140px]">
+            <SelectValue placeholder="Type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="episodic">Episodic</SelectItem>
+            <SelectItem value="semantic">Semantic</SelectItem>
+            <SelectItem value="graph">Graph</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={sourceFilter} onValueChange={setSourceFilter}>
+          <SelectTrigger className="w-full sm:w-[160px]">
+            <SelectValue placeholder="Source" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All sources</SelectItem>
+            <SelectItem value="task_completion">Task Completion</SelectItem>
+            <SelectItem value="code_change">Code Change</SelectItem>
+            <SelectItem value="observation">Observation</SelectItem>
+            <SelectItem value="inference">Inference</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-3">
+        {filteredMemories.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-muted-foreground">
+              <Brain className="mx-auto h-8 w-8 mb-2 opacity-50" />
+              <p className="text-sm">No memories match your filters</p>
+            </CardContent>
+          </Card>
+        ) : (
+          filteredMemories.map((memory) => (
+            <MemoryCard
+              key={memory.id}
+              memory={memory}
+              agentName={agentMap.get(memory.agentId) ?? "Unknown Agent"}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/demo/src/routes.tsx
+++ b/apps/demo/src/routes.tsx
@@ -25,6 +25,7 @@ import { NetworkPage } from "./pages/network";
 import { IntroPage } from "./pages/intro";
 import { MobileStatusPage } from "./pages/mobile-status";
 import { LiveViewPage } from "./pages/live-view";
+import { MemoryPage } from "./pages/memory";
 import { isBBTheme } from "./lib/dashboard-theme";
 
 const reduceMotion =
@@ -174,6 +175,12 @@ const statusRoute = createRoute({
   component: MobileStatusPage,
 });
 
+const memoryRoute = createRoute({
+  getParentRoute: () => layoutRoute,
+  path: "/memory",
+  component: MemoryPage,
+});
+
 // Build route tree
 const layoutChildren = [
   indexRoute,
@@ -188,6 +195,7 @@ const layoutChildren = [
   statusRoute,
   kanbanRoute,
   taskBoardRoute,
+  memoryRoute,
 ];
 
 const rootChildren = [

--- a/libs/demo-data/src/fixtures/index.ts
+++ b/libs/demo-data/src/fixtures/index.ts
@@ -5,3 +5,4 @@ export * from "./events";
 export * from "./messages";
 export * from "./webhooks";
 export * from "./github";
+export * from "./memory";

--- a/libs/demo-data/src/fixtures/memory.ts
+++ b/libs/demo-data/src/fixtures/memory.ts
@@ -1,0 +1,235 @@
+import type { DemoMemory } from "../types";
+import { AGENT_IDS } from "./agents";
+
+function uuid(): string {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+function hoursAgo(hours: number): string {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+}
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+export const MEMORY_IDS = {
+  ciPipelineInsight: "m0000000-0000-0000-0000-000000000001",
+  apiRateLimit: "m0000000-0000-0000-0000-000000000002",
+  budgetPattern: "m0000000-0000-0000-0000-000000000003",
+  deploymentPlaybook: "m0000000-0000-0000-0000-000000000004",
+  codeReviewChecklist: "m0000000-0000-0000-0000-000000000005",
+  seoStrategy: "m0000000-0000-0000-0000-000000000006",
+  leadScoringModel: "m0000000-0000-0000-0000-000000000007",
+  onboardingFlow: "m0000000-0000-0000-0000-000000000008",
+  bugTriageRules: "m0000000-0000-0000-0000-000000000009",
+  copyToneGuide: "m0000000-0000-0000-0000-000000000010",
+  frontendPatterns: "m0000000-0000-0000-0000-000000000011",
+  qaRegressionPlan: "m0000000-0000-0000-0000-000000000012",
+} as const;
+
+export const demoMemories: DemoMemory[] = [
+  {
+    id: MEMORY_IDS.ciPipelineInsight,
+    agentId: AGENT_IDS.codeReviewer,
+    type: "semantic",
+    visibility: "shared",
+    source: "task_completion",
+    content:
+      "CI pipeline builds fail when Node version mismatches. Always pin Node 20.x in .nvmrc and Dockerfile. The nx affected command saves ~60% build time on PRs touching <5 projects.",
+    tags: ["ci", "devops", "node", "nx"],
+    confidence: 90,
+    accessCount: 14,
+    lastAccessedAt: hoursAgo(1),
+    createdAt: daysAgo(12),
+    updatedAt: daysAgo(2),
+  },
+  {
+    id: MEMORY_IDS.apiRateLimit,
+    agentId: AGENT_IDS.analyst,
+    type: "episodic",
+    visibility: "shared",
+    source: "observation",
+    content:
+      "External analytics API rate-limits at 100 req/min. Batch requests with 500ms delay between batches of 10. Retry with exponential backoff on 429 responses.",
+    tags: ["api", "rate-limit", "analytics"],
+    confidence: 60,
+    accessCount: 8,
+    lastAccessedAt: hoursAgo(6),
+    createdAt: daysAgo(20),
+    updatedAt: daysAgo(5),
+  },
+  {
+    id: MEMORY_IDS.budgetPattern,
+    agentId: AGENT_IDS.bookkeeper,
+    type: "semantic",
+    visibility: "shared",
+    source: "inference",
+    content:
+      "Model costs spike on Mondays and Fridays. Monday spikes correlate with sprint planning (many agents querying simultaneously). Friday spikes are from end-of-week report generation.",
+    tags: ["budget", "costs", "patterns"],
+    confidence: 40,
+    accessCount: 5,
+    lastAccessedAt: daysAgo(1),
+    createdAt: daysAgo(15),
+    updatedAt: daysAgo(3),
+  },
+  {
+    id: MEMORY_IDS.deploymentPlaybook,
+    agentId: AGENT_IDS.codeReviewer,
+    type: "semantic",
+    visibility: "shared",
+    source: "task_completion",
+    content:
+      "Production deploys require: 1) All CI checks green, 2) At least one L5+ approval, 3) No open P0/P1 bugs, 4) Deploy window Mon-Thu 10am-4pm UTC. Rollback within 15 min if error rate >1%.",
+    tags: ["deployment", "production", "playbook"],
+    confidence: 90,
+    accessCount: 22,
+    lastAccessedAt: hoursAgo(3),
+    createdAt: daysAgo(25),
+    updatedAt: daysAgo(1),
+  },
+  {
+    id: MEMORY_IDS.codeReviewChecklist,
+    agentId: AGENT_IDS.codeReviewer,
+    type: "semantic",
+    visibility: "shared",
+    source: "code_change",
+    content:
+      "Code review priorities: 1) Security (injection, auth bypass), 2) Data integrity (migrations, schema changes), 3) Performance (N+1 queries, missing indexes), 4) Correctness, 5) Style (auto-handled by oxlint/oxfmt).",
+    tags: ["code-review", "checklist", "quality"],
+    confidence: 85,
+    accessCount: 31,
+    lastAccessedAt: hoursAgo(2),
+    createdAt: daysAgo(18),
+    updatedAt: daysAgo(4),
+  },
+  {
+    id: MEMORY_IDS.seoStrategy,
+    agentId: AGENT_IDS.seoBot,
+    type: "episodic",
+    visibility: "private",
+    source: "task_completion",
+    content:
+      "Blog posts with 1500-2500 words rank best for our target keywords. Include 3-5 internal links and 2-3 external authority links. Publish Tuesdays or Wednesdays for peak organic reach.",
+    tags: ["seo", "content", "strategy"],
+    confidence: 90,
+    accessCount: 7,
+    lastAccessedAt: daysAgo(2),
+    createdAt: daysAgo(10),
+    updatedAt: daysAgo(2),
+  },
+  {
+    id: MEMORY_IDS.leadScoringModel,
+    agentId: AGENT_IDS.prospector,
+    type: "semantic",
+    visibility: "targeted",
+    source: "inference",
+    content:
+      "Lead scoring weights: Company size (25%), tech stack match (20%), engagement recency (20%), role seniority (15%), industry fit (10%), budget signals (10%). Leads scoring >70 should be routed to Account Manager immediately.",
+    tags: ["sales", "leads", "scoring"],
+    confidence: 40,
+    accessCount: 12,
+    lastAccessedAt: hoursAgo(8),
+    createdAt: daysAgo(8),
+    updatedAt: daysAgo(1),
+  },
+  {
+    id: MEMORY_IDS.onboardingFlow,
+    agentId: AGENT_IDS.onboardingAgent,
+    type: "episodic",
+    visibility: "shared",
+    source: "observation",
+    content:
+      "New agent onboarding takes 2-3 simulated days. Agents that complete the sandbox tutorial before live tasks have 40% fewer errors in their first week. Always assign a buddy agent at L5+.",
+    tags: ["onboarding", "training", "agents"],
+    confidence: 60,
+    accessCount: 4,
+    lastAccessedAt: daysAgo(3),
+    createdAt: daysAgo(14),
+    updatedAt: daysAgo(7),
+  },
+  {
+    id: MEMORY_IDS.bugTriageRules,
+    agentId: AGENT_IDS.bugHunter,
+    type: "semantic",
+    visibility: "shared",
+    source: "task_completion",
+    content:
+      "Bug triage: P0 = data loss or security breach (fix immediately), P1 = feature broken for >10% users (fix within 4h), P2 = degraded experience (fix this sprint), P3 = cosmetic/minor (backlog). Always check error logs + Sentry before investigating.",
+    tags: ["bugs", "triage", "priorities"],
+    confidence: 90,
+    accessCount: 18,
+    lastAccessedAt: hoursAgo(4),
+    createdAt: daysAgo(22),
+    updatedAt: daysAgo(6),
+  },
+  {
+    id: MEMORY_IDS.copyToneGuide,
+    agentId: AGENT_IDS.copywriter,
+    type: "semantic",
+    visibility: "private",
+    source: "code_change",
+    content:
+      "Brand voice: Professional but approachable. Avoid jargon unless targeting developers. Use active voice. Headlines should be benefit-driven, not feature-driven. Max 3 CTAs per page.",
+    tags: ["copy", "brand", "guidelines"],
+    confidence: 85,
+    accessCount: 9,
+    lastAccessedAt: daysAgo(1),
+    createdAt: daysAgo(16),
+    updatedAt: daysAgo(3),
+  },
+  {
+    id: MEMORY_IDS.frontendPatterns,
+    agentId: AGENT_IDS.frontendDev,
+    type: "semantic",
+    visibility: "shared",
+    source: "code_change",
+    content:
+      "Use shadcn/ui components with Tailwind. No barrel files. Keep event handlers in named functions above JSX (handleClickSave, handleChangeName). Animations under 300ms with spring transitions. Respect prefers-reduced-motion.",
+    tags: ["frontend", "react", "patterns", "tailwind"],
+    confidence: 85,
+    accessCount: 15,
+    lastAccessedAt: hoursAgo(5),
+    createdAt: daysAgo(19),
+    updatedAt: daysAgo(2),
+  },
+  {
+    id: MEMORY_IDS.qaRegressionPlan,
+    agentId: AGENT_IDS.qaEngineer,
+    type: "episodic",
+    visibility: "shared",
+    source: "task_completion",
+    content:
+      "Regression test suite covers: auth flows, task CRUD, credit transactions, agent spawning, webhook delivery. Run full suite before every release. Flaky tests should be quarantined within 24h, not skipped.",
+    tags: ["qa", "testing", "regression"],
+    confidence: 90,
+    accessCount: 10,
+    lastAccessedAt: daysAgo(1),
+    createdAt: daysAgo(11),
+    updatedAt: daysAgo(4),
+  },
+];
+
+export function getMemoriesByAgent(agentId: string): DemoMemory[] {
+  return demoMemories.filter((m) => m.agentId === agentId);
+}
+
+export function getMemoriesByType(type: DemoMemory["type"]): DemoMemory[] {
+  return demoMemories.filter((m) => m.type === type);
+}
+
+export function getMemoriesByTag(tag: string): DemoMemory[] {
+  return demoMemories.filter((m) => m.tags.includes(tag));
+}
+
+export function searchMemories(query: string): DemoMemory[] {
+  const lower = query.toLowerCase();
+  return demoMemories.filter(
+    (m) => m.content.toLowerCase().includes(lower) || m.tags.some((t) => t.includes(lower)),
+  );
+}

--- a/libs/demo-data/src/types.ts
+++ b/libs/demo-data/src/types.ts
@@ -210,3 +210,27 @@ export interface DemoWebhook {
   lastError?: string;
   createdAt: string;
 }
+
+export type MemoryType = "episodic" | "semantic" | "graph";
+export type MemoryVisibility = "shared" | "private" | "targeted";
+export type MemorySource =
+  | "task_completion"
+  | "code_change"
+  | "observation"
+  | "inference"
+  | "unknown";
+
+export interface DemoMemory {
+  id: string;
+  agentId: string;
+  type: MemoryType;
+  visibility: MemoryVisibility;
+  source: MemorySource;
+  content: string;
+  tags: string[];
+  confidence: number;
+  accessCount: number;
+  lastAccessedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary
- Add 12 demo memory fixtures (`libs/demo-data/src/fixtures/memory.ts`) with episodic/semantic types, confidence scoring, tags, and access counts
- Add `DemoMemory` type to `libs/demo-data/src/types.ts`
- Add Memory page (`apps/demo/src/pages/memory.tsx`) with stat cards, source distribution chart, search/filter controls, and memory card list
- Wire route (`/memory`) and nav link (Brain icon) in layout

## Test plan
- [ ] Navigate to `/memory` — page renders with 12 demo memories
- [ ] Search filters memories by content and tags
- [ ] Type dropdown filters by episodic/semantic/graph
- [ ] Source dropdown filters by task_completion/code_change/observation/inference
- [ ] Stat cards show correct totals
- [ ] Confidence bars render with correct colors (green/amber/red)
- [ ] Nav sidebar shows Memory link with Brain icon
- [ ] Mobile responsive layout works

Closes #542