### PR TITLE
test(phase1): integration tests for spawner, MCP, SQLite, CLI

### DIFF
--- a/apps/api/tests/test_mcp_server.py
+++ b/apps/api/tests/test_mcp_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from unittest.mock import AsyncMock, patch
 
 from app.mcp_server.server import mcp
@@ -172,3 +173,33 @@ async def test_memory_graph_gaps() -> None:
         result = json.loads(await memory_graph_gaps())
         client.get.assert_called_once_with("/memory/graph/gaps")
         assert result["data"][0]["risk"] == "high"
+
+
+async def test_all_tools_have_schemas() -> None:
+    """Every tool must have an inputSchema with type=object and properties."""
+    tools = await mcp.list_tools()
+    for tool in tools:
+        mcp_tool = tool.to_mcp_tool()
+        schema = mcp_tool.inputSchema
+        assert schema is not None, f"{tool.name} missing inputSchema"
+        assert schema.get("type") == "object", (
+            f"{tool.name} inputSchema type is {schema.get('type')!r}, expected 'object'"
+        )
+        assert "properties" in schema, f"{tool.name} inputSchema missing 'properties' key"
+
+
+async def test_tool_names_are_snake_case() -> None:
+    """All tool names must be lowercase snake_case."""
+    pattern = re.compile(r"^[a-z][a-z0-9_]*$")
+    tools = await mcp.list_tools()
+    for tool in tools:
+        assert pattern.match(tool.name), f"Tool name {tool.name!r} is not snake_case"
+
+
+async def test_tool_descriptions_not_empty() -> None:
+    """Every tool must have a non-empty description."""
+    tools = await mcp.list_tools()
+    for tool in tools:
+        assert tool.description and tool.description.strip(), (
+            f"Tool {tool.name!r} has empty description"
+        )

--- a/apps/api/tests/test_spawner.py
+++ b/apps/api/tests/test_spawner.py
@@ -1,8 +1,13 @@
 """Tests for agent spawner."""
 
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from app.spawner.manager import SpawnManager
+from app.spawner.process import build_mcp_config, find_claude_cli, spawn_claude_process
 from app.spawner.prompt import build_bootstrap_prompt
 
 
@@ -64,3 +69,72 @@ async def test_spawn_manager_shutdown():
     await manager.shutdown()
     assert manager.active_count == 0
     assert manager.queued_count == 0
+
+
+# --- process.py tests ---
+
+
+def test_find_claude_cli_found():
+    with patch("app.spawner.process.shutil.which", return_value="/usr/bin/claude"):
+        assert find_claude_cli() == "/usr/bin/claude"
+
+
+def test_find_claude_cli_missing():
+    with (
+        patch("app.spawner.process.shutil.which", return_value=None),
+        pytest.raises(FileNotFoundError, match="Claude Code CLI not found"),
+    ):
+        find_claude_cli()
+
+
+def test_build_mcp_config():
+    config = build_mcp_config("http://localhost:8787")
+    assert config == {
+        "mcpServers": {
+            "openspawn": {
+                "url": "http://localhost:8787/mcp",
+            }
+        }
+    }
+
+
+def test_build_mcp_config_custom_url():
+    config = build_mcp_config("https://api.openspawn.ai")
+    assert config["mcpServers"]["openspawn"]["url"] == "https://api.openspawn.ai/mcp"
+
+
+@pytest.mark.asyncio
+async def test_spawn_claude_process_writes_mcp_config(tmp_path: Path):
+    mock_proc = AsyncMock()
+    with (
+        patch("app.spawner.process.find_claude_cli", return_value="/usr/bin/claude"),
+        patch(
+            "app.spawner.process.asyncio.create_subprocess_exec",
+            return_value=mock_proc,
+        ) as mock_exec,
+    ):
+        result = await spawn_claude_process(
+            agent_id="agent-1",
+            workspace=str(tmp_path),
+            prompt="do stuff",
+            mcp_url="http://localhost:8787",
+        )
+
+    # Verify .mcp.json written with correct content
+    mcp_json_path = tmp_path / ".mcp.json"
+    assert mcp_json_path.exists()
+    written = json.loads(mcp_json_path.read_text())
+    assert written == build_mcp_config("http://localhost:8787")
+
+    # Verify subprocess called with correct args
+    mock_exec.assert_called_once()
+    call_args = mock_exec.call_args
+    positional = call_args[0]
+    assert positional[0] == "/usr/bin/claude"
+    assert "--print" in positional
+    assert "--mcp-config" in positional
+    assert str(mcp_json_path) in positional
+    assert "-p" in positional
+    assert "do stuff" in positional
+
+    assert result is mock_proc

--- a/apps/api/tests/test_sqlite_integration.py
+++ b/apps/api/tests/test_sqlite_integration.py
@@ -2,6 +2,7 @@
 
 import os
 from collections.abc import AsyncGenerator
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -59,3 +60,108 @@ async def test_health_db(client: AsyncClient):
     data = r.json()
     assert data["status"] == "ok"
     assert data["database"] == "connected"
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Auth-gated endpoint smoke tests (all return 401 without creds)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agents_requires_auth(client: AsyncClient):
+    r = await client.get("/agents")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_tasks_requires_auth(client: AsyncClient):
+    r = await client.get("/tasks")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_credits_requires_auth(client: AsyncClient):
+    r = await client.get("/credits/balance")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_channels_requires_auth(client: AsyncClient):
+    r = await client.get("/channels")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_events_requires_auth(client: AsyncClient):
+    r = await client.get("/events")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_memory_requires_auth(client: AsyncClient):
+    r = await client.get("/memory")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_escalations_requires_auth(client: AsyncClient):
+    r = await client.get("/tasks/escalations/open")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_consensus_requires_auth(client: AsyncClient):
+    r = await client.get("/tasks/consensus/pending")
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Seeder end-to-end on SQLite
+# ---------------------------------------------------------------------------
+
+_MINIMAL_ORG_MD = """\
+# Test Org
+
+## Agents
+
+| Name  | Role   | Level | Reports To |
+|-------|--------|-------|------------|
+| Alice | lead   | 7     | —          |
+| Bob   | worker | 4     | Alice      |
+"""
+
+_SINGLE_AGENT_ORG_MD = """\
+# Solo Org
+
+## Agents
+
+| Name  | Role   | Level | Reports To |
+|-------|--------|-------|------------|
+| Carol | worker | 4     | —          |
+"""
+
+
+@pytest.mark.asyncio
+async def test_seed_from_org_creates_agents(client: AsyncClient, tmp_path: Path):
+    """Seeder creates agents from a minimal ORG.md table."""
+    org_file = tmp_path / "ORG.md"
+    org_file.write_text(_MINIMAL_ORG_MD, encoding="utf-8")
+
+    from app.seeder import seed_from_org
+
+    count = await seed_from_org(str(org_file))
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_seed_from_org_upserts_on_rerun(client: AsyncClient, tmp_path: Path):
+    """Seeder upserts (not duplicates) on repeated runs."""
+    org_file = tmp_path / "ORG.md"
+    org_file.write_text(_SINGLE_AGENT_ORG_MD, encoding="utf-8")
+
+    from app.seeder import seed_from_org
+
+    first = await seed_from_org(str(org_file))
+    second = await seed_from_org(str(org_file))
+    assert first == 1
+    assert second == 1

--- a/docs/plans/2026-03-09-phase1-integration-tests.md
+++ b/docs/plans/2026-03-09-phase1-integration-tests.md
@@ -1,0 +1,22 @@
+# Phase 1 Integration Tests — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Validate the agent spawning foundation end-to-end ($0, no LLM calls, deterministic)
+
+**Architecture:** Expand existing pytest + vitest suites to cover 3 gaps: (1) process.py subprocess logic at 0% coverage, (2) API endpoints + MCP tool schemas on SQLite, (3) CLI start.ts bridge. All tests mock external dependencies (claude CLI, network) and run against SQLite in-memory/tmp.
+
+**Tech Stack:** pytest + httpx ASGI transport (Python), vitest (TypeScript), tmp_path fixtures, unittest.mock
+
+**Issues:** #612 (FastAPI + MCP), #613 (CLI init + start)
+
+---
+
+## Tasks
+
+### Task 1: Process spawner unit tests (process.py — 0% → covered)
+### Task 2: MCP tool schema validation (all 33 tools have valid schemas)
+### Task 3: REST endpoint smoke tests on SQLite (auth gates work)
+### Task 4: Seeder end-to-end on SQLite (ORG.md → DB round-trip)
+### Task 5: CLI start command unit tests (TS bridge)
+### Task 6: CLI init scaffold smoke tests (template validation)

--- a/packages/openspawn/src/cli/commands/init.test.ts
+++ b/packages/openspawn/src/cli/commands/init.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { scaffold } from "./init.js";
 import { defaultAnswers } from "../wizard.js";
+import { listTemplates, getTemplate, renderTemplate } from "../templates/index.js";
+import { CulturePreset } from "../../core/types.js";
 import { mkdtempSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -63,5 +65,35 @@ describe("init scaffold", () => {
     const dir = mkdtempSync(join(tmpdir(), "os-init-"));
     scaffold(dir, defaultAnswers());
     expect(existsSync(join(dir, "docker-compose.yml"))).toBe(false);
+  });
+});
+
+describe("init scaffolding", () => {
+  it("all templates produce valid ORG.md with agents table or structure", () => {
+    for (const tmpl of listTemplates()) {
+      const rendered = renderTemplate(tmpl, "Test Corp");
+      const hasTable = rendered.includes("| Name");
+      const hasStructure = rendered.includes("## Structure");
+      expect(hasTable || hasStructure, `${tmpl.name} missing agents/structure`).toBe(true);
+    }
+  });
+
+  it("all templates have unique names", () => {
+    const names = listTemplates().map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("all templates have valid culture presets", () => {
+    const validPresets = Object.values(CulturePreset);
+    for (const tmpl of listTemplates()) {
+      expect(validPresets).toContain(tmpl.culturePreset);
+    }
+  });
+
+  it("rendered template has correct team name", () => {
+    const tmpl = getTemplate("assistant-team")!;
+    const rendered = renderTemplate(tmpl, "Acme Corp");
+    expect(rendered).toContain("# Acme Corp");
+    expect(rendered).not.toContain("{{TEAM_NAME}}");
   });
 });

--- a/packages/openspawn/src/cli/commands/start.test.ts
+++ b/packages/openspawn/src/cli/commands/start.test.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { describe, it, expect } from "vitest";
 import { buildServerCommand } from "./start.js";
 
@@ -10,5 +11,19 @@ describe("start command", () => {
     expect(cmd).toContain("/tmp/myorg");
     expect(cmd).toContain("--directory");
     expect(cmd).toContain("/path/to/api");
+  });
+
+  it("always starts with uv", () => {
+    const cmd = buildServerCommand("/any/dir", "/any/api");
+    expect(cmd[0]).toBe("uv");
+  });
+
+  it("uses absolute paths", () => {
+    const projectDir = resolve("/tmp/myorg");
+    const apiDir = resolve("/opt/openspawn/apps/api");
+    const cmd = buildServerCommand(projectDir, apiDir);
+    // cmd[3] = apiDir (after --directory), cmd[6] = projectDir (after --project-dir)
+    expect(cmd[3]).toMatch(/^\//);
+    expect(cmd[6]).toMatch(/^\//);
   });
 });


### PR DESCRIPTION
## Summary
- Process spawner (`process.py`) from 0% to full unit test coverage — CLI discovery, MCP config, subprocess spawning
- MCP tool schema validation — all 33 tools have valid input schemas, snake_case names, descriptions
- Auth-gated endpoint smoke tests on SQLite — 8 endpoints return 401 correctly on SQLite backend
- Seeder end-to-end on SQLite — ORG.md → database round-trip, upsert idempotency
- CLI `start` command — server command builder tests
- CLI `init` scaffold — template validation (structure, uniqueness, culture presets)

Closes #612, closes #613

## Test plan
- [x] 35 Python tests pass (`pytest tests/test_spawner.py tests/test_mcp_server.py tests/test_sqlite_integration.py`)
- [x] 59 TypeScript tests pass (`vitest run` in packages/openspawn)
- [x] Ruff lint clean
- [ ] CI passes