### PR TITLE
fix: update team.openspawn.ai Caddyfile for root base path

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -41,21 +41,16 @@ openspawn.ai {
 # ── team.openspawn.ai — Internal team dashboard (basic auth) ────────────────
 team.openspawn.ai {
 	basicauth {
-		{$TEAM_AUTH_USER} {$TEAM_AUTH_HASH}
+		adam $2a$14$ux.qbYaln9O8q0c97r0tie7TOb4BL.51Y5atyByJGhBt7vXC.4ay6
 	}
 
-	# Proxy /api requests to FastAPI (same pattern as openspawn.ai)
+	# Proxy /api requests to FastAPI
 	handle_path /api/* {
 		reverse_proxy localhost:8000
 	}
 
-	# Redirect bare / to /app/
-	handle / {
-		redir /app/ permanent
-	}
-
-	# Serve team SPA — Vite builds with base="/app/" so assets live under /app/assets/
-	handle_path /app/* {
+	# Serve team SPA at root — built with VITE_BASE_PATH=/
+	handle {
 		root * /opt/team-dashboard
 		try_files {path} /index.html
 		file_server


### PR DESCRIPTION
## Problem
team.openspawn.ai returns 401 for all requests and redirects to /app/.

Three issues:
1. `basicauth` used env vars (`TEAM_AUTH_USER`/`TEAM_AUTH_HASH`) that were never set → empty auth block → 401 on every request
2. `handle /` redirected to `/app/` — but the team app now builds with base path `/`
3. `handle_path /app/*` served files under `/app/` prefix — no longer needed

## Fix
- Hardcode bcrypt-hashed credentials (user: adam)
- Serve SPA at root with `try_files` fallback
- Remove the `/app/` redirect