### PR TITLE
feat(dashboard): bold information hierarchy + clickable cards (#167)

### DIFF
--- a/apps/dashboard/src/components/ui/page-header.tsx
+++ b/apps/dashboard/src/components/ui/page-header.tsx
@@ -10,8 +10,10 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div>
-        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">{title}</h1>
-        {description && <p className="text-sm sm:text-base text-muted-foreground">{description}</p>}
+        <h1 className="text-2xl sm:text-[34px] font-extrabold tracking-tighter leading-tight">
+          {title}
+        </h1>
+        {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
       </div>
       {actions && <div className="flex items-center gap-2">{actions}</div>}
     </div>

--- a/apps/dashboard/src/components/ui/stat-card.tsx
+++ b/apps/dashboard/src/components/ui/stat-card.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { ArrowUpRight, ArrowDownRight } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "./card";
 import { Sparkline } from "./sparkline";
+import { cn } from "../../lib/utils";
 
 export interface StatCardProps {
   title: string;
@@ -11,6 +12,8 @@ export interface StatCardProps {
   description?: string;
   sparklineData?: number[];
   sparklineColor?: string;
+  valueClassName?: string;
+  onClick?: () => void;
 }
 
 export function StatCard({
@@ -21,14 +24,20 @@ export function StatCard({
   description,
   sparklineData,
   sparklineColor = "#06b6d4",
+  valueClassName,
+  onClick,
 }: StatCardProps) {
   const isPositive = change && change > 0;
   const isNegative = change && change < 0;
 
   return (
-    <Card data-testid="stat-card">
+    <Card
+      data-testid="stat-card"
+      className={onClick ? "cursor-pointer transition-colors hover:bg-accent/50" : undefined}
+      onClick={onClick}
+    >
       <CardHeader className="flex flex-row items-center justify-between pb-2 p-3 sm:p-6 sm:pb-2">
-        <CardTitle className="text-xs sm:text-sm font-medium text-muted-foreground">
+        <CardTitle className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/60">
           {title}
         </CardTitle>
         {Icon && <Icon className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-muted-foreground" />}
@@ -40,7 +49,7 @@ export function StatCard({
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ type: "spring", stiffness: 400, damping: 30 }}
-            className="text-xl sm:text-2xl font-bold"
+            className={cn("text-2xl sm:text-3xl font-extrabold tracking-tighter", valueClassName)}
           >
             {value}
           </motion.div>

--- a/apps/dashboard/src/pages/dashboard.tsx
+++ b/apps/dashboard/src/pages/dashboard.tsx
@@ -226,6 +226,8 @@ export function DashboardPage() {
                   }
                   sparklineData={sparklines.agents}
                   sparklineColor="#06b6d4"
+                  valueClassName="text-cyan-500"
+                  onClick={() => navigate({ to: "/agents" })}
                 />
               </StaggerItem>
               <StaggerItem>
@@ -235,7 +237,9 @@ export function DashboardPage() {
                   icon={CheckSquare}
                   description={`${reviewTasks} in review`}
                   sparklineData={sparklines.tasks}
-                  sparklineColor="#06b6d4"
+                  sparklineColor="#f59e0b"
+                  valueClassName="text-amber-500"
+                  onClick={() => navigate({ to: "/tasks" })}
                 />
               </StaggerItem>
               <StaggerItem>
@@ -246,6 +250,8 @@ export function DashboardPage() {
                   description={`${tasks.length} total tasks`}
                   sparklineData={sparklines.completed}
                   sparklineColor="#10b981"
+                  valueClassName="text-emerald-500"
+                  onClick={() => navigate({ to: "/tasks" })}
                 />
               </StaggerItem>
               <StaggerItem>
@@ -256,6 +262,7 @@ export function DashboardPage() {
                   description={`-${totalCreditsSpent.toLocaleString()} spent`}
                   sparklineData={sparklines.credits}
                   sparklineColor="#f59e0b"
+                  onClick={() => navigate({ to: "/credits" })}
                 />
               </StaggerItem>
             </StaggerContainer>
@@ -325,7 +332,9 @@ export function DashboardPage() {
     return (
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Recent Activity</CardTitle>
+          <CardTitle className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+            Recent Activity
+          </CardTitle>
           <div className="flex items-center gap-2">
             <Badge variant="outline" className="text-xs">
               <Zap className="h-3 w-3 mr-1" />
@@ -354,7 +363,8 @@ export function DashboardPage() {
                       ? { duration: 0.15 }
                       : { type: "spring", stiffness: 400, damping: 30, delay: index * 0.03 }
                   }
-                  className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 rounded-lg border border-border p-3 hover:bg-accent/50 transition-colors min-h-[44px]"
+                  className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 rounded-lg border border-border p-3 hover:bg-accent/50 transition-colors min-h-[44px] cursor-pointer"
+                  onClick={() => navigate({ to: "/events" })}
                 >
                   <div className="flex items-center gap-3 min-w-0">
                     <div className="shrink-0">{getEventIcon(event.type)}</div>


### PR DESCRIPTION
## Summary

Closes #167. Part of #678.

**Typography hierarchy (bold direction):**
- Page titles: `text-[34px] font-extrabold tracking-tighter` (was text-2xl/3xl font-bold)
- Stat values: `text-3xl font-extrabold tracking-tighter` with semantic Tailwind color classes (was text-xl/2xl font-bold, no color)
- Stat labels: `text-[11px] font-semibold uppercase tracking-widest` (was text-xs/sm font-medium)
- Section headers: `text-xs font-bold uppercase tracking-widest text-muted-foreground` (was text-lg font-semibold)

**Clickable cards:**
- All 4 dashboard stat cards navigate to their respective pages on click
- Activity feed rows navigate to events page on click
- `StatCard` gained `valueClassName` (Tailwind class) and `onClick` props

## Test plan

- [x] Build passes
- [x] Lint passes (0 warnings)
- [ ] CI passes
- [ ] Visual check: stat values pop with color, page titles are clearly the biggest element