### PR TITLE
fix(deploy): use full GHCR image paths in docker-compose

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -9,7 +9,7 @@
 
 services:
   app:
-    image: bikinibottom:latest
+    image: ghcr.io/openspawn/openspawn:latest
     container_name: bikinibottom
     restart: unless-stopped
     environment:
@@ -30,7 +30,7 @@ services:
       start_period: 30s
 
   api:
-    image: openspawn-api:latest
+    image: ghcr.io/openspawn/openspawn-api:latest
     container_name: openspawn-api
     restart: unless-stopped
     environment:
@@ -69,7 +69,7 @@ services:
       start_period: 10s
 
   platform:
-    image: openspawn-platform:latest
+    image: ghcr.io/openspawn/openspawn-platform:latest
     container_name: openspawn-platform
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
- Fix docker-compose.yml image references from short names (`bikinibottom:latest`, `openspawn-api:latest`, `openspawn-platform:latest`) to full GHCR paths (`ghcr.io/openspawn/openspawn:latest`, etc.)
- VPS `docker compose pull` needs registry-qualified names since images are pushed to GHCR by CI

Closes #591

## Test plan
- [ ] Deploy workflow triggers on merge
- [ ] `docker compose pull` succeeds on VPS
- [ ] All three services start and pass health checks