### PR TITLE
fix(docker): add inject-workspace-packages for pnpm deploy

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+inject-workspace-packages=true


### PR DESCRIPTION
## Summary
Add `inject-workspace-packages=true` to `.npmrc` — required by pnpm v10 for `pnpm deploy` to resolve workspace dependencies.

## Context
Follow-up to #635. pnpm v10 changed `deploy` behavior to require injected workspace packages by default. Without this setting, the Docker build fails with `ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE`.