### PR TITLE
fix(dashboard): stub elkjs web-worker for browser builds

### DIFF
--- a/apps/dashboard/src/stubs/web-worker.ts
+++ b/apps/dashboard/src/stubs/web-worker.ts
@@ -1,0 +1,2 @@
+// Stub for elkjs's optional web-worker dependency (Node-only, unused in browser)
+export default undefined;

--- a/apps/dashboard/vite.config.mts
+++ b/apps/dashboard/vite.config.mts
@@ -62,6 +62,11 @@ export default defineConfig(() => ({
     __COMMIT_SHA__: JSON.stringify(commitSha),
     __BUILD_TIME__: JSON.stringify(buildTime),
   },
+  resolve: {
+    alias: {
+      "web-worker": resolve(import.meta.dirname, "src/stubs/web-worker.ts"),
+    },
+  },
   build: {
     outDir: "../../dist/apps/dashboard",
     emptyOutDir: true,

--- a/apps/demo/src/stubs/web-worker.ts
+++ b/apps/demo/src/stubs/web-worker.ts
@@ -1,0 +1,2 @@
+// Stub for elkjs's optional web-worker dependency (Node-only, unused in browser)
+export default undefined;

--- a/apps/demo/vite.config.mts
+++ b/apps/demo/vite.config.mts
@@ -62,6 +62,14 @@ export default defineConfig(() => ({
     __COMMIT_SHA__: JSON.stringify(commitSha),
     __BUILD_TIME__: JSON.stringify(buildTime),
   },
+  resolve: {
+    alias: {
+      // elkjs/lib/elk.bundled.js uses require('web-worker') with a try/catch
+      // fallback — Node-only, not needed in browser. Vite converts to a static
+      // ESM import that fails, so we stub it out.
+      "web-worker": resolve(import.meta.dirname, "src/stubs/web-worker.ts"),
+    },
+  },
   build: {
     outDir: "../../dist/apps/demo",
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- Stubs `web-worker` module in Vite config for both demo and dashboard apps
- `elkjs/lib/elk.bundled.js` has an optional `require('web-worker')` for Node.js — Vite converts it to a static ESM `import` that fails in the browser with `TypeError: Failed to resolve module specifier "web-worker"`
- The stub resolves to `undefined`, matching elkjs's own fallback behavior (it catches the error and runs synchronously)

## Test plan
- [ ] `pnpm nx run demo:build` succeeds
- [ ] No `import"web-worker"` in built bundles
- [ ] bikinibottom.ai loads without console errors