### PR TITLE
feat(memory): auto-expire time-bound memories #547

### DIFF
--- a/apps/api/app/memory/router.py
+++ b/apps/api/app/memory/router.py
@@ -28,6 +28,13 @@ async def store(
     auth: AuthContext = Depends(require_auth),
 ) -> DataMessageResponse[dict]:
     try:
+        # Compute expires_at from ttl_seconds if provided
+        expires_at = dto.expires_at
+        if expires_at is None and dto.ttl_seconds is not None:
+            import pendulum
+
+            expires_at = pendulum.now("UTC").add(seconds=dto.ttl_seconds)
+
         memory_id = await store_memory(
             session=db,
             org_id=auth.org_id,
@@ -38,7 +45,7 @@ async def store(
             visibility=dto.visibility,
             target_agent_ids=dto.target_agent_ids,
             occurred_at=dto.occurred_at.isoformat() if dto.occurred_at else None,
-            expires_at=dto.expires_at.isoformat() if dto.expires_at else None,
+            expires_at=expires_at.isoformat() if expires_at else None,
             metadata=dto.metadata,
         )
         await db.commit()

--- a/apps/api/app/memory/schemas.py
+++ b/apps/api/app/memory/schemas.py
@@ -14,6 +14,9 @@ class StoreMemoryDto(BaseModel):
     target_agent_ids: list[uuid.UUID] | None = None
     occurred_at: datetime | None = None
     expires_at: datetime | None = None
+    ttl_seconds: int | None = Field(
+        default=None, ge=1, description="Optional TTL in seconds, sets expires_at"
+    )
     metadata: dict = Field(default_factory=dict)
 
 

--- a/apps/api/app/memory/search.py
+++ b/apps/api/app/memory/search.py
@@ -102,6 +102,10 @@ async def hybrid_search(
     # Build visibility filter
     visibility_filter = _build_visibility_filter(requesting_agent_id)
     type_filter = "AND m.type = :memory_type" if memory_type else ""
+    expiry_filter = (
+        "AND (m.expires_at IS NULL OR m.expires_at > NOW()) "
+        "AND (m.metadata->>'expired' IS NULL OR m.metadata->>'expired' != 'true')"
+    )
 
     params: dict[str, str | int | float] = {
         "org_id": str(org_id),
@@ -122,6 +126,7 @@ async def hybrid_search(
               AND 1 - (m.embedding <=> :embedding::vector) >= :threshold
               {visibility_filter}
               {type_filter}
+              {expiry_filter}
             ORDER BY m.embedding <=> :embedding::vector
             LIMIT :fetch_limit
         """)
@@ -141,6 +146,7 @@ async def hybrid_search(
           AND m.content_tsv @@ plainto_tsquery('english', :query)
           {visibility_filter}
           {type_filter}
+          {expiry_filter}
         ORDER BY rank_score DESC
         LIMIT :fetch_limit
     """)

--- a/apps/api/app/workers/enrichment.py
+++ b/apps/api/app/workers/enrichment.py
@@ -17,6 +17,7 @@ from sqlalchemy import and_, select, text
 from app.database import async_session
 from app.models.memory import Memory
 from app.workers.config import get_redis_settings
+from app.workers.expiry import expire_memories
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -107,10 +108,11 @@ async def derive_facts(ctx: dict) -> int:
 class WorkerSettings:
     """arq WorkerSettings — run with: arq app.workers.enrichment.WorkerSettings"""
 
-    functions: ClassVar[list] = [boost_co_retrieved, identify_stale, derive_facts]
+    functions: ClassVar[list] = [boost_co_retrieved, identify_stale, derive_facts, expire_memories]
     cron_jobs: ClassVar[list] = [
         cron(boost_co_retrieved, hour={0, 6, 12, 18}),  # 4x daily
         cron(identify_stale, hour={3}),  # once daily at 3am
         cron(derive_facts, hour={4}),  # once daily at 4am
+        cron(expire_memories, minute={0}),  # every hour
     ]
     redis_settings = get_redis_settings()

--- a/apps/api/app/workers/expiry.py
+++ b/apps/api/app/workers/expiry.py
@@ -1,0 +1,34 @@
+"""Auto-expire time-bound memories past their expires_at timestamp."""
+
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import func, text, update
+
+from app.database import async_session
+from app.models.memory import Memory
+
+logger = structlog.get_logger()
+
+
+async def expire_memories(ctx: dict) -> int:
+    """Soft-delete memories past their expires_at by setting metadata.expired = true."""
+    async with async_session() as session:
+        result = await session.execute(
+            update(Memory)
+            .where(Memory.expires_at < func.now())
+            .where(
+                Memory.metadata_["expired"].as_boolean().is_not(True)  # type: ignore[union-attr]
+            )
+            .values(
+                metadata_=func.jsonb_set(
+                    func.coalesce(Memory.metadata_, text("'{}'::jsonb")),
+                    text("'{expired}'"),
+                    text("'true'::jsonb"),
+                )
+            )
+        )
+        expired = result.rowcount
+        await session.commit()
+        logger.info("expire_memories.done", expired=expired)
+        return expired

--- a/apps/api/tests/test_enrichment.py
+++ b/apps/api/tests/test_enrichment.py
@@ -7,12 +7,12 @@ class TestWorkerSettings:
     def test_functions_registered(self) -> None:
         from app.workers.enrichment import WorkerSettings
 
-        assert len(WorkerSettings.functions) == 3
+        assert len(WorkerSettings.functions) == 4
 
     def test_cron_jobs_registered(self) -> None:
         from app.workers.enrichment import WorkerSettings
 
-        assert len(WorkerSettings.cron_jobs) == 3
+        assert len(WorkerSettings.cron_jobs) == 4
 
     def test_functions_are_callable(self) -> None:
         from app.workers.enrichment import WorkerSettings

--- a/apps/api/tests/test_expiry.py
+++ b/apps/api/tests/test_expiry.py
@@ -1,0 +1,52 @@
+"""Tests for auto-expire time-bound memories."""
+
+from __future__ import annotations
+
+
+class TestTTLSchema:
+    def test_ttl_seconds_accepted(self) -> None:
+        from app.memory.schemas import StoreMemoryDto
+
+        dto = StoreMemoryDto(content="test", ttl_seconds=3600)
+        assert dto.ttl_seconds == 3600
+
+    def test_no_ttl_defaults_to_none(self) -> None:
+        from app.memory.schemas import StoreMemoryDto
+
+        dto = StoreMemoryDto(content="test")
+        assert dto.ttl_seconds is None
+
+    def test_ttl_computes_expires_at(self) -> None:
+        import pendulum
+
+        now = pendulum.now("UTC")
+        ttl = 3600
+        expires = now.add(seconds=ttl)
+        assert (expires - now).total_seconds() == 3600
+
+    def test_ttl_must_be_positive(self) -> None:
+        import pytest
+        from pydantic import ValidationError
+
+        from app.memory.schemas import StoreMemoryDto
+
+        with pytest.raises(ValidationError):
+            StoreMemoryDto(content="test", ttl_seconds=0)
+
+
+class TestExpiryWorkerRegistered:
+    def test_expire_memories_in_functions(self) -> None:
+        from app.workers.enrichment import WorkerSettings
+        from app.workers.expiry import expire_memories
+
+        assert expire_memories in WorkerSettings.functions
+
+    def test_expire_cron_registered(self) -> None:
+        from app.workers.enrichment import WorkerSettings
+
+        assert len(WorkerSettings.cron_jobs) == 4
+
+    def test_worker_has_four_functions(self) -> None:
+        from app.workers.enrichment import WorkerSettings
+
+        assert len(WorkerSettings.functions) == 4


### PR DESCRIPTION
## Summary
- Add `ttl_seconds` field to `StoreMemoryDto` — computes `expires_at` from TTL
- Create `expiry.py` worker: soft-deletes expired memories by setting `metadata.expired = true`
- Register `expire_memories` cron job (runs every hour) in WorkerSettings
- Filter expired memories from both vector and full-text hybrid search queries
- Update enrichment worker tests for 4 functions/cron jobs

## Test plan
- [x] 7 unit tests pass (`pytest tests/test_expiry.py`)
- [x] All 32 memory-related tests pass
- [x] `ttl_seconds` validation rejects 0 or negative values
- [x] Expiry worker registered in WorkerSettings

Closes #547