### PR TITLE
fix(platform): add build tools for native deps in Docker

### DIFF
--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -3,6 +3,7 @@
 
 # Stage 1: Build
 FROM node:24-alpine AS build
+RUN apk add --no-cache python3 make g++
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@latest --activate
 


### PR DESCRIPTION
## Summary
- `pnpm install` fails on `better-sqlite3` (needs python3/make/g++)
- Add `apk add python3 make g++` to build stage

## Test plan
- [ ] `deploy-platform.yml` succeeds
- [ ] `curl https://openspawn.ai` loads landing page