### PR TITLE
docs(website): merge Starlight content into overlapping pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,6 @@
 name: "[Deprecated] Deploy to GitHub Pages"
 
-# Replaced by deploy-docs.yml (Astro Starlight).
+# Docs are now served from the website app (openspawn.ai/docs/).
 # Kept as workflow_dispatch stub so existing links don't 404.
 on:
   workflow_dispatch:
@@ -10,5 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "This workflow is deprecated. Use deploy-docs.yml instead."
-          echo "See: https://github.com/openspawn/openspawn/actions/workflows/deploy-docs.yml"
+          echo "This workflow is deprecated. Docs are part of the website app."
+          echo "See: apps/website/ (openspawn.ai/docs/)"

--- a/apps/website/app/routes/docs/agent-quickstart.tsx
+++ b/apps/website/app/routes/docs/agent-quickstart.tsx
@@ -69,26 +69,84 @@ openspawn status`}
         gateway.
       </div>
 
+      {/* ── Boot Sequence ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Boot sequence protocol</h2>
+      <p className="mb-4 text-slate-400">
+        Every agent follows a planning-first startup protocol before executing work:
+      </p>
+      <CodeBlock title="Boot sequence">
+        {`1. Read ORG.md           → understand org structure, your role, who you report to
+2. Read SOUL.md          → internalize shared values and behavioral norms
+3. Read AGENTS.md        → understand workspace rules and tool access
+4. Write PLAN.md         → plan your approach before touching any code
+5. Begin execution       → follow plan, write RESULT.md when done`}
+      </CodeBlock>
+      <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
+        <strong className="text-slate-200">Q: Why planning-first?</strong>
+        <br />
+        A: Agents that plan before executing produce higher-quality output and escalate blockers
+        earlier. The plan is also reviewable by leads before work begins.
+      </div>
+
+      {/* ── Task Lifecycle via MCP ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Task lifecycle via MCP</h2>
+      <p className="mb-4 text-slate-400">Agents manage their task queue through MCP tools:</p>
+      <CodeBlock title="Task lifecycle MCP calls">
+        {`# Create a task (leads only, L7+)
+mcp.call("openspawn/task_create", {
+  title: "Implement rate limiting",
+  assignee: "backend-senior",
+  priority: "high"
+})
+
+# Claim an available task (workers)
+mcp.call("openspawn/task_claim", { agent_id: "backend-senior-1" })
+
+# List tasks for an agent
+mcp.call("openspawn/task_list", {
+  agent_id: "backend-senior-1",
+  status: "in_progress"
+})
+
+# Complete a task with results
+mcp.call("openspawn/task_complete", {
+  task_id: "task-123",
+  result: "Rate limiting implemented — 100 req/min per API key"
+})`}
+      </CodeBlock>
+
+      {/* ── Deploy shortcut ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Init + deploy in one step</h2>
+      <CodeBlock title="Terminal">{`openspawn init my-org --template=dev-shop --deploy`}</CodeBlock>
+      <p className="mb-4 text-slate-400">
+        The <code className="inline-code">--deploy</code> flag scaffolds and immediately starts the
+        server. Equivalent to <code className="inline-code">init</code> +{" "}
+        <code className="inline-code">cd</code> + <code className="inline-code">start</code>.
+      </p>
+
       {/* ── Pick a template ── */}
       <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Pick a template</h2>
 
       <p className="mb-4 text-slate-400">
-        Four templates ship with OpenSpawn. Each produces a complete ORG.md you can use immediately
-        or customize.
+        4 general-purpose templates + 7 industry-specific templates ship with OpenSpawn. Each
+        produces a complete ORG.md you can use immediately or customize.
       </p>
 
-      <CodeBlock title="Templates">
-        {`# Personal AI team (chief of staff + specialists)
-openspawn init my-org --template=assistant-team
+      <CodeBlock title="General-purpose templates">
+        {`openspawn init my-org --template=assistant-team    # Personal AI team
+openspawn init my-org --template=content-agency    # Content production pipeline
+openspawn init my-org --template=dev-shop          # Software development team
+openspawn init my-org --template=research-lab      # Research & analysis team`}
+      </CodeBlock>
 
-# Content production pipeline
-openspawn init my-org --template=content-agency
-
-# Software development team
-openspawn init my-org --template=dev-shop
-
-# Research & analysis team
-openspawn init my-org --template=research-lab`}
+      <CodeBlock title="Industry templates">
+        {`openspawn init my-org --template=saas-onboarding         # Customer onboarding pipeline
+openspawn init my-org --template=incident-response        # Production incident management
+openspawn init my-org --template=contract-review          # Legal contract analysis
+openspawn init my-org --template=compliance-monitoring    # Regulatory compliance
+openspawn init my-org --template=game-live-ops            # Game operations (events, patches)
+openspawn init my-org --template=catalog-management       # Product catalog maintenance
+openspawn init my-org --template=clinical-trials          # Clinical trial coordination`}
       </CodeBlock>
 
       <div className="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-300">
@@ -449,6 +507,16 @@ openspawn consensus --results
               <td className="px-3 py-2">
                 <code className="inline-code">openclaw gateway status</code> — ensure gateway is
                 running
+              </td>
+            </tr>
+            <tr className="border-b border-slate-800">
+              <td className="px-3 py-2">
+                <code className="inline-code">ERR_HMAC_INVALID</code>
+              </td>
+              <td className="px-3 py-2">
+                Check <code className="inline-code">AGENT_SECRET</code> env var matches the value in{" "}
+                <code className="inline-code">openspawn.config.json</code>. Regenerate with{" "}
+                <code className="inline-code">openspawn secrets rotate</code>
               </td>
             </tr>
           </tbody>

--- a/apps/website/app/routes/docs/communication-protocol.tsx
+++ b/apps/website/app/routes/docs/communication-protocol.tsx
@@ -386,6 +386,156 @@ Agent A:  "Sounds good!"
 // 1 message. Deterministic routing.`}
       </CodeBlock>
 
+      {/* ── Escalation Reasons ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Escalation Reasons</h2>
+      <p className="mb-4 text-slate-400">
+        Every ESCALATION message must include a typed reason. This enables routing and automated
+        responses.
+      </p>
+      <div className="mb-6 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium">Reason</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">When to use</th>
+              <th className="py-2 text-slate-400 font-medium">Routes to</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            {[
+              ["BLOCKED", "Missing resource, dependency, or permission", "Direct manager"],
+              ["OUT_OF_DOMAIN", "Task outside agent's expertise", "Manager for re-routing"],
+              ["BUDGET_EXCEEDED", "Agent hit credit limit", "Manager + human principal"],
+              ["AMBIGUOUS_TASK", "Task requirements unclear after 1 clarification", "Task creator"],
+              ["CONFLICT", "Two agents making contradictory changes", "Nearest shared manager"],
+              [
+                "QUALITY_CONCERN",
+                "Output doesn't meet standards after 2 attempts",
+                "Reviewer (L6+)",
+              ],
+              ["TIMEOUT", "Upstream dependency not responding", "Manager"],
+            ].map(([reason, when, routes]) => (
+              <tr key={reason} className="border-b border-white/5">
+                <td className="py-2 pr-6">
+                  <code className="inline-code">{reason}</code>
+                </td>
+                <td className="py-2 pr-6">{when}</td>
+                <td className="py-2">{routes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* ── ACP Data Model ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">ACP Data Model</h2>
+      <p className="mb-4 text-slate-400">
+        The Agent Communication Protocol (ACP) defines typed interfaces for all messages and events
+        in the system.
+      </p>
+      <CodeBlock title="ACP interfaces (TypeScript)">
+        {`interface AcpMessage {
+  id: string;
+  type: "TASK" | "RESULT" | "ESCALATION" | "DECISION";
+  from: string;       // agent ID
+  to: string;         // agent ID or channel
+  timestamp: string;  // ISO 8601
+  payload: AcpPayload;
+}
+
+interface TaskPayload {
+  title: string;
+  deliverable: string;     // file path or description
+  priority: "low" | "medium" | "high" | "urgent";
+  requirements?: string;
+}
+
+interface ResultPayload {
+  taskId: string;
+  location: string;        // where the output lives
+  summary: string;
+}
+
+interface EscalationPayload {
+  taskId: string;
+  reason: EscalationReason;
+  blocked: string;         // what's blocked
+  need: string;            // what's needed to unblock
+}
+
+interface DecisionPayload {
+  escalationId: string;
+  resolution: string;      // definitive action to take
+  unblocks: string[];      // task IDs being unblocked
+}
+
+type AcpPayload =
+  | TaskPayload
+  | ResultPayload
+  | EscalationPayload
+  | DecisionPayload;
+
+type EscalationReason =
+  | "BLOCKED"
+  | "OUT_OF_DOMAIN"
+  | "BUDGET_EXCEEDED"
+  | "AMBIGUOUS_TASK"
+  | "CONFLICT"
+  | "QUALITY_CONCERN"
+  | "TIMEOUT";`}
+      </CodeBlock>
+
+      {/* ── Agent Decision Model ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Agent Decision Model</h2>
+      <p className="mb-4 text-slate-400">
+        On each tick, every agent evaluates its state and decides one of 5 actions:
+      </p>
+      <CodeBlock title="Agent decision loop">
+        {`function decide(agent: Agent): Action {
+  // 1. Check inbox for new messages
+  if (hasEscalation())  → return resolveOrReEscalate()
+  if (hasNewTask())     → return beginWork()
+  if (hasResult())      → return reviewResult()
+
+  // 2. Check in-progress work
+  if (isBlocked())      → return escalate()
+  if (workComplete())   → return submitResult()
+  if (workInProgress()) → return continueWork()
+
+  // 3. Nothing to do
+  return idle()
+}`}
+      </CodeBlock>
+      <div className="mb-6 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium">Action</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Messages sent</th>
+              <th className="py-2 text-slate-400 font-medium">Cost</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            {[
+              ["beginWork()", "0 — silence is success", "1 LLM call"],
+              ["continueWork()", "0", "1 LLM call"],
+              ["submitResult()", "0 or 1 RESULT", "0"],
+              ["escalate()", "1 ESCALATION", "0"],
+              ["resolveOrReEscalate()", "1 DECISION or 1 ESCALATION", "0-1 LLM calls"],
+              ["idle()", "0", "0 (cheap models only)"],
+            ].map(([action, msgs, cost]) => (
+              <tr key={action} className="border-b border-white/5">
+                <td className="py-2 pr-6">
+                  <code className="inline-code">{action}</code>
+                </td>
+                <td className="py-2 pr-6">{msgs}</td>
+                <td className="py-2">{cost}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
       {/* ── Implementation Checklist ── */}
       <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Implementation Checklist</h2>
       <ol className="mb-6 list-decimal list-inside space-y-2 text-slate-400">

--- a/apps/website/app/routes/docs/getting-started.tsx
+++ b/apps/website/app/routes/docs/getting-started.tsx
@@ -51,6 +51,18 @@ export function GettingStarted() {
         <li>
           Node.js 18 or newer (<code className="inline-code">node --version</code> to check)
         </li>
+        <li>
+          Python 3.12+ and{" "}
+          <a
+            href="https://docs.astral.sh/uv/"
+            target="_blank"
+            rel="noopener"
+            className="text-cyan-400 underline"
+          >
+            uv
+          </a>{" "}
+          (for the FastAPI backend — <code className="inline-code">uv --version</code> to check)
+        </li>
       </ul>
       <p className="mb-3 text-slate-400">
         <strong className="text-slate-200">Optional but recommended:</strong>
@@ -104,6 +116,8 @@ export function GettingStarted() {
       <p className="mb-4 text-slate-400">This creates two files:</p>
       <CodeBlock title="structure">{`my-org/
 ├── ORG.md                  # Your org definition — this is the important one
+├── SOUL.md                 # Shared behavior/values for all agents
+├── AGENTS.md               # Workspace rules for agent tooling
 └── openspawn.config.json   # Server config (port, model providers, etc.)`}</CodeBlock>
       <p className="mb-4 text-slate-400">
         Let's look at what <code className="inline-code">ORG.md</code> contains by default:
@@ -468,6 +482,48 @@ Write code, run tests, build APIs.
           updates, escalations, completions — all flow through the Agent Communication Protocol. The
           dashboard reads ACP message streams in real-time via SSE.
         </p>
+      </div>
+
+      {/* SQLite vs PostgreSQL */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">SQLite vs PostgreSQL</h2>
+      <p className="mb-4 text-slate-400">
+        OpenSpawn supports two database tiers. Start with SQLite — upgrade when you need to.
+      </p>
+      <div className="overflow-x-auto mb-8">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium"></th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">SQLite (Tier 1)</th>
+              <th className="py-2 text-slate-400 font-medium">PostgreSQL (Tier 2)</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            {[
+              ["Setup", "Zero config — works out of the box", "Requires PostgreSQL 16+ and Redis"],
+              [
+                "Best for",
+                "Local dev, prototyping, small orgs",
+                "Production, multi-user, large orgs",
+              ],
+              [
+                "Concurrency",
+                "Single-writer, good for 1–5 agents",
+                "Full concurrent access, 50+ agents",
+              ],
+              ["Background jobs", "asyncio scheduler (in-process)", "arq + Redis (distributed)"],
+              ["Docker required?", "No", "Yes (recommended)"],
+              ["Data persistence", "Local file (test.db)", "Durable with backups"],
+              ["pgvector / search", "Not available", "Vector similarity search for memory"],
+            ].map(([feature, sqlite, pg]) => (
+              <tr key={feature} className="border-b border-white/5">
+                <td className="py-2 pr-6 font-medium text-slate-300">{feature}</td>
+                <td className="py-2 pr-6">{sqlite}</td>
+                <td className="py-2">{pg}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
 
       {/* Next Steps */}

--- a/apps/website/app/routes/docs/index.tsx
+++ b/apps/website/app/routes/docs/index.tsx
@@ -62,6 +62,41 @@ export function DocsIndex() {
           </Link>
         ))}
       </div>
+
+      {/* Key Concepts */}
+      <h2 className="mt-14 mb-6 text-2xl font-bold text-slate-100">Key Concepts</h2>
+      <div className="space-y-4">
+        {[
+          {
+            name: "ORG.md",
+            desc: "A single markdown file that defines your entire agent organization — roles, hierarchy, culture, policies, and playbooks. It's infrastructure-as-code for agent teams.",
+          },
+          {
+            name: "Hierarchy",
+            desc: "Agents have levels (L1–L10) and report-to relationships. Heading depth in ORG.md determines hierarchy. Tasks flow down, escalations flow up.",
+          },
+          {
+            name: "Communication Protocol",
+            desc: "4 message types (TASK, RESULT, ESCALATION, DECISION), silence-as-success, files-over-chat. Eliminates 40–60% of wasted coordination tokens.",
+          },
+          {
+            name: "Dashboard",
+            desc: "Real-time React UI showing network graph, task timelines, agent cards, trust scores, and org health. Powered by SSE streaming.",
+          },
+          {
+            name: "MCP & A2A",
+            desc: "Every org exposes 7 MCP tools and A2A agent cards. Any MCP-compatible client or A2A-capable agent can discover and interact with your org.",
+          },
+        ].map((concept) => (
+          <div
+            key={concept.name}
+            className="rounded-lg border border-white/5 bg-white/[0.02] px-5 py-4"
+          >
+            <p className="mb-1 font-semibold text-slate-200">{concept.name}</p>
+            <p className="text-sm text-slate-400">{concept.desc}</p>
+          </div>
+        ))}
+      </div>
     </DocsLayout>
   );
 }

--- a/apps/website/app/routes/docs/reference/org-md-reference.tsx
+++ b/apps/website/app/routes/docs/reference/org-md-reference.tsx
@@ -28,6 +28,38 @@ export function OrgMdReference() {
 
       <hr className="my-8 border-white/10" />
 
+      {/* ── Why Markdown? ──────────────────────────────────────────────────── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Why Markdown?</h2>
+      <p className="mb-4 text-slate-400">
+        ORG.md uses plain markdown instead of YAML, JSON, or a DSL. This is a deliberate design
+        decision:
+      </p>
+      <ul className="mb-6 list-disc pl-6 text-slate-400 space-y-2">
+        <li>
+          <strong className="text-slate-200">Human-readable:</strong> Non-technical stakeholders can
+          read and review org changes in a PR — no need to learn a schema
+        </li>
+        <li>
+          <strong className="text-slate-200">AI-native:</strong> Every LLM can read and write
+          markdown. Agents can parse their own org definition without a custom parser
+        </li>
+        <li>
+          <strong className="text-slate-200">Prose is config:</strong> Free-text descriptions become
+          system prompt context. There's no separate "config" vs "docs" — the documentation{" "}
+          <em>is</em> the configuration
+        </li>
+        <li>
+          <strong className="text-slate-200">Git-friendly:</strong> Diffs are meaningful, blame
+          shows who changed what, PRs let teams discuss org changes the same way they discuss code
+        </li>
+        <li>
+          <strong className="text-slate-200">Lenient:</strong> Missing sections use defaults.
+          Unknown fields are ignored. A 3-line file is valid. No schema validation errors to fight
+        </li>
+      </ul>
+
+      <hr className="my-8 border-white/10" />
+
       {/* ── Overview ──────────────────────────────────────────────────────── */}
       <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Overview</h2>
       <p className="mb-4 text-slate-400">
@@ -983,6 +1015,147 @@ Sets research direction. Reviews findings.
           </tbody>
         </table>
       </div>
+
+      <hr className="my-8 border-white/10" />
+
+      {/* ── SDLC Presets ──────────────────────────────────────────────────── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">SDLC Presets</h2>
+      <p className="mb-4 text-slate-400">
+        SDLC presets configure development lifecycle rules — review requirements, testing mandates,
+        and deployment gates. Set via <code className="inline-code">sdlc: preset-name</code> in the
+        Culture section.
+      </p>
+      <div className="overflow-x-auto mb-6">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-4 text-left font-medium text-slate-400">Preset</th>
+              <th className="py-2 pr-4 text-left font-medium text-slate-400">Review</th>
+              <th className="py-2 pr-4 text-left font-medium text-slate-400">Tests</th>
+              <th className="py-2 text-left font-medium text-slate-400">Deploy Gate</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/5 text-slate-400">
+            {[
+              ["standard", "L6+ required", "Required before merge", "CI pass + approval"],
+              [
+                "strict",
+                "2 reviewers (L7+)",
+                "Coverage threshold 80%",
+                "CI + security scan + approval",
+              ],
+              ["solo", "Self-review OK", "Optional", "CI pass"],
+              ["research", "No review", "None", "None — exploratory"],
+            ].map(([preset, review, tests, deploy]) => (
+              <tr key={preset}>
+                <td className="py-2 pr-4">
+                  <code className="inline-code">{preset}</code>
+                </td>
+                <td className="py-2 pr-4">{review}</td>
+                <td className="py-2 pr-4">{tests}</td>
+                <td className="py-2">{deploy}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <CodeBlock title="ORG.md">{`## Culture
+preset: startup
+sdlc: strict`}</CodeBlock>
+
+      <hr className="my-8 border-white/10" />
+
+      {/* ── Workspace Strategy ─────────────────────────────────────────────── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Workspace Strategy</h2>
+      <p className="mb-4 text-slate-400">
+        Each agent operates in an isolated workspace to prevent conflicts. The default strategy is{" "}
+        <strong className="text-slate-200">worktree-per-agent</strong> — each agent gets a git
+        worktree branched from main.
+      </p>
+      <CodeBlock title="Workspace isolation">{`Agent: Backend Senior 1
+  Worktree: .worktrees/backend-senior-1/
+  Branch:   agent/backend-senior-1
+  Base:     main
+
+Agent: Backend Senior 2
+  Worktree: .worktrees/backend-senior-2/
+  Branch:   agent/backend-senior-2
+  Base:     main`}</CodeBlock>
+      <p className="mb-4 text-slate-400">
+        When an agent completes a task, its changes are merged back to main via PR. Conflicts are
+        escalated to the agent's lead.
+      </p>
+
+      <hr className="my-8 border-white/10" />
+
+      {/* ── Lifecycle ──────────────────────────────────────────────────────── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Org Lifecycle</h2>
+
+      <h3 className="mt-6 mb-3 text-xl font-semibold text-slate-200">Deployment</h3>
+      <CodeBlock title="bash">{`npx openspawn deploy ORG.md           # Create org from scratch
+npx openspawn deploy ORG.md --dry-run  # Preview without creating`}</CodeBlock>
+
+      <h3 className="mt-6 mb-3 text-xl font-semibold text-slate-200">Upgrading</h3>
+      <CodeBlock title="bash">{`npx openspawn apply ORG.md    # Diff current state → apply changes
+# New roles → spawn | Removed roles → graceful wind-down
+# Changed policies → immediate | Changed prose → next tick`}</CodeBlock>
+
+      <h3 className="mt-6 mb-3 text-xl font-semibold text-slate-200">Teardown</h3>
+      <CodeBlock title="bash">{`npx openspawn destroy          # Graceful shutdown
+# 1. All agents finish in-flight tasks
+# 2. Results written to RESULT.md
+# 3. State exported to ORG.md.bak
+# 4. Server stops`}</CodeBlock>
+
+      <hr className="my-8 border-white/10" />
+
+      {/* ── Relationship to CONTRIBUTING.md ─────────────────────────────────── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">
+        Relationship to CONTRIBUTING.md
+      </h2>
+      <p className="mb-4 text-slate-400">
+        ORG.md and CONTRIBUTING.md serve different but complementary purposes:
+      </p>
+      <div className="overflow-x-auto mb-6">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-4 text-left font-medium text-slate-400"></th>
+              <th className="py-2 pr-4 text-left font-medium text-slate-400">ORG.md</th>
+              <th className="py-2 text-left font-medium text-slate-400">CONTRIBUTING.md</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/5 text-slate-400">
+            {[
+              ["Audience", "AI agents", "Human contributors"],
+              [
+                "Scope",
+                "Org structure, roles, policies, culture",
+                "Dev setup, PR conventions, testing",
+              ],
+              ["Parsed by", "OpenSpawn org parser", "Read by humans"],
+              ["Changes", "openspawn apply ORG.md", "Manual process"],
+              [
+                "Enforced",
+                "Programmatically (budget, permissions, routing)",
+                "By review (code review, CI)",
+              ],
+            ].map(([dim, org, contrib]) => (
+              <tr key={dim}>
+                <td className="py-2 pr-4 font-medium text-slate-300">{dim}</td>
+                <td className="py-2 pr-4">{org}</td>
+                <td className="py-2">{contrib}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mb-6 text-slate-400">
+        In practice, ORG.md is the superset for agent teams. Human contributors still use
+        CONTRIBUTING.md. When agents create PRs, they follow both: ORG.md for org-level policies
+        (budget, escalation) and CONTRIBUTING.md for repo-level conventions (commit format, test
+        requirements).
+      </p>
 
       <hr className="my-8 border-white/10" />
 

--- a/apps/website/app/routes/docs/templates.tsx
+++ b/apps/website/app/routes/docs/templates.tsx
@@ -469,6 +469,162 @@ autonomy: medium`}
         A: Higher per-agent credit limit and delayed escalation allow deeper exploration.
       </div>
 
+      {/* ── Industry Templates ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Industry templates</h2>
+      <p className="mb-4 text-slate-400">
+        7 industry-specific templates for common operational patterns. Each includes specialized
+        roles, domain-tuned policies, and ready-to-use playbooks.
+      </p>
+
+      <div className="mb-8 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium">Template</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Roles</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Culture</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            {[
+              [
+                "saas-onboarding",
+                "Onboarding Lead, Data Migration, Integration Engineer, Success Agent",
+                "agency",
+              ],
+              [
+                "incident-response",
+                "Incident Commander, Diagnostics, Remediator, Comms Agent",
+                "military",
+              ],
+              [
+                "contract-review",
+                "Legal Lead, Clause Analyzer, Risk Assessor, Summary Writer",
+                "enterprise",
+              ],
+              [
+                "compliance-monitoring",
+                "Compliance Officer, Auditor, Policy Checker, Report Generator",
+                "enterprise",
+              ],
+              [
+                "game-live-ops",
+                "Live Ops Director, Event Manager, Balance Analyst, QA Tester",
+                "startup",
+              ],
+              [
+                "catalog-management",
+                "Catalog Manager, Data Entry, Image Processor, Price Optimizer",
+                "agency",
+              ],
+              [
+                "clinical-trials",
+                "Trial Coordinator, Data Monitor, Adverse Event Tracker, Regulatory Agent",
+                "enterprise",
+              ],
+            ].map(([template, roles, culture]) => (
+              <tr key={template} className="border-b border-white/5">
+                <td className="py-2 pr-6">
+                  <code className="inline-code">{template}</code>
+                </td>
+                <td className="py-2 pr-6">{roles}</td>
+                <td className="py-2 pr-6">{culture}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 className="mt-8 mb-3 text-xl font-bold text-slate-100">
+        Example: incident-response ORG.md
+      </h3>
+      <CodeBlock title="ORG.md — incident-response">
+        {`# Incident Response Team
+
+## Identity
+- **Industry:** SaaS / Infrastructure
+- **Stage:** Production operations
+
+## Culture
+preset: military
+- **Escalation:** immediate — production incidents can't wait
+
+## Structure
+
+### Incident Commander
+Coordinates all agents, owns runbook execution, drives MTTR down.
+- **Model:** claude-opus
+- **Domain:** incident-management
+- **Level:** 8
+
+#### Diagnostics Agent
+Reads logs, traces, metrics. Identifies root cause.
+- **Model:** claude-sonnet
+- **Domain:** observability
+
+#### Remediator
+Applies fixes, rolls back deployments, validates recovery.
+- **Model:** claude-sonnet
+- **Domain:** infrastructure
+
+#### Comms Agent
+Posts status updates, notifies stakeholders, writes postmortems.
+- **Model:** claude-haiku
+- **Domain:** communications
+
+## Policies
+- All production changes require Incident Commander approval
+- Comms Agent posts update every 5 minutes during active incident`}
+      </CodeBlock>
+
+      {/* ── Boot Sequence Templates ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Boot sequence templates</h2>
+      <p className="mb-4 text-slate-400">
+        Every template includes boot sequence instructions in its generated{" "}
+        <code className="inline-code">SOUL.md</code>. Agents read these files at startup to
+        understand the org before they begin work.
+      </p>
+      <CodeBlock title="Default boot sequence (all templates)">
+        {`1. Read ORG.md — understand your role, hierarchy, and reporting chain
+2. Read SOUL.md — internalize org values and communication norms
+3. Read AGENTS.md — understand workspace rules and tool access
+4. Write PLAN.md — plan your approach before executing
+5. Execute — follow plan, write RESULT.md when done`}
+      </CodeBlock>
+
+      {/* ── Policy Guardrails ── */}
+      <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Policy guardrails</h2>
+      <p className="mb-4 text-slate-400">
+        Templates include sensible default policies. Override any of these in the{" "}
+        <code className="inline-code">## Policies</code> section of your ORG.md.
+      </p>
+      <div className="mb-8 overflow-x-auto">
+        <table className="w-full text-sm text-left border-collapse">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="py-2 pr-6 text-slate-400 font-medium">Guardrail</th>
+              <th className="py-2 pr-6 text-slate-400 font-medium">Default</th>
+              <th className="py-2 text-slate-400 font-medium">Override with</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-400">
+            {[
+              ["Budget per agent", "500 credits/day", "Per-agent limit in Policies > Budget"],
+              ["Department cap", "10 agents max", "Department Caps in Policies"],
+              ["Spawn permissions", "L7+ only", "Permissions section"],
+              ["Overage behavior", "pause and escalate", "Overage behavior in Budget"],
+              ["Review required", "L6+ for code changes", "Permissions section"],
+            ].map(([guardrail, def_, override]) => (
+              <tr key={guardrail} className="border-b border-white/5">
+                <td className="py-2 pr-6 text-slate-300">{guardrail}</td>
+                <td className="py-2 pr-6">{def_}</td>
+                <td className="py-2">{override}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
       {/* Customizing a template */}
       <h2 className="mt-10 mb-4 text-2xl font-bold text-slate-100">Customizing a template</h2>
 

--- a/apps/website/content/docs/faq.mdx
+++ b/apps/website/content/docs/faq.mdx
@@ -292,7 +292,7 @@ Instead of sending messages, agents write to shared workspace files:
 | `RESULT.md`     | Workers    | Completed deliverables                    |
 | `HANDOFF.md`    | Any agent  | Work ready for next stage                 |
 | `REVIEW.md`     | Reviewers  | Feedback and approvals                    |
-| `ESCALATION.md` | Any agent  | Complex issues needing &gt;3 turns           |
+| `ESCALATION.md` | Any agent  | Complex issues needing &gt;3 turns        |
 
 ---
 

--- a/apps/website/content/docs/reference/event-driven-agents.mdx
+++ b/apps/website/content/docs/reference/event-driven-agents.mdx
@@ -95,13 +95,13 @@ completion arrives → wake → process result ($0.12)
 
 The decision is straightforward:
 
-| Factor            | Use Polling                    | Use Event-Driven                 |
-| ----------------- | ------------------------------ | -------------------------------- |
+| Factor            | Use Polling                       | Use Event-Driven                    |
+| ----------------- | --------------------------------- | ----------------------------------- |
 | Model cost        | Cheap (&lt;$0.01/call)            | Expensive (&gt;$0.05/call)          |
 | Activity level    | Busy (&gt;50% of ticks have work) | Sparse (&lt;20% of ticks have work) |
-| Role type         | Worker (always has tasks)      | Manager (waits for reports)      |
-| Latency tolerance | Needs sub-second response      | Can wait for next tick check     |
-| Budget priority   | Predictable spend              | Minimized spend                  |
+| Role type         | Worker (always has tasks)         | Manager (waits for reports)         |
+| Latency tolerance | Needs sub-second response         | Can wait for next tick check        |
+| Budget priority   | Predictable spend                 | Minimized spend                     |
 
 Most orgs will use both. That's the point.
 

--- a/apps/website/public/docs/agent-quickstart.md
+++ b/apps/website/public/docs/agent-quickstart.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/agent-quickstart
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # Agent Quickstart
@@ -36,20 +36,65 @@ id, model (opus for L7+, sonnet for L6-), workspace,
 
 tools.profile: "full". Manager agents (L7+ with direct reports) also get subagents.allowAgents. The highest-level agent gets default: true.
 
+## Boot sequence protocol
+
+```
+1. Read ORG.md → understand org structure, your role, who you report to
+2. Read SOUL.md → internalize shared values and behavioral norms
+3. Read AGENTS.md → understand workspace rules and tool access
+4. Write PLAN.md → plan your approach before touching any code
+5. Begin execution → follow plan, write RESULT.md when done
+```
+
+Q: How do I apply the patch to my gateway? A: Copy the entries from openclaw-patch.json into your OpenClaw agents.list configuration, then restart the gateway. Every agent follows a planning-first startup protocol before executing work:
+
+## Task lifecycle via MCP
+
+Q: Why planning-first? A: Agents that plan before executing produce higher-quality output and escalate blockers earlier. The plan is also reviewable by leads before work begins.
+
+```
+# Create a task (leads only, L7+)
+mcp.call("openspawn/task_create", {
+title: "Implement rate limiting",
+assignee: "backend-senior",
+priority: "high"
+})
+# Claim an available task (workers)
+mcp.call("openspawn/task_claim", { agent_id: "backend-senior-1" })
+# List tasks for an agent
+mcp.call("openspawn/task_list", {
+agent_id: "backend-senior-1",
+status: "in_progress"
+})
+# Complete a task with results
+mcp.call("openspawn/task_complete", {
+task_id: "task-123",
+result: "Rate limiting implemented — 100 req/min per API key"
+})
+```
+
+## Init + deploy in one step
+
 ## Pick a template
 
 ```
-# Personal AI team (chief of staff + specialists)
-openspawn init my-org --template=assistant-team
-# Content production pipeline
-openspawn init my-org --template=content-agency
-# Software development team
-openspawn init my-org --template=dev-shop
-# Research & analysis team
-openspawn init my-org --template=research-lab
+openspawn init my-org --template=assistant-team # Personal AI team
+openspawn init my-org --template=content-agency # Content production pipeline
+openspawn init my-org --template=dev-shop # Software development team
+openspawn init my-org --template=research-lab # Research & analysis team
 ```
 
-Q: How do I apply the patch to my gateway? A: Copy the entries from openclaw-patch.json into your OpenClaw agents.list configuration, then restart the gateway. Four templates ship with OpenSpawn. Each produces a complete ORG.md you can use immediately or customize.
+```
+openspawn init my-org --template=saas-onboarding # Customer onboarding pipeline
+openspawn init my-org --template=incident-response # Production incident management
+openspawn init my-org --template=contract-review # Legal contract analysis
+openspawn init my-org --template=compliance-monitoring # Regulatory compliance
+openspawn init my-org --template=game-live-ops # Game operations (events, patches)
+openspawn init my-org --template=catalog-management # Product catalog maintenance
+openspawn init my-org --template=clinical-trials # Clinical trial coordination
+```
+
+Agents manage their task queue through MCP tools:
 
 ```
 What's your primary output?
@@ -302,6 +347,12 @@ openspawn status — verify agent name spelling
 
 ERR_GATEWAY_UNREACHABLE
 
+openclaw gateway status — ensure gateway is running
+
+ERR_HMAC_INVALID Check AGENT_SECRET env var matches the value in
+
+openspawn.config.json. Regenerate with
+
 ## Next steps
 
-openclaw gateway status — ensure gateway is running to="/docs/templates" Customize ORG.md → Full reference for every section, field, and option in your org definition. to="/docs/comparison" Connect real models → Configure API keys and model providers for production deployments. to="/getting-started" Full CLI reference → Every command, flag, and option for the OpenSpawn CLI. to="/app/live" See live demo → Watch a multi-agent org handle tasks, escalations, and consensus in real time.
+openspawn secrets rotate to="/docs/templates" Customize ORG.md → Full reference for every section, field, and option in your org definition. to="/docs/comparison" Connect real models → Configure API keys and model providers for production deployments. to="/getting-started" Full CLI reference → Every command, flag, and option for the OpenSpawn CLI. to="/app/live" See live demo → Watch a multi-agent org handle tasks, escalations, and consensus in real time.

--- a/apps/website/public/docs/architecture/ceo-agent.md
+++ b/apps/website/public/docs/architecture/ceo-agent.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/architecture/ceo-agent
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 > A real agent organization running on real infrastructure — the bridge between OpenSpawn's simulation and production multi-agent systems.
 

--- a/apps/website/public/docs/architecture/integrations.md
+++ b/apps/website/public/docs/architecture/integrations.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/architecture/integrations
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 # BikiniBottom — Integration Strategy & Growth Roadmap
 

--- a/apps/website/public/docs/architecture/worktree-isolation.md
+++ b/apps/website/public/docs/architecture/worktree-isolation.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/architecture/worktree-isolation
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 # Worktree Isolation Spec
 

--- a/apps/website/public/docs/communication-protocol.md
+++ b/apps/website/public/docs/communication-protocol.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/communication-protocol
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # Communication Protocol v1
@@ -264,9 +264,83 @@ Lead: @agent-b TASK: Build API integration
 // 1 message. Deterministic routing.
 ```
 
+## Escalation Reasons
+
+5 messages, 0 work done, ~2,000 tokens wasted Cost: 2 wasted messages Cost: 5 messages for a routing decision Every ESCALATION message must include a typed reason. This enables routing and automated responses.
+
+Reason
+
+When to use
+
+## ACP Data Model
+
+```
+interface AcpMessage {
+id: string;
+type: "TASK" | "RESULT" | "ESCALATION" | "DECISION";
+from: string; // agent ID
+to: string; // agent ID or channel
+timestamp: string; // ISO 8601
+payload: AcpPayload;
+interface TaskPayload {
+title: string;
+deliverable: string; // file path or description
+priority: "low" | "medium" | "high" | "urgent";
+requirements?: string;
+interface ResultPayload {
+taskId: string;
+location: string; // where the output lives
+summary: string;
+interface EscalationPayload {
+taskId: string;
+reason: EscalationReason;
+blocked: string; // what's blocked
+need: string; // what's needed to unblock
+interface DecisionPayload {
+escalationId: string;
+resolution: string; // definitive action to take
+unblocks: string[]; // task IDs being unblocked
+type AcpPayload =
+| TaskPayload
+| ResultPayload
+| EscalationPayload
+| DecisionPayload;
+type EscalationReason =
+| "BLOCKED"
+| "OUT_OF_DOMAIN"
+| "BUDGET_EXCEEDED"
+| "AMBIGUOUS_TASK"
+| "CONFLICT"
+| "QUALITY_CONCERN"
+| "TIMEOUT";
+```
+
+## Agent Decision Model
+
+```
+function decide(agent: Agent): Action {
+// 1. Check inbox for new messages
+if (hasEscalation()) → return resolveOrReEscalate()
+if (hasNewTask()) → return beginWork()
+if (hasResult()) → return reviewResult()
+// 2. Check in-progress work
+if (isBlocked()) → return escalate()
+if (workComplete()) → return submitResult()
+if (workInProgress()) → return continueWork()
+// 3. Nothing to do
+return idle()
+}
+```
+
+Routes to ["BLOCKED", "Missing resource, dependency, or permission", "Direct manager"], ["OUT_OF_DOMAIN", "Task outside agent's expertise", "Manager for re-routing"], ["BUDGET_EXCEEDED", "Agent hit credit limit", "Manager + human principal"], ["AMBIGUOUS_TASK", "Task requirements unclear after 1 clarification", "Task creator"], ["CONFLICT", "Two agents making contradictory changes", "Nearest shared manager"], "QUALITY_CONCERN", "Output doesn't meet standards after 2 attempts", "Reviewer (L6+)", ["TIMEOUT", "Upstream dependency not responding", "Manager"], ].map(([reason, when, routes]) => ( The Agent Communication Protocol (ACP) defines typed interfaces for all messages and events in the system. On each tick, every agent evaluates its state and decides one of 5 actions:
+
+Action
+
+Messages sent
+
 ## Implementation Checklist
 
-5 messages, 0 work done, ~2,000 tokens wasted Cost: 2 wasted messages Cost: 5 messages for a routing decision Add protocol rules to SOUL.md — every agent must internalize the 4 principles Use role-specific AGENTS.md templates — include message type examples Create shared files — PLAN.md,
+Cost ["beginWork()", "0 — silence is success", "1 LLM call"], ["continueWork()", "0", "1 LLM call"], ["submitResult()", "0 or 1 RESULT", "0"], ["escalate()", "1 ESCALATION", "0"], ["resolveOrReEscalate()", "1 DECISION or 1 ESCALATION", "0-1 LLM calls"], ["idle()", "0", "0 (cheap models only)"], ].map(([action, msgs, cost]) => ( Add protocol rules to SOUL.md — every agent must internalize the 4 principles Use role-specific AGENTS.md templates — include message type examples Create shared files — PLAN.md,
 
 RESULT.md,
 

--- a/apps/website/public/docs/comparison.md
+++ b/apps/website/public/docs/comparison.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/comparison
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # OpenSpawn vs CrewAI vs LangGraph

--- a/apps/website/public/docs/concepts/acp-vs-a2a.md
+++ b/apps/website/public/docs/concepts/acp-vs-a2a.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/concepts/acp-vs-a2a
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # ACP vs A2A

--- a/apps/website/public/docs/faq.md
+++ b/apps/website/public/docs/faq.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/faq
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 # OpenSpawn FAQ
 
@@ -292,7 +292,7 @@ Instead of sending messages, agents write to shared workspace files:
 | `RESULT.md`     | Workers    | Completed deliverables                    |
 | `HANDOFF.md`    | Any agent  | Work ready for next stage                 |
 | `REVIEW.md`     | Reviewers  | Feedback and approvals                    |
-| `ESCALATION.md` | Any agent  | Complex issues needing &gt;3 turns           |
+| `ESCALATION.md` | Any agent  | Complex issues needing &gt;3 turns        |
 
 ---
 

--- a/apps/website/public/docs/features/dashboard.md
+++ b/apps/website/public/docs/features/dashboard.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/features/dashboard
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # Dashboard

--- a/apps/website/public/docs/features/model-router.md
+++ b/apps/website/public/docs/features/model-router.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/features/model-router
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # Model Router

--- a/apps/website/public/docs/getting-started.md
+++ b/apps/website/public/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/getting-started
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # Getting Started with OpenSpawn
@@ -15,6 +15,8 @@ What you'll have in ~10 minutes: a local org of AI agents, coordinated by a mark
 
 ```
 ├── ORG.md # Your org definition — this is the important one
+├── SOUL.md # Shared behavior/values for all agents
+├── AGENTS.md # Workspace rules for agent tooling
 ```
 
 ```
@@ -182,11 +184,17 @@ Tick-based execution: The server runs a loop. On each "tick", every agent checks
 
 The model router: OpenSpawn automatically routes to the right model based on agent level. L9–L10 executives get top-tier models. L7–L8 leads get mid-tier. L1–L6 workers get local Ollama — free. A 25-agent org with naive polling on the best model could cost $36/hour. With tiered routing, it's closer to $8.
 
+## SQLite vs PostgreSQL
+
+ACP is the nervous system: Every meaningful agent action generates a structured message. Delegations, acknowledgments, progress updates, escalations, completions — all flow through the Agent Communication Protocol. The dashboard reads ACP message streams in real-time via SSE. OpenSpawn supports two database tiers. Start with SQLite — upgrade when you need to.
+
+SQLite (Tier 1)
+
 ## Next Steps
 
 ## Quick Reference
 
-ACP is the nervous system: Every meaningful agent action generates a structured message. Delegations, acknowledgments, progress updates, escalations, completions — all flow through the Agent Communication Protocol. The dashboard reads ACP message streams in real-time via SSE. title: "Your First ORG.md", desc: "Full tutorial — all five sections, from scratch", to: "/docs/tutorials/your-first-org-md", title: "Dashboard Walkthrough", desc: "Reading health scores, diagnosing escalation chains", to: "/docs/features/dashboard", title: "A2A Protocol", desc: "External agent discovery and task routing", to: "/docs/protocols/a2a", title: "MCP Tools", desc: "All 7 tools with examples", to: "/docs/protocols/mcp", ].map((item) => ( key={item.to} to={item.to}
+PostgreSQL (Tier 2) ["Setup", "Zero config — works out of the box", "Requires PostgreSQL 16+ and Redis"], "Best for", "Local dev, prototyping, small orgs", "Production, multi-user, large orgs", "Concurrency", "Single-writer, good for 1–5 agents", "Full concurrent access, 50+ agents", ["Background jobs", "asyncio scheduler (in-process)", "arq + Redis (distributed)"], ["Docker required?", "No", "Yes (recommended)"], ["Data persistence", "Local file (test.db)", "Durable with backups"], ["pgvector / search", "Not available", "Vector similarity search for memory"], ].map(([feature, sqlite, pg]) => ( title: "Your First ORG.md", desc: "Full tutorial — all five sections, from scratch", to: "/docs/tutorials/your-first-org-md", title: "Dashboard Walkthrough", desc: "Reading health scores, diagnosing escalation chains", to: "/docs/features/dashboard", title: "A2A Protocol", desc: "External agent discovery and task routing", to: "/docs/protocols/a2a", title: "MCP Tools", desc: "All 7 tools with examples", to: "/docs/protocols/mcp", ].map((item) => ( key={item.to} to={item.to}
 
 Command
 

--- a/apps/website/public/docs/guides/connecting-agents.md
+++ b/apps/website/public/docs/guides/connecting-agents.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/guides/connecting-agents
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # Connecting Real Agents

--- a/apps/website/public/docs/guides/dashboard-guide.md
+++ b/apps/website/public/docs/guides/dashboard-guide.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/guides/dashboard-guide
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # Dashboard Guide

--- a/apps/website/public/docs/guides/troubleshooting.md
+++ b/apps/website/public/docs/guides/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/guides/troubleshooting
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 **Quick diagnostic:** When something breaks, start here:
 

--- a/apps/website/public/docs/guides/values-framework.md
+++ b/apps/website/public/docs/guides/values-framework.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/guides/values-framework
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 **What you'll learn:** How alignment values work in OpenSpawn — what each value does to agent behavior, where they come from, which ones conflict, and how to choose the right set for your org.
 

--- a/apps/website/public/docs/guides/webhooks.md
+++ b/apps/website/public/docs/guides/webhooks.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/guides/webhooks
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 OpenSpawn has two complementary webhook directions:
 

--- a/apps/website/public/docs/how-it-works.md
+++ b/apps/website/public/docs/how-it-works.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/how-it-works
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # How It Works

--- a/apps/website/public/docs/index.md
+++ b/apps/website/public/docs/index.md
@@ -1,8 +1,10 @@
 ---
 source: https://openspawn.ai/docs/
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # Documentation
 
-Learn how to set up, configure, and integrate with OpenSpawn. key={s.to} to={s.to}
+## Key Concepts
+
+Learn how to set up, configure, and integrate with OpenSpawn. key={s.to} to={s.to} name: "ORG.md", desc: "A single markdown file that defines your entire agent organization — roles, hierarchy, culture, policies, and playbooks. It's infrastructure-as-code for agent teams.", name: "Hierarchy", desc: "Agents have levels (L1–L10) and report-to relationships. Heading depth in ORG.md determines hierarchy. Tasks flow down, escalations flow up.", name: "Communication Protocol", desc: "4 message types (TASK, RESULT, ESCALATION, DECISION), silence-as-success, files-over-chat. Eliminates 40–60% of wasted coordination tokens.", name: "Dashboard", desc: "Real-time React UI showing network graph, task timelines, agent cards, trust scores, and org health. Powered by SSE streaming.", name: "MCP & A2A", desc: "Every org exposes 7 MCP tools and A2A agent cards. Any MCP-compatible client or A2A-capable agent can discover and interact with your org.", ].map((concept) => ( key={concept.name}

--- a/apps/website/public/docs/openclaw-quickstart.md
+++ b/apps/website/public/docs/openclaw-quickstart.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/openclaw-quickstart
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # OpenSpawn for OpenClaw Agents

--- a/apps/website/public/docs/protocols/a2a.md
+++ b/apps/website/public/docs/protocols/a2a.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/protocols/a2a
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # A2A Protocol

--- a/apps/website/public/docs/protocols/mcp-reference.md
+++ b/apps/website/public/docs/protocols/mcp-reference.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/protocols/mcp-reference
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # MCP Tools & Integrations

--- a/apps/website/public/docs/protocols/mcp.md
+++ b/apps/website/public/docs/protocols/mcp.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/protocols/mcp
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # MCP Tools

--- a/apps/website/public/docs/reference/acp.md
+++ b/apps/website/public/docs/reference/acp.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/reference/acp
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 # Agent Communication Protocol (ACP)
 

--- a/apps/website/public/docs/reference/agent-config-compat.md
+++ b/apps/website/public/docs/reference/agent-config-compat.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/reference/agent-config-compat
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 # OpenClaw-Compatible Agent Configuration
 

--- a/apps/website/public/docs/reference/api.md
+++ b/apps/website/public/docs/reference/api.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/reference/api
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 # OpenSpawn REST API Reference
 

--- a/apps/website/public/docs/reference/event-driven-agents.md
+++ b/apps/website/public/docs/reference/event-driven-agents.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/reference/event-driven-agents
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 # Event-Driven Agent Architecture
 
@@ -95,13 +95,13 @@ completion arrives → wake → process result ($0.12)
 
 The decision is straightforward:
 
-| Factor            | Use Polling                    | Use Event-Driven                 |
-| ----------------- | ------------------------------ | -------------------------------- |
+| Factor            | Use Polling                       | Use Event-Driven                    |
+| ----------------- | --------------------------------- | ----------------------------------- |
 | Model cost        | Cheap (&lt;$0.01/call)            | Expensive (&gt;$0.05/call)          |
 | Activity level    | Busy (&gt;50% of ticks have work) | Sparse (&lt;20% of ticks have work) |
-| Role type         | Worker (always has tasks)      | Manager (waits for reports)      |
-| Latency tolerance | Needs sub-second response      | Can wait for next tick check     |
-| Budget priority   | Predictable spend              | Minimized spend                  |
+| Role type         | Worker (always has tasks)         | Manager (waits for reports)         |
+| Latency tolerance | Needs sub-second response         | Can wait for next tick check        |
+| Budget priority   | Predictable spend                 | Minimized spend                     |
 
 Most orgs will use both. That's the point.
 

--- a/apps/website/public/docs/reference/org-md-reference.md
+++ b/apps/website/public/docs/reference/org-md-reference.md
@@ -1,9 +1,11 @@
 ---
 source: https://openspawn.ai/docs/reference/org-md-reference
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # ORG.md Reference
+
+## Why Markdown?
 
 ## Overview
 
@@ -373,9 +375,56 @@ ORG.md. Relationship to Other Standards
 
 Standard
 
+## SDLC Presets
+
+Relationship to ORG.md "CLAUDE.md", "One agent's behavior", "ORG.md wraps multiple agents; each role description is that agent's implicit CLAUDE.md", "AGENTS.md", "Workspace rules", "ORG.md is the superset — workspace rules + org structure + policies", "ACP", "Communication protocol", "ORG.md's Culture section configures ACP parameters", "A2A", "Inter-org communication", "ORG.md defines one org; A2A connects multiple orgs", "Terraform / Pulumi", "Infrastructure as code", "ORG.md is the same pattern applied to agent organizations", ].map(([std, scope, rel]) => ( SDLC presets configure development lifecycle rules — review requirements, testing mandates, and deployment gates. Set via sdlc: preset-name in the Culture section.
+
+Preset
+
+Review
+
+```
+preset: startup
+```
+
+## Workspace Strategy
+
+Deploy Gate ["standard", "L6+ required", "Required before merge", "CI pass + approval"], "strict", "2 reviewers (L7+)", "Coverage threshold 80%", "CI + security scan + approval", ["solo", "Self-review OK", "Optional", "CI pass"], ["research", "No review", "None", "None — exploratory"], ].map(([preset, review, tests, deploy]) => ( Each agent operates in an isolated workspace to prevent conflicts. The default strategy is
+
+```
+Worktree: .worktrees/backend-senior-1/
+Branch: agent/backend-senior-1
+Base: main
+Agent: Backend Senior 2
+Worktree: .worktrees/backend-senior-2/
+Branch: agent/backend-senior-2
+```
+
+## Org Lifecycle
+
+### Deployment
+
+### Upgrading
+
+```
+# New roles → spawn | Removed roles → graceful wind-down
+```
+
+### Teardown
+
+```
+# 1. All agents finish in-flight tasks
+# 2. Results written to RESULT.md
+# 3. State exported to ORG.md.bak
+```
+
+worktree-per-agent — each agent gets a git worktree branched from main. When an agent completes a task, its changes are merged back to main via PR. Conflicts are escalated to the agent's lead. Relationship to CONTRIBUTING.md ORG.md and CONTRIBUTING.md serve different but complementary purposes:
+
+ORG.md
+
 ## Further Reading
 
-Relationship to ORG.md "CLAUDE.md", "One agent's behavior", "ORG.md wraps multiple agents; each role description is that agent's implicit CLAUDE.md", "AGENTS.md", "Workspace rules", "ORG.md is the superset — workspace rules + org structure + policies", "ACP", "Communication protocol", "ORG.md's Culture section configures ACP parameters", "A2A", "Inter-org communication", "ORG.md defines one org; A2A connects multiple orgs", "Terraform / Pulumi", "Infrastructure as code", "ORG.md is the same pattern applied to agent organizations", ].map(([std, scope, rel]) => ( to="/docs/tutorials/your-first-org-md"
+CONTRIBUTING.md ["Audience", "AI agents", "Human contributors"], "Scope", "Org structure, roles, policies, culture", "Dev setup, PR conventions, testing", ["Parsed by", "OpenSpawn org parser", "Read by humans"], ["Changes", "openspawn apply ORG.md", "Manual process"], "Enforced", "Programmatically (budget, permissions, routing)", "By review (code review, CI)", ].map(([dim, org, contrib]) => ( In practice, ORG.md is the superset for agent teams. Human contributors still use CONTRIBUTING.md. When agents create PRs, they follow both: ORG.md for org-level policies (budget, escalation) and CONTRIBUTING.md for repo-level conventions (commit format, test requirements). to="/docs/tutorials/your-first-org-md"
 
 Your First ORG.md →
 

--- a/apps/website/public/docs/reference/scenario-engine.md
+++ b/apps/website/public/docs/reference/scenario-engine.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/reference/scenario-engine
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 # BikiniBottom Scenario Engine
 

--- a/apps/website/public/docs/templates.md
+++ b/apps/website/public/docs/templates.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/templates
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # Templates Guide
@@ -266,6 +266,65 @@ Synthesis
 
 When to use: exploratory or open-ended work, high autonomy needed, long-running tasks.
 
+## Industry templates
+
+Q: What's the exploration budget? A: Higher per-agent credit limit and delayed escalation allow deeper exploration. 7 industry-specific templates for common operational patterns. Each includes specialized roles, domain-tuned policies, and ready-to-use playbooks.
+
+Template
+
+```
+# Incident Response Team
+## Identity
+- **Industry:** SaaS / Infrastructure
+- **Stage:** Production operations
+## Culture
+preset: military
+- **Escalation:** immediate — production incidents can't wait
+## Structure
+### Incident Commander
+Coordinates all agents, owns runbook execution, drives MTTR down.
+- **Model:** claude-opus
+- **Domain:** incident-management
+- **Level:** 8
+#### Diagnostics Agent
+Reads logs, traces, metrics. Identifies root cause.
+- **Model:** claude-sonnet
+- **Domain:** observability
+#### Remediator
+Applies fixes, rolls back deployments, validates recovery.
+- **Model:** claude-sonnet
+- **Domain:** infrastructure
+#### Comms Agent
+Posts status updates, notifies stakeholders, writes postmortems.
+- **Model:** claude-haiku
+- **Domain:** communications
+## Policies
+- All production changes require Incident Commander approval
+- Comms Agent posts update every 5 minutes during active incident
+```
+
+## Boot sequence templates
+
+Culture "saas-onboarding", "Onboarding Lead, Data Migration, Integration Engineer, Success Agent", "agency", "incident-response", "Incident Commander, Diagnostics, Remediator, Comms Agent", "military", "contract-review", "Legal Lead, Clause Analyzer, Risk Assessor, Summary Writer", "enterprise", "compliance-monitoring", "Compliance Officer, Auditor, Policy Checker, Report Generator", "enterprise", "game-live-ops", "Live Ops Director, Event Manager, Balance Analyst, QA Tester", "startup", "catalog-management", "Catalog Manager, Data Entry, Image Processor, Price Optimizer", "agency", "clinical-trials", "Trial Coordinator, Data Monitor, Adverse Event Tracker, Regulatory Agent", "enterprise", ].map(([template, roles, culture]) => ( Example: incident-response ORG.md Every template includes boot sequence instructions in its generated
+
+```
+1. Read ORG.md — understand your role, hierarchy, and reporting chain
+2. Read SOUL.md — internalize org values and communication norms
+3. Read AGENTS.md — understand workspace rules and tool access
+4. Write PLAN.md — plan your approach before executing
+5. Execute — follow plan, write RESULT.md when done
+```
+
+## Policy guardrails
+
+SOUL.md. Agents read these files at startup to understand the org before they begin work. Templates include sensible default policies. Override any of these in the
+
+## Policies section of your ORG.md.
+
+Guardrail
+
+Default
+
 ## Customizing a template
 
 ### Add an agent
@@ -283,7 +342,7 @@ When to use: exploratory or open-ended work, high autonomy needed, long-running 
 
 ### Change culture
 
-Q: What's the exploration budget? A: Higher per-agent credit limit and delayed escalation allow deeper exploration. Delete the agent's line from the Structure section. Re-assign or remove any agents that reported to it. Run openspawn validate to confirm. Move agent lines to different indentation levels or under different parents. Validate after changes. Edit the preset value in the Culture section. Valid presets: agency,
+Override with ["Budget per agent", "500 credits/day", "Per-agent limit in Policies > Budget"], ["Department cap", "10 agents max", "Department Caps in Policies"], ["Spawn permissions", "L7+ only", "Permissions section"], ["Overage behavior", "pause and escalate", "Overage behavior in Budget"], ["Review required", "L6+ for code changes", "Permissions section"], ].map(([guardrail, def_, override]) => ( Delete the agent's line from the Structure section. Re-assign or remove any agents that reported to it. Run openspawn validate to confirm. Move agent lines to different indentation levels or under different parents. Validate after changes. Edit the preset value in the Culture section. Valid presets: agency,
 
 ### Add a playbook
 

--- a/apps/website/public/docs/tutorials/your-first-org-md.md
+++ b/apps/website/public/docs/tutorials/your-first-org-md.md
@@ -1,6 +1,6 @@
 ---
 source: https://openspawn.ai/docs/tutorials/your-first-org-md
-generated: 2026-03-13
+generated: 2026-03-14
 ---
 
 # Your First ORG.md

--- a/docs/openspawn/plans/2026-03-13-artifact-bus.md
+++ b/docs/openspawn/plans/2026-03-13-artifact-bus.md
@@ -14,24 +14,25 @@
 
 ## File Map
 
-| File | Action | Responsibility |
-|------|--------|---------------|
-| `apps/api/app/models/enums.py` | Modify | Add ArtifactType, ArtifactStatus, ARTIFACTS_BATCH_PUBLISHED |
-| `apps/api/app/models/artifact.py` | Create | Artifact + ArtifactSubscription SQLAlchemy models |
-| `apps/api/app/artifacts/__init__.py` | Create | Package init |
-| `apps/api/app/artifacts/schemas.py` | Create | Pydantic DTOs + response schemas |
-| `apps/api/app/artifacts/router.py` | Create | REST endpoints (10 routes) |
-| `apps/api/app/main.py` | Modify | Register artifacts_router |
-| `apps/api/app/mcp_server/server.py` | Modify | Add 5 artifact MCP tools |
-| `apps/api/alembic/versions/0005_add_artifacts_tables.py` | Create | Migration for artifacts + artifact_subscriptions |
-| `apps/api/tests/test_artifact_unit.py` | Create | Unit tests for publish logic, hashing, versioning |
-| `apps/api/tests/test_artifact_integration.py` | Create | Integration tests on SQLite |
+| File                                                     | Action | Responsibility                                              |
+| -------------------------------------------------------- | ------ | ----------------------------------------------------------- |
+| `apps/api/app/models/enums.py`                           | Modify | Add ArtifactType, ArtifactStatus, ARTIFACTS_BATCH_PUBLISHED |
+| `apps/api/app/models/artifact.py`                        | Create | Artifact + ArtifactSubscription SQLAlchemy models           |
+| `apps/api/app/artifacts/__init__.py`                     | Create | Package init                                                |
+| `apps/api/app/artifacts/schemas.py`                      | Create | Pydantic DTOs + response schemas                            |
+| `apps/api/app/artifacts/router.py`                       | Create | REST endpoints (10 routes)                                  |
+| `apps/api/app/main.py`                                   | Modify | Register artifacts_router                                   |
+| `apps/api/app/mcp_server/server.py`                      | Modify | Add 5 artifact MCP tools                                    |
+| `apps/api/alembic/versions/0005_add_artifacts_tables.py` | Create | Migration for artifacts + artifact_subscriptions            |
+| `apps/api/tests/test_artifact_unit.py`                   | Create | Unit tests for publish logic, hashing, versioning           |
+| `apps/api/tests/test_artifact_integration.py`            | Create | Integration tests on SQLite                                 |
 
 ---
 
 ## Task 1: Enums + Model
 
 **Files:**
+
 - Modify: `apps/api/app/models/enums.py`
 - Create: `apps/api/app/models/artifact.py`
 
@@ -172,6 +173,7 @@ git commit -m "feat(api): add Artifact + ArtifactSubscription models (#665)"
 ## Task 2: Schemas + Publish Helpers
 
 **Files:**
+
 - Create: `apps/api/app/artifacts/__init__.py`
 - Create: `apps/api/app/artifacts/schemas.py`
 
@@ -271,6 +273,7 @@ git commit -m "feat(api): add artifact schemas + content hash helper (#665)"
 ## Task 3: Router — CRUD + Publish + Subscribe
 
 **Files:**
+
 - Create: `apps/api/app/artifacts/router.py`
 - Modify: `apps/api/app/main.py`
 
@@ -684,11 +687,13 @@ async def delete_subscription(
 - [ ] **Step 2: Register router in `app/main.py`**
 
 Add import:
+
 ```python
 from app.artifacts.router import router as artifacts_router
 ```
 
 Add registration (before `sse_router` to avoid path conflicts):
+
 ```python
 app.include_router(artifacts_router)
 ```
@@ -714,6 +719,7 @@ git commit -m "feat(api): add artifact REST endpoints + subscription routing (#6
 ## Task 4: MCP Tools
 
 **Files:**
+
 - Modify: `apps/api/app/mcp_server/server.py`
 
 - [ ] **Step 1: Add artifact tools section**
@@ -831,6 +837,7 @@ git commit -m "feat(api): add 5 artifact MCP tools (#665)"
 ## Task 5: Alembic Migration
 
 **Files:**
+
 - Create: `apps/api/alembic/versions/0005_add_artifacts_tables.py`
 
 - [ ] **Step 1: Create migration file**
@@ -908,6 +915,7 @@ git commit -m "feat(api): add alembic migration for artifacts tables (#665)"
 ## Task 6: Unit Tests
 
 **Files:**
+
 - Create: `apps/api/tests/test_artifact_unit.py`
 
 - [ ] **Step 1: Write unit tests**
@@ -915,6 +923,7 @@ git commit -m "feat(api): add alembic migration for artifacts tables (#665)"
 Tests for: content hashing, publish logic (version increment, dedup, supersede), status transitions, subscription filtering. Use mocked DB (AsyncMock) following `test_sse_bus.py` pattern.
 
 Key tests:
+
 - `test_content_hash_deterministic` — same dict regardless of key order
 - `test_content_hash_differs` — different content → different hash
 - `test_valid_status_transitions` — draft→published, published→superseded
@@ -940,6 +949,7 @@ git commit -m "test(api): add artifact unit tests (#665)"
 ## Task 7: Integration Tests
 
 **Files:**
+
 - Create: `apps/api/tests/test_artifact_integration.py`
 
 - [ ] **Step 1: Write integration tests**
@@ -947,6 +957,7 @@ git commit -m "test(api): add artifact unit tests (#665)"
 Use SQLite fixture pattern from `test_sse_integration.py` (sqlite_env + client fixtures, AUTH_MODE=none).
 
 Key tests:
+
 - `test_publish_creates_v1` — POST /artifacts returns artifact with version=1
 - `test_publish_existing_name_increments_version` — second publish → version=2
 - `test_publish_supersedes_previous` — v1 gets superseded_by_id set

--- a/docs/openspawn/specs/2026-03-13-artifact-bus-design.md
+++ b/docs/openspawn/specs/2026-03-13-artifact-bus-design.md
@@ -82,18 +82,18 @@ class ArtifactStatus(StrEnum):
 
 ## REST API
 
-| Method | Path | Purpose |
-|--------|------|---------|
-| POST | /artifacts | Publish single artifact |
-| POST | /artifacts/batch | Publish multiple, grouped SSE |
-| GET | /artifacts | List with filters: type, name, task_id, status, producer_agent_id |
-| GET | /artifacts/latest | Latest published version by name |
-| GET | /artifacts/{id} | Get single artifact |
-| GET | /artifacts/{id}/history | All versions by name |
-| PUT | /artifacts/{id}/status | Transition status |
-| POST | /artifacts/subscribe | Create subscription |
-| GET | /artifacts/subscriptions | List agent's subscriptions |
-| DELETE | /artifacts/subscriptions/{id} | Remove subscription |
+| Method | Path                          | Purpose                                                           |
+| ------ | ----------------------------- | ----------------------------------------------------------------- |
+| POST   | /artifacts                    | Publish single artifact                                           |
+| POST   | /artifacts/batch              | Publish multiple, grouped SSE                                     |
+| GET    | /artifacts                    | List with filters: type, name, task_id, status, producer_agent_id |
+| GET    | /artifacts/latest             | Latest published version by name                                  |
+| GET    | /artifacts/{id}               | Get single artifact                                               |
+| GET    | /artifacts/{id}/history       | All versions by name                                              |
+| PUT    | /artifacts/{id}/status        | Transition status                                                 |
+| POST   | /artifacts/subscribe          | Create subscription                                               |
+| GET    | /artifacts/subscriptions      | List agent's subscriptions                                        |
+| DELETE | /artifacts/subscriptions/{id} | Remove subscription                                               |
 
 ### Publish Flow
 
@@ -123,13 +123,13 @@ class UpdateStatusDto(BaseModel):
 
 ## MCP Tools
 
-| Tool | Params | Maps to |
-|------|--------|---------|
-| artifact_publish | type, name, content_json, task_id, source_artifact_ids?, metadata_json? | POST /artifacts |
-| artifact_get | artifact_id?, name? | GET /artifacts/{id} or /latest |
-| artifact_list | task_id?, type?, status?, producer_agent_id? | GET /artifacts |
-| artifact_subscribe | artifact_type, task_id? | POST /artifacts/subscribe |
-| artifact_history | name | GET /artifacts/{id}/history |
+| Tool               | Params                                                                  | Maps to                        |
+| ------------------ | ----------------------------------------------------------------------- | ------------------------------ |
+| artifact_publish   | type, name, content_json, task_id, source_artifact_ids?, metadata_json? | POST /artifacts                |
+| artifact_get       | artifact_id?, name?                                                     | GET /artifacts/{id} or /latest |
+| artifact_list      | task_id?, type?, status?, producer_agent_id?                            | GET /artifacts                 |
+| artifact_subscribe | artifact_type, task_id?                                                 | POST /artifacts/subscribe      |
+| artifact_history   | name                                                                    | GET /artifacts/{id}/history    |
 
 `content_json` accepted as string, parsed + validated server-side. One tool for publish and update (auto-versions on existing name).
 


### PR DESCRIPTION
## Summary

- **Phase 3b** of docs consolidation — enrich 6 existing JSX doc pages with content from the now-deleted Starlight docs
- **docs/index.tsx**: Add "Key Concepts" section (ORG.md, Hierarchy, Communication, Dashboard, MCP)
- **getting-started.tsx**: Add Python 3.12 + uv prerequisites, SOUL.md/AGENTS.md workspace output, SQLite vs PostgreSQL comparison table
- **agent-quickstart.tsx**: Add boot sequence protocol, task lifecycle MCP calls, `--deploy` flag, 7 industry templates, HMAC auth error recovery
- **templates.tsx**: Add 7 industry templates table + incident-response ORG.md example, boot sequence templates, policy guardrails
- **communication-protocol.tsx**: Add escalation reasons enum, ACP data model (TypeScript interfaces), agent decision model
- **org-md-reference.tsx**: Add "Why Markdown?" section, SDLC presets, workspace strategy, org lifecycle, CONTRIBUTING.md relationship
- Update deprecated `pages.yml` workflow stub
- Regenerate search index (12 pages) + llms.txt markdown (30 files)

## Test plan

- [x] `pnpm exec oxfmt --write .` — 0 formatting changes
- [x] `pnpm exec nx run-many -t lint` — 0 warnings, 19 projects pass
- [x] `pnpm exec nx build website` — builds successfully
- [x] `pnpm exec nx run-many -t test --exclude=openspawn` — 84 TS tests pass
- [x] `uv run pytest tests/ -v` — 409 Python tests pass
- [x] Search index rebuilt (12 MDX pages indexed)
- [x] `generate-md` regenerated 30 .md files for llms.txt
- [ ] Visual check: navigate to each modified page in dev server