### PR TITLE
fix(deploy): source .env.production before docker compose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,8 +77,9 @@ jobs:
             set -e
             cd /opt/openspawn
 
-            # Create .env.production if it doesn't exist
+            # Source .env.production so compose interpolation works
             touch .env.production
+            set -a && source .env.production && set +a
 
             # Log in to GHCR to pull the image
             echo "${GH_TOKEN}" | docker login ghcr.io -u github-actions --password-stdin


### PR DESCRIPTION
## Summary
- `docker compose` interpolates `${POSTGRES_PASSWORD}` from the host shell env, not from `env_file`
- Source `.env.production` into the shell before running compose commands

## Test plan
- [ ] Deploy workflow succeeds without POSTGRES_PASSWORD warning