### PR TITLE
fix(docs): hide Starlight auto-generated page title

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -6,6 +6,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "OpenSpawn Docs",
+      customCss: ["./src/styles/custom.css"],
       social: [{ icon: "github", label: "GitHub", href: "https://github.com/openspawn/openspawn" }],
       sidebar: [
         {

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -1,0 +1,4 @@
+/* Hide Starlight's auto-generated page title — we use # headings in markdown instead */
+.content-panel h1#_top {
+  display: none;
+}


### PR DESCRIPTION
Markdown files use `# Title` headings for portability. Starlight also auto-renders the frontmatter `title` as an h1, causing duplicate titles on every page.

Hides the Starlight-generated title (`h1#_top`) via custom CSS so only the markdown heading shows.