### PR TITLE
fix(ci): exclude deprecated projects from test + increase import timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,7 @@ jobs:
         run: pnpm exec nx run-many -t build --parallel=3 --exclude=dashboard
 
       - name: Test
-        run: pnpm exec nx run-many -t test --parallel=3
-        continue-on-error: true # Tests have pre-existing failures
+        run: pnpm exec nx run-many -t test --parallel=3 --exclude=dashboard --exclude=openspawn
         env:
           DATABASE_URL: postgres://openspawn:openspawn@localhost:5432/openspawn
 

--- a/apps/demo/src/app/app.spec.tsx
+++ b/apps/demo/src/app/app.spec.tsx
@@ -48,18 +48,18 @@ describe("App", () => {
     const mod = await import("./app");
     expect(mod.default).toBeDefined();
     expect(typeof mod.default).toBe("function");
-  });
+  }, 15_000);
 
   it("App component is named App", async () => {
     const mod = await import("./app");
     expect(mod.App).toBeDefined();
     expect(mod.App.name).toBe("App");
-  });
+  }, 15_000);
 
   it("router is configured with /app basepath", async () => {
     const { router } = await import("../routes");
     expect(router.basepath).toBe("/app");
-  });
+  }, 15_000);
 });
 
 /**


### PR DESCRIPTION
## Summary
- Exclude `dashboard` (deprecated) and `openspawn` (no test files) from `nx run-many -t test`
- Remove `continue-on-error` — tests should fail the build
- Increase timeout for demo app import tests (CI is slow resolving full module tree)

## Test plan
- [ ] CI passes without test failures