### PR TITLE
fix: set VITE_BASE_PATH=/ for team dashboard Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV VITE_SANDBOX_MODE=true
 ENV VITE_DASHBOARD_THEME=${VITE_DASHBOARD_THEME}
 RUN pnpm nx build shared-types
 RUN pnpm nx run demo:build --configuration=production
-RUN pnpm nx run team:build --configuration=production
+RUN VITE_BASE_PATH="/" pnpm nx run team:build --configuration=production
 RUN pnpm nx run website:build
 
 # Create standalone sandbox package with resolved workspace deps


### PR DESCRIPTION
## Problem
team.openspawn.ai shows a white screen after login.

The deploy workflow extracts the team dashboard from the Docker image and serves it at `/` via Caddy. But the Dockerfile builds the team app without `VITE_BASE_PATH`, so it defaults to `/app/` — wrong base path for the standalone team site.

## Fix
Set `VITE_BASE_PATH=/` in the Dockerfile's team build step.

This is the CI/CD fix — PR #655 fixed the router code, but without this the Docker-built artifact still has the wrong base.