### PR TITLE
fix(docker): copy .npmrc into Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 RUN apk add --no-cache python3 make g++
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml nx.json tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml nx.json tsconfig.base.json .npmrc ./
 COPY apps/ ./apps/
 COPY libs/ ./libs/
 COPY tools/sandbox/package.json tools/sandbox/tsconfig.json tools/sandbox/

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -7,7 +7,7 @@ RUN apk add --no-cache python3 make g++
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml nx.json tsconfig.base.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml nx.json tsconfig.base.json .npmrc ./
 COPY apps/website/ ./apps/website/
 COPY apps/platform/server.ts ./apps/platform/server.ts
 


### PR DESCRIPTION
## Summary
Add `.npmrc` to the COPY line in both `Dockerfile` and `Dockerfile.platform`.

pnpm needs to see `inject-workspace-packages=true` during `pnpm install --frozen-lockfile` inside Docker, otherwise the lockfile config doesn't match.