### PR TITLE
fix(deploy): pass bikinibottom theme build-arg to Docker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            VITE_DASHBOARD_THEME=bikinibottom
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}


### PR DESCRIPTION
## Summary
- Adds `VITE_DASHBOARD_THEME=bikinibottom` as a build-arg to the sandbox Docker build in deploy.yml
- Without this, the demo builds with the `openspawn` theme — intro/live routes aren't registered and bikinibottom.ai shows "NOT FOUND"

## Test plan
- [ ] Deploy workflow passes
- [ ] bikinibottom.ai loads the intro page (not "NOT FOUND")