### PR TITLE
fix(deploy): use localhost in Caddyfile for host-mode Caddy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,9 @@ jobs:
             fuser -k 3333/tcp 2>/dev/null || true
             sleep 2
 
+            # Update Caddy config and reload
+            cp Caddyfile /etc/caddy/Caddyfile 2>/dev/null && systemctl reload caddy 2>/dev/null || true
+
             # Force recreate to pick up compose changes + new images
             docker compose up -d app api postgres --force-recreate --remove-orphans
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,8 +1,9 @@
 # ── OpenSpawn Caddy Config ────────────────────────────────────────────────────
 # Auto-HTTPS via Let's Encrypt. Place at /opt/openspawn/Caddyfile
+# Caddy runs on host, containers expose ports to localhost.
 
 bikinibottom.ai {
-	reverse_proxy app:3333
+	reverse_proxy localhost:3333
 
 	header {
 		X-Content-Type-Options nosniff
@@ -21,11 +22,11 @@ bikinibottom.ai {
 openspawn.ai {
 	# API at /api/ -> FastAPI container
 	handle_path /api/* {
-		reverse_proxy api:8000
+		reverse_proxy localhost:8000
 	}
 
 	# Everything else -> platform landing page
-	reverse_proxy platform:3334
+	reverse_proxy localhost:3334
 
 	header {
 		X-Content-Type-Options nosniff


### PR DESCRIPTION
## Summary
- Caddy runs as a systemd service on the host, not inside Docker
- Docker service names (`api:8000`) don't resolve from the host — use `localhost:8000` instead
- Auto-reload Caddy after copying updated Caddyfile during deploy

## Test plan
- [ ] `curl https://openspawn.ai/api/health` returns OK
- [ ] `curl https://bikinibottom.ai` loads demo