### PR TITLE
fix(deploy): scope docker compose pull to managed services

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,8 +83,8 @@ jobs:
             # Log in to GHCR to pull the image
             echo "${GH_TOKEN}" | docker login ghcr.io -u github-actions --password-stdin
 
-            # Pull latest image
-            docker compose pull
+            # Pull only the images this workflow builds
+            docker compose pull app api postgres
 
             # Stop native sandbox service if running (port 3333 conflict)
             systemctl stop sandbox 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `docker compose pull` was pulling ALL services including `platform`, which is built by `deploy-platform.yml` and hasn't been pushed yet
- Scope pull to only `app api postgres` (the services this workflow manages)

## Test plan
- [ ] Deploy workflow triggers on merge
- [ ] `docker compose pull app api postgres` succeeds (no platform image needed)
- [ ] Health checks pass