### PR TITLE
feat(dashboard): wire hooks to REST API in live mode + fix Dockerfile

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,14 +1,20 @@
-FROM ghcr.io/astral-sh/uv:python3.12-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 WORKDIR /app
-COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --no-dev
+COPY . /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
 
-FROM python:3.12-slim AS runtime
+FROM python:3.12-slim-bookworm AS runtime
 WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
-COPY app/ app/
-COPY alembic/ alembic/
-COPY alembic.ini .
+COPY --from=builder /app/app app/
+COPY --from=builder /app/alembic alembic/
+COPY --from=builder /app/alembic.ini .
 ENV PATH="/app/.venv/bin:$PATH"
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=3s CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"

--- a/libs/dashboard-data/src/hooks/use-agents.ts
+++ b/libs/dashboard-data/src/hooks/use-agents.ts
@@ -1,15 +1,29 @@
+import { isDemoMode, isSandboxMode } from "../lib/mode";
 import { useAgentsQuery } from "../graphql/generated/hooks";
+import { useAgents as useRestAgents } from "../rest/hooks/use-agents";
 import { DEFAULT_ORG_ID } from "../lib/constants";
 
 export type { AgentType as Agent } from "../graphql/generated/hooks";
 
+const isLiveMode = !isDemoMode && !isSandboxMode;
+
 export function useAgents(orgId: string = DEFAULT_ORG_ID) {
-  const { data, isLoading, error, refetch } = useAgentsQuery({ orgId });
+  const rest = useRestAgents({ enabled: isLiveMode });
+  const gql = useAgentsQuery({ orgId }, { enabled: !isLiveMode });
+
+  if (!isLiveMode) {
+    return {
+      agents: gql.data?.agents ?? [],
+      loading: gql.isLoading,
+      error: gql.error ?? null,
+      refetch: gql.refetch,
+    };
+  }
 
   return {
-    agents: data?.agents ?? [],
-    loading: isLoading,
-    error: error ?? null,
-    refetch,
+    agents: Array.isArray(rest.data) ? rest.data : [],
+    loading: rest.isLoading,
+    error: rest.error ?? null,
+    refetch: rest.refetch,
   };
 }

--- a/libs/dashboard-data/src/hooks/use-events.ts
+++ b/libs/dashboard-data/src/hooks/use-events.ts
@@ -1,19 +1,29 @@
+import { isDemoMode, isSandboxMode } from "../lib/mode";
 import { useEventsQuery } from "../graphql/generated/hooks";
+import { useEvents as useRestEvents } from "../rest/hooks/use-events";
 import { DEFAULT_ORG_ID } from "../lib/constants";
 
 export type { EventType as Event } from "../graphql/generated/hooks";
 
+const isLiveMode = !isDemoMode && !isSandboxMode;
+
 export function useEvents(orgId: string = DEFAULT_ORG_ID, limit = 50) {
-  const { data, isLoading, error, refetch } = useEventsQuery({
-    orgId,
-    limit,
-    page: 1,
-  });
+  const rest = useRestEvents({ enabled: isLiveMode });
+  const gql = useEventsQuery({ orgId, limit, page: 1 }, { enabled: !isLiveMode });
+
+  if (!isLiveMode) {
+    return {
+      events: gql.data?.events ?? [],
+      loading: gql.isLoading,
+      error: gql.error ?? null,
+      refetch: gql.refetch,
+    };
+  }
 
   return {
-    events: data?.events ?? [],
-    loading: isLoading,
-    error: error ?? null,
-    refetch,
+    events: Array.isArray(rest.data) ? rest.data : [],
+    loading: rest.isLoading,
+    error: rest.error ?? null,
+    refetch: rest.refetch,
   };
 }

--- a/libs/dashboard-data/src/hooks/use-tasks.ts
+++ b/libs/dashboard-data/src/hooks/use-tasks.ts
@@ -1,16 +1,30 @@
+import { isDemoMode, isSandboxMode } from "../lib/mode";
 import { useTasksQuery, type TaskStatus, type TasksQuery } from "../graphql/generated/hooks";
+import { useTasks as useRestTasks } from "../rest/hooks/use-tasks";
 import { DEFAULT_ORG_ID } from "../lib/constants";
 
 /** Task as returned by the Tasks list query (subset of full TaskType) */
 export type Task = TasksQuery["tasks"][number];
 
+const isLiveMode = !isDemoMode && !isSandboxMode;
+
 export function useTasks(orgId: string = DEFAULT_ORG_ID, status?: TaskStatus) {
-  const { data, isLoading, error, refetch } = useTasksQuery({ orgId, status });
+  const rest = useRestTasks({ enabled: isLiveMode });
+  const gql = useTasksQuery({ orgId, status }, { enabled: !isLiveMode });
+
+  if (!isLiveMode) {
+    return {
+      tasks: gql.data?.tasks ?? [],
+      loading: gql.isLoading,
+      error: gql.error ?? null,
+      refetch: gql.refetch,
+    };
+  }
 
   return {
-    tasks: data?.tasks ?? [],
-    loading: isLoading,
-    error: error ?? null,
-    refetch,
+    tasks: Array.isArray(rest.data) ? rest.data : [],
+    loading: rest.isLoading,
+    error: rest.error ?? null,
+    refetch: rest.refetch,
   };
 }

--- a/libs/dashboard-data/src/rest/client.ts
+++ b/libs/dashboard-data/src/rest/client.ts
@@ -1,7 +1,25 @@
 import createClient from "openapi-fetch";
 import type { paths } from "./generated/schema";
+import { isDemoMode, isSandboxMode } from "../lib/mode";
 import { getSandboxUrl } from "../lib/sandbox-url";
 
+function getApiBaseUrl(): string {
+  if (import.meta.env.VITE_API_URL) return import.meta.env.VITE_API_URL;
+
+  // Demo/sandbox: use sandbox server's /api path
+  if (isDemoMode || isSandboxMode) return `${getSandboxUrl()}/api`;
+
+  // Production: API is at /api on same origin (Caddy routes to FastAPI)
+  if (typeof window !== "undefined") {
+    const { protocol, hostname, port } = window.location;
+    if (!port || port === "443" || port === "80") return "/api";
+    // Dev: assume FastAPI on port 8000
+    return `${protocol}//${hostname}:8000`;
+  }
+
+  return "http://localhost:8000";
+}
+
 export const api = createClient<paths>({
-  baseUrl: `${getSandboxUrl()}/api`,
+  baseUrl: getApiBaseUrl(),
 });

--- a/libs/dashboard-data/src/rest/hooks/use-agents.ts
+++ b/libs/dashboard-data/src/rest/hooks/use-agents.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../client";
 
-export function useAgents() {
+export function useAgents(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ["agents"],
     queryFn: async () => {
@@ -9,5 +9,6 @@ export function useAgents() {
       if (error) throw error;
       return data;
     },
+    enabled: options?.enabled ?? true,
   });
 }

--- a/libs/dashboard-data/src/rest/hooks/use-events.ts
+++ b/libs/dashboard-data/src/rest/hooks/use-events.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../client";
 
-export function useEvents() {
+export function useEvents(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ["events"],
     queryFn: async () => {
@@ -9,5 +9,6 @@ export function useEvents() {
       if (error) throw error;
       return data;
     },
+    enabled: options?.enabled ?? true,
   });
 }

--- a/libs/dashboard-data/src/rest/hooks/use-tasks.ts
+++ b/libs/dashboard-data/src/rest/hooks/use-tasks.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../client";
 
-export function useTasks() {
+export function useTasks(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ["tasks"],
     queryFn: async () => {
@@ -9,6 +9,7 @@ export function useTasks() {
       if (error) throw error;
       return data;
     },
+    enabled: options?.enabled ?? true,
   });
 }
 


### PR DESCRIPTION
## Summary
- **Dashboard live mode**: `useAgents`, `useTasks`, `useEvents` hooks now use the REST API when not in demo/sandbox mode. Demo mode continues to use the GraphQL mock path unchanged.
- **REST client**: Auto-detects API URL — `/api` in production (same-origin via Caddy), `localhost:8000` in dev, configurable via `VITE_API_URL`
- **Dockerfile fix**: Updated uv base image from `python3.12-slim` (doesn't exist) to `python3.12-bookworm-slim` + added cache mounts per uv best practices

### How it works
```
Live mode:  Page -> useAgents() -> REST hook -> GET /agents -> FastAPI
Demo mode:  Page -> useAgents() -> GraphQL hook -> mock fetcher -> fixtures
```

Each hook checks `isDemoMode || isSandboxMode` at module load time and enables the appropriate data source. Both hooks are always called (React rules) but only one is `enabled`.

Refs #591, #592

## Test plan
- [x] `nx build demo` succeeds
- [ ] Demo mode still works (`?demo=true`)
- [ ] Live mode fetches from API when running against FastAPI backend
- [ ] Dockerfile builds successfully in CI