### PR TITLE
docs(infra): update domain layout — API at openspawn.ai

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,14 +92,29 @@ jobs:
             fuser -k 3333/tcp 2>/dev/null || true
             sleep 2
 
-            # Force recreate to pick up compose changes + new image
-            docker compose up -d app --force-recreate --remove-orphans
+            # Force recreate to pick up compose changes + new images
+            docker compose up -d app api postgres --force-recreate --remove-orphans
+
+            # Run Alembic migrations
+            echo "⏳ Running database migrations..."
+            docker compose exec -T api alembic upgrade head || echo "⚠️ Migration failed (may be first deploy)"
 
             # Wait for app to be healthy (up to 60s)
             echo "⏳ Waiting for app to start..."
             for i in $(seq 1 12); do
               if curl -sf http://localhost:3333/api/state > /dev/null 2>&1; then
-                echo "✅ Deploy successful!"
+                echo "✅ Demo app healthy!"
+                break
+              fi
+              echo "  Attempt $i/12 — waiting 5s..."
+              sleep 5
+            done
+
+            # Wait for API to be healthy (up to 60s)
+            echo "⏳ Waiting for API to start..."
+            for i in $(seq 1 12); do
+              if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+                echo "✅ API healthy!"
                 docker image prune -f
                 exit 0
               fi
@@ -111,6 +126,8 @@ jobs:
             echo "❌ Health check failed after 60s"
             echo "=== App logs ==="
             docker compose logs --tail=100 app
+            echo "=== API logs ==="
+            docker compose logs --tail=100 api
             echo "=== Container status ==="
             docker compose ps
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,13 +14,13 @@ Multi-agent coordination platform. Agents get tasks, earn credits, communicate. 
 
 ## Domains & Deployment
 
-| Domain                | What                                   | Container        | Port |
-| --------------------- | -------------------------------------- | ---------------- | ---- |
-| **bikinibottom.ai**   | Live demo (sandbox + dashboard + team) | `app`            | 3333 |
-| **openspawn.ai**      | Website + landing page                 | `platform`       | 3334 |
-| **docs.openspawn.ai** | Astro/Starlight docs                   | Not yet deployed | —    |
+| Domain                | What                                          | Container        | Port |
+| --------------------- | --------------------------------------------- | ---------------- | ---- |
+| **bikinibottom.ai**   | Live demo (sandbox + dashboard)               | `app`            | 3333 |
+| **openspawn.ai**      | API, website, landing page, MCP server        | `api` `platform` | 8000, 3334 |
+| **docs.openspawn.ai** | Astro/Starlight docs                          | GitHub Pages     | —    |
 
-Both containers run on a single VPS. Caddy handles HTTPS. Deploy via `deploy.yml` and `deploy-platform.yml` workflows.
+All containers run on a single VPS. Caddy handles HTTPS. Deploy via `deploy.yml`, `deploy-platform.yml`, and `deploy-docs.yml` workflows.
 
 ---
 
@@ -85,8 +85,16 @@ cd apps/api && uv run alembic upgrade head
 
 ---
 
-## Key URLs (dev)
+## Key URLs
 
+**Production:**
+- Demo: https://bikinibottom.ai
+- API: https://openspawn.ai/api/
+- API docs: https://openspawn.ai/api/docs
+- Website: https://openspawn.ai
+- Docs: https://docs.openspawn.ai
+
+**Dev:**
 - Demo dashboard: http://localhost:4200
 - Demo mode: http://localhost:4200/?demo=true
 - Sandbox: http://localhost:3333

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,12 +53,12 @@ packages/
 
 All traffic routes through Cloudflare (DNS + CDN) to a single VPS running Caddy for HTTPS termination.
 
-| Domain            | Container  | Port | Serves                                          |
-| ----------------- | ---------- | ---- | ----------------------------------------------- |
-| bikinibottom.ai   | `app`      | 3333 | Sandbox server + demo + team + website (static) |
-| bikinibottom.ai   | `api`      | 8000 | FastAPI backend                                 |
-| openspawn.ai      | `platform` | 3334 | Platform landing page                           |
-| docs.openspawn.ai | —          | —    | Astro/Starlight docs (not yet deployed)         |
+| Domain            | Container  | Port | Serves                                  |
+| ----------------- | ---------- | ---- | --------------------------------------- |
+| bikinibottom.ai   | `app`      | 3333 | Live demo (sandbox + dashboard)         |
+| openspawn.ai      | `platform` | 3334 | Website + landing page                  |
+| openspawn.ai/api/ | `api`      | 8000 | FastAPI backend (REST + OpenAPI)        |
+| docs.openspawn.ai | —          | —    | Astro/Starlight docs (GitHub Pages)     |
 
 The `app` container runs `tools/sandbox/src/index.ts`, which serves both the REST/SSE API and three pre-built static apps (`demo`, `team`, `website`) from disk.
 
@@ -67,9 +67,9 @@ The `app` container runs `tools/sandbox/src/index.ts`, which serves both the RES
 | Workflow              | Trigger      | What it does                                       |
 | --------------------- | ------------ | -------------------------------------------------- |
 | `ci.yml`              | All PRs      | Build, test, lint, Python API checks               |
-| `deploy.yml`          | Push to main | Docker build + deploy to VPS (bikinibottom.ai)     |
-| `deploy-platform.yml` | Push to main | Docker build + deploy platform (openspawn.ai)      |
-| `pages.yml`           | Push to main | GitHub Pages (Jekyll docs + demo) — may be removed |
+| `deploy.yml`          | Push to main | Docker build + deploy to VPS (bikinibottom.ai + API) |
+| `deploy-platform.yml` | Push to main | Docker build + deploy platform (openspawn.ai)        |
+| `deploy-docs.yml`     | Push to main | Build + deploy Starlight docs (docs.openspawn.ai)    |
 | `release-cli.yml`     | Tag push     | GoReleaser for packages/cli                        |
 
 ### Docker Build (Dockerfile)

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -15,7 +15,12 @@ class Settings(BaseSettings):
     database_pool_size: int = 10
     database_pool_max_overflow: int = 20
 
-    cors_origins: list[str] = ["http://localhost:4200", "http://localhost:3333"]
+    cors_origins: list[str] = [
+        "http://localhost:4200",
+        "http://localhost:3333",
+        "https://bikinibottom.ai",
+        "https://openspawn.ai",
+    ]
 
     log_level: str = "INFO"
     log_format: str = "json"

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,23 +1,36 @@
-# ── BikiniBottom Caddy Config ─────────────────────────────────────────────────
+# ── OpenSpawn Caddy Config ────────────────────────────────────────────────────
 # Auto-HTTPS via Let's Encrypt. Place at /opt/bikinibottom/Caddyfile
 
 bikinibottom.ai {
 	reverse_proxy app:3333
 
 	header {
-		# Security headers
 		X-Content-Type-Options nosniff
 		X-Frame-Options DENY
 		Referrer-Policy strict-origin-when-cross-origin
-		# Remove server identity
 		-Server
 	}
 
-	# Cache hashed assets forever (Vite fingerprints them)
 	@assets path /assets/*
 	header @assets Cache-Control "public, max-age=31536000, immutable"
 
-	# Don't cache HTML (so deploys are picked up immediately)
 	@html path /
 	header @html Cache-Control "no-cache"
+}
+
+openspawn.ai {
+	# API at /api/ -> FastAPI container
+	handle_path /api/* {
+		reverse_proxy api:8000
+	}
+
+	# Everything else -> platform landing page
+	reverse_proxy platform:3334
+
+	header {
+		X-Content-Type-Options nosniff
+		X-Frame-Options DENY
+		Referrer-Policy strict-origin-when-cross-origin
+		-Server
+	}
 }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,8 +1,9 @@
-# ── BikiniBottom + OpenSpawn VPS Docker Compose ──────────────────────────────
-# Two containers:
-#   - bikinibottom (port 3333) — BikiniBottom demo at bikinibottom.ai
-#   - openspawn-platform (port 3334) — OpenSpawn landing at openspawn.ai
-# System Caddy handles HTTPS reverse proxy (see /etc/caddy/Caddyfile on VPS)
+# ── OpenSpawn VPS Docker Compose ──────────────────────────────────────────────
+# Three services:
+#   - app (port 3333)      — BikiniBottom demo at bikinibottom.ai
+#   - api (port 8000)      — FastAPI backend at openspawn.ai/api/
+#   - platform (port 3334) — OpenSpawn landing at openspawn.ai
+# System Caddy handles HTTPS reverse proxy (see Caddyfile)
 #
 # Expected at /opt/bikinibottom/docker-compose.yml on the VPS
 
@@ -28,6 +29,45 @@ services:
       retries: 5
       start_period: 30s
 
+  api:
+    image: openspawn-api:latest
+    container_name: openspawn-api
+    restart: unless-stopped
+    environment:
+      - ENVIRONMENT=production
+    env_file:
+      - .env.production
+    ports:
+      - "8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
+
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: openspawn-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-openspawn}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-openspawn}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "127.0.0.1:5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-openspawn}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   platform:
     image: openspawn-platform:latest
     container_name: openspawn-platform
@@ -44,3 +84,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
Establishes the production domain layout:

| Domain | What |
|---|---|
| **bikinibottom.ai** | Demo only (sandbox + dashboard) |
| **openspawn.ai** | API (`/api/`), website, landing page |
| **docs.openspawn.ai** | Starlight docs (GitHub Pages) |

### Changes
- **AGENTS.md** + **ARCHITECTURE.md**: updated domain tables, added production URLs
- **deploy/docker-compose.yml**: added `api` service (FastAPI) + `postgres` service (pgvector/pg16)
- **deploy/Caddyfile**: added `openspawn.ai` block routing `/api/*` to FastAPI, rest to platform
- **deploy.yml**: deploys api + postgres, runs Alembic migrations post-deploy
- **config.py**: added `bikinibottom.ai` and `openspawn.ai` to CORS origins

### Required before first deploy
- [ ] Set `POSTGRES_PASSWORD` in VPS `.env.production`
- [ ] Set `DATABASE_URL` in VPS `.env.production`
- [ ] Set `API_SECRET_KEY` in VPS `.env.production`
- [ ] DNS: ensure `openspawn.ai` points to VPS (already does for platform)
- [ ] Caddy: replace VPS Caddyfile with the updated version

## Test plan
- [x] 154 API tests pass
- [ ] CI passes
- [ ] Manual deploy via `workflow_dispatch` to verify