### PR TITLE
chore(deploy): scrub VPS provider and port details from public docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,12 +53,12 @@ packages/
 
 All traffic routes through Cloudflare (DNS + CDN) to a single VPS running Caddy for HTTPS termination.
 
-| Domain            | Container  | Port | Serves                              |
-| ----------------- | ---------- | ---- | ----------------------------------- |
-| bikinibottom.ai   | `app`      | 3333 | Live demo (sandbox + dashboard)     |
-| openspawn.ai      | `platform` | 3334 | Website + landing page              |
-| openspawn.ai/api/ | `api`      | 8000 | FastAPI backend (REST + OpenAPI)    |
-| docs.openspawn.ai | —          | —    | Astro/Starlight docs (GitHub Pages) |
+| Domain            | Serves                              |
+| ----------------- | ----------------------------------- |
+| bikinibottom.ai   | Live demo (sandbox + dashboard)     |
+| openspawn.ai      | Website + landing page              |
+| openspawn.ai/api/ | FastAPI backend (REST + OpenAPI)    |
+| docs.openspawn.ai | Astro/Starlight docs (GitHub Pages) |
 
 The `app` container runs `tools/sandbox/src/index.ts`, which serves both the REST/SSE API and three pre-built static apps (`demo`, `team`, `website`) from disk.
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,11 +1,6 @@
 # ── OpenSpawn VPS Docker Compose ──────────────────────────────────────────────
-# Three services:
-#   - app (port 3333)      — BikiniBottom demo at bikinibottom.ai
-#   - api (port 8000)      — FastAPI backend at openspawn.ai/api/
-#   - platform (port 3334) — OpenSpawn landing at openspawn.ai
-# System Caddy handles HTTPS reverse proxy (see Caddyfile)
-#
-# Expected at /opt/openspawn/docker-compose.yml on the VPS
+# Services: app (demo), api (FastAPI), platform (landing), postgres
+# Caddy handles HTTPS reverse proxy (see Caddyfile)
 
 services:
   app:

--- a/deploy/setup-vps.sh
+++ b/deploy/setup-vps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ── OpenSpawn VPS Setup Script ───────────────────────────────────────────────
-# Run this once on a fresh Hetzner CX22 (Ubuntu 24.04)
+# Run this once on a fresh VPS (tested on Ubuntu 24.04)
 # Usage: ssh root@your-vps-ip 'bash -s' < deploy/setup-vps.sh
 
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Remove Hetzner CX22 machine type from `deploy/setup-vps.sh` (keep generic "fresh VPS")
- Strip port numbers and container name columns from `ARCHITECTURE.md` deployment topology table
- Simplify `deploy/docker-compose.yml` header comments (remove port-by-port listing)

Functional configs (docker-compose port mappings, Caddyfile routing) are unchanged — only docs/comments scrubbed.

## Context
Follow-up to #633 — audit found VPS provider details and port summaries exposed in docs that don't need them.