### PR TITLE
fix(dashboard): add missing AgentSortField and TaskSortField enums

### DIFF
--- a/apps/dashboard/src/lib/enums.ts
+++ b/apps/dashboard/src/lib/enums.ts
@@ -5,6 +5,21 @@ export enum SortDirection {
   Desc = "desc",
 }
 
+export enum AgentSortField {
+  Name = "name",
+  Level = "level",
+  Balance = "balance",
+  Status = "status",
+  Created = "created",
+}
+
+export enum TaskSortField {
+  Title = "title",
+  Priority = "priority",
+  Status = "status",
+  Created = "created",
+}
+
 export enum DialogModeValue {
   View = "view",
   Edit = "edit",

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -51,7 +51,7 @@ import { AgentVirtualGrid } from "./agent-virtual-grid";
 
 type Agent = AgentFieldsFragment;
 
-import { DialogModeValue, type DialogMode, SortDirection } from "../lib/enums";
+import { AgentSortField, DialogModeValue, type DialogMode, SortDirection } from "../lib/enums";
 
 // Suppress unused-variable warning for usePresence (destructured but not used directly in JSX)
 void usePresence;

--- a/apps/dashboard/src/pages/tasks.tsx
+++ b/apps/dashboard/src/pages/tasks.tsx
@@ -39,7 +39,7 @@ import { AgentDetailPanel } from "../components/agent-detail-panel";
 import { darkenForBackground } from "../lib/avatar-utils";
 import { resolveAvatarUrl } from "../lib/resolve-avatar-url";
 
-import { SortDirection } from "../lib/enums";
+import { SortDirection, TaskSortField } from "../lib/enums";
 
 const statusColumns = [
   { id: "BACKLOG", label: "Backlog", color: "bg-slate-500" },

--- a/apps/demo/src/lib/enums.ts
+++ b/apps/demo/src/lib/enums.ts
@@ -5,6 +5,21 @@ export enum SortDirection {
   Desc = "desc",
 }
 
+export enum AgentSortField {
+  Name = "name",
+  Level = "level",
+  Balance = "balance",
+  Status = "status",
+  Created = "created",
+}
+
+export enum TaskSortField {
+  Title = "title",
+  Priority = "priority",
+  Status = "status",
+  Created = "created",
+}
+
 export enum DialogModeValue {
   View = "view",
   Edit = "edit",

--- a/apps/demo/src/pages/agents.tsx
+++ b/apps/demo/src/pages/agents.tsx
@@ -52,7 +52,7 @@ import { AgentVirtualGrid } from "./agent-virtual-grid";
 
 type Agent = AgentFieldsFragment;
 
-import { DialogModeValue, type DialogMode, SortDirection } from "../lib/enums";
+import { AgentSortField, DialogModeValue, type DialogMode, SortDirection } from "../lib/enums";
 
 // Suppress unused-variable warning for usePresence (destructured but not used directly in JSX)
 void usePresence;

--- a/apps/demo/src/pages/tasks.tsx
+++ b/apps/demo/src/pages/tasks.tsx
@@ -39,7 +39,7 @@ import { AgentDetailPanel } from "../components/agent-detail-panel";
 import { darkenForBackground } from "../lib/avatar-utils";
 import { resolveAvatarUrl } from "../lib/resolve-avatar-url";
 
-import { SortDirection } from "../lib/enums";
+import { SortDirection, TaskSortField } from "../lib/enums";
 
 const statusColumns = [
   { id: "BACKLOG", label: "Backlog", color: "bg-slate-500" },


### PR DESCRIPTION
Fixes runtime crashes on bikinibottom.ai/app/agents and /app/tasks.

Both enums were used but never defined — lost during the REST migration. Pages crashed with `AgentSortField is not defined` / `TaskSortField is not defined`.

Added both enums to `lib/enums.ts` and the missing imports in both `apps/demo` and `apps/dashboard`.