### PR TITLE
fix(frontend): resolve dashboard-data + demo typecheck errors

### DIFF
--- a/apps/demo/src/components/agent-detail-panel.tsx
+++ b/apps/demo/src/components/agent-detail-panel.tsx
@@ -26,8 +26,8 @@ import { Progress } from "./ui/progress";
 import { useAgents } from "../hooks/use-agents";
 import { useTasks } from "../hooks/use-tasks";
 import { useCredits } from "../hooks/use-credits";
-import { AgentRole, TaskStatus } from "@openspawn/shared-types";
-import type { AgentFieldsFragment } from "@openspawn/shared-types";
+import { AgentRole, TaskStatus } from "@openspawn/dashboard-data";
+import type { AgentFieldsFragment } from "@openspawn/dashboard-data";
 // recharts v3 has infinite-loop bug — using custom bars instead
 import { useContainerSize } from "../hooks/use-container-size";
 // ChartTooltip removed — using custom bars

--- a/apps/demo/src/components/agent-mode-selector.tsx
+++ b/apps/demo/src/components/agent-mode-selector.tsx
@@ -11,7 +11,7 @@ import {
 import { Badge } from "./ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 
-import { AgentMode } from "@openspawn/shared-types";
+import { AgentMode } from "@openspawn/dashboard-data";
 
 interface AgentModeSelectorProps {
   value: AgentMode;

--- a/apps/demo/src/components/idle-agents-widget.tsx
+++ b/apps/demo/src/components/idle-agents-widget.tsx
@@ -16,7 +16,7 @@ import { AgentAvatar } from "./agent-avatar";
 import { cn } from "../lib/utils";
 import { useAgents } from "../hooks/use-agents";
 import { useTasks } from "../hooks/use-tasks";
-import type { AgentFieldsFragment } from "@openspawn/shared-types";
+import type { AgentFieldsFragment } from "@openspawn/dashboard-data";
 
 // Idle reason mapping
 type IdleReason = "task_complete" | "blocked" | "awaiting_input" | "unassigned" | "newly_activated";

--- a/apps/demo/src/components/task-timeline.tsx
+++ b/apps/demo/src/components/task-timeline.tsx
@@ -27,7 +27,7 @@ import { useAgents, useTasks, useMessages } from "../hooks";
 import type { Task } from "../hooks/use-tasks";
 import type { Message } from "../hooks/use-messages";
 import { getTaskStatusVariant } from "../lib/status-colors";
-import { TaskStatus } from "@openspawn/shared-types";
+import { TaskStatus } from "@openspawn/dashboard-data";
 
 // ── Timeline event types ────────────────────────────────────────────────────
 

--- a/apps/demo/src/components/team-detail-panel.tsx
+++ b/apps/demo/src/components/team-detail-panel.tsx
@@ -37,7 +37,7 @@ import { getStatusVariant } from "../lib/status-colors";
 import { type Team, getTeamById, getSubTeams, getParentTeams, getTeamColor } from "../demo/teams";
 import { useAgents } from "../hooks/use-agents";
 import { useTeamStats } from "../hooks/use-teams";
-import { AgentMode, AgentStatus } from "@openspawn/shared-types";
+import { AgentMode, AgentStatus } from "@openspawn/dashboard-data";
 import { TeamDialog, DeleteTeamDialog } from "./team-management";
 import { Button } from "./ui/button";
 

--- a/apps/demo/src/components/team-view.tsx
+++ b/apps/demo/src/components/team-view.tsx
@@ -38,8 +38,8 @@ import { useAgents } from "../hooks/use-agents";
 import { useTeamStats } from "../hooks/use-teams";
 import { usePresence } from "../hooks/use-presence";
 import { useAgentHealth } from "../hooks/use-agent-health";
-import { AgentMode } from "@openspawn/shared-types";
-import type { AgentFieldsFragment } from "@openspawn/shared-types";
+import { AgentMode } from "@openspawn/dashboard-data";
+import type { AgentFieldsFragment } from "@openspawn/dashboard-data";
 
 type Agent = AgentFieldsFragment;
 

--- a/apps/demo/src/hooks/use-self-claim.ts
+++ b/apps/demo/src/hooks/use-self-claim.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useDemo } from "../demo";
-import type { TaskStatus, TaskPriority } from "@openspawn/shared-types";
+import type { TaskStatus, TaskPriority } from "@openspawn/dashboard-data";
 import type { DemoTask } from "@openspawn/demo-data";
 
 /** Shape returned by the claimNextTask mutation (or demo equivalent) */

--- a/apps/demo/src/pages/agent-dialogs.tsx
+++ b/apps/demo/src/pages/agent-dialogs.tsx
@@ -20,8 +20,8 @@ import {
 import { AgentModeBadge, AgentModeSelector } from "../components/agent-mode-selector";
 import { getStatusVariant } from "../lib/status-colors";
 import { REPUTATION_COLORS, REPUTATION_EMOJI } from "./agent-reputation-tab";
-import { AgentMode, AgentStatus } from "@openspawn/shared-types";
-import type { AgentFieldsFragment } from "@openspawn/shared-types";
+import { AgentMode, AgentStatus } from "@openspawn/dashboard-data";
+import type { AgentFieldsFragment } from "@openspawn/dashboard-data";
 
 type Agent = AgentFieldsFragment;
 

--- a/apps/demo/src/pages/agent-reputation-tab.tsx
+++ b/apps/demo/src/pages/agent-reputation-tab.tsx
@@ -10,8 +10,8 @@ import { Progress } from "../components/ui/progress";
 import { AgentAvatar } from "../components/agent-avatar";
 import { TrustLeaderboard } from "../components/trust-leaderboard";
 import { usePresence, useAgentHealth } from "../hooks";
-import { AgentStatus } from "@openspawn/shared-types";
-import type { AgentFieldsFragment } from "@openspawn/shared-types";
+import { AgentStatus } from "@openspawn/dashboard-data";
+import type { AgentFieldsFragment } from "@openspawn/dashboard-data";
 
 type Agent = AgentFieldsFragment;
 

--- a/apps/demo/src/pages/agent-virtual-grid.tsx
+++ b/apps/demo/src/pages/agent-virtual-grid.tsx
@@ -22,8 +22,8 @@ import { AgentModeBadge } from "../components/agent-mode-selector";
 import { usePresence, useAgentHealth } from "../hooks";
 import { getStatusVariant, getLevelColor, getLevelLabel } from "../lib/status-colors";
 import { TeamBadge } from "../components/team-badge";
-import { AgentMode, AgentStatus } from "@openspawn/shared-types";
-import type { AgentFieldsFragment } from "@openspawn/shared-types";
+import { AgentMode, AgentStatus } from "@openspawn/dashboard-data";
+import type { AgentFieldsFragment } from "@openspawn/dashboard-data";
 
 type Agent = AgentFieldsFragment;
 type DialogMode = "view" | "edit" | "credits" | null;

--- a/apps/demo/src/pages/agents.tsx
+++ b/apps/demo/src/pages/agents.tsx
@@ -41,8 +41,8 @@ import { getParentTeams } from "../demo/teams";
 import { useSidePanel } from "../contexts";
 import { TeamFilterDropdown } from "../components/team-badge";
 import { useTeams } from "../hooks";
-import { AgentStatus } from "@openspawn/shared-types";
-import type { AgentFieldsFragment } from "@openspawn/shared-types";
+import { AgentStatus } from "@openspawn/dashboard-data";
+import type { AgentFieldsFragment } from "@openspawn/dashboard-data";
 
 // Extracted sub-components
 import { AgentDetailsDialog, EditAgentDialog, AdjustCreditsDialog } from "./agent-dialogs";

--- a/apps/demo/src/pages/mobile-status.tsx
+++ b/apps/demo/src/pages/mobile-status.tsx
@@ -30,8 +30,8 @@ import { Sparkline, generateSparklineData } from "../components/ui/sparkline";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { getLevelLabel, getLevelColor } from "../lib/status-colors";
-import { AgentStatus } from "@openspawn/shared-types";
-import type { AgentFieldsFragment } from "@openspawn/shared-types";
+import { AgentStatus } from "@openspawn/dashboard-data";
+import type { AgentFieldsFragment } from "@openspawn/dashboard-data";
 
 /* ------------------------------------------------------------------ */
 /*  Status ordering & colors                                           */

--- a/apps/demo/tsconfig.app.json
+++ b/apps/demo/tsconfig.app.json
@@ -37,7 +37,7 @@
       "path": "../../libs/dashboard-ui"
     },
     {
-      "path": "../../libs/shared-types"
+      "path": "../../libs/shared-types/tsconfig.lib.json"
     }
   ]
 }

--- a/libs/dashboard-data/src/hooks/use-presence.ts
+++ b/libs/dashboard-data/src/hooks/use-presence.ts
@@ -7,7 +7,7 @@
 import { useMemo } from "react";
 import { useAgents } from "./use-agents";
 import { useTasks } from "./use-tasks";
-import { AgentStatus } from "@openspawn/shared-types";
+import { AgentStatus } from "../graphql/generated/hooks";
 
 export type PresenceStatus = "active" | "busy" | "idle" | "error";
 
@@ -55,7 +55,7 @@ export function usePresence(): {
 
     // Pick up to 4 active agents (agents with active status + tasks)
     // Mark 1 as error for visual variety
-    const activeAgents = agents.filter((a: any) => a.status === AgentStatus.Active);
+    const activeAgents = agents.filter((a: { status: string }) => a.status === AgentStatus.Active);
     let activeCount = 0;
     let errorSet = false;
 

--- a/libs/dashboard-data/src/index.ts
+++ b/libs/dashboard-data/src/index.ts
@@ -52,6 +52,16 @@ export { isDemoMode, isSandboxMode } from "./lib/mode";
 // GraphQL fetcher (legacy — kept for demo/sandbox mock compatibility)
 export { fetcher, graphqlClient, setDemoFetcher, setSandboxFetcher } from "./graphql/fetcher";
 
+// GraphQL-generated enums + types (legacy — still used by demo data layer)
+export {
+  AgentMode,
+  AgentRole,
+  AgentStatus,
+  TaskPriority,
+  TaskStatus,
+  type AgentFieldsFragment,
+} from "./graphql/generated/hooks";
+
 // Lib utilities
 export * from "./lib/avatar-utils";
 export * from "./lib/avatar";

--- a/libs/dashboard-data/src/lib/mode.ts
+++ b/libs/dashboard-data/src/lib/mode.ts
@@ -5,7 +5,8 @@ const urlParams =
   typeof window !== "undefined" && window.location.search
     ? new URLSearchParams(window.location.search)
     : null;
-const _env = (typeof import.meta !== "undefined" && import.meta.env) || {};
+const _env: Record<string, string | undefined> =
+  (typeof import.meta !== "undefined" && import.meta.env) || {};
 
 export const isDemoMode =
   urlParams?.get("demo") === "true" ||

--- a/libs/dashboard-data/src/lib/status-colors.ts
+++ b/libs/dashboard-data/src/lib/status-colors.ts
@@ -1,4 +1,4 @@
-import { AgentStatus, TaskStatus } from "@openspawn/shared-types";
+import { AgentStatus, TaskStatus } from "../graphql/generated/hooks";
 
 /**
  * Shared status → badge variant mapping for agent statuses.

--- a/libs/dashboard-data/src/rest/hooks/index.ts
+++ b/libs/dashboard-data/src/rest/hooks/index.ts
@@ -3,5 +3,5 @@ export { useTasks, useTask } from "./use-tasks";
 export { useCreditHistory } from "./use-credits";
 export { useEvents } from "./use-events";
 export { useChannels } from "./use-channels";
-export { useMessages } from "./use-messages";
+export { useRestMessages } from "./use-messages";
 export { useWebhooks, useWebhook, useCreateWebhook, useDeleteWebhook } from "./use-webhooks";

--- a/libs/dashboard-data/src/rest/hooks/use-channels.ts
+++ b/libs/dashboard-data/src/rest/hooks/use-channels.ts
@@ -5,7 +5,7 @@ export function useChannels() {
   return useQuery({
     queryKey: ["channels"],
     queryFn: async () => {
-      const { data, error } = await api.GET("/messages/channels");
+      const { data, error } = await api.GET("/channels");
       if (error) throw error;
       return data;
     },

--- a/libs/dashboard-data/src/rest/hooks/use-credits.ts
+++ b/libs/dashboard-data/src/rest/hooks/use-credits.ts
@@ -1,13 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../client";
 
-export function useCreditHistory() {
+export function useCreditHistory(agentId: string) {
   return useQuery({
-    queryKey: ["credits"],
+    queryKey: ["credits", agentId],
     queryFn: async () => {
-      const { data, error } = await api.GET("/credits");
+      const { data, error } = await api.GET("/agents/{agent_id}/credits/balance", {
+        params: { path: { agent_id: agentId } },
+      });
       if (error) throw error;
       return data;
     },
+    enabled: !!agentId,
   });
 }

--- a/libs/dashboard-data/src/rest/hooks/use-messages.ts
+++ b/libs/dashboard-data/src/rest/hooks/use-messages.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../client";
 
-export function useMessages(channelId?: string) {
+export function useRestMessages(channelId: string) {
   return useQuery({
     queryKey: ["messages", channelId],
     queryFn: async () => {

--- a/libs/dashboard-data/src/rest/hooks/use-webhooks.ts
+++ b/libs/dashboard-data/src/rest/hooks/use-webhooks.ts
@@ -1,53 +1,28 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "../client";
+// Webhook CRUD hooks — stubbed until generic webhook endpoints exist in FastAPI
+// The OpenAPI schema currently only has /integrations/github/webhook and /integrations/linear/webhook
 
 export function useWebhooks() {
-  return useQuery({
-    queryKey: ["webhooks"],
-    queryFn: async () => {
-      const { data, error } = await api.GET("/integrations/webhooks");
-      if (error) throw error;
-      return data;
-    },
-  });
+  return { data: undefined, isLoading: false, error: null };
 }
 
-export function useWebhook(webhookId: string) {
-  return useQuery({
-    queryKey: ["webhooks", webhookId],
-    queryFn: async () => {
-      const { data, error } = await api.GET("/integrations/webhooks/{webhook_id}", {
-        params: { path: { webhook_id: webhookId } },
-      });
-      if (error) throw error;
-      return data;
-    },
-    enabled: !!webhookId,
-  });
+export function useWebhook(_webhookId: string) {
+  return { data: undefined, isLoading: false, error: null };
 }
 
 export function useCreateWebhook() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async (body: { url: string; events: string[] }) => {
-      const { data, error } = await api.POST("/integrations/webhooks", { body });
-      if (error) throw error;
-      return data;
+  return {
+    mutateAsync: async (_body: { url: string; events: string[] }) => {
+      throw new Error("Webhook CRUD not yet implemented in FastAPI");
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["webhooks"] }),
-  });
+    isPending: false,
+  };
 }
 
 export function useDeleteWebhook() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async (webhookId: string) => {
-      const { data, error } = await api.DELETE("/integrations/webhooks/{webhook_id}", {
-        params: { path: { webhook_id: webhookId } },
-      });
-      if (error) throw error;
-      return data;
+  return {
+    mutateAsync: async (_webhookId: string) => {
+      throw new Error("Webhook CRUD not yet implemented in FastAPI");
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["webhooks"] }),
-  });
+    isPending: false,
+  };
 }

--- a/libs/dashboard-data/src/vite-env.d.ts
+++ b/libs/dashboard-data/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/libs/dashboard-data/tsconfig.json
+++ b/libs/dashboard-data/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": true,
+    "composite": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/libs/dashboard-ui/src/panels/agent-detail-panel.tsx
+++ b/libs/dashboard-ui/src/panels/agent-detail-panel.tsx
@@ -144,11 +144,11 @@ export function AgentDetailPanel({
   const successRate =
     agent.tasksCompleted > 0 ? Math.round((agent.tasksSuccessful / agent.tasksCompleted) * 100) : 0;
   const trustData = useMemo(
-    () => generateSparklineData(12, agent.trustScore, 8),
+    () => generateSparklineData(12, agent.trustScore > 50 ? "up" : "down"),
     [agent.trustScore],
   );
   const earningsData = useMemo(
-    () => generateSparklineData(12, agent.lifetimeEarnings / 100, 15),
+    () => generateSparklineData(12, agent.lifetimeEarnings > 5000 ? "up" : "stable"),
     [agent.lifetimeEarnings],
   );
   const activeTasks = tasks.filter((t) => !["DONE", "CANCELLED"].includes(t.status.toUpperCase()));

--- a/libs/dashboard-ui/tsconfig.json
+++ b/libs/dashboard-ui/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": true,
+    "composite": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/libs/database/tsconfig.lib.json
+++ b/libs/database/tsconfig.lib.json
@@ -19,5 +19,10 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx"
+  ],
+  "references": [
+    {
+      "path": "../shared-types/tsconfig.lib.json"
+    }
   ]
 }

--- a/libs/shared-types/tsconfig.lib.json
+++ b/libs/shared-types/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
+    "composite": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,12 @@
   "references": [
     {
       "path": "./tools/sandbox"
+    },
+    {
+      "path": "./libs/dashboard-data"
+    },
+    {
+      "path": "./libs/dashboard-ui"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix all typecheck errors in `dashboard-data` and `dashboard-ui` libs
- Fix demo app enum imports: revert from `@openspawn/shared-types` to `@openspawn/dashboard-data` (GraphQL-generated enums have different casing than shared-types)
- Add `composite` + `declaration` to lib tsconfigs for nx project references
- Stub webhook REST hooks (generic CRUD endpoints not yet in FastAPI)
- Fix REST hook API paths to match OpenAPI schema

## Test plan
- [x] `nx typecheck dashboard-data` passes
- [x] `nx typecheck dashboard-ui` passes
- [x] `nx typecheck demo` passes (with NX_SYNC_ENABLED=false)
- [x] `nx build demo` passes
- [x] `nx test demo` — 23/23 tests pass