### PR TITLE
feat(dashboard): contextual actions, mutation hooks, emoji rebrand (#169)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ apps/sandbox-cli/publish/*.cjs
 # SQLite databases (except database lib reference files)
 *.db
 !libs/database/**/*.db
+.superpowers/

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -13,10 +13,9 @@
     <meta name="theme-color" content="#0a1929" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#1a2942" media="(prefers-color-scheme: light)" />
 
-    <!-- Favicon (pineapple emoji) -->
     <link
       rel="icon"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐙</text></svg>"
     />
 
     <!-- PWA -->

--- a/apps/dashboard/src/components/agent-actions.tsx
+++ b/apps/dashboard/src/components/agent-actions.tsx
@@ -1,0 +1,86 @@
+import { MoreHorizontal, Play, Ban, ExternalLink } from "lucide-react";
+import { toast } from "sonner";
+import { useActivateAgent, useRevokeAgent } from "@openspawn/dashboard-data";
+import { AgentStatus } from "@openspawn/shared-types";
+import { Button } from "./ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+import { useSidePanel } from "../contexts";
+import { AgentDetailPanel } from "./agent-detail-panel";
+
+interface AgentActionsProps {
+  agentId: string;
+  agentStatus: string;
+  agentName: string;
+}
+
+export function AgentActions({ agentId, agentStatus, agentName }: AgentActionsProps) {
+  const { openSidePanel, closeSidePanel } = useSidePanel();
+  const activate = useActivateAgent(agentId);
+  const revoke = useRevokeAgent(agentId);
+
+  const handleViewDetails = () => {
+    openSidePanel(<AgentDetailPanel agentId={agentId} onClose={closeSidePanel} />, { width: 520 });
+  };
+
+  const handleActivate = async () => {
+    try {
+      await activate.mutateAsync();
+      toast.success(`${agentName} activated`);
+    } catch {
+      toast.error("Failed to activate agent");
+    }
+  };
+
+  const handleRevoke = async () => {
+    try {
+      await revoke.mutateAsync();
+      toast.success(`${agentName} revoked`);
+    } catch {
+      toast.error("Failed to revoke agent");
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={handleViewDetails}>
+          <ExternalLink className="mr-2 h-4 w-4" /> View Details
+        </DropdownMenuItem>
+
+        {agentStatus === AgentStatus.PENDING && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={handleActivate}>
+              <Play className="mr-2 h-4 w-4" /> Activate
+            </DropdownMenuItem>
+          </>
+        )}
+
+        {agentStatus === AgentStatus.ACTIVE && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="text-destructive" onClick={handleRevoke}>
+              <Ban className="mr-2 h-4 w-4" /> Revoke
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/dashboard/src/components/error-boundary.tsx
+++ b/apps/dashboard/src/components/error-boundary.tsx
@@ -1,5 +1,6 @@
 import { Component } from "react";
 import type { ReactNode, ErrorInfo } from "react";
+import { isBBTheme } from "../lib/dashboard-theme";
 
 interface Props {
   children: ReactNode;
@@ -67,13 +68,8 @@ export class AppErrorBoundary extends Component<Props, State> {
             textAlign: "center",
           }}
         >
-          {/* Pineapple + title */}
-          <span
-            style={{ fontSize: "4rem", marginBottom: "1rem" }}
-            role="img"
-            aria-label="pineapple"
-          >
-            🍍
+          <span style={{ fontSize: "4rem", marginBottom: "1rem" }} role="img" aria-label="logo">
+            {isBBTheme ? "🍍" : "🐙"}
           </span>
           <h1
             style={{

--- a/apps/dashboard/src/components/live/OpenSpawnBadge.tsx
+++ b/apps/dashboard/src/components/live/OpenSpawnBadge.tsx
@@ -43,7 +43,7 @@ export function OpenSpawnBadge({
         zIndex: 20,
       }}
     >
-      <span className="text-sm">🪸</span>
+      <span className="text-sm">🐙</span>
       <span
         className="text-xs font-bold"
         style={{ color: "#4AAED9", fontFamily: "Nunito, sans-serif" }}

--- a/apps/dashboard/src/components/live/intro-card.tsx
+++ b/apps/dashboard/src/components/live/intro-card.tsx
@@ -146,7 +146,7 @@ export function IntroCard({ onStart }: IntroCardProps) {
               </span>
             </div>
             <div className="mt-3" style={{ color: "rgba(184,228,247,0.5)" }}>
-              <div>🪸 OpenSpawn v0.1.0</div>
+              <div>🐙 OpenSpawn v0.1.0</div>
               <div className="mt-1">
                 <span style={{ color: "#4AE88A" }}>✓</span> Parsed ORG.md — 22 agents, 5 departments
               </div>

--- a/apps/dashboard/src/components/spawn-agent-modal.tsx
+++ b/apps/dashboard/src/components/spawn-agent-modal.tsx
@@ -39,7 +39,7 @@ const DOMAINS = [
   "Backend",
   "Infrastructure",
 ];
-const EMOJIS = ["🐡", "🦈", "🐬", "🐢", "🦑", "🐠", "🪸", "🦞", "🐚", "🦭"];
+const EMOJIS = ["🐡", "🦈", "🐬", "🐢", "🦑", "🐠", "🐙", "🦞", "🐚", "🦭"];
 const COLORS = [
   "#dc2626",
   "#f97316",

--- a/apps/dashboard/src/components/task-actions.tsx
+++ b/apps/dashboard/src/components/task-actions.tsx
@@ -1,0 +1,113 @@
+import { MoreHorizontal, Play, CheckCircle2, Pause, ArrowRight } from "lucide-react";
+import { toast } from "sonner";
+import { useTransitionTask, useApproveTask } from "@openspawn/dashboard-data";
+import { TaskStatus } from "@openspawn/shared-types";
+import { Button } from "./ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+
+interface TaskActionsProps {
+  taskId: string;
+  taskStatus: string;
+  taskTitle: string;
+  approvalRequired?: boolean;
+}
+
+function TaskActions({ taskId, taskStatus, taskTitle, approvalRequired }: TaskActionsProps) {
+  const transition = useTransitionTask(taskId);
+  const approve = useApproveTask(taskId);
+
+  const handleTransition = async (status: TaskStatus, label: string) => {
+    try {
+      await transition.mutateAsync({ status });
+      toast.success(`"${taskTitle}" ${label}`);
+    } catch {
+      toast.error(`Failed to transition task`);
+    }
+  };
+
+  const handleApprove = async () => {
+    try {
+      await approve.mutateAsync();
+      toast.success(`"${taskTitle}" approved`);
+    } catch {
+      toast.error("Failed to approve task");
+    }
+  };
+
+  const canStart = taskStatus === TaskStatus.TODO || taskStatus === TaskStatus.BACKLOG;
+  const canSubmitForReview = taskStatus === TaskStatus.IN_PROGRESS;
+  const canComplete = taskStatus === TaskStatus.REVIEW;
+  const canBlock = taskStatus === TaskStatus.IN_PROGRESS;
+  const canApprove = taskStatus === TaskStatus.REVIEW && approvalRequired;
+
+  const hasActions = canStart || canSubmitForReview || canComplete || canBlock || canApprove;
+
+  if (!hasActions) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 flex-shrink-0"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {canStart && (
+          <DropdownMenuItem onClick={() => handleTransition(TaskStatus.IN_PROGRESS, "started")}>
+            <Play className="mr-2 h-4 w-4" /> Start
+          </DropdownMenuItem>
+        )}
+
+        {canSubmitForReview && (
+          <DropdownMenuItem
+            onClick={() => handleTransition(TaskStatus.REVIEW, "submitted for review")}
+          >
+            <ArrowRight className="mr-2 h-4 w-4" /> Submit for Review
+          </DropdownMenuItem>
+        )}
+
+        {canComplete && (
+          <DropdownMenuItem onClick={() => handleTransition(TaskStatus.DONE, "completed")}>
+            <CheckCircle2 className="mr-2 h-4 w-4" /> Complete
+          </DropdownMenuItem>
+        )}
+
+        {canApprove && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={handleApprove}>
+              <CheckCircle2 className="mr-2 h-4 w-4 text-green-500" /> Approve
+            </DropdownMenuItem>
+          </>
+        )}
+
+        {canBlock && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-destructive"
+              onClick={() => handleTransition(TaskStatus.BLOCKED, "blocked")}
+            >
+              <Pause className="mr-2 h-4 w-4" /> Block
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export { TaskActions };

--- a/apps/dashboard/src/components/ui/logo.tsx
+++ b/apps/dashboard/src/components/ui/logo.tsx
@@ -1,3 +1,5 @@
+import { isBBTheme } from "../../lib/dashboard-theme";
+
 const sizes = {
   sm: 24,
   md: 32,
@@ -13,6 +15,8 @@ interface LogoProps {
   style?: React.CSSProperties;
 }
 
+const LOGO_EMOJI = isBBTheme ? "🍍" : "🐙";
+
 export function Logo({ size = "md", className = "", style }: LogoProps) {
   const px = sizes[size];
   return (
@@ -22,7 +26,7 @@ export function Logo({ size = "md", className = "", style }: LogoProps) {
       className={`flex-shrink-0 leading-none select-none ${className}`}
       style={{ fontSize: px, lineHeight: 1, ...style }}
     >
-      🍍
+      {LOGO_EMOJI}
     </span>
   );
 }

--- a/apps/dashboard/src/pages/agent-virtual-grid.tsx
+++ b/apps/dashboard/src/pages/agent-virtual-grid.tsx
@@ -5,19 +5,11 @@
 import { useState, useMemo, useRef, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { motion, AnimatePresence } from "motion/react";
-import { MoreVertical, Coins, Edit, Eye, Ban } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
-import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import { Sparkline, generateSparklineData } from "../components/ui/sparkline";
 import { AgentAvatar } from "../components/agent-avatar";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  DropdownMenuSeparator,
-} from "../components/ui/dropdown-menu";
+import { AgentActions } from "../components/agent-actions";
 import { AgentModeBadge } from "../components/agent-mode-selector";
 import { usePresence, useAgentHealth } from "../hooks";
 import { getStatusVariant, getLevelColor, getLevelLabel } from "../lib/status-colors";
@@ -27,15 +19,12 @@ import type { AgentFieldsFragment } from "@openspawn/dashboard-data";
 
 type Agent = AgentFieldsFragment;
 
-import { DialogModeValue, type DialogMode } from "../lib/enums";
-
 interface AgentVirtualGridProps {
   filteredAgents: Agent[];
   onCardClick: (id: string) => void;
-  onAction: (agent: Agent, mode: DialogMode) => void;
 }
 
-export function AgentVirtualGrid({ filteredAgents, onCardClick, onAction }: AgentVirtualGridProps) {
+export function AgentVirtualGrid({ filteredAgents, onCardClick }: AgentVirtualGridProps) {
   const { presenceMap } = usePresence();
   const healthMap = useAgentHealth();
   const parentRef = useRef<HTMLDivElement>(null);
@@ -143,39 +132,11 @@ export function AgentVirtualGrid({ filteredAgents, onCardClick, onAction }: Agen
                             </div>
                           </div>
 
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-8 w-8"
-                                onClick={(e) => e.stopPropagation()}
-                              >
-                                <MoreVertical className="h-4 w-4" />
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem
-                                onClick={() => onAction(agent, DialogModeValue.View)}
-                              >
-                                <Eye className="mr-2 h-4 w-4" /> View Details
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={() => onAction(agent, DialogModeValue.Edit)}
-                              >
-                                <Edit className="mr-2 h-4 w-4" /> Edit
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={() => onAction(agent, DialogModeValue.Credits)}
-                              >
-                                <Coins className="mr-2 h-4 w-4" /> Adjust Credits
-                              </DropdownMenuItem>
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem className="text-destructive">
-                                <Ban className="mr-2 h-4 w-4" /> Revoke Access
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
+                          <AgentActions
+                            agentId={agent.agentId}
+                            agentStatus={agent.status}
+                            agentName={agent.name}
+                          />
                         </CardHeader>
 
                         <CardContent>

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -160,11 +160,6 @@ export function AgentsPage() {
     }
   }
 
-  function handleAction(agent: Agent, mode: DialogMode) {
-    setSelectedAgent(agent);
-    setDialogMode(mode);
-  }
-
   function handleCloseDialog() {
     setSelectedAgent(null);
     setDialogMode(null);
@@ -365,11 +360,7 @@ export function AgentsPage() {
               Showing {filteredAgents.length} of {agents.length} agents
             </div>
 
-            <AgentVirtualGrid
-              filteredAgents={filteredAgents}
-              onCardClick={openAgentDetail}
-              onAction={handleAction}
-            />
+            <AgentVirtualGrid filteredAgents={filteredAgents} onCardClick={openAgentDetail} />
 
             {filteredAgents.length === 0 && agents.length > 0 && (
               <div className="flex flex-col items-center justify-center py-12 rounded-lg border border-dashed border-border">

--- a/apps/dashboard/src/pages/live-view.tsx
+++ b/apps/dashboard/src/pages/live-view.tsx
@@ -515,7 +515,7 @@ function AnnotationBubble({ annotation }: { annotation: Annotation | null }) {
           className="text-[10px]"
           style={{ color: "rgba(74,174,217,0.4)", fontFamily: "Nunito, sans-serif" }}
         >
-          🪸 OpenSpawn feature
+          🐙 OpenSpawn feature
         </span>
       </div>
     </div>
@@ -657,7 +657,7 @@ function CompletionOverlay({
             }}
           >
             <div className="flex items-center justify-center gap-2 mb-3">
-              <span className="text-2xl">🪸</span>
+              <span className="text-2xl">🐙</span>
               <span
                 className="text-lg font-black"
                 style={{ color: "#4AAED9", fontFamily: '"Baloo 2", cursive' }}

--- a/apps/dashboard/src/pages/tasks/list-view.tsx
+++ b/apps/dashboard/src/pages/tasks/list-view.tsx
@@ -1,6 +1,7 @@
 import { motion, AnimatePresence } from "motion/react";
 import { Badge } from "../../components/ui/badge";
 import { Card } from "../../components/ui/card";
+import { TaskActions } from "../../components/task-actions";
 import type { Task } from "../../hooks";
 import { darkenForBackground } from "../../lib/avatar-utils";
 import { resolveAvatarUrl } from "../../lib/resolve-avatar-url";
@@ -96,6 +97,14 @@ function ListView({ tasks, onTaskClick, selectedTaskId, agentMap }: ListViewProp
                       {dueDate}
                     </span>
                   )}
+                </div>
+                <div className="flex-shrink-0 sm:order-7">
+                  <TaskActions
+                    taskId={task.id}
+                    taskStatus={task.status}
+                    taskTitle={task.title}
+                    approvalRequired={Boolean(task.approvalRequired)}
+                  />
                 </div>
               </motion.div>
             );

--- a/apps/dashboard/src/pages/tasks/task-card.tsx
+++ b/apps/dashboard/src/pages/tasks/task-card.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "../../components/ui/card";
 import { Badge } from "../../components/ui/badge";
+import { TaskActions } from "../../components/task-actions";
 import type { Task } from "../../hooks";
 import { darkenForBackground } from "../../lib/avatar-utils";
 import { resolveAvatarUrl } from "../../lib/resolve-avatar-url";
@@ -47,50 +48,58 @@ function TaskCard({ task, onClick, compact, agentMap }: TaskCardProps) {
           <div className="flex items-start gap-2">
             <GripVertical className="h-4 w-4 mt-0.5 text-muted-foreground/50 flex-shrink-0" />
             <div className="flex-1 min-w-0 space-y-2">
-              {/* Header: ID + Priority */}
-              <div className="flex items-center gap-2 flex-wrap">
-                <span className="text-xs font-mono text-muted-foreground">{task.identifier}</span>
-                <Badge variant={getPriorityVariant(task.priority)} className="text-xs">
-                  {task.priority?.toLowerCase()}
-                </Badge>
-                {task.approvalRequired && (
-                  <Badge variant="outline" className="text-xs text-amber-500 border-amber-500/30">
-                    approval
+              {/* Header: ID + Priority + Actions */}
+              <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 flex-wrap flex-1 min-w-0">
+                  <span className="text-xs font-mono text-muted-foreground">{task.identifier}</span>
+                  <Badge variant={getPriorityVariant(task.priority)} className="text-xs">
+                    {task.priority?.toLowerCase()}
                   </Badge>
-                )}
-                {createdViaWebhook && (
-                  <Badge variant="outline" className="text-xs text-cyan-500 border-cyan-500/30">
-                    <Webhook className="w-3 h-3 mr-1" />
-                    webhook
-                  </Badge>
-                )}
-                {task.source === "a2a" && (
-                  <Badge
-                    variant="outline"
-                    className="text-xs text-cyan-400 border-cyan-500/30 bg-cyan-500/10"
-                  >
-                    <Link2 className="w-3 h-3 mr-1" />
-                    A2A
-                  </Badge>
-                )}
-                {task.source === "mcp" && (
-                  <Badge
-                    variant="outline"
-                    className="text-xs text-violet-400 border-violet-500/30 bg-violet-500/10"
-                  >
-                    <Plug className="w-3 h-3 mr-1" />
-                    MCP
-                  </Badge>
-                )}
-                {hasRejection && (
-                  <Badge
-                    variant="outline"
-                    className="text-xs text-amber-600 border-amber-500/50 bg-amber-500/10 animate-pulse"
-                  >
-                    <AlertTriangle className="w-3 h-3 mr-1" />
-                    needs fixes
-                  </Badge>
-                )}
+                  {task.approvalRequired && (
+                    <Badge variant="outline" className="text-xs text-amber-500 border-amber-500/30">
+                      approval
+                    </Badge>
+                  )}
+                  {createdViaWebhook && (
+                    <Badge variant="outline" className="text-xs text-cyan-500 border-cyan-500/30">
+                      <Webhook className="w-3 h-3 mr-1" />
+                      webhook
+                    </Badge>
+                  )}
+                  {task.source === "a2a" && (
+                    <Badge
+                      variant="outline"
+                      className="text-xs text-cyan-400 border-cyan-500/30 bg-cyan-500/10"
+                    >
+                      <Link2 className="w-3 h-3 mr-1" />
+                      A2A
+                    </Badge>
+                  )}
+                  {task.source === "mcp" && (
+                    <Badge
+                      variant="outline"
+                      className="text-xs text-violet-400 border-violet-500/30 bg-violet-500/10"
+                    >
+                      <Plug className="w-3 h-3 mr-1" />
+                      MCP
+                    </Badge>
+                  )}
+                  {hasRejection && (
+                    <Badge
+                      variant="outline"
+                      className="text-xs text-amber-600 border-amber-500/50 bg-amber-500/10 animate-pulse"
+                    >
+                      <AlertTriangle className="w-3 h-3 mr-1" />
+                      needs fixes
+                    </Badge>
+                  )}
+                </div>
+                <TaskActions
+                  taskId={task.id}
+                  taskStatus={task.status}
+                  taskTitle={task.title}
+                  approvalRequired={Boolean(task.approvalRequired)}
+                />
               </div>
 
               {/* Title */}

--- a/apps/platform/app/landing-page.tsx
+++ b/apps/platform/app/landing-page.tsx
@@ -45,7 +45,7 @@ function FeatureCard({
 function TerminalDemo() {
   const lines = [
     { text: "$ npx openspawn init my-reef", color: "text-slate-300", delay: 0 },
-    { text: "🪸 Created ORG.md, config, .gitignore", color: "text-emerald-400", delay: 900 },
+    { text: "🐙 Created ORG.md, config, .gitignore", color: "text-emerald-400", delay: 900 },
     { text: "", color: "", delay: 1300 },
     { text: "$ npx openspawn start", color: "text-slate-300", delay: 1500 },
     { text: "🌐 Server running at http://localhost:3333", color: "text-cyan-400", delay: 2400 },
@@ -145,7 +145,7 @@ const openclawJsonSnippet = `{
   }
 }`;
 
-const orgMdSnippet = `# 🪸 My Agent Org
+const orgMdSnippet = `# 🐙 My Agent Org
 
 ## Structure
 - 🔬 Research (lead: Alice, model: opus)
@@ -197,7 +197,7 @@ export function LandingPage() {
       <nav className="sticky top-0 z-50 border-b border-white/5 bg-navy-950/80 backdrop-blur-xl">
         <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-5 sm:px-6">
           <a href="/" className="flex items-center gap-2 text-lg font-bold">
-            <span className="text-2xl">🪸</span>
+            <span className="text-2xl">🐙</span>
             <span className="gradient-text">OpenSpawn</span>
           </a>
           <div className="hidden items-center gap-8 md:flex">
@@ -240,7 +240,7 @@ export function LandingPage() {
             <div className="absolute right-1/4 top-20 h-[400px] w-[400px] rounded-full bg-violet-500/5 blur-[100px]" />
           </div>
           <div className="relative mx-auto max-w-4xl text-center">
-            <div className="animate-fade-in-up mb-6 text-6xl md:text-8xl">🪸</div>
+            <div className="animate-fade-in-up mb-6 text-6xl md:text-8xl">🐙</div>
             <h1 className="animate-fade-in-up animate-delay-100 mb-6 text-4xl font-extrabold tracking-tight sm:text-5xl md:text-7xl">
               <span className="gradient-text">OpenSpawn</span>
             </h1>
@@ -452,7 +452,7 @@ export function LandingPage() {
                 <span className="ml-2 text-xs text-slate-500">terminal</span>
               </div>
               <pre className="p-4 text-left text-sm leading-relaxed text-slate-300">
-                <code>{`$ openclaw skill add openspawn\n🪸 OpenSpawn skill installed\n\n$ echo "# My Org" > ORG.md\n✨ Agents now coordinate automatically`}</code>
+                <code>{`$ openclaw skill add openspawn\n🐙 OpenSpawn skill installed\n\n$ echo "# My Org" > ORG.md\n✨ Agents now coordinate automatically`}</code>
               </pre>
             </div>
           </div>
@@ -486,7 +486,7 @@ export function LandingPage() {
           <div className="grid gap-8 md:grid-cols-4">
             <div>
               <div className="mb-3 text-lg font-bold">
-                <span className="mr-2">🪸</span>
+                <span className="mr-2">🐙</span>
                 <span className="gradient-text">OpenSpawn</span>
               </div>
               <p className="text-sm text-slate-500">The coordination layer for AI agent teams.</p>

--- a/apps/platform/index.html
+++ b/apps/platform/index.html
@@ -17,7 +17,7 @@
     <meta property="og:url" content="https://openspawn.ai" />
     <link
       rel="icon"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪸</text></svg>"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐙</text></svg>"
     />
   </head>
   <body class="bg-navy-950 text-slate-200">

--- a/apps/website/app/components/footer.tsx
+++ b/apps/website/app/components/footer.tsx
@@ -5,7 +5,7 @@ export function Footer() {
         <div className="grid gap-8 md:grid-cols-4">
           <div>
             <div className="mb-3 flex items-center gap-2 text-lg font-bold">
-              <span>🪸</span>
+              <span>🐙</span>
               <span className="gradient-text">OpenSpawn</span>
             </div>
             <p className="text-sm text-slate-500">

--- a/apps/website/app/components/nav.tsx
+++ b/apps/website/app/components/nav.tsx
@@ -8,7 +8,7 @@ export function Nav() {
     <nav className="sticky top-0 z-50 border-b border-white/5 bg-navy-950/80 backdrop-blur-xl">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-5 sm:px-6">
         <Link to="/" className="flex items-center gap-2 text-lg font-bold">
-          <span className="text-2xl">🪸</span>
+          <span className="text-2xl">🐙</span>
           <span className="gradient-text">OpenSpawn</span>
         </Link>
         <div className="hidden items-center gap-8 md:flex">

--- a/apps/website/app/components/og/og-getting-started.tsx
+++ b/apps/website/app/components/og/og-getting-started.tsx
@@ -66,7 +66,7 @@ export function OgGettingStarted() {
           fontWeight: 600,
         }}
       >
-        <span style={{ color: "var(--os-accent-light, #22d3ee)" }}>🪸 OpenSpawn</span>
+        <span style={{ color: "var(--os-accent-light, #22d3ee)" }}>🐙 OpenSpawn</span>
         <span style={{ opacity: 0.4 }}>›</span>
         <span>Docs</span>
         <span style={{ opacity: 0.4 }}>›</span>

--- a/apps/website/app/components/og/og-openspawn.tsx
+++ b/apps/website/app/components/og/og-openspawn.tsx
@@ -74,7 +74,7 @@ export function OgOpenspawn() {
             marginBottom: 28,
           }}
         >
-          <span style={{ fontSize: 20 }}>🪸</span>
+          <span style={{ fontSize: 20 }}>🐙</span>
           <span
             style={{
               fontSize: 13,

--- a/apps/website/app/components/powered-by-badge.tsx
+++ b/apps/website/app/components/powered-by-badge.tsx
@@ -66,7 +66,7 @@ interface PoweredByBadgeProps {
 }
 
 // ─── Coral SVG icon ──────────────────────────────────────────────────────────
-// Geometric interpretation of the 🪸 coral emoji. Two-tone orange coral
+// Geometric interpretation of the 🐙 coral emoji. Two-tone orange coral
 // branches with rounded tips. aria-hidden — decorative when next to text.
 
 function CoralIcon({ className, ...props }: SVGProps<SVGSVGElement>) {

--- a/apps/website/app/components/terminal-demo.tsx
+++ b/apps/website/app/components/terminal-demo.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 
 const lines = [
   { text: "$ npx openspawn init my-org", color: "text-slate-300", delay: 0 },
-  { text: "🪸 Created ORG.md, config, .gitignore", color: "text-emerald-400", delay: 900 },
+  { text: "🐙 Created ORG.md, config, .gitignore", color: "text-emerald-400", delay: 900 },
   { text: "", color: "", delay: 1300 },
   { text: "$ npx openspawn start", color: "text-slate-300", delay: 1500 },
   { text: "🌐 Server running at http://localhost:3333", color: "text-cyan-400", delay: 2400 },

--- a/apps/website/app/routes/docs/how-it-works.tsx
+++ b/apps/website/app/routes/docs/how-it-works.tsx
@@ -73,7 +73,7 @@ export function HowItWorks() {
           caps per agent
         </li>
       </ul>
-      <CodeBlock title="ORG.md example">{`# 🪸 Acme Corp
+      <CodeBlock title="ORG.md example">{`# 🐙 Acme Corp
 
 > Mission: Ship great software faster
 

--- a/apps/website/app/routes/getting-started.tsx
+++ b/apps/website/app/routes/getting-started.tsx
@@ -157,7 +157,7 @@ openspawn v0.3.0`}
           <Terminal title="terminal">
             {`$ openspawn init my-org
 
-🪸 OpenSpawn — Create a new org
+🐙 OpenSpawn — Create a new org
 
 ? What kind of org? (Use arrow keys)
 ❯ SaaS Onboarding — data migration, integrations, success check-in

--- a/apps/website/app/routes/index.tsx
+++ b/apps/website/app/routes/index.tsx
@@ -209,7 +209,7 @@ Configures API connectors and runs integration tests.
 Schedules check-ins, collects feedback, flags churn risk.
 - Model: ollama/qwen2.5`;
 
-const orgMdPivotSnippet = `# 🪸 MyOrg
+const orgMdPivotSnippet = `# 🐙 MyOrg
 
 ## Structure
 - 🔬 Research (lead: Analyst, model: opus)
@@ -409,7 +409,7 @@ export function LandingPage() {
           {/* Icon — floats gently */}
           <div className="animate-fade-in-up mb-6">
             <span className="coral-float text-6xl md:text-8xl" role="img" aria-label="coral">
-              🪸
+              🐙
             </span>
           </div>
 
@@ -865,7 +865,7 @@ export function LandingPage() {
             {/* OpenSpawn column */}
             <div className="rounded-xl border border-cyan-500/20 bg-cyan-500/[0.04] p-6 ring-1 ring-cyan-500/10">
               <div className="mb-3 flex items-center gap-2">
-                <span className="text-2xl">🪸</span>
+                <span className="text-2xl">🐙</span>
                 <h3 className="font-semibold text-cyan-300">OpenSpawn org</h3>
               </div>
               <ul className="space-y-2 text-sm text-slate-400">

--- a/apps/website/app/routes/not-found.tsx
+++ b/apps/website/app/routes/not-found.tsx
@@ -17,7 +17,7 @@ export function NotFoundPage() {
       </div>
 
       <div className="relative">
-        <div className="mb-6 text-7xl md:text-8xl">{tick % 2 === 0 ? "🪸" : "🐠"}</div>
+        <div className="mb-6 text-7xl md:text-8xl">{tick % 2 === 0 ? "🐙" : "🐠"}</div>
 
         <div className="mb-2 font-mono text-xs font-semibold uppercase tracking-widest text-cyan-500">
           404 — Page Not Found

--- a/apps/website/app/routes/templates.tsx
+++ b/apps/website/app/routes/templates.tsx
@@ -844,7 +844,7 @@ export function TemplatesPage() {
       <section className="py-16 pb-24">
         <div className="mx-auto max-w-2xl text-center">
           <div className="rounded-2xl border border-white/5 bg-white/[0.02] p-8 md:p-12">
-            <div className="mb-4 text-4xl">🪸</div>
+            <div className="mb-4 text-4xl">🐙</div>
             <h2 className="mb-4 text-2xl font-bold text-slate-100 md:text-3xl">
               Ready to spawn your org?
             </h2>

--- a/libs/dashboard-data/src/hooks/use-tasks.ts
+++ b/libs/dashboard-data/src/hooks/use-tasks.ts
@@ -22,6 +22,7 @@ export type Task = {
   dueDate?: string | null;
   completedAt?: string | null;
   source?: string | null;
+  approvalRequired?: boolean;
   rejection?: TaskRejection | null;
 };
 

--- a/libs/dashboard-data/src/rest/hooks/index.ts
+++ b/libs/dashboard-data/src/rest/hooks/index.ts
@@ -1,5 +1,13 @@
 export { useAgents } from "./use-agents";
 export { useTasks, useTask } from "./use-tasks";
+export {
+  useCreateTask,
+  useTransitionTask,
+  useAssignTask,
+  useApproveTask,
+  useAddComment,
+  useEscalateTask,
+} from "./use-task-mutations";
 export { useCreditHistory, useRestCredits } from "./use-credits";
 export { useEvents } from "./use-events";
 export { useChannels } from "./use-channels";
@@ -11,3 +19,11 @@ export {
   useRestGraphCytoscape,
 } from "./use-graph";
 export { useWebhooks, useWebhook, useCreateWebhook, useDeleteWebhook } from "./use-webhooks";
+export {
+  useUpdateAgent,
+  useActivateAgent,
+  useRevokeAgent,
+  useSpawnAgent,
+  useTransferCredits,
+  useSetBudget,
+} from "./use-agent-mutations";

--- a/libs/dashboard-data/src/rest/hooks/use-agent-mutations.ts
+++ b/libs/dashboard-data/src/rest/hooks/use-agent-mutations.ts
@@ -1,0 +1,106 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../client";
+import type { components } from "../generated/schema";
+
+type UpdateAgentBody = components["schemas"]["UpdateAgentDto"];
+type SpawnAgentBody = components["schemas"]["SpawnAgentDto"];
+type TransferCreditsBody = components["schemas"]["TransferCreditsDto"];
+type SetBudgetBody = components["schemas"]["SetBudgetDto"];
+
+export function useUpdateAgent(agentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: UpdateAgentBody) => {
+      const { data, error } = await api.PATCH("/agents/{agent_id}", {
+        params: { path: { agent_id: agentId } },
+        body,
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+export function useActivateAgent(agentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const { data, error } = await api.POST("/agents/{agent_id}/activate", {
+        params: { path: { agent_id: agentId } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+export function useRevokeAgent(agentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const { data, error } = await api.POST("/agents/{agent_id}/revoke", {
+        params: { path: { agent_id: agentId } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+export function useSpawnAgent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: SpawnAgentBody) => {
+      const { data, error } = await api.POST("/agents/spawn", {
+        body,
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+export function useTransferCredits() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: TransferCreditsBody) => {
+      const { data, error } = await api.POST("/agents/credits/transfer", {
+        body,
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+export function useSetBudget(agentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: SetBudgetBody) => {
+      const { data, error } = await api.PATCH("/agents/{agent_id}/budget", {
+        params: { path: { agent_id: agentId } },
+        body,
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}

--- a/libs/dashboard-data/src/rest/hooks/use-task-mutations.ts
+++ b/libs/dashboard-data/src/rest/hooks/use-task-mutations.ts
@@ -1,0 +1,107 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../client";
+import type { components } from "../generated/schema";
+
+export function useCreateTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: components["schemas"]["CreateTaskDto"]) => {
+      const { data, error } = await api.POST("/tasks", { body });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+    },
+  });
+}
+
+export function useTransitionTask(taskId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: components["schemas"]["TransitionTaskDto"]) => {
+      const { data, error } = await api.POST("/tasks/{task_id}/transition", {
+        params: { path: { task_id: taskId } },
+        body,
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+    },
+  });
+}
+
+export function useAssignTask(taskId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: components["schemas"]["AssignTaskDto"]) => {
+      const { data, error } = await api.POST("/tasks/{task_id}/assign", {
+        params: { path: { task_id: taskId } },
+        body,
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+    },
+  });
+}
+
+export function useApproveTask(taskId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const { data, error } = await api.POST("/tasks/{task_id}/approve", {
+        params: { path: { task_id: taskId } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+    },
+  });
+}
+
+export function useAddComment(taskId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: components["schemas"]["AddCommentDto"]) => {
+      const { data, error } = await api.POST("/tasks/{task_id}/comments", {
+        params: { path: { task_id: taskId } },
+        body,
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+    },
+  });
+}
+
+export function useEscalateTask(taskId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: components["schemas"]["EscalateTaskDto"]) => {
+      const { data, error } = await api.POST("/tasks/{task_id}/escalate", {
+        params: { path: { task_id: taskId } },
+        body,
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Closes #169. Part of #678.

### Mutation hooks (libs/dashboard-data)
12 new hooks using `useMutation` + OpenAPI client, with query invalidation on success:

**Agent:** `useUpdateAgent`, `useActivateAgent`, `useRevokeAgent`, `useSpawnAgent`, `useTransferCredits`, `useSetBudget`

**Task:** `useCreateTask`, `useTransitionTask`, `useAssignTask`, `useApproveTask`, `useAddComment`, `useEscalateTask`

### Action UI (apps/dashboard)
- **AgentActions** dropdown: View Details, Activate (PENDING), Revoke (ACTIVE)
- **TaskActions** dropdown: Start, Submit for Review, Complete, Approve, Block — status-dependent
- Wired into agent grid cards + task card/list views
- Toast feedback via sonner

### Emoji rebrand
- OpenSpawn logo: 🪸 → 🐙 across dashboard, website, platform
- Theme-aware: 🍍 for BikiniBottom, 🐙 for OpenSpawn
- Updated favicon, logo component, error boundary, badges, OG images

## Test plan

- [x] `nx run-many -t lint` — 17 projects pass (0 warnings)
- [x] `nx run-many -t build` — 11 projects pass
- [x] `nx run-many -t test --exclude=openspawn` — 4 projects pass
- [ ] CI passes
- [ ] Agent "..." menu shows on cards with correct actions per status
- [ ] Task "..." menu shows on cards/rows with correct transitions per status