### PR TITLE
fix(ci): resolve pre-existing pyright errors + exclude deprecated dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         continue-on-error: true # Don't fail on lint for now
 
       - name: Build
-        run: pnpm exec nx run-many -t build --parallel=3
+        run: pnpm exec nx run-many -t build --parallel=3 --exclude=dashboard
 
       - name: Test
         run: pnpm exec nx run-many -t test --parallel=3

--- a/apps/api/app/memory/compression.py
+++ b/apps/api/app/memory/compression.py
@@ -45,7 +45,7 @@ async def compress_to_facts(
     langfuse = get_langfuse()
     generation = None
     if langfuse:
-        trace = langfuse.trace(name="compress_to_facts", input={"content": raw_content[:200]})
+        trace = langfuse.trace(name="compress_to_facts", input={"content": raw_content[:200]})  # type: ignore[attr-defined]
         generation = trace.generation(name="instructor_compress", model=llm_model)
 
     client = instructor.from_litellm(litellm.acompletion)

--- a/apps/api/app/memory/dedup.py
+++ b/apps/api/app/memory/dedup.py
@@ -138,7 +138,7 @@ async def _llm_decide(existing_content: str, new_content: str) -> DedupDecision:
     langfuse = get_langfuse()
     generation = None
     if langfuse:
-        trace = langfuse.trace(
+        trace = langfuse.trace(  # type: ignore[attr-defined]
             name="dedup_llm_decide",
             input={"existing": existing_content[:200], "new": new_content[:200]},
         )

--- a/apps/api/app/observability.py
+++ b/apps/api/app/observability.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import structlog
+
+if TYPE_CHECKING:
+    from langfuse import Langfuse
 
 logger = structlog.get_logger()
 
@@ -23,7 +27,7 @@ def setup_logfire(app: object) -> None:
     logger.info("logfire enabled")
 
 
-def get_langfuse() -> object | None:
+def get_langfuse() -> Langfuse | None:
     """Return Langfuse client if keys configured, else None."""
     pub = os.getenv("LANGFUSE_PUBLIC_KEY")
     sec = os.getenv("LANGFUSE_SECRET_KEY")

--- a/apps/api/app/workers/expiry.py
+++ b/apps/api/app/workers/expiry.py
@@ -14,7 +14,7 @@ logger = structlog.get_logger()
 async def expire_memories(ctx: dict) -> int:
     """Soft-delete memories past their expires_at by setting metadata.expired = true."""
     async with async_session() as session:
-        result = await session.execute(
+        cursor = await session.execute(
             update(Memory)
             .where(Memory.expires_at < func.now())
             .where(
@@ -28,7 +28,7 @@ async def expire_memories(ctx: dict) -> int:
                 )
             )
         )
-        expired = result.rowcount
+        expired = getattr(cursor, "rowcount", 0) or 0
         await session.commit()
         logger.info("expire_memories.done", expired=expired)
         return expired


### PR DESCRIPTION
## Summary
- Fix 4 pyright errors that have been failing `python-api` CI on every push to main
- Exclude deprecated `apps/dashboard` from `nx run-many -t build` (replaced by `apps/demo`)

### Pyright fixes
- `observability.py`: Return `Langfuse | None` instead of `object | None` so `.trace()` resolves
- `compression.py` / `dedup.py`: `type: ignore[attr-defined]` on `langfuse.trace()` (langfuse stubs missing method)
- `expiry.py`: Use `getattr` for `rowcount` (SQLAlchemy `Result` vs `CursorResult` stub mismatch)

### Dashboard exclusion
- `ci.yml`: Add `--exclude=dashboard` to `nx run-many -t build`

## Test plan
- [x] `uv run pyright app/` — 0 errors
- [x] `uv run pytest tests/ -x -q` — 154 passed
- [ ] CI passes on this PR

Closes no issue (pre-existing tech debt)