### PR TITLE
fix(api): migrate all models from UUID(as_uuid=True) to CompatUUID()

### DIFF
--- a/apps/api/app/models/agent.py
+++ b/apps/api/app/models/agent.py
@@ -5,11 +5,10 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import CheckConstraint, ForeignKey, Index, LargeBinary, SmallInteger, String
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB
+from app.models.compat import CompatJSONB, CompatUUID
 from app.models.enums import AgentMode, AgentRole, AgentStatus, Proficiency
 
 if TYPE_CHECKING:
@@ -31,7 +30,7 @@ class Agent(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     agent_id: Mapped[str] = mapped_column(String(100), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -55,7 +54,7 @@ class Agent(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     budget_period_start: Mapped[datetime | None] = mapped_column(nullable=True)
     hmac_secret_enc: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     parent_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+        CompatUUID(), ForeignKey("agents.id"), nullable=True
     )
     max_children: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
     metadata_: Mapped[dict] = mapped_column(
@@ -96,10 +95,10 @@ class AgentCapability(UUIDPrimaryKeyMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     capability: Mapped[str] = mapped_column(String(100), nullable=False)
     proficiency: Mapped[str] = mapped_column(

--- a/apps/api/app/models/auth.py
+++ b/apps/api/app/models/auth.py
@@ -4,11 +4,10 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, LargeBinary, String
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB
+from app.models.compat import CompatJSONB, CompatUUID
 from app.models.enums import UserRole
 
 
@@ -17,7 +16,7 @@ class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __table_args__ = (Index("ix_users_org_id_email", "org_id", "email", unique=True),)
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     email: Mapped[str] = mapped_column(String(255), nullable=False)
     password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -44,7 +43,7 @@ class RefreshToken(UUIDPrimaryKeyMixin, Base):
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        CompatUUID(), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
     token_hash: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     expires_at: Mapped[datetime] = mapped_column(nullable=False)
@@ -64,11 +63,9 @@ class ApiKey(UUIDPrimaryKeyMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
-    )
+    user_id: Mapped[uuid.UUID] = mapped_column(CompatUUID(), ForeignKey("users.id"), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     key_prefix: Mapped[str] = mapped_column(String(12), nullable=False)
     key_hash: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
@@ -87,7 +84,7 @@ class Nonce(Base):
     __table_args__ = (Index("ix_nonces_expires_at", "expires_at"),)
 
     nonce: Mapped[str] = mapped_column(String(64), primary_key=True)
-    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    agent_id: Mapped[uuid.UUID] = mapped_column(CompatUUID(), nullable=False)
     expires_at: Mapped[datetime] = mapped_column(nullable=False)
     created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
 
@@ -96,12 +93,12 @@ class IdempotencyKey(UUIDPrimaryKeyMixin, Base):
     __tablename__ = "idempotency_keys"
     __table_args__ = (Index("ix_idempotency_keys_expires_at", "expires_at"),)
 
-    key: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, unique=True)
+    key: Mapped[uuid.UUID] = mapped_column(CompatUUID(), nullable=False, unique=True)
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     method: Mapped[str] = mapped_column(String(10), nullable=False)
     path: Mapped[str] = mapped_column(String(500), nullable=False)

--- a/apps/api/app/models/base.py
+++ b/apps/api/app/models/base.py
@@ -2,8 +2,9 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import func
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from app.models.compat import CompatUUID
 
 
 class Base(DeclarativeBase):
@@ -24,7 +25,7 @@ class TimestampMixin:
 
 class UUIDPrimaryKeyMixin:
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        CompatUUID(),
         primary_key=True,
         default=uuid.uuid4,
     )

--- a/apps/api/app/models/consensus.py
+++ b/apps/api/app/models/consensus.py
@@ -4,11 +4,10 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, SmallInteger, String, Text
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB
+from app.models.compat import CompatJSONB, CompatUUID
 from app.models.enums import ConsensusStatus
 
 
@@ -22,7 +21,7 @@ class ConsensusRequest(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     type: Mapped[str] = mapped_column(String(50), nullable=False)
     status: Mapped[str] = mapped_column(
@@ -31,9 +30,9 @@ class ConsensusRequest(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
     requester_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
-    subject_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    subject_id: Mapped[uuid.UUID | None] = mapped_column(CompatUUID(), nullable=True)
     subject_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
     quorum_required: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="2")
     approval_threshold: Mapped[int] = mapped_column(
@@ -62,13 +61,13 @@ class ConsensusVote(UUIDPrimaryKeyMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     request_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("consensus_requests.id"), nullable=False
+        CompatUUID(), ForeignKey("consensus_requests.id"), nullable=False
     )
     voter_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     vote: Mapped[str] = mapped_column(String(20), nullable=False)
     reason: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/apps/api/app/models/credit.py
+++ b/apps/api/app/models/credit.py
@@ -4,11 +4,10 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import CheckConstraint, ForeignKey, Index, Numeric, String
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB
+from app.models.compat import CompatJSONB, CompatUUID
 from app.models.enums import AmountMode
 
 
@@ -25,10 +24,10 @@ class CreditTransaction(UUIDPrimaryKeyMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     type: Mapped[str] = mapped_column(String(10), nullable=False)
     amount: Mapped[int] = mapped_column(nullable=False)
@@ -36,17 +35,17 @@ class CreditTransaction(UUIDPrimaryKeyMixin, Base):
     reason: Mapped[str] = mapped_column(String(500), nullable=False)
     trigger_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
     trigger_event_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("events.id"), nullable=True
+        CompatUUID(), ForeignKey("events.id"), nullable=True
     )
     source_task_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=True
+        CompatUUID(), ForeignKey("tasks.id"), nullable=True
     )
     source_agent_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+        CompatUUID(), ForeignKey("agents.id"), nullable=True
     )
     litellm_cost_usd: Mapped[float | None] = mapped_column(Numeric(10, 6), nullable=True)
     idempotency_key: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), nullable=True, unique=True
+        CompatUUID(), nullable=True, unique=True
     )
     metadata_: Mapped[dict] = mapped_column(
         "metadata", CompatJSONB(), nullable=False, server_default="{}"
@@ -74,7 +73,7 @@ class CreditRateConfig(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     trigger_type: Mapped[str] = mapped_column(String(100), nullable=False)
     direction: Mapped[str] = mapped_column(String(10), nullable=False)

--- a/apps/api/app/models/escalation.py
+++ b/apps/api/app/models/escalation.py
@@ -4,11 +4,10 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, SmallInteger, String, Text
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB
+from app.models.compat import CompatJSONB, CompatUUID
 
 
 class Escalation(UUIDPrimaryKeyMixin, Base):
@@ -21,16 +20,14 @@ class Escalation(UUIDPrimaryKeyMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
-    task_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=False
-    )
+    task_id: Mapped[uuid.UUID] = mapped_column(CompatUUID(), ForeignKey("tasks.id"), nullable=False)
     from_agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     to_agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     reason: Mapped[str] = mapped_column(String(50), nullable=False)
     levels_escalated: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="1")

--- a/apps/api/app/models/event.py
+++ b/apps/api/app/models/event.py
@@ -4,11 +4,10 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, String
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB
+from app.models.compat import CompatJSONB, CompatUUID
 from app.models.enums import EventSeverity
 
 
@@ -22,14 +21,14 @@ class Event(UUIDPrimaryKeyMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     type: Mapped[str] = mapped_column(String(100), nullable=False)
     actor_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     entity_type: Mapped[str] = mapped_column(String(50), nullable=False)
-    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(CompatUUID(), nullable=False)
     data: Mapped[dict] = mapped_column(CompatJSONB(), nullable=False)
     severity: Mapped[str] = mapped_column(
         String(10), nullable=False, server_default=EventSeverity.INFO.value

--- a/apps/api/app/models/graph.py
+++ b/apps/api/app/models/graph.py
@@ -4,11 +4,10 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, String, Text, UniqueConstraint, func
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB, CompatVector
+from app.models.compat import CompatJSONB, CompatUUID, CompatVector
 from app.models.memory import EMBEDDING_DIMENSIONS
 
 
@@ -19,7 +18,7 @@ class GraphEntity(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     entity_type: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -39,16 +38,16 @@ class GraphRelationship(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __tablename__ = "graph_relationships"
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     source_entity_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        CompatUUID(),
         ForeignKey("graph_entities.id"),
         nullable=False,
         index=True,
     )
     target_entity_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        CompatUUID(),
         ForeignKey("graph_entities.id"),
         nullable=False,
         index=True,
@@ -70,12 +69,12 @@ class MemoryEntityLink(Base):
     )
 
     memory_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("memories.id"), primary_key=True
+        CompatUUID(), ForeignKey("memories.id"), primary_key=True
     )
     entity_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("graph_entities.id"), primary_key=True
+        CompatUUID(), ForeignKey("graph_entities.id"), primary_key=True
     )
     agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(server_default=func.now(), nullable=False)

--- a/apps/api/app/models/integration.py
+++ b/apps/api/app/models/integration.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import uuid
 
 from sqlalchemy import ForeignKey, Index, String
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB
+from app.models.compat import CompatJSONB, CompatUUID
 
 
 class GitHubConnection(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -15,7 +14,7 @@ class GitHubConnection(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __table_args__ = (Index("ix_github_connections_org_id_enabled", "org_id", "enabled"),)
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     installation_id: Mapped[int] = mapped_column(nullable=False, unique=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -35,7 +34,7 @@ class LinearConnection(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __table_args__ = (Index("ix_linear_connections_org_id_enabled", "org_id", "enabled"),)
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     team_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -70,13 +69,13 @@ class IntegrationLink(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     provider: Mapped[str] = mapped_column(String(50), nullable=False, server_default="github")
     source_type: Mapped[str] = mapped_column(String(50), nullable=False)
     source_id: Mapped[str] = mapped_column(String(255), nullable=False)
     target_type: Mapped[str] = mapped_column(String(50), nullable=False)
-    target_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    target_id: Mapped[uuid.UUID] = mapped_column(CompatUUID(), nullable=False)
     metadata_: Mapped[dict] = mapped_column(
         "metadata", CompatJSONB(), nullable=False, server_default="{}"
     )

--- a/apps/api/app/models/memory.py
+++ b/apps/api/app/models/memory.py
@@ -13,11 +13,10 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
-from app.models.compat import CompatArray, CompatJSONB, CompatTSVector, CompatVector
+from app.models.compat import CompatArray, CompatJSONB, CompatTSVector, CompatUUID, CompatVector
 from app.models.enums import MemorySource, MemoryType, MemoryVisibility
 
 EMBEDDING_DIMENSIONS = 1024
@@ -41,10 +40,10 @@ class Memory(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     type: Mapped[str] = mapped_column(
         String(20), nullable=False, server_default=MemoryType.EPISODIC.value
@@ -65,7 +64,7 @@ class Memory(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         String(20), nullable=False, server_default=MemoryVisibility.SHARED.value
     )
     target_agent_ids: Mapped[list[uuid.UUID] | None] = mapped_column(
-        CompatArray(UUID(as_uuid=True)), nullable=True
+        CompatArray(CompatUUID()), nullable=True
     )
     confidence: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
     strength: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")

--- a/apps/api/app/models/message.py
+++ b/apps/api/app/models/message.py
@@ -4,11 +4,10 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, String, Text
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB
+from app.models.compat import CompatJSONB, CompatUUID
 from app.models.enums import MessageType
 
 
@@ -21,12 +20,12 @@ class Channel(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     type: Mapped[str] = mapped_column(String(20), nullable=False)
     task_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=True
+        CompatUUID(), ForeignKey("tasks.id"), nullable=True
     )
     metadata_: Mapped[dict] = mapped_column(
         "metadata", CompatJSONB(), nullable=False, server_default="{}"
@@ -47,23 +46,23 @@ class Message(UUIDPrimaryKeyMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     channel_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("channels.id"), nullable=False
+        CompatUUID(), ForeignKey("channels.id"), nullable=False
     )
     sender_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     recipient_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+        CompatUUID(), ForeignKey("agents.id"), nullable=True
     )
     type: Mapped[str] = mapped_column(
         String(20), nullable=False, server_default=MessageType.TEXT.value
     )
     body: Mapped[str] = mapped_column(Text, nullable=False)
     parent_message_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("messages.id"), nullable=True
+        CompatUUID(), ForeignKey("messages.id"), nullable=True
     )
     metadata_: Mapped[dict] = mapped_column(
         "metadata", CompatJSONB(), nullable=False, server_default="{}"

--- a/apps/api/app/models/reputation.py
+++ b/apps/api/app/models/reputation.py
@@ -4,11 +4,10 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, SmallInteger, String
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB
+from app.models.compat import CompatJSONB, CompatUUID
 
 
 class ReputationEvent(UUIDPrimaryKeyMixin, Base):
@@ -20,20 +19,20 @@ class ReputationEvent(UUIDPrimaryKeyMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     type: Mapped[str] = mapped_column(String(50), nullable=False)
     impact: Mapped[int] = mapped_column(SmallInteger, nullable=False)
     previous_score: Mapped[int] = mapped_column(SmallInteger, nullable=False)
     new_score: Mapped[int] = mapped_column(SmallInteger, nullable=False)
     task_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=True
+        CompatUUID(), ForeignKey("tasks.id"), nullable=True
     )
     triggered_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+        CompatUUID(), ForeignKey("agents.id"), nullable=True
     )
     reason: Mapped[str | None] = mapped_column(String(500), nullable=True)
     metadata_: Mapped[dict] = mapped_column(

--- a/apps/api/app/models/task.py
+++ b/apps/api/app/models/task.py
@@ -4,11 +4,10 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, String, Text
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
-from app.models.compat import CompatJSONB
+from app.models.compat import CompatJSONB, CompatUUID
 from app.models.enums import TaskPriority, TaskStatus
 
 
@@ -24,7 +23,7 @@ class Task(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     identifier: Mapped[str] = mapped_column(String(20), nullable=False)
     title: Mapped[str] = mapped_column(String(500), nullable=False)
@@ -36,13 +35,13 @@ class Task(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         String(10), nullable=False, server_default=TaskPriority.NORMAL.value
     )
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+        CompatUUID(), ForeignKey("agents.id"), nullable=True
     )
     creator_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     parent_task_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=True
+        CompatUUID(), ForeignKey("tasks.id"), nullable=True
     )
     approval_required: Mapped[bool] = mapped_column(nullable=False, server_default="false")
     approved_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -91,13 +90,11 @@ class TaskDependency(UUIDPrimaryKeyMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
-    task_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=False
-    )
+    task_id: Mapped[uuid.UUID] = mapped_column(CompatUUID(), ForeignKey("tasks.id"), nullable=False)
     depends_on_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=False
+        CompatUUID(), ForeignKey("tasks.id"), nullable=False
     )
     blocking: Mapped[bool] = mapped_column(nullable=False, server_default="true")
     created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
@@ -117,11 +114,9 @@ class TaskTag(UUIDPrimaryKeyMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
-    task_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=False
-    )
+    task_id: Mapped[uuid.UUID] = mapped_column(CompatUUID(), ForeignKey("tasks.id"), nullable=False)
     tag: Mapped[str] = mapped_column(String(100), nullable=False)
     created_at: Mapped[datetime] = mapped_column(server_default="now()", nullable=False)
 
@@ -137,17 +132,15 @@ class TaskComment(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
-    task_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id"), nullable=False
-    )
+    task_id: Mapped[uuid.UUID] = mapped_column(CompatUUID(), ForeignKey("tasks.id"), nullable=False)
     author_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=False
+        CompatUUID(), ForeignKey("agents.id"), nullable=False
     )
     body: Mapped[str] = mapped_column(Text, nullable=False)
     parent_comment_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("task_comments.id"), nullable=True
+        CompatUUID(), ForeignKey("task_comments.id"), nullable=True
     )
 
     organization: Mapped[Organization] = relationship("Organization")

--- a/apps/api/app/models/webhook.py
+++ b/apps/api/app/models/webhook.py
@@ -4,10 +4,10 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, String, Text
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+from app.models.compat import CompatUUID
 
 
 class Webhook(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -17,7 +17,7 @@ class Webhook(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     url: Mapped[str] = mapped_column(String(2048), nullable=False)
@@ -39,13 +39,13 @@ class InboundWebhookKey(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __table_args__ = (Index("ix_inbound_webhook_keys_org_id_enabled", "org_id", "enabled"),)
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+        CompatUUID(), ForeignKey("organizations.id"), nullable=False
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     key: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
     secret: Mapped[str] = mapped_column(String(64), nullable=False)
     default_agent_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True
+        CompatUUID(), ForeignKey("agents.id"), nullable=True
     )
     default_priority: Mapped[str | None] = mapped_column(String(10), nullable=True)
     default_tags: Mapped[str] = mapped_column(Text, nullable=False, server_default="")


### PR DESCRIPTION
## Summary

- Replace `UUID(as_uuid=True)` from `sqlalchemy.dialects.postgresql` with `CompatUUID()` across all 14 model files + `UUIDPrimaryKeyMixin`
- Fixes SQLite UUID round-trip failure on Python 3.14 (`AttributeError: 'int' object has no attribute 'replace'`)
- No Alembic migration needed — `CompatUUID` is a `TypeDecorator` that adapts at runtime (native UUID on PG, Text on SQLite)

Closes #685

## Test plan

- [x] All 409 tests pass
- [x] `ruff check`, `ruff format`, `pyright` clean
- [x] No remaining `UUID(as_uuid=True)` outside `compat.py`