### PR TITLE
chore(ci): deploy workflow path triggers + Starlight docs deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,51 @@
+name: Deploy Docs (docs.openspawn.ai)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Starlight docs
+        run: pnpm exec nx build docs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/docs/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -1,6 +1,12 @@
 name: Deploy Platform (openspawn.ai)
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/platform/**"
+      - "Dockerfile.platform"
+      - "pnpm-lock.yaml"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,16 @@ name: Deploy to VPS
 on:
   push:
     branches: [main]
+    paths:
+      - "apps/demo/**"
+      - "apps/team/**"
+      - "apps/website/**"
+      - "apps/api/**"
+      - "tools/sandbox/**"
+      - "libs/**"
+      - "deploy/**"
+      - "Dockerfile"
+      - "pnpm-lock.yaml"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,86 +1,14 @@
-name: Deploy to GitHub Pages
+name: "[Deprecated] Deploy to GitHub Pages"
 
+# Replaced by deploy-docs.yml (Astro Starlight).
+# Kept as workflow_dispatch stub so existing links don't 404.
 on:
-  # Disabled: workflow references deprecated Jekyll docs + dashboard app.
-  # TODO: rewrite for Astro Starlight (apps/docs) when docs.openspawn.ai is ready.
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
-  build:
+  redirect:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Needed for Nx affected commands
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      # Nx cache for faster builds
-      - name: Cache Nx
-        uses: actions/cache@v4
-        with:
-          path: .nx/cache
-          key: nx-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
-          restore-keys: |
-            nx-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
-            nx-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build demo dashboard
-        run: pnpm exec nx build dashboard
-        env:
-          VITE_DEMO_MODE: "true"
-          VITE_API_URL: ""
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.2"
-          bundler-cache: true
-          working-directory: docs
-
-      - name: Build Jekyll site
-        run: |
-          cd docs
-          bundle exec jekyll build --baseurl /openspawn
-        env:
-          JEKYLL_ENV: production
-
-      - name: Merge demo into site
-        run: |
-          mkdir -p docs/_site/demo
-          cp -r dist/apps/dashboard/* docs/_site/demo/
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs/_site
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - run: |
+          echo "This workflow is deprecated. Use deploy-docs.yml instead."
+          echo "See: https://github.com/openspawn/openspawn/actions/workflows/deploy-docs.yml"


### PR DESCRIPTION
## Summary
- **deploy.yml**: Add `paths` filter — only triggers on app/lib/deploy file changes, not docs or markdown
- **deploy-platform.yml**: Add `push` trigger with `paths` for `apps/platform/**` (was manual-only)
- **deploy-docs.yml**: New workflow for Astro Starlight site, triggers on `apps/docs/**` changes
- **pages.yml**: Deprecated — replaced by `deploy-docs.yml`, kept as stub

Closes #554

## Test plan
- [ ] Verify `deploy.yml` doesn't trigger on docs-only commits
- [ ] Verify `deploy-docs.yml` triggers on `apps/docs/**` changes
- [ ] Verify `deploy-platform.yml` triggers on `apps/platform/**` changes
- [ ] Manual `workflow_dispatch` still works on all workflows