### PR TITLE
fix(dashboard): resolve all lint warnings, fix team SPA asset serving

### DIFF
--- a/apps/dashboard/e2e/tests/pages.spec.ts
+++ b/apps/dashboard/e2e/tests/pages.spec.ts
@@ -29,7 +29,9 @@ test.describe("Page Tests", () => {
       expect(first).toBeTruthy();
       expect(second).toBeTruthy();
       // Rows should be stacked vertically, not overlapping
-      expect(second!.y).toBeGreaterThan(first!.y);
+      if (first && second) {
+        expect(second.y).toBeGreaterThan(first.y);
+      }
     }
   });
 

--- a/apps/dashboard/src/app/app.tsx
+++ b/apps/dashboard/src/app/app.tsx
@@ -2,10 +2,10 @@ import { RouterProvider } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NotificationProvider } from "../components";
 import { ThemeProvider } from "../components/theme-provider";
-import { KeyboardShortcutsHelp, useKeyboardShortcuts } from "../components/keyboard-shortcuts";
+
 import { DemoProvider, DemoControls, DemoWelcome } from "../demo";
 import { isSandboxMode } from "@openspawn/dashboard-data";
-import { CommandPalette } from "../components/command-palette";
+
 import { OfflineIndicator } from "../components/offline-indicator";
 
 import { isBBTheme } from "../lib/dashboard-theme";
@@ -62,16 +62,6 @@ function DemoWrapper({ children }: { children: ReactNode }) {
       <DemoWelcome />
       <DemoControls />
     </DemoProvider>
-  );
-}
-
-function KeyboardShortcutsWrapper({ children }: { children: ReactNode }) {
-  const { helpOpen, setHelpOpen } = useKeyboardShortcuts();
-  return (
-    <>
-      {children}
-      <KeyboardShortcutsHelp open={helpOpen} onClose={() => setHelpOpen(false)} />
-    </>
   );
 }
 

--- a/apps/dashboard/src/components/agent-avatar.tsx
+++ b/apps/dashboard/src/components/agent-avatar.tsx
@@ -153,7 +153,7 @@ export function AgentAvatar({
           : undefined
       }
     >
-      <AvatarImage src={avatarUrl!} alt={name || agentId} />
+      <AvatarImage src={avatarUrl ?? undefined} alt={name || agentId} />
       <AvatarFallback style={{ backgroundColor: `${levelColor}20` }}>
         <Bot className="h-1/2 w-1/2" style={{ color: levelColor }} />
       </AvatarFallback>

--- a/apps/dashboard/src/components/agent-detail-panel.tsx
+++ b/apps/dashboard/src/components/agent-detail-panel.tsx
@@ -37,6 +37,25 @@ import { Sparkline, generateSparklineData } from "./ui/sparkline";
 
 type Agent = AgentFieldsFragment;
 
+/** Shape of a message returned by the sandbox /api/agent/:id/messages endpoint */
+interface SandboxMessage {
+  id: string;
+  type: string;
+  from: string;
+  to: string;
+  body?: string;
+  summary?: string;
+  pct?: number | null;
+  timestamp: string;
+}
+
+/** Shape of an agent returned by the sandbox /api/agents endpoint */
+interface SandboxAgent {
+  id: string;
+  agentId: string;
+  systemPrompt?: string;
+}
+
 interface AgentDetailPanelProps {
   agentId: string | null;
   onClose: () => void;
@@ -70,7 +89,6 @@ function OverviewTab({ agent }: { agent: Agent }) {
     [agents, agent.parentId],
   );
 
-  const levelColor = getLevelColor(agent.level);
   const trustScore = agent.trustScore ?? 50;
   const successRate =
     agent.tasksCompleted && agent.tasksCompleted > 0
@@ -484,11 +502,11 @@ function MessagesTab({ agent }: { agent: Agent }) {
   const firstReport = reports[0];
 
   // Fetch real messages from sandbox API when in sandbox mode
-  const { data: sandboxMessages } = useQuery({
+  const { data: sandboxMessages } = useQuery<SandboxMessage[]>({
     queryKey: ["sandbox-agent-messages", agent.agentId],
     queryFn: async () => {
       const res = await fetch(`${SANDBOX_URL}/api/agent/${agent.agentId}/messages`);
-      return res.json();
+      return res.json() as Promise<SandboxMessage[]>;
     },
     enabled: isSandboxMode,
     // Refetch driven by SSE tick_complete (see use-sandbox-tick.ts)
@@ -498,7 +516,6 @@ function MessagesTab({ agent }: { agent: Agent }) {
   const generatedMessages = useMemo(() => {
     if (isSandboxMode) return [];
     const domain = agent.domain ?? "operations";
-    const parentName = parent?.name ?? "Manager";
     const reportName = firstReport?.name;
     const now = Date.now();
 
@@ -593,7 +610,7 @@ function MessagesTab({ agent }: { agent: Agent }) {
             <p>No messages yet</p>
           </div>
         ) : (
-          msgs.map((msg: any, index: number) => {
+          msgs.map((msg, index) => {
             const isSent = msg.from === agent.agentId;
             const style = acpTypeStyles[msg.type] || acpTypeStyles.ack;
             const fromAgent = allAgents.find((a) => a.agentId === msg.from);
@@ -678,20 +695,18 @@ function MessagesTab({ agent }: { agent: Agent }) {
 
 // Prompt Tab Content
 function PromptTab({ agent }: { agent: Agent }) {
-  const { data: sandboxAgents } = useQuery({
+  const { data: sandboxAgents } = useQuery<SandboxAgent[]>({
     queryKey: ["sandbox-agents-for-prompt"],
     queryFn: async () => {
       const res = await fetch(`${SANDBOX_URL}/api/agents`);
-      return res.json();
+      return res.json() as Promise<SandboxAgent[]>;
     },
     enabled: isSandboxMode,
   });
 
   const systemPrompt = useMemo(() => {
     if (!isSandboxMode || !sandboxAgents) return null;
-    const match = sandboxAgents.find(
-      (a: any) => a.agentId === agent.agentId || a.id === agent.agentId,
-    );
+    const match = sandboxAgents.find((a) => a.agentId === agent.agentId || a.id === agent.agentId);
     return match?.systemPrompt || null;
   }, [sandboxAgents, agent.agentId]);
 

--- a/apps/dashboard/src/components/agent-efficiency.tsx
+++ b/apps/dashboard/src/components/agent-efficiency.tsx
@@ -83,11 +83,6 @@ export function AgentEfficiencyLeaderboard() {
     return results.slice(0, 8);
   }, [agents, tasks]);
 
-  const maxEfficiency = useMemo(() => {
-    const vals = efficiencyData.filter((a) => a.efficiency !== null).map((a) => a.efficiency!);
-    return vals.length > 0 ? Math.max(...vals) : 1;
-  }, [efficiencyData]);
-
   const handleRowClick = (agentId: string) => {
     openSidePanel(<AgentDetailPanel agentId={agentId} onClose={closeSidePanel} />, { width: 520 });
   };
@@ -150,9 +145,6 @@ export function AgentEfficiencyLeaderboard() {
             color: "text-muted-foreground/70",
             bg: "bg-muted/50",
           };
-          const RankIcon = rankConfig.icon;
-          const efficiencyPercent =
-            agent.efficiency !== null ? (agent.efficiency / maxEfficiency) * 100 : 0;
           const progressPercent =
             agent.totalAssigned > 0 ? (agent.tasksCompleted / agent.totalAssigned) * 100 : 0;
 

--- a/apps/dashboard/src/components/agent-heartbeat.tsx
+++ b/apps/dashboard/src/components/agent-heartbeat.tsx
@@ -16,8 +16,8 @@ interface AgentHeartbeatProps {
 }
 
 export function AgentHeartbeat({
-  agentId,
-  level,
+  agentId: _agentId,
+  level: _level,
   status,
   size = "md",
   showPulse = true,

--- a/apps/dashboard/src/components/agent-network.tsx
+++ b/apps/dashboard/src/components/agent-network.tsx
@@ -27,8 +27,13 @@ import { useDemo } from "../demo";
 import { isSandboxMode } from "@openspawn/dashboard-data";
 import { useSandboxSSE, type SandboxSSEEvent } from "../hooks/use-sandbox-sse";
 import { useAgents, type Agent } from "../hooks/use-agents";
-import { useTasks } from "../hooks/use-tasks";
-import { useMessages, useConversations } from "../hooks/use-messages";
+import { useTasks, type Task } from "../hooks/use-tasks";
+import {
+  useMessages,
+  useConversations,
+  type Message,
+  type Conversation,
+} from "../hooks/use-messages";
 import { resolveAvatarUrl } from "../lib/resolve-avatar-url";
 import { useAgentHealth } from "../hooks/use-agent-health";
 import { useTouchDevice } from "../hooks/use-touch-device";
@@ -96,16 +101,16 @@ async function getLayoutedElements(
 
 function calculateAgentActivity(
   agents: Agent[],
-  tasks: any[],
-  messages: any[],
-  conversations: any[],
+  tasks: Task[],
+  messages: Message[],
+  conversations: Conversation[],
 ): Map<string, AgentActivity> {
   const activityMap = new Map<string, AgentActivity>();
 
   const taskCounts = new Map<string, number>();
   tasks.forEach((task) => {
-    if (task.assignedToId)
-      taskCounts.set(task.assignedToId, (taskCounts.get(task.assignedToId) || 0) + 1);
+    if (task.assigneeId)
+      taskCounts.set(task.assigneeId, (taskCounts.get(task.assigneeId) || 0) + 1);
   });
 
   const messageCounts = new Map<string, number>();
@@ -134,8 +139,8 @@ function calculateAgentActivity(
 }
 
 function calculateEdgeMessages(
-  messages: any[],
-  conversations: any[],
+  messages: Message[],
+  conversations: Conversation[],
 ): Map<string, EdgeMessageData> {
   const edgeMap = new Map<string, EdgeMessageData>();
 
@@ -306,7 +311,7 @@ function AgentNetworkInner({ className, onAgentClick }: AgentNetworkProps) {
   const { tasks, loading: tasksLoading } = useTasks();
   const { messages } = useMessages(100);
   const { conversations } = useConversations();
-  const { fitView, zoomIn, setCenter } = useReactFlow();
+  const { fitView, setCenter } = useReactFlow();
   const { isMobileOrTouch, isMobile } = useTouchDevice();
 
   const [selectedEdge, setSelectedEdge] = useState<{
@@ -455,7 +460,7 @@ function AgentNetworkInner({ className, onAgentClick }: AgentNetworkProps) {
     if (node.id !== "human") onAgentClick?.(node.id);
   }
 
-  function handleNodeMouseDown(_event: React.MouseEvent, node: Node) {
+  function handleNodeMouseDown(_event: React.MouseEvent, node: Node, _nodes: Node[]) {
     if (!isMobileOrTouch) return;
     longPressNodeRef.current = node.id;
     longPressTimerRef.current = setTimeout(() => {
@@ -463,12 +468,20 @@ function AgentNetworkInner({ className, onAgentClick }: AgentNetworkProps) {
     }, 500);
   }
 
-  function handleNodeMouseUp() {
+  function clearLongPress() {
     if (longPressTimerRef.current) {
       clearTimeout(longPressTimerRef.current);
       longPressTimerRef.current = null;
     }
     longPressNodeRef.current = null;
+  }
+
+  function handleNodeMouseUp(_event: React.MouseEvent, _node: Node, _nodes: Node[]) {
+    clearLongPress();
+  }
+
+  function handleNodeMouseLeave(_event: React.MouseEvent, _node: Node) {
+    clearLongPress();
   }
 
   function handleEdgeClick(_event: React.MouseEvent, edge: Edge) {
@@ -523,7 +536,7 @@ function AgentNetworkInner({ className, onAgentClick }: AgentNetworkProps) {
           onEdgesChange={onEdgesChange}
           onNodeClick={handleNodeClick}
           onNodeMouseEnter={undefined}
-          onNodeMouseLeave={handleNodeMouseUp}
+          onNodeMouseLeave={handleNodeMouseLeave}
           onEdgeClick={handleEdgeClick}
           edgeTypes={edgeTypes}
           nodeTypes={nodeTypes}
@@ -544,8 +557,8 @@ function AgentNetworkInner({ className, onAgentClick }: AgentNetworkProps) {
             markerEnd: { type: MarkerType.ArrowClosed, color: "#6366f1" },
             style: { stroke: "#6366f1", strokeWidth: 2 },
           }}
-          onNodeDragStart={handleNodeMouseDown as any}
-          onNodeDragStop={handleNodeMouseUp as any}
+          onNodeDragStart={handleNodeMouseDown}
+          onNodeDragStop={handleNodeMouseUp}
         >
           <Background
             variant={BackgroundVariant.Dots}

--- a/apps/dashboard/src/components/budget-burndown.tsx
+++ b/apps/dashboard/src/components/budget-burndown.tsx
@@ -64,10 +64,8 @@ export function BudgetBurndown({ budget, spent, periodDays, daysElapsed }: Budge
   const dailyRate = spent / daysElapsed;
   const projectedTotal = dailyRate * periodDays;
   const projectedOver = projectedTotal > budget;
-  const percentUsed = (spent / budget) * 100;
   const daysRemaining = periodDays - daysElapsed;
   const budgetRemaining = budget - spent;
-  const dailyBudgetRemaining = budgetRemaining / daysRemaining;
 
   // Calculate runway
   const runwayDays = budgetRemaining / dailyRate;

--- a/apps/dashboard/src/components/budget-manager.tsx
+++ b/apps/dashboard/src/components/budget-manager.tsx
@@ -64,7 +64,6 @@ export function BudgetManager({ onAgentClick }: { onAgentClick?: (id: string) =>
   const [targetAgent, setTargetAgent] = useState("");
 
   const alertBudgets = budgets.filter((b) => (b.utilizationPercent || 0) >= 80);
-  const healthyBudgets = budgets.filter((b) => (b.utilizationPercent || 0) < 80);
 
   const handleTransfer = async () => {
     setTransferring(true);
@@ -119,7 +118,7 @@ export function BudgetManager({ onAgentClick }: { onAgentClick?: (id: string) =>
                     <Badge
                       variant="outline"
                       className={
-                        budget.utilizationPercent! >= 90
+                        (budget.utilizationPercent ?? 0) >= 90
                           ? "border-red-500 text-red-500"
                           : "border-amber-500 text-amber-500"
                       }

--- a/apps/dashboard/src/components/kanban/KanbanBoard.tsx
+++ b/apps/dashboard/src/components/kanban/KanbanBoard.tsx
@@ -6,9 +6,8 @@ import {
   type TaskPriority,
 } from "../../hooks/use-mcp-tasks";
 import { Badge } from "../ui/badge";
-import { Card, CardContent } from "../ui/card";
 import { cn } from "../../lib/utils";
-import { Clock, User, X, AlertTriangle, ChevronDown, ChevronUp, Wifi, WifiOff } from "lucide-react";
+import { Clock, X, ChevronDown, ChevronUp, Wifi, WifiOff } from "lucide-react";
 
 const COLUMNS: { key: TaskStatus; label: string; color: string; bg: string; border: string }[] = [
   {
@@ -196,7 +195,7 @@ function TaskDetail({ task, onClose }: { task: KanbanTask; onClose: () => void }
 }
 
 export function KanbanBoard() {
-  const { tasks, connected, error } = useMcpTasks();
+  const { tasks, connected, error: _error } = useMcpTasks();
   const [selectedTask, setSelectedTask] = useState<KanbanTask | null>(null);
   const [collapsedCols, setCollapsedCols] = useState<Set<TaskStatus>>(new Set());
 

--- a/apps/dashboard/src/components/keyboard-shortcuts.tsx
+++ b/apps/dashboard/src/components/keyboard-shortcuts.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { motion, AnimatePresence } from "motion/react";
 import { Command, X } from "lucide-react";
-import { cn } from "../lib/utils";
 
 interface Shortcut {
   key: string;

--- a/apps/dashboard/src/components/layout.tsx
+++ b/apps/dashboard/src/components/layout.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useSandboxTickInvalidation } from "../hooks/use-sandbox-tick";
 import { Logo } from "./ui/logo";
-import { Link, useLocation, useSearch, useNavigate } from "@tanstack/react-router";
+import { Link, useLocation, useSearch } from "@tanstack/react-router";
 import { motion } from "motion/react";
 import {
   LayoutDashboard,
@@ -131,7 +131,6 @@ function useSidebarCollapsed() {
 export function Layout({ children }: LayoutProps) {
   const location = useLocation();
   const searchParams = useSearch({ strict: false }) as Record<string, string | undefined>;
-  const navigate = useNavigate();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const demo = useDemo();
   const isDemo = searchParams?.demo === "true";
@@ -473,7 +472,7 @@ export function Layout({ children }: LayoutProps) {
                     </DropdownMenuLabel>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem asChild>
-                      <Link to={"/settings/profile" as any} className="flex items-center gap-2">
+                      <Link to="/settings" className="flex items-center gap-2">
                         <User className="h-4 w-4" />
                         Profile
                       </Link>
@@ -521,7 +520,7 @@ export function Layout({ children }: LayoutProps) {
                     </DropdownMenuLabel>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem asChild>
-                      <Link to={"/settings/profile" as any} className="flex items-center gap-2">
+                      <Link to="/settings" className="flex items-center gap-2">
                         <User className="h-4 w-4" />
                         Profile
                       </Link>

--- a/apps/dashboard/src/components/live/org-chart-live.tsx
+++ b/apps/dashboard/src/components/live/org-chart-live.tsx
@@ -395,7 +395,6 @@ function buildGraph(
   // Add edge from SpongeBob to pool node (aggregates all spawn animations)
   if (spawnedAgents.length > 0) {
     const poolParent = "spongebob-squarepants";
-    const poolKey = `${poolParent}-grill-station-pool`;
 
     // Aggregate all spawn animations to show on the pool edge
     const poolAnimations: EdgeAnimation[] = [];

--- a/apps/dashboard/src/components/model-router-widget.tsx
+++ b/apps/dashboard/src/components/model-router-widget.tsx
@@ -35,12 +35,6 @@ const PROVIDER_COLORS: Record<string, string> = {
   anthropic: "text-orange-400",
 };
 
-const PROVIDER_BG: Record<string, string> = {
-  ollama: "bg-emerald-500/20",
-  groq: "bg-amber-500/20",
-  openrouter: "bg-violet-500/20",
-};
-
 const PROVIDER_BAR: Record<string, string> = {
   ollama: "bg-emerald-500",
   groq: "bg-amber-500",

--- a/apps/dashboard/src/components/model-usage.tsx
+++ b/apps/dashboard/src/components/model-usage.tsx
@@ -60,8 +60,6 @@ export function ModelUsageBreakdown() {
 
   const totalCalls = modelUsage.reduce((sum, m) => sum + m.calls, 0);
   const totalCost = modelUsage.reduce((sum, m) => sum + m.cost, 0);
-  const totalTokens = modelUsage.reduce((sum, m) => sum + m.tokens, 0);
-
   const sortedByUsage = [...modelUsage].sort((a, b) => b.calls - a.calls);
 
   let startAngle = 0;

--- a/apps/dashboard/src/components/org-chart.tsx
+++ b/apps/dashboard/src/components/org-chart.tsx
@@ -524,7 +524,6 @@ function OrgChartInner({
   const [isLayouted, setIsLayouted] = useState(false);
   const baseEdgesRef = useRef<Edge[]>([]);
   const previousAgentIdsRef = useRef<Set<string>>(new Set());
-  const [newAgentIds, setNewAgentIds] = useState<Set<string>>(new Set());
 
   // Only re-layout when agent IDs change (add/remove), not on every data update
   const agentIds = useMemo(
@@ -539,20 +538,7 @@ function OrgChartInner({
   useEffect(() => {
     if (loading) return;
 
-    // Detect new agents
     const currentIds = new Set(agents.map((a) => a.id));
-    const prevIds = previousAgentIdsRef.current;
-    if (prevIds.size > 0) {
-      const freshIds = new Set<string>();
-      currentIds.forEach((id) => {
-        if (!prevIds.has(id)) freshIds.add(id);
-      });
-      if (freshIds.size > 0) {
-        setNewAgentIds(freshIds);
-        // Clear highlight after 2.5s
-        setTimeout(() => setNewAgentIds(new Set()), 2500);
-      }
-    }
     previousAgentIdsRef.current = currentIds;
 
     const { nodes: rawNodes, edges: rawEdges } = buildOrgGraph(teams, agents);
@@ -649,7 +635,7 @@ function OrgChartInner({
       setEdges((prev) =>
         prev.map((e) => {
           const shouldAnimate = animatedIds.has(e.id);
-          const wasAnimated = (e.data as any)?.animated;
+          const wasAnimated = e.data?.animated;
           if (shouldAnimate === wasAnimated) return e;
           return { ...e, data: { ...((e.data as object) || {}), animated: shouldAnimate } };
         }),
@@ -658,7 +644,7 @@ function OrgChartInner({
       setTimeout(() => {
         setEdges((prev) =>
           prev.map((e) => {
-            if (!(e.data as any)?.animated) return e;
+            if (!e.data?.animated) return e;
             return { ...e, data: { ...((e.data as object) || {}), animated: false } };
           }),
         );

--- a/apps/dashboard/src/components/protected-route.tsx
+++ b/apps/dashboard/src/components/protected-route.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from "@tanstack/react-router";
+import { Navigate } from "@tanstack/react-router";
 
 import { useAuth } from "../contexts";
 
@@ -9,7 +9,6 @@ interface ProtectedRouteProps {
 
 export function ProtectedRoute({ children, requiredRole }: ProtectedRouteProps) {
   const { isAuthenticated, isLoading, user } = useAuth();
-  const location = useLocation();
 
   // Show loading state while checking auth
   if (isLoading) {

--- a/apps/dashboard/src/components/self-claim-button.tsx
+++ b/apps/dashboard/src/components/self-claim-button.tsx
@@ -107,7 +107,7 @@ export function SelfClaimButton({ agentId, size = "md", showCount = true, onClai
 
 export function SelfClaimHero({
   agentId,
-  agentName,
+  agentName: _agentName,
   onClaimSuccess,
 }: {
   agentId: string;

--- a/apps/dashboard/src/components/settings/github-settings.tsx
+++ b/apps/dashboard/src/components/settings/github-settings.tsx
@@ -29,7 +29,6 @@ import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { cn } from "../../lib/utils";
 import { useNotifications } from "../live-notifications";
-import { useDemo } from "../../demo";
 
 interface GitHubConnectionData {
   id: string;
@@ -163,7 +162,6 @@ const MOCK_LINKS: IntegrationLinkData[] = [
 ];
 
 export function GitHubSettings() {
-  const { scenario } = useDemo();
   const { addNotification } = useNotifications();
   const [connections, setConnections] = useState<GitHubConnectionData[]>(MOCK_CONNECTIONS);
   const [links] = useState<IntegrationLinkData[]>(MOCK_LINKS);

--- a/apps/dashboard/src/components/settings/inbound-webhooks-settings.tsx
+++ b/apps/dashboard/src/components/settings/inbound-webhooks-settings.tsx
@@ -29,7 +29,6 @@ import { Label } from "../ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { cn } from "../../lib/utils";
 import { useNotifications } from "../live-notifications";
-import { useDemo } from "../../demo";
 
 enum TaskPriority {
   Low = "LOW",
@@ -101,7 +100,6 @@ interface CreateFormData {
 }
 
 export function InboundWebhooksSettings() {
-  const { scenario } = useDemo();
   const { addNotification } = useNotifications();
   const [webhookKeys, setWebhookKeys] = useState<InboundWebhookKeyData[]>(MOCK_WEBHOOK_KEYS);
   const [agents] = useState<AgentData[]>(MOCK_AGENTS);

--- a/apps/dashboard/src/components/settings/security-settings.tsx
+++ b/apps/dashboard/src/components/settings/security-settings.tsx
@@ -103,7 +103,7 @@ export function SecuritySettings() {
           throw new Error(error.message || "Failed to setup 2FA");
         }
 
-        const data = await response.json();
+        const _data = await response.json();
         // In a real implementation, show the QR code and recovery codes
         setTwoFaStatus({
           type: "success",

--- a/apps/dashboard/src/components/task-timeline.tsx
+++ b/apps/dashboard/src/components/task-timeline.tsx
@@ -18,7 +18,7 @@ import {
   ChevronRight,
   ArrowRight,
 } from "lucide-react";
-import { Card, CardTitle } from "./ui/card";
+import { Card } from "./ui/card";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { AgentAvatar } from "./agent-avatar";
@@ -43,10 +43,18 @@ interface TimelineEvent {
   color: string;
 }
 
+interface TimelineAgentInfo {
+  name: string;
+  level: number;
+  avatar?: string | null;
+  avatarUrl?: string | null;
+  avatarColor?: string | null;
+}
+
 function buildTimelineEvents(
   task: Task,
   messages: Message[],
-  agentMap: Map<string, { name: string; level: number }>,
+  agentMap: Map<string, TimelineAgentInfo>,
 ): TimelineEvent[] {
   const events: TimelineEvent[] = [];
 
@@ -260,7 +268,7 @@ function TaskTimelineRow({
 }: {
   task: Task;
   messages: Message[];
-  agentMap: Map<string, { name: string; level: number }>;
+  agentMap: Map<string, TimelineAgentInfo>;
   onAgentClick?: (id: string) => void;
   defaultOpen?: boolean;
 }) {
@@ -305,9 +313,9 @@ function TaskTimelineRow({
               name={agentMap.get(task.assigneeId)?.name || "?"}
               level={agentMap.get(task.assigneeId)?.level || 1}
               size="sm"
-              avatar={(agentMap.get(task.assigneeId) as any)?.avatar}
-              avatarUrl={(agentMap.get(task.assigneeId) as any)?.avatarUrl}
-              avatarColor={(agentMap.get(task.assigneeId) as any)?.avatarColor}
+              avatar={agentMap.get(task.assigneeId)?.avatar}
+              avatarUrl={agentMap.get(task.assigneeId)?.avatarUrl}
+              avatarColor={agentMap.get(task.assigneeId)?.avatarColor}
             />
           )}
         </div>
@@ -373,7 +381,10 @@ function TaskTimelineRow({
                     )}
                     {selectedEvent.agentId && onAgentClick && (
                       <button
-                        onClick={() => onAgentClick(selectedEvent.agentId!)}
+                        onClick={() => {
+                          const id = selectedEvent.agentId;
+                          if (id) onAgentClick(id);
+                        }}
                         className="mt-2 pl-8 text-xs text-primary hover:underline flex items-center gap-1"
                       >
                         View {selectedEvent.agentName || "agent"} <ArrowRight className="h-3 w-3" />
@@ -400,8 +411,16 @@ export function TaskTimeline({ onAgentClick }: { onAgentClick?: (id: string) => 
   const [limit, setLimit] = useState(10);
 
   const agentMap = useMemo(() => {
-    const map = new Map<string, { name: string; level: number }>();
-    agents.forEach((a) => map.set(a.id, { name: a.name, level: a.level }));
+    const map = new Map<string, TimelineAgentInfo>();
+    agents.forEach((a) =>
+      map.set(a.id, {
+        name: a.name,
+        level: a.level,
+        avatar: a.avatar,
+        avatarUrl: a.avatarUrl,
+        avatarColor: a.avatarColor,
+      }),
+    );
     return map;
   }, [agents]);
 

--- a/apps/dashboard/src/components/team-detail-panel.tsx
+++ b/apps/dashboard/src/components/team-detail-panel.tsx
@@ -34,9 +34,8 @@ import { AgentAvatar } from "./agent-avatar";
 import { AgentModeBadge } from "./agent-mode-selector";
 import { Progress } from "./ui/progress";
 import { getStatusVariant } from "../lib/status-colors";
-import { type Team, getTeamById, getSubTeams, getParentTeams, getTeamColor } from "../demo/teams";
+import { getTeamById, getSubTeams, getParentTeams, getTeamColor } from "../demo/teams";
 import { useAgents } from "../hooks/use-agents";
-import { useTeamStats } from "../hooks/use-teams";
 import { AgentMode, AgentStatus } from "@openspawn/shared-types";
 import { TeamDialog, DeleteTeamDialog } from "./team-management";
 import { Button } from "./ui/button";
@@ -71,7 +70,6 @@ export function TeamDetailPanel({ teamId, onAgentClick, onTeamClick }: TeamDetai
   const team = useMemo(() => getTeamById(teamId), [teamId]);
   const subTeams = useMemo(() => getSubTeams(teamId), [teamId]);
   const { agents } = useAgents();
-  const stats = useTeamStats(teamId);
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const parentTeams = useMemo(() => getParentTeams(), []);

--- a/apps/dashboard/src/components/team-management.tsx
+++ b/apps/dashboard/src/components/team-management.tsx
@@ -2,12 +2,8 @@
  * Team CRUD — create, edit, delete teams from the dashboard.
  * In demo mode, changes persist to localStorage.
  */
-import { useState, useMemo } from "react";
-import { motion } from "motion/react";
+import { useState } from "react";
 import {
-  Plus,
-  Pencil,
-  Trash2,
   Users,
   Crown,
   Code2,
@@ -29,7 +25,6 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { Button } from "./ui/button";
-import { Badge } from "./ui/badge";
 import {
   Dialog,
   DialogPopup,
@@ -39,13 +34,7 @@ import {
   DialogDescription,
   DialogClose,
 } from "./ui/dialog";
-import {
-  type Team,
-  teams as allTeams,
-  getParentTeams,
-  getTeamColor,
-  TEAM_COLOR_MAP,
-} from "../demo/teams";
+import { type Team, getTeamColor, TEAM_COLOR_MAP } from "../demo/teams";
 import { useAgents } from "../hooks/use-agents";
 import { cn } from "../lib/utils";
 

--- a/apps/dashboard/src/components/theme-provider.tsx
+++ b/apps/dashboard/src/components/theme-provider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from "react";
 
-import { DASHBOARD_THEME, isOpenSpawnTheme } from "../lib/dashboard-theme";
+import { isOpenSpawnTheme } from "../lib/dashboard-theme";
 
 // Named ocean themes
 export const THEME_NAMES = [

--- a/apps/dashboard/src/components/thread-view.tsx
+++ b/apps/dashboard/src/components/thread-view.tsx
@@ -10,7 +10,7 @@ import { Badge } from "./ui/badge";
 import { cn } from "../lib/utils";
 import { darkenForBackground } from "../lib/avatar-utils";
 import { resolveAvatarUrl } from "../lib/resolve-avatar-url";
-import { useAgents, type Message } from "../hooks";
+import { useAgents, type Agent, type Message } from "../hooks";
 
 interface ThreadViewProps {
   /** All messages in this conversation (between two agents) */
@@ -78,8 +78,8 @@ function formatThreadTime(dateStr: string) {
 export function ThreadView({ messages, onClose }: ThreadViewProps) {
   const { agents } = useAgents();
   const agentMap = useMemo(() => {
-    const map = new Map<string, any>();
-    agents.forEach((a: any) => map.set(a.id, a));
+    const map = new Map<string, Agent>();
+    agents.forEach((a) => map.set(a.id, a));
     return map;
   }, [agents]);
 
@@ -160,7 +160,7 @@ export function ThreadView({ messages, onClose }: ThreadViewProps) {
               const sender = msg.fromAgent;
               const showAvatar = idx === 0 || sorted[idx - 1].fromAgentId !== msg.fromAgentId;
 
-              const acpType = (msg as any).acpType as string | undefined;
+              const acpType = msg.acpType;
               const acpStyle = acpType ? acpStyles[acpType] : undefined;
 
               // Compact ack chip
@@ -248,7 +248,7 @@ export function ThreadView({ messages, onClose }: ThreadViewProps) {
                     )}
                     {acpType === "escalation" && (
                       <p className="text-xs font-medium text-red-400 mb-0.5">
-                        ⚠️ Escalated: {(msg as any).reason || "unknown"}
+                        ⚠️ Escalated: {msg.reason || "unknown"}
                       </p>
                     )}
                     {acpType === "completion" && (
@@ -256,7 +256,7 @@ export function ThreadView({ messages, onClose }: ThreadViewProps) {
                     )}
                     {acpType === "progress" && (
                       <p className="text-xs font-medium text-muted-foreground mb-0.5">
-                        📊 Progress{(msg as any).pct != null ? ` (${(msg as any).pct}%)` : ""}
+                        📊 Progress{msg.pct != null ? ` (${msg.pct}%)` : ""}
                       </p>
                     )}
                     <p className="text-xs md:text-sm text-foreground/90 leading-relaxed">

--- a/apps/dashboard/src/components/timeline-view.tsx
+++ b/apps/dashboard/src/components/timeline-view.tsx
@@ -390,8 +390,12 @@ export function TimelineView({ events: eventsProp, agentId, className }: Timelin
     const map = new Map<string, TimelineEvent[]>();
     for (const ev of events) {
       const key = ev.taskId ?? "__general__";
-      if (!map.has(key)) map.set(key, []);
-      map.get(key)!.push(ev);
+      const existing = map.get(key);
+      if (existing) {
+        existing.push(ev);
+      } else {
+        map.set(key, [ev]);
+      }
     }
     return Array.from(map.entries()).map(([taskId, evts]) => ({
       taskId: taskId === "__general__" ? null : taskId,

--- a/apps/dashboard/src/demo/DemoControls.tsx
+++ b/apps/dashboard/src/demo/DemoControls.tsx
@@ -329,61 +329,68 @@ export function DemoControls({ compact = false, header = false }: DemoControlsPr
   );
 }
 
-function EventLabel({ event }: { event: { type: string; payload: any } }) {
+function isRecord(val: unknown): val is Record<string, unknown> {
+  return typeof val === "object" && val !== null;
+}
+
+function EventLabel({ event }: { event: { type: string; payload: unknown } }) {
+  const p = isRecord(event.payload) ? event.payload : {};
+  const agent = isRecord(p.agent) ? p.agent : {};
+  const task = isRecord(p.task) ? p.task : {};
   switch (event.type) {
     case "agent_created":
       return (
         <span className="text-green-500">
-          🤖 <strong>{event.payload.name}</strong> spawned
+          🤖 <strong>{String(p.name ?? "")}</strong> spawned
         </span>
       );
     case "agent_promoted":
       return (
         <span className="text-blue-500">
-          ⬆️ <strong>{event.payload.agent.name}</strong> promoted to L{event.payload.newLevel}
+          ⬆️ <strong>{String(agent.name ?? "")}</strong> promoted to L{String(p.newLevel ?? "")}
         </span>
       );
     case "agent_terminated":
       return (
         <span className="text-orange-500">
-          ⏸️ <strong>{event.payload.agent.name}</strong> → {event.payload.newStatus}
+          ⏸️ <strong>{String(agent.name ?? "")}</strong> → {String(p.newStatus ?? "")}
         </span>
       );
     case "task_created":
       return (
         <span className="text-purple-500">
-          📋 Task created: <strong>{event.payload.title}</strong>
+          📋 Task created: <strong>{String(p.title ?? "")}</strong>
         </span>
       );
     case "task_completed":
       return (
         <span className="text-emerald-500">
-          ✅ Task done: <strong>{event.payload.task.title}</strong>
+          ✅ Task done: <strong>{String(task.title ?? "")}</strong>
         </span>
       );
     case "credit_earned":
       return (
         <span className="text-yellow-500">
-          💰 <strong>{event.payload.agent.name}</strong> earned {event.payload.amount} credits
+          💰 <strong>{String(agent.name ?? "")}</strong> earned {String(p.amount ?? "")} credits
         </span>
       );
     case "credit_spent":
       return (
         <span className="text-red-400">
-          💸 <strong>{event.payload.agent.name}</strong> spent {event.payload.amount} credits
+          💸 <strong>{String(agent.name ?? "")}</strong> spent {String(p.amount ?? "")} credits
         </span>
       );
     case "prehook_blocked":
       return (
         <span className="text-amber-500">
-          🛡️ <strong>{event.payload.webhookName}</strong> blocked:{" "}
-          {event.payload.reason || event.payload.eventType}
+          🛡️ <strong>{String(p.webhookName ?? "")}</strong> blocked:{" "}
+          {String(p.reason || p.eventType || "")}
         </span>
       );
     case "prehook_allowed":
       return (
         <span className="text-green-400">
-          ✓ <strong>{event.payload.webhookName}</strong> approved {event.payload.eventType}
+          ✓ <strong>{String(p.webhookName ?? "")}</strong> approved {String(p.eventType ?? "")}
         </span>
       );
     default:

--- a/apps/dashboard/src/hooks/use-teams.ts
+++ b/apps/dashboard/src/hooks/use-teams.ts
@@ -1,12 +1,5 @@
 import { useMemo } from "react";
-import {
-  teams,
-  type Team,
-  getParentTeams,
-  getSubTeams,
-  getTeamById,
-  getTeamColor,
-} from "../demo/teams";
+import { teams, getParentTeams, getSubTeams, getTeamById, getTeamColor } from "../demo/teams";
 import { useAgents, type Agent } from "./use-agents";
 
 export type { Team } from "../demo/teams";

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from "react";
 import * as ReactDOM from "react-dom/client";
 import App from "./app/app";
 import { AppErrorBoundary } from "./components/error-boundary";

--- a/apps/dashboard/src/pages/agent-virtual-grid.tsx
+++ b/apps/dashboard/src/pages/agent-virtual-grid.tsx
@@ -137,7 +137,7 @@ export function AgentVirtualGrid({ filteredAgents, onCardClick, onAction }: Agen
                               </p>
                               {presenceMap.get(agent.id)?.currentTask && (
                                 <p className="text-[10px] text-emerald-400 truncate max-w-[160px]">
-                                  working on: {presenceMap.get(agent.id)!.currentTask}
+                                  working on: {presenceMap.get(agent.id)?.currentTask}
                                 </p>
                               )}
                             </div>

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -21,7 +21,7 @@ import {
   Network,
 } from "lucide-react";
 import { Button } from "../components/ui/button";
-import { Sparkline, generateSparklineData } from "../components/ui/sparkline";
+import { generateSparklineData } from "../components/ui/sparkline";
 import { PageHeader } from "../components/ui/page-header";
 import { StatCard } from "../components/ui/stat-card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs";
@@ -52,14 +52,6 @@ import { AgentVirtualGrid } from "./agent-virtual-grid";
 type Agent = AgentFieldsFragment;
 
 import { DialogModeValue, type DialogMode, SortDirection } from "../lib/enums";
-
-enum AgentAgentSortField {
-  Name = "name",
-  Level = "level",
-  Balance = "balance",
-  Status = "status",
-  Created = "created",
-}
 
 // Suppress unused-variable warning for usePresence (destructured but not used directly in JSX)
 void usePresence;

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useRef, useCallback, type ReactNode } from "react";
+import { useMemo, useState, useEffect, useRef, useCallback } from "react";
 
 import { useNavigate, Link } from "@tanstack/react-router";
 import { motion, AnimatePresence } from "motion/react";
@@ -29,7 +29,6 @@ import { useAgents } from "../hooks/use-agents";
 import { useTasks } from "../hooks/use-tasks";
 import { useCredits } from "../hooks/use-credits";
 import { useEvents } from "../hooks/use-events";
-import { EmptyState } from "../components/ui/empty-state";
 import { useDemo, PROJECT_PHASES } from "../demo/DemoProvider";
 import { useSparklines } from "../hooks/use-sandbox-metrics";
 import { useACPMetrics } from "../hooks/use-acp-metrics";
@@ -176,40 +175,8 @@ export function DashboardPage() {
     [transactions],
   );
 
-  // Real task status counts from simulation (normalized to uppercase)
-  const tasksByStatus = useMemo(
-    () => [
-      {
-        status: "Backlog",
-        count: tasks.filter((t) => t.status?.toUpperCase() === "BACKLOG").length,
-        fill: "#64748b",
-      },
-      {
-        status: "To Do",
-        count: tasks.filter((t) => t.status?.toUpperCase() === "TODO").length,
-        fill: "#f59e0b",
-      },
-      {
-        status: "In Progress",
-        count: tasks.filter((t) => t.status?.toUpperCase() === "IN_PROGRESS").length,
-        fill: "#06b6d4",
-      },
-      {
-        status: "Review",
-        count: tasks.filter((t) => t.status?.toUpperCase() === "REVIEW").length,
-        fill: "#8b5cf6",
-      },
-      {
-        status: "Done",
-        count: tasks.filter((t) => t.status?.toUpperCase() === "DONE").length,
-        fill: "#10b981",
-      },
-    ],
-    [tasks],
-  );
-
   // Real credit flow - aggregate last N transactions into buckets
-  const creditHistory = useMemo(() => {
+  const _creditHistory = useMemo(() => {
     // Group transactions into time buckets (last 10 "periods")
     const bucketCount = 8;
     const sortedTx = [...transactions].sort(

--- a/apps/dashboard/src/pages/live-view.tsx
+++ b/apps/dashboard/src/pages/live-view.tsx
@@ -35,10 +35,8 @@ import {
   agentRegister,
   escalate,
   eventList,
-  taskList,
-  McpError,
 } from "../services/mcp-client";
-import { useMcpOrgStatus } from "../hooks/use-mcp";
+
 import "../components/controls/control-animations.css";
 
 // ── Variable tick timing ──────────────────────────────────────────────────────
@@ -944,7 +942,6 @@ export function LiveViewPage() {
     console.log("[LiveView] view-plan: opening PLAN.md");
   }, []);
 
-  const mcpOrg = useMcpOrgStatus();
   const replay = useReplay();
   const annotation = getActiveAnnotation(replay.tick);
 

--- a/apps/dashboard/src/pages/message-communication-graph.tsx
+++ b/apps/dashboard/src/pages/message-communication-graph.tsx
@@ -21,12 +21,12 @@ import { ScrollArea } from "../components/ui/scroll-area";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { isSandboxMode } from "@openspawn/dashboard-data";
 import { useSandboxSSE, type SandboxSSEEvent } from "../hooks/use-sandbox-sse";
-import type { Message } from "../hooks";
+import type { Agent, Message } from "../hooks";
 import { InlineAvatar, formatTime } from "./message-utils";
 
 interface CommunicationGraphProps {
   messages: Message[];
-  agents: any[];
+  agents: Agent[];
 }
 
 export function CommunicationGraph({ messages, agents }: CommunicationGraphProps) {

--- a/apps/dashboard/src/pages/message-context-filter.tsx
+++ b/apps/dashboard/src/pages/message-context-filter.tsx
@@ -11,12 +11,12 @@ import { ScrollArea } from "../components/ui/scroll-area";
 import { cn } from "../lib/utils";
 import { useTeams } from "../hooks";
 import { TeamFilterDropdown } from "../components/team-badge";
-import type { Message } from "../hooks";
+import type { Agent, Message } from "../hooks";
 import { InlineAvatar, formatTime, typeColors, typeIcons } from "./message-utils";
 
 interface ContextLinkedMessagesProps {
   messages: Message[];
-  agents: any[];
+  agents: Agent[];
   onViewThread: (convoKey: string) => void;
 }
 
@@ -43,7 +43,7 @@ export function ContextLinkedMessages({
 
   const teamAgentIds = useMemo(() => {
     if (teamFilter === "all") return null;
-    return new Set(agents.filter((a: any) => a.teamId === teamFilter).map((a: any) => a.id));
+    return new Set(agents.filter((a) => a.teamId === teamFilter).map((a) => a.id));
   }, [agents, teamFilter]);
 
   const filteredMessages = messages.filter((msg) => {
@@ -99,7 +99,7 @@ export function ContextLinkedMessages({
                     {selectedAgentData ? (
                       <>
                         <InlineAvatar
-                          agentId={selectedAgent!}
+                          agentId={selectedAgent ?? ""}
                           agents={agents}
                           className="w-4 h-4"
                           fontSize="text-[8px]"
@@ -318,7 +318,7 @@ export function ContextLinkedMessages({
                               className="text-[9px] md:text-[10px] cursor-pointer hover:bg-muted transition-colors"
                               onClick={(e) => {
                                 e.stopPropagation();
-                                setSelectedTask(msg.taskRef!);
+                                if (msg.taskRef) setSelectedTask(msg.taskRef);
                               }}
                             >
                               🔗 {msg.taskRef}

--- a/apps/dashboard/src/pages/message-conversation-cards.tsx
+++ b/apps/dashboard/src/pages/message-conversation-cards.tsx
@@ -11,12 +11,12 @@ import { ScrollArea } from "../components/ui/scroll-area";
 import { cn } from "../lib/utils";
 import { isSandboxMode } from "@openspawn/dashboard-data";
 import { TeamBadge } from "../components/team-badge";
-import type { Message } from "../hooks";
+import type { Agent, Message } from "../hooks";
 import { InlineAvatar, formatTime, acpTypeRenderers } from "./message-utils";
 
 interface ConversationCardsProps {
   messages: Message[];
-  agents: any[];
+  agents: Agent[];
   onViewThread: (convoKey: string) => void;
 }
 
@@ -100,9 +100,9 @@ export function ConversationCards({ messages, agents, onViewThread }: Conversati
                         <p className="text-[10px] md:text-xs text-muted-foreground">
                           {msgs.length} messages
                         </p>
-                        {(agent1 as any)?.teamId && (
+                        {agentMap.get(agent1Id)?.teamId && (
                           <TeamBadge
-                            teamId={(agent1 as any).teamId}
+                            teamId={agentMap.get(agent1Id)?.teamId ?? ""}
                             compact
                             className="text-[8px]"
                           />
@@ -133,7 +133,7 @@ export function ConversationCards({ messages, agents, onViewThread }: Conversati
                           .slice(-10)
                           .map((msg) => {
                             const isAgent1 = msg.fromAgentId === agent1Id;
-                            const acpType = (msg as any).acpType as string | undefined;
+                            const acpType = msg.acpType;
                             const renderer =
                               acpType && isSandboxMode ? acpTypeRenderers[acpType] : undefined;
                             const acpResult = renderer?.(msg);

--- a/apps/dashboard/src/pages/message-feed.tsx
+++ b/apps/dashboard/src/pages/message-feed.tsx
@@ -14,7 +14,7 @@ import { ScrollArea } from "../components/ui/scroll-area";
 import { cn } from "../lib/utils";
 import { isSandboxMode } from "@openspawn/dashboard-data";
 import { TeamFilterDropdown } from "../components/team-badge";
-import type { Message } from "../hooks";
+import type { Agent, Message } from "../hooks";
 import { InlineAvatar, formatTime, typeColors, typeIcons } from "./message-utils";
 
 // ─── FeedVirtualList ──────────────────────────────────────────────────────────
@@ -23,7 +23,7 @@ interface FeedVirtualListProps {
   filtered: Message[];
   allMessages: Message[];
   onViewThread: (convoKey: string) => void;
-  agents: any[];
+  agents: Agent[];
 }
 
 function FeedVirtualList({ filtered, onViewThread, agents }: FeedVirtualListProps) {
@@ -50,15 +50,15 @@ function FeedVirtualList({ filtered, onViewThread, agents }: FeedVirtualListProp
                   <Card
                     className={cn(
                       "flex-1 border-l-4",
-                      isSandboxMode && (msg as any).acpType === "delegation" && "border-l-blue-500",
+                      isSandboxMode && msg.acpType === "delegation" && "border-l-blue-500",
                       isSandboxMode &&
-                        (msg as any).acpType === "escalation" &&
+                        msg.acpType === "escalation" &&
                         "border-l-red-500 bg-red-500/5",
                       isSandboxMode &&
-                        (msg as any).acpType === "completion" &&
+                        msg.acpType === "completion" &&
                         "border-l-emerald-500 bg-emerald-500/5",
-                      isSandboxMode && (msg as any).acpType === "progress" && "border-l-slate-400",
-                      isSandboxMode && (msg as any).acpType === "ack" && "border-l-transparent",
+                      isSandboxMode && msg.acpType === "progress" && "border-l-slate-400",
+                      isSandboxMode && msg.acpType === "ack" && "border-l-transparent",
                       !isSandboxMode && msg.type === "TASK" && "border-l-blue-500",
                       !isSandboxMode && msg.type === "STATUS" && "border-l-green-500",
                       !isSandboxMode && msg.type === "REPORT" && "border-l-purple-500",

--- a/apps/dashboard/src/pages/message-utils.tsx
+++ b/apps/dashboard/src/pages/message-utils.tsx
@@ -4,13 +4,13 @@
  */
 import { darkenForBackground } from "../lib/avatar-utils";
 import { resolveAvatarUrl } from "../lib/resolve-avatar-url";
-import type { Message } from "../hooks";
+import type { Agent, Message } from "../hooks";
 
 // ─── InlineAvatar ─────────────────────────────────────────────────────────────
 
 interface InlineAvatarProps {
   agentId: string;
-  agents: any[];
+  agents: Agent[];
   className?: string;
   fontSize?: string;
 }
@@ -22,10 +22,10 @@ export function InlineAvatar({
   className = "w-5 h-5",
   fontSize = "text-xs",
 }: InlineAvatarProps) {
-  const agent = agents.find((a: any) => a.id === agentId);
-  const avatar = (agent as any)?.avatar;
-  const avatarColor = (agent as any)?.avatarColor || "#71717a";
-  const avatarUrl = (agent as any)?.avatarUrl;
+  const agent = agents.find((a) => a.id === agentId);
+  const avatar = agent?.avatar;
+  const avatarColor = agent?.avatarColor || "#71717a";
+  const avatarUrl = agent?.avatarUrl;
 
   if (avatarUrl) {
     return (
@@ -94,11 +94,11 @@ export const acpTypeRenderers: Record<string, (msg: Message) => AcpRenderResult>
   }),
   progress: (msg) => ({ label: `📊 ${msg.content}`, className: "bg-muted/30" }),
   escalation: (msg) => ({
-    label: `⚠️ Escalated: ${(msg as any).reason || "unknown"} — ${msg.content}`,
+    label: `⚠️ Escalated: ${msg.reason || "unknown"} — ${msg.content}`,
     className: "bg-red-500/10 border border-red-500/20",
   }),
   completion: (msg) => ({
-    label: `✅ Completed: ${(msg as any).summary || msg.content}`,
+    label: `✅ Completed: ${msg.summary || msg.content}`,
     className: "bg-emerald-500/10 border border-emerald-500/20",
   }),
 };

--- a/apps/dashboard/src/pages/mobile-status.tsx
+++ b/apps/dashboard/src/pages/mobile-status.tsx
@@ -30,7 +30,6 @@ import { Sparkline, generateSparklineData } from "../components/ui/sparkline";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { getLevelLabel, getLevelColor } from "../lib/status-colors";
-import { AgentStatus } from "@openspawn/shared-types";
 import type { AgentFieldsFragment } from "@openspawn/dashboard-data";
 
 /* ------------------------------------------------------------------ */
@@ -321,8 +320,12 @@ export function MobileStatusPage() {
 
     for (const agent of agents) {
       const presence = presenceMap.get(agent.id)?.status ?? "idle";
-      if (!groups.has(presence)) groups.set(presence, []);
-      groups.get(presence)!.push(agent);
+      const existing = groups.get(presence);
+      if (existing) {
+        existing.push(agent);
+      } else {
+        groups.set(presence, [agent]);
+      }
     }
 
     // Sort groups by STATUS_ORDER, then agents within each by balance descending
@@ -338,9 +341,7 @@ export function MobileStatusPage() {
 
   // Compute summary stats
   const inProgressTasks = useMemo(
-    () =>
-      (tasks ?? []).filter((t: any) => t.status === "in_progress" || t.status === "assigned")
-        .length,
+    () => (tasks ?? []).filter((t) => t.status === "in_progress" || t.status === "assigned").length,
     [tasks],
   );
 

--- a/apps/dashboard/src/pages/task-board.tsx
+++ b/apps/dashboard/src/pages/task-board.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { useRepoTasks, type RepoTask, type RepoTaskStatus } from "../hooks/use-repo-tasks";
 import { PageHeader } from "../components/ui/page-header";
-import { Badge } from "../components/ui/badge";
 import { Clock, User, ExternalLink, Wifi, WifiOff, RefreshCw, AlertTriangle } from "lucide-react";
 import { cn } from "../lib/utils";
 

--- a/apps/dashboard/src/pages/tasks.tsx
+++ b/apps/dashboard/src/pages/tasks.tsx
@@ -20,7 +20,6 @@ import {
   Link2,
   Plug,
 } from "lucide-react";
-import { HoverLiftCard } from "../components/motion-primitives";
 import { Card, CardContent } from "../components/ui/card";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
@@ -41,13 +40,6 @@ import { darkenForBackground } from "../lib/avatar-utils";
 import { resolveAvatarUrl } from "../lib/resolve-avatar-url";
 
 import { SortDirection } from "../lib/enums";
-
-enum TaskTaskSortField {
-  Created = "created",
-  Priority = "priority",
-  Status = "status",
-  Title = "title",
-}
 
 const statusColumns = [
   { id: "BACKLOG", label: "Backlog", color: "bg-slate-500" },
@@ -70,40 +62,6 @@ function getPriorityVariant(priority: string) {
       return "outline";
     default:
       return "secondary";
-  }
-}
-
-function getPriorityColor(priority: string) {
-  switch (priority?.toUpperCase()) {
-    case "URGENT":
-      return "text-rose-500";
-    case "HIGH":
-      return "text-violet-500";
-    case "NORMAL":
-      return "text-blue-500";
-    case "LOW":
-      return "text-muted-foreground";
-    default:
-      return "text-muted-foreground";
-  }
-}
-
-function getStatusColor(status: string) {
-  switch (status?.toUpperCase()) {
-    case "DONE":
-      return "text-emerald-500";
-    case "IN_PROGRESS":
-      return "text-cyan-500";
-    case "REVIEW":
-      return "text-violet-500";
-    case "TODO":
-      return "text-amber-500";
-    case "BACKLOG":
-      return "text-muted-foreground";
-    case "BLOCKED":
-      return "text-rose-500";
-    default:
-      return "text-muted-foreground";
   }
 }
 
@@ -179,7 +137,7 @@ function TaskCard({ task, onClick, compact, agentMap }: TaskCardProps) {
                     webhook
                   </Badge>
                 )}
-                {(task as any).source === "a2a" && (
+                {task.source === "a2a" && (
                   <Badge
                     variant="outline"
                     className="text-xs text-cyan-400 border-cyan-500/30 bg-cyan-500/10"
@@ -188,7 +146,7 @@ function TaskCard({ task, onClick, compact, agentMap }: TaskCardProps) {
                     A2A
                   </Badge>
                 )}
-                {(task as any).source === "mcp" && (
+                {task.source === "mcp" && (
                   <Badge
                     variant="outline"
                     className="text-xs text-violet-400 border-violet-500/30 bg-violet-500/10"
@@ -226,7 +184,7 @@ function TaskCard({ task, onClick, compact, agentMap }: TaskCardProps) {
                 {task.assignee ? (
                   <div className="flex items-center gap-1">
                     {(() => {
-                      const a = agentMap.get(task.assigneeId!);
+                      const a = agentMap.get(task.assigneeId ?? "");
                       return (
                         <div
                           className="w-4 h-4 rounded-full flex items-center justify-center text-[10px]"
@@ -401,7 +359,7 @@ function TaskDetailSidebar({ task, onClose, agentMap }: TaskDetailSidebarProps) 
               {task.assignee ? (
                 <div className="flex items-center gap-2">
                   {(() => {
-                    const a = agentMap.get(task.assigneeId!);
+                    const a = agentMap.get(task.assigneeId ?? "");
                     return (
                       <div
                         className="w-6 h-6 rounded-full flex items-center justify-center text-sm"
@@ -611,7 +569,7 @@ function ListView({ tasks, onTaskClick, selectedTaskId, agentMap }: ListViewProp
                   {task.assignee ? (
                     <div className="flex items-center gap-1 sm:w-28 flex-shrink-0 sm:order-5">
                       {(() => {
-                        const a = agentMap.get(task.assigneeId!);
+                        const a = agentMap.get(task.assigneeId ?? "");
                         return (
                           <div
                             className="w-5 h-5 rounded-full flex items-center justify-center text-xs"
@@ -693,7 +651,7 @@ export function TasksPage() {
       string,
       { avatar?: string | null; avatarColor?: string | null; avatarUrl?: string | null }
     >();
-    agents.forEach((a: any) =>
+    agents.forEach((a) =>
       m.set(a.id, { avatar: a.avatar, avatarColor: a.avatarColor, avatarUrl: a.avatarUrl }),
     );
     return m;

--- a/apps/dashboard/tsconfig.app.json
+++ b/apps/dashboard/tsconfig.app.json
@@ -31,10 +31,13 @@
       "path": "../../libs/demo-data/tsconfig.lib.json"
     },
     {
-      "path": "../../libs/dashboard-data"
+      "path": "../../libs/dashboard-ui"
     },
     {
-      "path": "../../libs/dashboard-ui"
+      "path": "../../libs/shared-types/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/dashboard-data"
     }
   ]
 }

--- a/apps/platform/app/main.tsx
+++ b/apps/platform/app/main.tsx
@@ -3,7 +3,9 @@ import { createRoot } from "react-dom/client";
 import { LandingPage } from "./landing-page";
 import "./styles/globals.css";
 
-createRoot(document.getElementById("root")!).render(
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("Missing #root element");
+createRoot(rootEl).render(
   <StrictMode>
     <LandingPage />
   </StrictMode>,

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -49,10 +49,18 @@ team.openspawn.ai {
 		reverse_proxy localhost:8000
 	}
 
-	root * /opt/team-dashboard
-	file_server
+	# Redirect bare / to /app/
+	handle / {
+		redir /app/ permanent
+	}
 
-	try_files {path} /index.html
+	# Serve team SPA — Vite builds with base="/app/" so assets live under /app/assets/
+	handle_path /app/* {
+		root * /opt/team-dashboard
+		try_files {path} /index.html
+		file_server
+	}
+
 	import security_headers
 }
 

--- a/libs/dashboard-data/src/hooks/use-messages.ts
+++ b/libs/dashboard-data/src/hooks/use-messages.ts
@@ -42,20 +42,37 @@ export function useMessages() {
   };
 }
 
-export function useConversations() {
+interface ConversationsResult {
+  conversations: Conversation[];
+  loading: boolean;
+  error: string | undefined;
+  refetch: () => Promise<void>;
+}
+
+export function useConversations(): ConversationsResult {
   return {
-    conversations: [] as Conversation[],
+    conversations: [],
     loading: false,
-    error: undefined as string | undefined,
-    refetch: () => Promise.resolve({} as ReturnType<typeof useRestMessages>),
+    error: undefined,
+    refetch: () => Promise.resolve(),
   };
 }
 
-export function useConversationMessages(_agent1Id: string, _agent2Id: string) {
+interface ConversationMessagesResult {
+  messages: Message[];
+  loading: boolean;
+  error: string | undefined;
+  refetch: () => Promise<void>;
+}
+
+export function useConversationMessages(
+  _agent1Id: string,
+  _agent2Id: string,
+): ConversationMessagesResult {
   return {
-    messages: [] as Message[],
+    messages: [],
     loading: false,
-    error: undefined as string | undefined,
-    refetch: () => Promise.resolve({} as ReturnType<typeof useRestMessages>),
+    error: undefined,
+    refetch: () => Promise.resolve(),
   };
 }

--- a/libs/dashboard-data/src/hooks/use-tasks.ts
+++ b/libs/dashboard-data/src/hooks/use-tasks.ts
@@ -1,5 +1,12 @@
 import { useTasks as useRestTasks } from "../rest/hooks/use-tasks";
 
+export type TaskRejection = {
+  feedback: string;
+  rejectedBy?: string;
+  rejectedAt?: string;
+  rejectionCount: number;
+};
+
 export type Task = {
   id: string;
   identifier: string;
@@ -12,6 +19,10 @@ export type Task = {
   creatorId?: string | null;
   createdAt: string;
   updatedAt: string;
+  dueDate?: string | null;
+  completedAt?: string | null;
+  source?: string | null;
+  rejection?: TaskRejection | null;
 };
 
 export function useTasks() {

--- a/libs/dashboard-data/src/index.ts
+++ b/libs/dashboard-data/src/index.ts
@@ -27,7 +27,7 @@ export {
 } from "./hooks/use-sandbox-metrics";
 export { useSandboxSSE, type SandboxSSEEvent } from "./hooks/use-sandbox-sse";
 export { useSandboxTickInvalidation } from "./hooks/use-sandbox-tick";
-export { useTasks, type Task } from "./hooks/use-tasks";
+export { useTasks, type Task, type TaskRejection } from "./hooks/use-tasks";
 export { useTouchDevice } from "./hooks/use-touch-device";
 export { useMemories, useMemorySearch, useContradictions } from "./hooks/use-memory";
 export { useGraphEntities, useGraphRelationships, useGraphCytoscape } from "./hooks/use-graph";
@@ -93,6 +93,7 @@ export interface AgentFields {
   teamId?: string | null;
   avatar?: string | null;
   avatarColor?: string | null;
+  avatarUrl?: string | null;
 }
 
 /** @deprecated Use AgentFields instead */

--- a/libs/dashboard-ui/src/panels/task-detail-panel.tsx
+++ b/libs/dashboard-ui/src/panels/task-detail-panel.tsx
@@ -13,7 +13,6 @@ import {
   Clock,
   AlertTriangle,
   Activity,
-  User,
   Calendar,
   ArrowRight,
   Flag,

--- a/packages/coordinator/src/db.ts
+++ b/packages/coordinator/src/db.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { randomUUID } from "crypto";
-import { TaskStatus, AgentStatus } from "@openspawn/shared-types";
+import { TaskStatus } from "@openspawn/shared-types";
 
 // ─── Row types (mirror the SQLite schema) ────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Resolve all 118 lint warnings across 50 files (0 errors, 0 warnings now)
- Replace all `any` types with proper types from `@openspawn/dashboard-data` and inline interfaces
- Remove all unused imports, variables, and dead code
- Replace all non-null assertions (`!`) with null guards, optional chaining, or early returns
- Fix team.openspawn.ai MIME type errors — Caddy now uses `handle_path /app/*` to strip the Vite `base` prefix so hashed assets resolve correctly

## What was wrong with team.openspawn.ai
Vite builds with `base: "/app/"`, so HTML references `/app/assets/index-*.css`. But Caddy's `root * /opt/team-dashboard` + `try_files` looked for `/opt/team-dashboard/app/assets/...` (doesn't exist) and fell back to `index.html` (MIME `text/html`). The fix: `handle_path /app/*` strips the prefix before file lookup.

## Test plan
- [ ] `pnpm exec nx run-many -t lint` — 0 warnings
- [ ] `pnpm exec nx run-many -t build` — all pass
- [ ] `pnpm exec nx run-many -t test --exclude=openspawn` — all pass
- [ ] After deploy: verify team.openspawn.ai loads without MIME errors
- [ ] After deploy: verify bikinibottom.ai still works