### PR TITLE
fix(api): pin Python 3.12 + auto-fix DATABASE_URL scheme

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,13 +1,13 @@
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
-ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_PYTHON=python3.12
 WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project --no-dev
+    uv sync --locked --no-install-project --no-dev --python 3.12
 COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --locked --no-dev --python 3.12
 ENV PATH="/app/.venv/bin:$PATH"
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=3s CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"

--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -19,6 +19,8 @@ target_metadata = Base.metadata
 # Override sqlalchemy.url from DATABASE_URL env var
 database_url = os.environ.get("DATABASE_URL", "")
 if database_url:
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
     config.set_main_option("sqlalchemy.url", database_url)
 
 

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -12,6 +13,15 @@ class Settings(BaseSettings):
     debug: bool = False
 
     database_url: str = "postgresql+asyncpg://localhost:5432/openspawn"
+
+    @model_validator(mode="after")
+    def _fix_database_url_scheme(self) -> "Settings":
+        if self.database_url.startswith("postgresql://"):
+            self.database_url = self.database_url.replace(
+                "postgresql://", "postgresql+asyncpg://", 1
+            )
+        return self
+
     database_pool_size: int = 10
     database_pool_max_overflow: int = 20
 


### PR DESCRIPTION
## Summary
- Pin `--python 3.12` in Dockerfile — uv was resolving to Python 3.14 from `>=3.12` constraint
- Auto-fix `postgresql://` → `postgresql+asyncpg://` in Settings and Alembic env
- Fixes `ModuleNotFoundError: No module named 'psycopg2'` in production

## Test plan
- [ ] API container starts without psycopg2 error
- [ ] `curl https://openspawn.ai/api/health` returns OK