### PR TITLE
fix(team): replace GraphQL enums with shared-types, proxy API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,25 +16,25 @@ Deploy via `deploy.yml`, `deploy-platform.yml`, and `deploy-docs.yml` workflows.
 
 **Live:**
 
-| Domain                  | What                                                             |
-| ----------------------- | ---------------------------------------------------------------- |
-| **openspawn.ai**        | Marketing website (React SPA, serves llms.txt + A2A agent.json) |
-| **api.openspawn.ai**    | Core API — GraphQL + REST (Python rewrite WIP)                  |
-| **bikinibottom.ai**     | Demo sandbox + dashboard                                        |
-| **team.openspawn.ai**   | Internal team dashboard (password-protected)                    |
-| **id.openspawn.ai**     | SSO/identity provider (OIDC)                                    |
-| **wiki.openspawn.ai**   | Internal knowledge base                                         |
+| Domain                | What                                                            |
+| --------------------- | --------------------------------------------------------------- |
+| **openspawn.ai**      | Marketing website (React SPA, serves llms.txt + A2A agent.json) |
+| **api.openspawn.ai**  | Core API — GraphQL + REST (Python rewrite WIP)                  |
+| **bikinibottom.ai**   | Demo sandbox + dashboard                                        |
+| **team.openspawn.ai** | Internal team dashboard (password-protected)                    |
+| **id.openspawn.ai**   | SSO/identity provider (OIDC)                                    |
+| **wiki.openspawn.ai** | Internal knowledge base                                         |
 
 **Reserved (DNS exists, not deployed):**
 
-| Domain                    | Intent                                      |
-| ------------------------- | ------------------------------------------- |
+| Domain                    | Intent                                         |
+| ------------------------- | ---------------------------------------------- |
 | **docs.openspawn.ai**     | Developer docs (Starlight app at `apps/docs/`) |
-| **hub.openspawn.ai**      | Agent/skill marketplace UI                  |
-| **logs.openspawn.ai**     | Centralized logging/observability dashboard |
-| **mcp.openspawn.ai**      | Dedicated MCP endpoint (standalone)         |
-| **registry.openspawn.ai** | Agent/package registry API                  |
-| **status.openspawn.ai**   | Public status page                          |
+| **hub.openspawn.ai**      | Agent/skill marketplace UI                     |
+| **logs.openspawn.ai**     | Centralized logging/observability dashboard    |
+| **mcp.openspawn.ai**      | Dedicated MCP endpoint (standalone)            |
+| **registry.openspawn.ai** | Agent/package registry API                     |
+| **status.openspawn.ai**   | Public status page                             |
 
 ## How to Contribute
 

--- a/apps/demo/vite.config.mts
+++ b/apps/demo/vite.config.mts
@@ -80,12 +80,7 @@ export default defineConfig(() => ({
     rollupOptions: {
       output: {
         manualChunks: {
-          "vendor-react": [
-            "react",
-            "react-dom",
-            "@tanstack/react-router",
-            "@tanstack/react-query",
-          ],
+          "vendor-react": ["react", "react-dom", "@tanstack/react-router", "@tanstack/react-query"],
           "vendor-motion": ["motion/react"],
           "vendor-xyflow": ["@xyflow/react", "elkjs"],
         },

--- a/apps/team/src/graphql/index.ts
+++ b/apps/team/src/graphql/index.ts
@@ -1,1 +1,0 @@
-export { fetcher, graphqlClient } from "@openspawn/dashboard-data";

--- a/apps/team/src/pages/agents.tsx
+++ b/apps/team/src/pages/agents.tsx
@@ -35,10 +35,10 @@ function initials(name: string) {
 }
 
 const ROLE_COLORS: Record<string, string> = {
-  FOUNDER: "bg-amber-500/20 text-amber-400",
-  ADMIN: "bg-cyan-500/20 text-cyan-400",
-  WORKER: "bg-violet-500/20 text-violet-400",
-  HR: "bg-emerald-500/20 text-emerald-400",
+  founder: "bg-amber-500/20 text-amber-400",
+  admin: "bg-cyan-500/20 text-cyan-400",
+  worker: "bg-violet-500/20 text-violet-400",
+  hr: "bg-emerald-500/20 text-emerald-400",
 };
 
 export function AgentsPage() {
@@ -81,7 +81,7 @@ export function AgentsPage() {
       ) : (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((agent) => {
-            const isActive = agent.status === AgentStatus.Active;
+            const isActive = agent.status.toLowerCase() === AgentStatus.ACTIVE;
             const taskCount = tasksByAgent[agent.id] || 0;
             const completion =
               agent.tasksCompleted > 0
@@ -100,7 +100,8 @@ export function AgentsPage() {
                   <div
                     className={cn(
                       "h-10 w-10 shrink-0 rounded-full flex items-center justify-center text-xs font-bold",
-                      ROLE_COLORS[agent.role ?? ""] ?? "bg-slate-500/20 text-slate-400",
+                      ROLE_COLORS[agent.role?.toLowerCase() ?? ""] ??
+                        "bg-slate-500/20 text-slate-400",
                     )}
                   >
                     {initials(agent.name)}

--- a/apps/team/src/pages/dashboard.tsx
+++ b/apps/team/src/pages/dashboard.tsx
@@ -26,7 +26,7 @@ import {
   CircleDot,
 } from "lucide-react";
 import { useAgents, useTasks, useEvents, type Agent, type Task } from "../hooks";
-import { AgentStatus, TaskStatus } from "@openspawn/dashboard-data";
+import { AgentStatus, TaskStatus, TaskPriority } from "@openspawn/dashboard-data";
 
 /* ── Helpers ────────────────────────────────────────────────────── */
 
@@ -51,22 +51,22 @@ function levelLabel(level: number): string {
 }
 
 function priorityVariant(p: string) {
-  switch (p) {
-    case "URGENT":
+  switch (p.toLowerCase()) {
+    case TaskPriority.URGENT:
       return "destructive" as const;
-    case "HIGH":
+    case TaskPriority.HIGH:
       return "warning" as const;
     default:
       return "secondary" as const;
   }
 }
 function statusVariant(s: string) {
-  switch (s) {
-    case "DONE":
+  switch (s.toLowerCase()) {
+    case TaskStatus.DONE:
       return "success" as const;
-    case "IN_PROGRESS":
+    case TaskStatus.IN_PROGRESS:
       return "info" as const;
-    case "CLAIMED":
+    case TaskStatus.ASSIGNED:
       return "warning" as const;
     default:
       return "secondary" as const;
@@ -83,10 +83,10 @@ function initials(name: string) {
 }
 
 const ROLE_COLORS: Record<string, string> = {
-  FOUNDER: "bg-amber-500/20 text-amber-400",
-  ADMIN: "bg-cyan-500/20 text-cyan-400",
-  WORKER: "bg-violet-500/20 text-violet-400",
-  HR: "bg-emerald-500/20 text-emerald-400",
+  founder: "bg-amber-500/20 text-amber-400",
+  admin: "bg-cyan-500/20 text-cyan-400",
+  worker: "bg-violet-500/20 text-violet-400",
+  hr: "bg-emerald-500/20 text-emerald-400",
 };
 
 /* ── Agent Card ─────────────────────────────────────────────────── */
@@ -116,12 +116,14 @@ function AgentCard({
               <StatusRing
                 completionRate={completion}
                 creditUsage={credit}
-                status={agent.status === "ACTIVE" ? "active" : "idle"}
+                status={agent.status.toLowerCase() === AgentStatus.ACTIVE ? "active" : "idle"}
                 size="sm"
               >
                 <Avatar className="h-8 w-8">
                   <AvatarFallback
-                    className={ROLE_COLORS[agent.role] ?? "bg-slate-500/20 text-slate-400"}
+                    className={
+                      ROLE_COLORS[agent.role?.toLowerCase()] ?? "bg-slate-500/20 text-slate-400"
+                    }
                   >
                     {initials(agent.name)}
                   </AvatarFallback>
@@ -132,7 +134,9 @@ function AgentCard({
                 <div className="flex items-center gap-2">
                   <span className="font-semibold text-sm truncate">{agent.name}</span>
                   <Badge
-                    variant={agent.status === "ACTIVE" ? "success" : "secondary"}
+                    variant={
+                      agent.status.toLowerCase() === AgentStatus.ACTIVE ? "success" : "secondary"
+                    }
                     className="text-[10px] px-1.5 py-0"
                   >
                     {agent.status}
@@ -186,9 +190,9 @@ function TaskRow({ task, index, onClick }: { task: Task; index: number; onClick?
         <div className="flex items-center gap-3 py-2.5 px-3 rounded-lg hover:bg-white/5 transition-colors cursor-pointer">
           <CircleDot
             className={`h-3.5 w-3.5 shrink-0 ${
-              task.status === "DONE"
+              task.status.toLowerCase() === TaskStatus.DONE
                 ? "text-emerald-400"
-                : task.status === "IN_PROGRESS"
+                : task.status.toLowerCase() === TaskStatus.IN_PROGRESS
                   ? "text-cyan-400"
                   : "text-amber-400"
             }`}
@@ -230,13 +234,14 @@ export function DashboardPage() {
   const { openAgentPanel, openTaskPanel } = useDashboardPanels({ agents, tasks });
 
   const stats = useMemo(() => {
-    const active = agents.filter((a) => a.status === AgentStatus.Active);
-    const done = tasks.filter((t) => t.status === TaskStatus.Done);
+    const norm = (s: string) => s.toLowerCase();
+    const active = agents.filter((a) => norm(a.status) === AgentStatus.ACTIVE);
+    const done = tasks.filter((t) => norm(t.status) === TaskStatus.DONE);
     const wip = tasks.filter(
-      (t) => t.status === TaskStatus.InProgress || t.status === TaskStatus.Review,
+      (t) => norm(t.status) === TaskStatus.IN_PROGRESS || norm(t.status) === TaskStatus.REVIEW,
     );
     const pending = tasks.filter(
-      (t) => t.status === TaskStatus.Todo || t.status === TaskStatus.Backlog,
+      (t) => norm(t.status) === TaskStatus.TODO || norm(t.status) === TaskStatus.BACKLOG,
     );
     const pct = tasks.length ? Math.round((done.length / tasks.length) * 100) : 0;
     return {
@@ -261,13 +266,13 @@ export function DashboardPage() {
     () =>
       [...tasks].sort((a, b) => {
         const o: Record<string, number> = {
-          IN_PROGRESS: 0,
-          CLAIMED: 1,
-          PENDING: 2,
-          REVIEW: 3,
-          DONE: 4,
+          [TaskStatus.IN_PROGRESS]: 0,
+          [TaskStatus.ASSIGNED]: 1,
+          [TaskStatus.PENDING]: 2,
+          [TaskStatus.REVIEW]: 3,
+          [TaskStatus.DONE]: 4,
         };
-        return (o[a.status] ?? 5) - (o[b.status] ?? 5);
+        return (o[a.status.toLowerCase()] ?? 5) - (o[b.status.toLowerCase()] ?? 5);
       }),
     [tasks],
   );

--- a/apps/team/src/pages/task-board.tsx
+++ b/apps/team/src/pages/task-board.tsx
@@ -2,25 +2,26 @@ import { PageHeader } from "@openspawn/dashboard-ui";
 import { useTasks, useAgents, useDashboardPanels } from "../hooks";
 import { TaskStatus, TaskPriority } from "@openspawn/dashboard-data";
 
-const COLUMNS: { id: TaskStatus; label: string; color: string }[] = [
-  { id: TaskStatus.Todo, label: "To Do", color: "border-white/10      bg-white/[0.02]" },
+const COLUMNS: { id: string; label: string; color: string }[] = [
+  { id: TaskStatus.TODO, label: "To Do", color: "border-white/10      bg-white/[0.02]" },
   {
-    id: TaskStatus.InProgress,
+    id: TaskStatus.IN_PROGRESS,
     label: "In Progress",
     color: "border-cyan-500/30   bg-cyan-500/[0.04]",
   },
-  { id: TaskStatus.Review, label: "In Review", color: "border-violet-500/30 bg-violet-500/[0.04]" },
-  { id: TaskStatus.Blocked, label: "Blocked", color: "border-red-500/30    bg-red-500/[0.04]" },
-  { id: TaskStatus.Done, label: "Done", color: "border-emerald-500/30 bg-emerald-500/[0.04]" },
+  { id: TaskStatus.REVIEW, label: "In Review", color: "border-violet-500/30 bg-violet-500/[0.04]" },
+  { id: TaskStatus.BLOCKED, label: "Blocked", color: "border-red-500/30    bg-red-500/[0.04]" },
+  { id: TaskStatus.DONE, label: "Done", color: "border-emerald-500/30 bg-emerald-500/[0.04]" },
 ];
 
-function priorityColor(p: TaskPriority): string {
-  switch (p) {
-    case TaskPriority.Urgent:
+function priorityColor(p: string): string {
+  const lp = p.toLowerCase();
+  switch (lp) {
+    case TaskPriority.URGENT:
       return "bg-red-500/20 text-red-400";
-    case TaskPriority.High:
+    case TaskPriority.HIGH:
       return "bg-amber-500/20 text-amber-400";
-    case TaskPriority.Normal:
+    case TaskPriority.NORMAL:
       return "bg-blue-500/20 text-blue-400";
     default:
       return "bg-white/10 text-white/40";
@@ -38,10 +39,11 @@ export function TaskBoardPage() {
   }, {});
 
   for (const task of tasks) {
-    if (task.status in byColumn) {
-      byColumn[task.status].push(task);
+    const s = task.status.toLowerCase();
+    if (s in byColumn) {
+      byColumn[s].push(task);
     } else {
-      byColumn[TaskStatus.Todo].push(task);
+      byColumn[TaskStatus.TODO].push(task);
     }
   }
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -44,6 +44,11 @@ team.openspawn.ai {
 		{$TEAM_AUTH_USER} {$TEAM_AUTH_HASH}
 	}
 
+	# Proxy /api requests to FastAPI (same pattern as openspawn.ai)
+	handle_path /api/* {
+		reverse_proxy localhost:8000
+	}
+
 	root * /opt/team-dashboard
 	file_server
 

--- a/docs/plans/2026-03-09-bundle-optimization-design.md
+++ b/docs/plans/2026-03-09-bundle-optimization-design.md
@@ -15,6 +15,7 @@ Lazy pages: `/tasks`, `/agents`, `/credits`, `/events`, `/messages`, `/network`,
 ### 2. Vendor Chunk Splitting
 
 `manualChunks` in vite `rollupOptions`:
+
 - `vendor-react`: react, react-dom, @tanstack/react-router, @tanstack/react-query
 - `vendor-motion`: motion/react
 - `vendor-xyflow`: @xyflow/react, elkjs

--- a/docs/plans/2026-03-10-agentic-auth-design.md
+++ b/docs/plans/2026-03-10-agentic-auth-design.md
@@ -1,0 +1,112 @@
+# Agentic-First Auth Design
+
+**Date:** 2026-03-10
+**Status:** Phase 1 approved, Phases 2-3 deferred
+
+## Decision: Casdoor over Authentik
+
+Dropped Authentik in favor of [Casdoor](https://casdoor.org/) for unified identity.
+Casdoor is lighter, Go-based, and has better API-driven identity management for programmatic agent registration.
+
+## Design Decisions
+
+### Unified Identity (Casdoor)
+
+Both humans and agents are first-class Casdoor identities. Tokens carry **delegation provenance** — every token traces back to the original human owner through the full spawn chain.
+
+Example ancestry for a deeply-spawned agent:
+
+```
+agent_3 → spawned_by: agent_2 → spawned_by: agent_1 → spawned_by: alice → org: openspawn
+```
+
+### Casdoor Org Mapping
+
+**Org + App split (Option C):**
+
+- Casdoor Organization = OpenSpawn Org
+- Separate Casdoor Applications for humans vs agents within each org
+- Rationale: agents need shorter TTLs, different refresh policies, task-scoped claims; humans need OAuth, 2FA, longer sessions
+
+### Agent Identity Lifecycle
+
+**API-driven registration:**
+
+- Our API calls Casdoor's API to create agent identities when `POST /agents/register` is called
+- Agents never interact with Casdoor directly — they just receive credentials
+- Parent agents or humans trigger registration; Casdoor issues scoped tokens with `spawned_by` claims
+
+### Token Scoping: Intersection Model
+
+Agent permissions = intersection of **agent-level ceiling** and **task-required scopes**.
+
+- Agent level (L1-L10) defines the max permission set
+- Each task declares `required_scopes` at creation
+- Token gets the intersection — an L3 agent can't claim a task requiring L7+ permissions
+- Mismatches caught at claim time, not runtime
+
+### Token Lifecycle
+
+```
+spawn → task-scoped (active) → idle → task-scoped (active) → ... → revoked
+```
+
+**Active state:** Token TTL matches task SLA deadline (capped at 24h max).
+**Idle state:** Token downgrades to minimal permission set (can only claim tasks). Short fixed TTL (15 min) with refresh. If no new task claimed within window, token expires → re-auth required.
+**Task completion:** Immediate downgrade to idle, not revocation.
+
+### JWT Claims (Agent Token)
+
+```json
+{
+  "sub": "agent_456",
+  "org": "openspawn",
+  "app": "agents",
+  "task_id": "task_789",
+  "scopes": ["read:channels", "write:messages", "transition:task"],
+  "spawned_by": "agent_123",
+  "owner": "user_alice",
+  "level": 3,
+  "state": "active",
+  "exp": 1741612800
+}
+```
+
+### Migration: Big Bang
+
+No parallel/deprecation period needed — existing HMAC/API key auth has no external consumers yet. Replace entirely with Casdoor JWT auth.
+
+## Phased Rollout
+
+### Phase 1 (now) — Ship basic auth
+
+Wire up the auth router endpoints the dashboard already expects. Models, UI, and dependency injection exist — only the router is missing. API key auth covers agents. Unblocks the hosted product.
+
+**No Casdoor deployment needed.**
+
+### Phase 2 (when users exist) — Add OAuth
+
+Google OAuth for human login. Still no Casdoor — just a FastAPI OAuth flow.
+
+### Phase 3 (when orgs need delegation/audit) — Deploy Casdoor
+
+Full Casdoor deployment at `id.openspawn.ai:9000`. Unified identity, task-scoped tokens, delegation chains, provenance tracking. This is when the design above gets implemented.
+
+## Current State (as of 2026-03-10)
+
+| Layer                 | Status                                                          |
+| --------------------- | --------------------------------------------------------------- |
+| Agent HMAC auth       | Done — `X-Agent-ID` + `X-Signature` headers                     |
+| API key auth          | Done — `osp_` prefixed bearer tokens                            |
+| Agent registration    | Done — `POST /agents/register`, returns secret once             |
+| User DB models        | Done — User, RefreshToken, ApiKey, Nonce                        |
+| Dashboard login UI    | Done — login page, auth context, OAuth callback                 |
+| Auth router endpoints | **Not built** — the only missing piece for Phase 1              |
+| Casdoor               | Not deployed — Caddy route to `:9000` exists, nothing behind it |
+
+## Unresolved Questions
+
+- Casdoor storage backend — share Postgres or separate DB?
+- Agent secret rotation policy once on Casdoor?
+- Rate limiting on token refresh for idle agents?
+- How does task `required_scopes` get defined — manual or inferred from task type?

--- a/libs/dashboard-data/src/hooks/use-presence.ts
+++ b/libs/dashboard-data/src/hooks/use-presence.ts
@@ -8,7 +8,7 @@ import { useMemo } from "react";
 import { TaskStatus } from "@openspawn/shared-types";
 import { useAgents } from "./use-agents";
 import { useTasks } from "./use-tasks";
-import { AgentStatus } from "../graphql/generated/hooks";
+import { AgentStatus } from "@openspawn/shared-types";
 
 export enum PresenceStatus {
   Active = "active",
@@ -62,22 +62,26 @@ export function usePresence(): {
 
     // Pick up to 4 active agents (agents with active status + tasks)
     // Mark 1 as error for visual variety
-    const activeAgents = agents.filter((a: { status: string }) => a.status === AgentStatus.Active);
+    const norm = (s: string) => s.toLowerCase();
+    const activeAgents = agents.filter(
+      (a: { status: string }) => norm(a.status) === AgentStatus.ACTIVE,
+    );
     let activeCount = 0;
     let errorSet = false;
 
     for (const agent of agents) {
       const id = agent.id;
+      const s = norm(agent.status);
 
       // Suspended/revoked → error
-      if (agent.status === AgentStatus.Suspended || agent.status === AgentStatus.Revoked) {
+      if (s === AgentStatus.SUSPENDED || s === AgentStatus.REVOKED) {
         map.set(id, { agentId: id, status: PresenceStatus.Error });
         if (!errorSet) errorSet = true;
         continue;
       }
 
       // Has in-progress task → active
-      if (busyAgentIds.has(id) && agent.status === AgentStatus.Active) {
+      if (busyAgentIds.has(id) && s === AgentStatus.ACTIVE) {
         activeCount++;
         map.set(id, {
           agentId: id,
@@ -90,7 +94,7 @@ export function usePresence(): {
       }
 
       // Paused → busy
-      if (agent.status === AgentStatus.Pending) {
+      if (s === AgentStatus.PENDING || s === AgentStatus.PAUSED) {
         map.set(id, { agentId: id, status: PresenceStatus.Busy });
         continue;
       }

--- a/libs/dashboard-data/src/index.ts
+++ b/libs/dashboard-data/src/index.ts
@@ -58,15 +58,48 @@ export { isDemoMode, isSandboxMode } from "./lib/mode";
 // GraphQL fetcher (legacy — kept for demo/sandbox mock compatibility)
 export { fetcher, graphqlClient, setDemoFetcher, setSandboxFetcher } from "./graphql/fetcher";
 
-// GraphQL-generated enums + types (legacy — still used by demo data layer)
+// Enums — canonical source is @openspawn/shared-types, re-exported for convenience
 export {
   AgentMode,
   AgentRole,
   AgentStatus,
+  ReputationLevel,
   TaskPriority,
   TaskStatus,
-  type AgentFieldsFragment,
-} from "./graphql/generated/hooks";
+} from "@openspawn/shared-types";
+
+// Agent type for components — mirrors the GraphQL AgentFieldsFragment shape
+export interface AgentFields {
+  id: string;
+  agentId: string;
+  name: string;
+  role: string;
+  mode: string;
+  status: string;
+  level: number;
+  model: string;
+  currentBalance: number;
+  budgetPeriodLimit?: number | null;
+  budgetPeriodSpent: number;
+  managementFeePct: number;
+  parentId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  trustScore: number;
+  reputationLevel: string;
+  tasksCompleted: number;
+  tasksSuccessful: number;
+  lastActivityAt?: string | null;
+  lastPromotionAt?: string | null;
+  lifetimeEarnings: number;
+  domain?: string | null;
+  teamId?: string | null;
+  avatar?: string | null;
+  avatarColor?: string | null;
+}
+
+/** @deprecated Use AgentFields instead */
+export type AgentFieldsFragment = AgentFields;
 
 // Lib utilities
 export * from "./lib/avatar-utils";

--- a/libs/dashboard-data/src/lib/status-colors.ts
+++ b/libs/dashboard-data/src/lib/status-colors.ts
@@ -1,4 +1,4 @@
-import { AgentStatus, TaskStatus } from "../graphql/generated/hooks";
+import { AgentStatus, TaskStatus } from "@openspawn/shared-types";
 
 /**
  * Shared status → badge variant mapping for agent statuses.
@@ -11,15 +11,18 @@ import { AgentStatus, TaskStatus } from "../graphql/generated/hooks";
  *   default → secondary (slate)
  */
 export function getStatusVariant(
-  status: AgentStatus,
+  status: string,
 ): "success" | "warning" | "destructive" | "secondary" {
-  switch (status) {
-    case AgentStatus.Active:
+  const s = status.toLowerCase();
+  switch (s) {
+    case AgentStatus.ACTIVE:
+    case AgentStatus.BUSY:
       return "success";
-    case AgentStatus.Pending:
+    case AgentStatus.PENDING:
+    case AgentStatus.IDLE:
       return "warning";
-    case AgentStatus.Suspended:
-    case AgentStatus.Revoked:
+    case AgentStatus.SUSPENDED:
+    case AgentStatus.REVOKED:
       return "destructive";
     default:
       return "secondary";
@@ -50,16 +53,19 @@ export function getLevelColor(level: number): string {
  * Task status → badge variant mapping.
  */
 export function getTaskStatusVariant(
-  status: TaskStatus,
+  status: string,
 ): "success" | "warning" | "destructive" | "secondary" {
-  switch (status) {
-    case TaskStatus.Done:
+  const s = status.toLowerCase();
+  switch (s) {
+    case TaskStatus.DONE:
       return "success";
-    case TaskStatus.Review:
-    case TaskStatus.InProgress:
+    case TaskStatus.REVIEW:
+    case TaskStatus.IN_PROGRESS:
+    case TaskStatus.ASSIGNED:
       return "warning";
-    case TaskStatus.Cancelled:
-    case TaskStatus.Blocked:
+    case TaskStatus.CANCELLED:
+    case TaskStatus.BLOCKED:
+    case TaskStatus.REJECTED:
       return "destructive";
     default:
       return "secondary";


### PR DESCRIPTION
## Summary
- **team.openspawn.ai was broken** — REST hooks resolved to `/api` (same-origin) but there's no API on that subdomain, and GraphQL enum values (`"ACTIVE"`) never matched REST data (`"active"`)
- Add Caddy `/api/*` reverse proxy on team subdomain (same pattern as openspawn.ai)
- Replace all GraphQL enum imports with `@openspawn/shared-types` (lowercase values matching REST)
- Normalize all status comparisons with `.toLowerCase()` to handle both demo (UPPERCASE) and live (lowercase) data
- Delete dead `apps/team/src/graphql/` directory
- Add `AgentFields` interface to dashboard-data replacing `AgentFieldsFragment` from GraphQL codegen
- Add agentic-first auth design doc (`docs/plans/2026-03-10-agentic-auth-design.md`)

## Test plan
- [x] `nx build team` passes
- [x] `nx build demo` passes (no breakage to bikinibottom.ai)
- [x] `nx lint team demo dashboard-data` — 0 errors
- [x] `nx test demo` — 23/23 tests pass
- [ ] Deploy and verify team.openspawn.ai loads with live API data
- [ ] Verify bikinibottom.ai still works (demo/sandbox mode unchanged)