### PR TITLE
fix(team): derive router basepath from VITE_BASE_PATH

### DIFF
--- a/apps/team/src/routes.tsx
+++ b/apps/team/src/routes.tsx
@@ -85,7 +85,11 @@ const routeTree = rootRoute.addChildren([
   ]),
 ]);
 
-export const router = createRouter({ routeTree, basepath: "/app" });
+// VITE_BASE_PATH controls both Vite's `base` and the router basepath.
+// team.openspawn.ai sets "/" while bikinibottom.ai embeds at "/app/".
+const basepath = (import.meta.env.BASE_URL || "/app/").replace(/\/$/, "") || "/";
+
+export const router = createRouter({ routeTree, basepath });
 
 declare module "@tanstack/react-router" {
   interface Register {


### PR DESCRIPTION
## Problem
team.openspawn.ai shows a white screen after login.

Router basepath was hardcoded to `/app`, but team.openspawn.ai is served at `/`. After basic auth, the browser lands on `/` which doesn't match any route → blank page.

## Fix
Derive the router basepath from Vite's `BASE_URL` (which is set by the `VITE_BASE_PATH` env var). This way:
- `VITE_BASE_PATH=/` (team.openspawn.ai) → basepath `/`
- `VITE_BASE_PATH=/app/` (bikinibottom.ai) → basepath `/app`
- Default (no env var) → `/app` (backwards compatible)

## Testing
Built with `VITE_BASE_PATH='/' pnpm nx run team:build` — output has correct `<base href='/' />` and asset paths.