### PR TITLE
fix(docs): add padding between sidebar and content

### DIFF
--- a/libs/docs-ui/src/ui/docs-layout.tsx
+++ b/libs/docs-ui/src/ui/docs-layout.tsx
@@ -31,7 +31,7 @@ export function DocsLayout({ children, sidebar, flatPages }: DocsLayoutProps) {
       </div>
       <div className="flex gap-10">
         <DocsSidebar items={sidebar} open={open} />
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 md:border-l md:border-white/5 md:pl-10">
           {children}
           <DocsPagination prev={prevPage} next={nextPage} />
         </div>


### PR DESCRIPTION
## Summary

Docs content was flush against the sidebar with no visual separation. Added a subtle left border (`border-white/5`) and `pl-10` padding on desktop between the sidebar nav and main content area.

## Test plan

- [ ] CI passes
- [ ] Visual: clear gap between sidebar and content on docs pages