### PR TITLE
fix(dashboard): remove fake sparkline data from stat cards

### DIFF
--- a/apps/team/src/pages/dashboard.tsx
+++ b/apps/team/src/pages/dashboard.tsx
@@ -13,7 +13,6 @@ import {
   StatusRing,
   Avatar,
   AvatarFallback,
-  generateSparklineData,
 } from "@openspawn/dashboard-ui";
 import {
   Users,
@@ -277,8 +276,7 @@ export function DashboardPage() {
     [tasks],
   );
 
-  const sparkA = useMemo(() => generateSparklineData(12, "up"), []);
-  const sparkT = useMemo(() => generateSparklineData(12, "stable"), []);
+  // No fake sparklines — only show real data. Time-series tracking TBD.
 
   return (
     <div className="space-y-6">
@@ -292,8 +290,6 @@ export function DashboardPage() {
             value={stats.agents}
             icon={Users}
             description={`${stats.active} active`}
-            sparklineData={sparkA}
-            sparklineColor="#06b6d4"
           />
         </Link>
         <Link to="/tasks">
@@ -302,8 +298,6 @@ export function DashboardPage() {
             value={stats.total}
             icon={CheckSquare}
             description={`${stats.done} done · ${stats.wip} active`}
-            sparklineData={sparkT}
-            sparklineColor="#10b981"
           />
         </Link>
         <StatCard

--- a/libs/dashboard-ui/src/panels/agent-detail-panel.tsx
+++ b/libs/dashboard-ui/src/panels/agent-detail-panel.tsx
@@ -8,7 +8,7 @@
  *
  * No data-fetching — consumers pass agent + related data as props.
  */
-import { useMemo } from "react";
+
 import {
   Shield,
   Zap,
@@ -25,7 +25,7 @@ import { Badge } from "../ui/badge";
 import { Progress } from "../ui/progress";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { ScrollArea } from "../ui/scroll-area";
-import { Sparkline, generateSparklineData } from "../ui/sparkline";
+
 import { cn } from "../lib/utils";
 
 /* ── Types ─────────────────────────────────────────────────────── */
@@ -143,14 +143,7 @@ export function AgentDetailPanel({
 }: AgentDetailPanelProps) {
   const successRate =
     agent.tasksCompleted > 0 ? Math.round((agent.tasksSuccessful / agent.tasksCompleted) * 100) : 0;
-  const trustData = useMemo(
-    () => generateSparklineData(12, agent.trustScore > 50 ? "up" : "down"),
-    [agent.trustScore],
-  );
-  const earningsData = useMemo(
-    () => generateSparklineData(12, agent.lifetimeEarnings > 5000 ? "up" : "stable"),
-    [agent.lifetimeEarnings],
-  );
+  // No fake sparklines — only show real time-series data when available
   const activeTasks = tasks.filter((t) => !["DONE", "CANCELLED"].includes(t.status.toUpperCase()));
   const completedTasks = tasks.filter((t) => t.status.toUpperCase() === "DONE");
 
@@ -213,7 +206,7 @@ export function AgentDetailPanel({
             icon={<Shield className="w-4 h-4 text-cyan-400" />}
             label="Trust"
             value={`${agent.trustScore}%`}
-            sparkline={<Sparkline data={trustData} color="#06b6d4" height={24} />}
+            
           />
           <StatBox
             icon={<Zap className="w-4 h-4 text-amber-400" />}
@@ -225,7 +218,7 @@ export function AgentDetailPanel({
             icon={<Coins className="w-4 h-4 text-emerald-400" />}
             label="Balance"
             value={`${agent.currentBalance.toLocaleString()}c`}
-            sparkline={<Sparkline data={earningsData} color="#10b981" height={24} />}
+            
           />
         </div>
 


### PR DESCRIPTION
The stat cards on the dashboard and agent detail panel used `generateSparklineData()` which produced random noise — not real metrics. Removed all fake sparklines.

Real time-series tracking is TBD.