### PR TITLE
feat(memory): contradiction resolution #546

### DIFF
--- a/apps/api/app/memory/contradictions.py
+++ b/apps/api/app/memory/contradictions.py
@@ -1,0 +1,103 @@
+"""Contradiction resolution for conflicting memories."""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from typing import TYPE_CHECKING
+
+import structlog
+from sqlalchemy import select
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.models.memory import Memory
+
+logger = structlog.get_logger()
+
+
+class ResolutionStrategy(enum.StrEnum):
+    KEEP_NEWER = "keep_newer"
+    KEEP_OLDER = "keep_older"
+    MERGE = "merge"
+    FLAG = "flag"
+
+
+async def list_contradictions(
+    org_id: uuid.UUID, session: AsyncSession
+) -> list[tuple[Memory, Memory]]:
+    """Find memory pairs with contradiction links in an org."""
+    from app.models.memory import Memory
+
+    stmt = select(Memory).where(
+        Memory.org_id == org_id,
+        Memory.metadata_["contradicts_id"].isnot(None),
+    )
+    newer_mems = (await session.scalars(stmt)).all()
+    pairs: list[tuple[Memory, Memory]] = []
+    for mem in newer_mems:
+        older_id = (mem.metadata_ or {}).get("contradicts_id")
+        if older_id:
+            older = await session.get(Memory, older_id)
+            if older:
+                pairs.append((older, mem))
+    return pairs
+
+
+async def resolve_contradiction(
+    memory_id: uuid.UUID,
+    strategy: ResolutionStrategy,
+    session: AsyncSession,
+) -> Memory | None:
+    """Resolve a contradiction between two linked memories."""
+    from app.models.memory import Memory
+
+    mem = await session.get(Memory, memory_id)
+    if not mem:
+        return None
+
+    contradicts_id = (mem.metadata_ or {}).get("contradicts_id")
+    other = await session.get(Memory, contradicts_id) if contradicts_id else None
+
+    if strategy == ResolutionStrategy.KEEP_NEWER:
+        if other:
+            other.confidence = 0
+            other.metadata_ = {**(other.metadata_ or {}), "resolved": "superseded"}
+        mem.metadata_ = {**(mem.metadata_ or {}), "resolved": "kept"}
+    elif strategy == ResolutionStrategy.KEEP_OLDER:
+        mem.confidence = 0
+        mem.metadata_ = {**(mem.metadata_ or {}), "resolved": "superseded"}
+        if other:
+            other.metadata_ = {**(other.metadata_ or {}), "resolved": "kept"}
+    elif strategy == ResolutionStrategy.FLAG:
+        mem.metadata_ = {**(mem.metadata_ or {}), "resolved": "flagged_for_review"}
+        if other:
+            other.metadata_ = {**(other.metadata_ or {}), "resolved": "flagged_for_review"}
+    elif strategy == ResolutionStrategy.MERGE:
+        # Stub — would use instructor + litellm to merge content
+        mem.metadata_ = {**(mem.metadata_ or {}), "resolved": "merge_pending"}
+
+    await session.flush()
+    logger.info(
+        "contradiction.resolved",
+        memory_id=str(memory_id),
+        strategy=strategy.value,
+    )
+    return mem
+
+
+def link_contradiction(
+    existing: Memory,
+    new_memory: Memory,
+) -> None:
+    """Cross-link two memories as contradictions and penalize the older one."""
+    existing.metadata_ = {
+        **(existing.metadata_ or {}),
+        "contradicted_by": str(new_memory.id),
+    }
+    existing.confidence = max(0, existing.confidence - 20)
+    new_memory.metadata_ = {
+        **(new_memory.metadata_ or {}),
+        "contradicts_id": str(existing.id),
+    }

--- a/apps/api/app/memory/router.py
+++ b/apps/api/app/memory/router.py
@@ -8,8 +8,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.dependencies import AuthContext, require_auth
 from app.database import get_db
 from app.memory.schemas import (
+    ContradictionPairResponse,
     MemoryFeedbackDto,
     MemoryResponse,
+    ResolveContradictionDto,
     SearchResultResponse,
     StoreMemoryDto,
 )
@@ -102,6 +104,52 @@ async def list_all(
     return PaginatedResponse(
         data=[MemoryResponse.model_validate(m) for m in memories],
         meta=PaginationMeta(total=total, page=(offset // limit) + 1, limit=limit),
+    )
+
+
+@router.get("/contradictions")
+async def list_contradiction_pairs(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataResponse[list[ContradictionPairResponse]]:
+    from app.memory.contradictions import list_contradictions
+
+    pairs = await list_contradictions(auth.org_id, db)
+    return DataResponse(
+        data=[
+            ContradictionPairResponse(
+                older_memory=MemoryResponse.model_validate(older),
+                newer_memory=MemoryResponse.model_validate(newer),
+            )
+            for older, newer in pairs
+        ]
+    )
+
+
+@router.post("/contradictions/{memory_id}/resolve")
+async def resolve_contradiction_endpoint(
+    memory_id: uuid.UUID,
+    dto: ResolveContradictionDto,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_auth),
+) -> DataMessageResponse[dict]:
+    from app.memory.contradictions import ResolutionStrategy, resolve_contradiction
+
+    try:
+        strategy = ResolutionStrategy(dto.strategy)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid strategy. Must be one of: {[s.value for s in ResolutionStrategy]}",
+        ) from e
+
+    mem = await resolve_contradiction(memory_id, strategy, db)
+    if not mem:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Memory not found")
+    await db.commit()
+    return DataMessageResponse(
+        data={"memory_id": str(memory_id)},
+        message=f"Contradiction resolved: {strategy.value}",
     )
 
 

--- a/apps/api/app/memory/schemas.py
+++ b/apps/api/app/memory/schemas.py
@@ -55,6 +55,15 @@ class SearchMemoryDto(BaseModel):
     similarity_threshold: float = Field(default=0.7, ge=0.0, le=1.0)
 
 
+class ContradictionPairResponse(BaseModel):
+    older_memory: MemoryResponse
+    newer_memory: MemoryResponse
+
+
+class ResolveContradictionDto(BaseModel):
+    strategy: str = Field(description="Resolution strategy: keep_newer, keep_older, merge, flag")
+
+
 class SearchResultResponse(BaseModel):
     memory_id: uuid.UUID
     content: str

--- a/apps/api/tests/test_contradictions.py
+++ b/apps/api/tests/test_contradictions.py
@@ -1,0 +1,89 @@
+"""Tests for contradiction resolution logic."""
+
+from __future__ import annotations
+
+
+class TestResolutionStrategy:
+    def test_all_strategies_valid(self) -> None:
+        from app.memory.contradictions import ResolutionStrategy
+
+        assert len(ResolutionStrategy) == 4
+        assert ResolutionStrategy.KEEP_NEWER == "keep_newer"
+        assert ResolutionStrategy.KEEP_OLDER == "keep_older"
+        assert ResolutionStrategy.MERGE == "merge"
+        assert ResolutionStrategy.FLAG == "flag"
+
+
+class TestLinkContradiction:
+    def test_links_memories_and_penalizes(self) -> None:
+        from unittest.mock import MagicMock
+
+        from app.memory.contradictions import link_contradiction
+
+        existing = MagicMock()
+        existing.id = "existing-id"
+        existing.metadata_ = {}
+        existing.confidence = 80
+
+        new_mem = MagicMock()
+        new_mem.id = "new-id"
+        new_mem.metadata_ = {}
+
+        link_contradiction(existing, new_mem)
+
+        assert existing.metadata_["contradicted_by"] == "new-id"
+        assert existing.confidence == 60
+        assert new_mem.metadata_["contradicts_id"] == "existing-id"
+
+    def test_confidence_floors_at_zero(self) -> None:
+        from unittest.mock import MagicMock
+
+        from app.memory.contradictions import link_contradiction
+
+        existing = MagicMock()
+        existing.id = "e"
+        existing.metadata_ = {}
+        existing.confidence = 10
+
+        new_mem = MagicMock()
+        new_mem.id = "n"
+        new_mem.metadata_ = {}
+
+        link_contradiction(existing, new_mem)
+        assert existing.confidence == 0
+
+    def test_preserves_existing_metadata(self) -> None:
+        from unittest.mock import MagicMock
+
+        from app.memory.contradictions import link_contradiction
+
+        existing = MagicMock()
+        existing.id = "e"
+        existing.metadata_ = {"foo": "bar"}
+        existing.confidence = 50
+
+        new_mem = MagicMock()
+        new_mem.id = "n"
+        new_mem.metadata_ = {"baz": 1}
+
+        link_contradiction(existing, new_mem)
+        assert existing.metadata_["foo"] == "bar"
+        assert existing.metadata_["contradicted_by"] == "n"
+        assert new_mem.metadata_["baz"] == 1
+        assert new_mem.metadata_["contradicts_id"] == "e"
+
+
+class TestContradictionSchemas:
+    def test_resolve_dto_accepts_valid_strategy(self) -> None:
+        from app.memory.schemas import ResolveContradictionDto
+
+        dto = ResolveContradictionDto(strategy="keep_newer")
+        assert dto.strategy == "keep_newer"
+
+    def test_contradiction_pair_response_structure(self) -> None:
+        from app.memory.schemas import ContradictionPairResponse
+
+        # Verify the model has the expected fields
+        fields = ContradictionPairResponse.model_fields
+        assert "older_memory" in fields
+        assert "newer_memory" in fields


### PR DESCRIPTION
## Summary
- Create `contradictions.py` with `list_contradictions()`, `resolve_contradiction()`, and `link_contradiction()` helper
- Add 4 resolution strategies: keep_newer, keep_older, merge (stub), flag
- Add `GET /memory/contradictions` and `POST /memory/contradictions/{id}/resolve` endpoints
- Add `ContradictionPairResponse` and `ResolveContradictionDto` schemas

## Test plan
- [x] 6 unit tests pass (`pytest tests/test_contradictions.py`)
- [x] `link_contradiction` cross-links memories and penalizes confidence
- [x] Confidence floors at 0 when penalized
- [x] Existing metadata preserved during linking

Closes #546