### PR TITLE
chore: enforce zero-warnings lint policy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,8 @@ jobs:
           fi
           echo "✅ Codegen files are up to date"
 
-      - name: Lint
-        run: pnpm exec nx run-many -t lint --parallel=3
-        continue-on-error: true # Don't fail on lint for now
+      - name: Lint (zero warnings policy)
+        run: pnpm exec nx run-many -t lint --parallel=3 -- --max-warnings 0
 
       - name: Build
         run: pnpm exec nx run-many -t build --parallel=3

--- a/apps/demo-e2e/src/agents.spec.ts
+++ b/apps/demo-e2e/src/agents.spec.ts
@@ -10,8 +10,6 @@ test.describe("Agents page", () => {
   });
 
   test("renders agent cards or list", async ({ page }) => {
-    // Should have at least one agent visible (demo data)
-    const agentElements = page.locator("[data-testid=agent-card], [data-agent-id], .agent-row");
     // If demo data is loaded, we expect agents. If not, at least no crash.
     const body = await page.textContent("body");
     expect(body).toBeTruthy();

--- a/apps/demo-e2e/src/smoke.spec.ts
+++ b/apps/demo-e2e/src/smoke.spec.ts
@@ -46,7 +46,7 @@ for (const page of PAGES) {
   });
 }
 
-test("sidebar navigation links work", async ({ page, browserName }, testInfo) => {
+test("sidebar navigation links work", async ({ page }, testInfo) => {
   // Skip on mobile viewports — sidebar is hidden behind hamburger menu
   const isMobile = testInfo.project.name.includes("mobile");
   if (isMobile) {


### PR DESCRIPTION
Closes #649

## Changes
- **Removed `continue-on-error: true`** from CI lint step — lint failures now block PRs
- **Added `--max-warnings 0`** to eslint via Nx — any warning fails the build
- **Fixed 2 warnings** in e2e tests (unused `agentElements` variable, unused `browserName` param)
- **Python (ruff):** already exits non-zero on any issue — no change needed

## Verified locally
- `pnpm exec nx run-many -t lint -- --max-warnings 0` → 19/19 projects pass
- `uv run ruff check .` in `apps/api/` → all checks passed