### PR TITLE
fix(api): OpenAPI spec generation + codegen for SSE router (#686)

### DIFF
--- a/apps/api/app/events/sse_router.py
+++ b/apps/api/app/events/sse_router.py
@@ -108,7 +108,7 @@ def _validate_sse_token(token: str) -> tuple[uuid.UUID, uuid.UUID]:
     return uuid.UUID(str(decoded["sub"])), uuid.UUID(str(decoded["org_id"]))
 
 
-@router.get("/stream", response_class=EventSourceResponse)
+@router.get("/stream", response_class=EventSourceResponse, response_model=None)
 async def event_stream(
     token: str = Query(..., description="SSE JWT from POST /events/token"),
     last_event_id: int | None = Header(None, alias="Last-Event-ID"),

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5,9 +5,178 @@
     "version": "0.1.0"
   },
   "paths": {
+    "/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login",
+        "description": "Authenticate user and return access + refresh tokens.\n\nBehavior varies by auth mode:\n- mode=none: returns static owner token, any credentials accepted\n- mode=local: validates password against config hash, returns bearer token\n- mode=full: validates credentials against User DB, optional TOTP, returns JWT",
+        "operationId": "login_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/refresh": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Refresh",
+        "description": "Exchange refresh token for new access + refresh tokens.\n\nIn full mode, implements token rotation (old refresh token revoked).",
+        "operationId": "refresh_auth_refresh_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Logout",
+        "description": "Revoke refresh token (logout).",
+        "operationId": "logout_auth_logout_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogoutRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/me": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Get Current User Info",
+        "description": "Return current user profile from bearer token.",
+        "operationId": "get_current_user_info_auth_me_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserInfoResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/google": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Google Oauth",
+        "description": "Google OAuth login \u2014 stub for Phase 2.",
+        "operationId": "google_oauth_auth_google_get",
+        "responses": {
+          "501": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Google Oauth Auth Google Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/agents/register": {
       "post": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Register Agent",
         "operationId": "register_agent_agents_register_post",
         "requestBody": {
@@ -48,7 +217,9 @@
     },
     "/agents": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "List Agents",
         "operationId": "list_agents_agents_get",
         "parameters": [
@@ -111,7 +282,9 @@
     },
     "/agents/{agent_id}": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Get Agent",
         "operationId": "get_agent_agents__agent_id__get",
         "parameters": [
@@ -150,7 +323,9 @@
         }
       },
       "patch": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Update Agent",
         "operationId": "update_agent_agents__agent_id__patch",
         "parameters": [
@@ -201,7 +376,9 @@
     },
     "/agents/{agent_id}/revoke": {
       "post": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Revoke Agent",
         "operationId": "revoke_agent_agents__agent_id__revoke_post",
         "parameters": [
@@ -242,7 +419,9 @@
     },
     "/agents/spawn": {
       "post": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Spawn Agent",
         "operationId": "spawn_agent_agents_spawn_post",
         "requestBody": {
@@ -281,7 +460,9 @@
     },
     "/agents/capacity": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Get Capacity",
         "operationId": "get_capacity_agents_capacity_get",
         "responses": {
@@ -300,7 +481,9 @@
     },
     "/agents/pending": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Get Pending Agents",
         "operationId": "get_pending_agents_agents_pending_get",
         "responses": {
@@ -319,7 +502,9 @@
     },
     "/agents/{agent_id}/activate": {
       "post": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Activate Agent",
         "operationId": "activate_agent_agents__agent_id__activate_post",
         "parameters": [
@@ -360,7 +545,9 @@
     },
     "/agents/{agent_id}/reject": {
       "delete": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Reject Agent",
         "operationId": "reject_agent_agents__agent_id__reject_delete",
         "parameters": [
@@ -401,7 +588,9 @@
     },
     "/agents/{agent_id}/hierarchy": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Get Hierarchy",
         "operationId": "get_hierarchy_agents__agent_id__hierarchy_get",
         "parameters": [
@@ -454,7 +643,9 @@
     },
     "/agents/{agent_id}/credits/balance": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Get Balance",
         "operationId": "get_balance_agents__agent_id__credits_balance_get",
         "parameters": [
@@ -495,7 +686,9 @@
     },
     "/agents/{agent_id}/budget": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Get Budget",
         "operationId": "get_budget_agents__agent_id__budget_get",
         "parameters": [
@@ -534,7 +727,9 @@
         }
       },
       "patch": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Set Budget",
         "operationId": "set_budget_agents__agent_id__budget_patch",
         "parameters": [
@@ -585,7 +780,9 @@
     },
     "/agents/credits/transfer": {
       "post": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Transfer Credits",
         "operationId": "transfer_credits_agents_credits_transfer_post",
         "requestBody": {
@@ -624,7 +821,9 @@
     },
     "/agents/{agent_id}/budget/can-spend": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Can Spend",
         "operationId": "can_spend_agents__agent_id__budget_can_spend_get",
         "parameters": [
@@ -675,7 +874,9 @@
     },
     "/agents/budget/alerts": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Budget Alerts",
         "operationId": "budget_alerts_agents_budget_alerts_get",
         "responses": {
@@ -694,7 +895,9 @@
     },
     "/agents/capabilities": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "List Org Capabilities",
         "operationId": "list_org_capabilities_agents_capabilities_get",
         "responses": {
@@ -713,7 +916,9 @@
     },
     "/agents/capabilities/match": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Match Capabilities",
         "operationId": "match_capabilities_agents_capabilities_match_get",
         "parameters": [
@@ -774,7 +979,9 @@
     },
     "/agents/{agent_id}/capabilities": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Get Agent Capabilities",
         "operationId": "get_agent_capabilities_agents__agent_id__capabilities_get",
         "parameters": [
@@ -813,7 +1020,9 @@
         }
       },
       "post": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Add Capability",
         "operationId": "add_capability_agents__agent_id__capabilities_post",
         "parameters": [
@@ -864,7 +1073,9 @@
     },
     "/agents/capabilities/{capability_id}": {
       "patch": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Update Capability",
         "operationId": "update_capability_agents_capabilities__capability_id__patch",
         "parameters": [
@@ -913,7 +1124,9 @@
         }
       },
       "delete": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Delete Capability",
         "operationId": "delete_capability_agents_capabilities__capability_id__delete",
         "parameters": [
@@ -947,7 +1160,9 @@
     },
     "/agents/{agent_id}/reputation": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Get Reputation",
         "operationId": "get_reputation_agents__agent_id__reputation_get",
         "parameters": [
@@ -988,7 +1203,9 @@
     },
     "/agents/{agent_id}/reputation/history": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Get Reputation History",
         "operationId": "get_reputation_history_agents__agent_id__reputation_history_get",
         "parameters": [
@@ -1051,7 +1268,9 @@
     },
     "/agents/{agent_id}/reputation/bonus": {
       "post": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Award Bonus",
         "operationId": "award_bonus_agents__agent_id__reputation_bonus_post",
         "parameters": [
@@ -1102,7 +1321,9 @@
     },
     "/agents/{agent_id}/reputation/penalty": {
       "post": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Apply Penalty",
         "operationId": "apply_penalty_agents__agent_id__reputation_penalty_post",
         "parameters": [
@@ -1153,7 +1374,9 @@
     },
     "/agents/leaderboard/trust": {
       "get": {
-        "tags": ["agents"],
+        "tags": [
+          "agents"
+        ],
         "summary": "Trust Leaderboard",
         "operationId": "trust_leaderboard_agents_leaderboard_trust_get",
         "parameters": [
@@ -1195,7 +1418,9 @@
     },
     "/tasks": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Create Task",
         "operationId": "create_task_tasks_post",
         "requestBody": {
@@ -1232,7 +1457,9 @@
         }
       },
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "List Tasks",
         "operationId": "list_tasks_tasks_get",
         "parameters": [
@@ -1352,7 +1579,9 @@
     },
     "/tasks/{task_id}": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Get Task",
         "operationId": "get_task_tasks__task_id__get",
         "parameters": [
@@ -1393,7 +1622,9 @@
     },
     "/tasks/{task_id}/transition": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Transition Task",
         "operationId": "transition_task_tasks__task_id__transition_post",
         "parameters": [
@@ -1444,7 +1675,9 @@
     },
     "/tasks/{task_id}/approve": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Approve Task",
         "operationId": "approve_task_tasks__task_id__approve_post",
         "parameters": [
@@ -1485,7 +1718,9 @@
     },
     "/tasks/{task_id}/assign": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Assign Task",
         "operationId": "assign_task_tasks__task_id__assign_post",
         "parameters": [
@@ -1536,7 +1771,9 @@
     },
     "/tasks/{task_id}/dependencies": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Add Dependency",
         "operationId": "add_dependency_tasks__task_id__dependencies_post",
         "parameters": [
@@ -1587,7 +1824,9 @@
     },
     "/tasks/{task_id}/dependencies/{dep_id}": {
       "delete": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Remove Dependency",
         "operationId": "remove_dependency_tasks__task_id__dependencies__dep_id__delete",
         "parameters": [
@@ -1631,7 +1870,9 @@
     },
     "/tasks/{task_id}/comments": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Add Comment",
         "operationId": "add_comment_tasks__task_id__comments_post",
         "parameters": [
@@ -1680,7 +1921,9 @@
         }
       },
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "List Comments",
         "operationId": "list_comments_tasks__task_id__comments_get",
         "parameters": [
@@ -1721,7 +1964,9 @@
     },
     "/tasks/{task_id}/escalate": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Escalate Task",
         "operationId": "escalate_task_tasks__task_id__escalate_post",
         "parameters": [
@@ -1772,7 +2017,9 @@
     },
     "/tasks/{task_id}/escalations": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Get Task Escalations",
         "operationId": "get_task_escalations_tasks__task_id__escalations_get",
         "parameters": [
@@ -1813,7 +2060,9 @@
     },
     "/tasks/escalations/open": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "List Open Escalations",
         "operationId": "list_open_escalations_tasks_escalations_open_get",
         "responses": {
@@ -1832,7 +2081,9 @@
     },
     "/tasks/escalations/{escalation_id}/resolve": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Resolve Escalation",
         "operationId": "resolve_escalation_tasks_escalations__escalation_id__resolve_post",
         "parameters": [
@@ -1883,7 +2134,9 @@
     },
     "/tasks/consensus": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Create Consensus",
         "operationId": "create_consensus_tasks_consensus_post",
         "requestBody": {
@@ -1922,7 +2175,9 @@
     },
     "/tasks/consensus/pending": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Get Pending Consensus",
         "operationId": "get_pending_consensus_tasks_consensus_pending_get",
         "responses": {
@@ -1941,7 +2196,9 @@
     },
     "/tasks/consensus/{request_id}": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Get Consensus",
         "operationId": "get_consensus_tasks_consensus__request_id__get",
         "parameters": [
@@ -1980,7 +2237,9 @@
         }
       },
       "delete": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Cancel Consensus",
         "operationId": "cancel_consensus_tasks_consensus__request_id__delete",
         "parameters": [
@@ -2014,7 +2273,9 @@
     },
     "/tasks/consensus/{request_id}/vote": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "Cast Vote",
         "operationId": "cast_vote_tasks_consensus__request_id__vote_post",
         "parameters": [
@@ -2065,7 +2326,9 @@
     },
     "/credits/balance": {
       "get": {
-        "tags": ["credits"],
+        "tags": [
+          "credits"
+        ],
         "summary": "Get Balance",
         "operationId": "get_balance_credits_balance_get",
         "responses": {
@@ -2084,7 +2347,9 @@
     },
     "/credits/spend": {
       "post": {
-        "tags": ["credits"],
+        "tags": [
+          "credits"
+        ],
         "summary": "Spend Credits",
         "operationId": "spend_credits_credits_spend_post",
         "requestBody": {
@@ -2123,7 +2388,9 @@
     },
     "/credits/history": {
       "get": {
-        "tags": ["credits"],
+        "tags": [
+          "credits"
+        ],
         "summary": "Get History",
         "operationId": "get_history_credits_history_get",
         "parameters": [
@@ -2176,7 +2443,9 @@
     },
     "/credits/adjust": {
       "post": {
-        "tags": ["credits"],
+        "tags": [
+          "credits"
+        ],
         "summary": "Adjust Credits",
         "operationId": "adjust_credits_credits_adjust_post",
         "requestBody": {
@@ -2215,7 +2484,9 @@
     },
     "/credits/analytics/stats": {
       "get": {
-        "tags": ["credits"],
+        "tags": [
+          "credits"
+        ],
         "summary": "Get Stats",
         "operationId": "get_stats_credits_analytics_stats_get",
         "responses": {
@@ -2234,7 +2505,9 @@
     },
     "/credits/analytics/trends": {
       "get": {
-        "tags": ["credits"],
+        "tags": [
+          "credits"
+        ],
         "summary": "Get Trends",
         "operationId": "get_trends_credits_analytics_trends_get",
         "parameters": [
@@ -2294,7 +2567,9 @@
     },
     "/credits/analytics/agents": {
       "get": {
-        "tags": ["credits"],
+        "tags": [
+          "credits"
+        ],
         "summary": "Get Spending By Agent",
         "operationId": "get_spending_by_agent_credits_analytics_agents_get",
         "responses": {
@@ -2313,7 +2588,9 @@
     },
     "/credits/analytics/top-spenders": {
       "get": {
-        "tags": ["credits"],
+        "tags": [
+          "credits"
+        ],
         "summary": "Get Top Spenders",
         "operationId": "get_top_spenders_credits_analytics_top_spenders_get",
         "parameters": [
@@ -2367,7 +2644,9 @@
     },
     "/channels": {
       "get": {
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "List Channels",
         "operationId": "list_channels_channels_get",
         "responses": {
@@ -2384,7 +2663,9 @@
         }
       },
       "post": {
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "Create Channel",
         "operationId": "create_channel_channels_post",
         "requestBody": {
@@ -2423,7 +2704,9 @@
     },
     "/channels/{channel_id}": {
       "get": {
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "Get Channel",
         "operationId": "get_channel_channels__channel_id__get",
         "parameters": [
@@ -2464,7 +2747,9 @@
     },
     "/messages": {
       "post": {
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "Send Message",
         "operationId": "send_message_messages_post",
         "requestBody": {
@@ -2501,7 +2786,9 @@
         }
       },
       "get": {
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "List Messages",
         "operationId": "list_messages_messages_get",
         "parameters": [
@@ -2570,7 +2857,9 @@
     },
     "/messages/{message_id}": {
       "get": {
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "Get Message",
         "operationId": "get_message_messages__message_id__get",
         "parameters": [
@@ -2611,7 +2900,9 @@
     },
     "/messages/{message_id}/thread": {
       "get": {
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "Get Thread",
         "operationId": "get_thread_messages__message_id__thread_get",
         "parameters": [
@@ -2652,7 +2943,9 @@
     },
     "/dm": {
       "post": {
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "Send Dm",
         "operationId": "send_dm_dm_post",
         "requestBody": {
@@ -2691,7 +2984,9 @@
     },
     "/dm/{agent_id}": {
       "get": {
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "Get Dm History",
         "operationId": "get_dm_history_dm__agent_id__get",
         "parameters": [
@@ -2741,9 +3036,609 @@
         }
       }
     },
+    "/artifacts": {
+      "post": {
+        "tags": [
+          "artifacts"
+        ],
+        "summary": "Publish Artifact",
+        "operationId": "publish_artifact_artifacts_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublishArtifactDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_ArtifactResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "artifacts"
+        ],
+        "summary": "List Artifacts",
+        "operationId": "list_artifacts_artifacts_get",
+        "parameters": [
+          {
+            "name": "artifact_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ArtifactType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Artifact Type"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Name"
+            }
+          },
+          {
+            "name": "task_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Task Id"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ArtifactStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "producer_agent_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Producer Agent Id"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "default": 50,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_ArtifactResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artifacts/batch": {
+      "post": {
+        "tags": [
+          "artifacts"
+        ],
+        "summary": "Publish Batch",
+        "operationId": "publish_batch_artifacts_batch_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/PublishArtifactDto"
+                },
+                "type": "array",
+                "title": "Dtos"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_list_ArtifactResponse__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artifacts/latest": {
+      "get": {
+        "tags": [
+          "artifacts"
+        ],
+        "summary": "Get Latest Artifact",
+        "operationId": "get_latest_artifact_artifacts_latest_get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_ArtifactResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artifacts/subscribe": {
+      "post": {
+        "tags": [
+          "artifacts"
+        ],
+        "summary": "Create Subscription",
+        "operationId": "create_subscription_artifacts_subscribe_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/app__artifacts__schemas__SubscribeDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_SubscriptionResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artifacts/subscriptions": {
+      "get": {
+        "tags": [
+          "artifacts"
+        ],
+        "summary": "List Subscriptions",
+        "operationId": "list_subscriptions_artifacts_subscriptions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_list_SubscriptionResponse__"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artifacts/subscriptions/{subscription_id}": {
+      "delete": {
+        "tags": [
+          "artifacts"
+        ],
+        "summary": "Delete Subscription",
+        "operationId": "delete_subscription_artifacts_subscriptions__subscription_id__delete",
+        "parameters": [
+          {
+            "name": "subscription_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Subscription Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artifacts/{artifact_id}": {
+      "get": {
+        "tags": [
+          "artifacts"
+        ],
+        "summary": "Get Artifact",
+        "operationId": "get_artifact_artifacts__artifact_id__get",
+        "parameters": [
+          {
+            "name": "artifact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Artifact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_ArtifactResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artifacts/{artifact_id}/history": {
+      "get": {
+        "tags": [
+          "artifacts"
+        ],
+        "summary": "Get Artifact History",
+        "operationId": "get_artifact_history_artifacts__artifact_id__history_get",
+        "parameters": [
+          {
+            "name": "artifact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Artifact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_list_ArtifactResponse__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/artifacts/{artifact_id}/status": {
+      "put": {
+        "tags": [
+          "artifacts"
+        ],
+        "summary": "Update Artifact Status",
+        "operationId": "update_artifact_status_artifacts__artifact_id__status_put",
+        "parameters": [
+          {
+            "name": "artifact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Artifact Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateStatusDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_ArtifactResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events/token": {
+      "post": {
+        "tags": [
+          "events-sse"
+        ],
+        "summary": "Create Sse Token",
+        "description": "Issue short-lived JWT for SSE auth (EventSource can't set headers).",
+        "operationId": "create_sse_token_events_token_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_SSETokenResponse_"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events/stream": {
+      "get": {
+        "tags": [
+          "events-sse"
+        ],
+        "summary": "Event Stream",
+        "description": "SSE stream. Auth via query param token. Supports Last-Event-ID replay.",
+        "operationId": "event_stream_events_stream_get",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "SSE JWT from POST /events/token",
+              "title": "Token"
+            },
+            "description": "SSE JWT from POST /events/token"
+          },
+          {
+            "name": "Last-Event-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last-Event-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/event-stream": {
+                "itemSchema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "string"
+                    },
+                    "event": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "retry": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/events": {
       "get": {
-        "tags": ["events"],
+        "tags": [
+          "events"
+        ],
         "summary": "List Events",
         "operationId": "list_events_events_get",
         "parameters": [
@@ -2912,7 +3807,9 @@
     },
     "/events/{event_id}": {
       "get": {
-        "tags": ["events"],
+        "tags": [
+          "events"
+        ],
         "summary": "Get Event",
         "operationId": "get_event_events__event_id__get",
         "parameters": [
@@ -2953,7 +3850,9 @@
     },
     "/integrations/github/connections": {
       "get": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "List Github Connections",
         "operationId": "list_github_connections_integrations_github_connections_get",
         "responses": {
@@ -2970,7 +3869,9 @@
         }
       },
       "post": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Create Github Connection",
         "operationId": "create_github_connection_integrations_github_connections_post",
         "requestBody": {
@@ -3009,7 +3910,9 @@
     },
     "/integrations/github/connections/{conn_id}": {
       "get": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Get Github Connection",
         "operationId": "get_github_connection_integrations_github_connections__conn_id__get",
         "parameters": [
@@ -3048,7 +3951,9 @@
         }
       },
       "patch": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Update Github Connection",
         "operationId": "update_github_connection_integrations_github_connections__conn_id__patch",
         "parameters": [
@@ -3097,7 +4002,9 @@
         }
       },
       "delete": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Delete Github Connection",
         "operationId": "delete_github_connection_integrations_github_connections__conn_id__delete",
         "parameters": [
@@ -3131,7 +4038,9 @@
     },
     "/integrations/github/connections/{conn_id}/test": {
       "post": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Test Github Connection",
         "operationId": "test_github_connection_integrations_github_connections__conn_id__test_post",
         "parameters": [
@@ -3172,7 +4081,9 @@
     },
     "/integrations/github/connections/{conn_id}/links": {
       "get": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Get Github Links",
         "operationId": "get_github_links_integrations_github_connections__conn_id__links_get",
         "parameters": [
@@ -3213,7 +4124,9 @@
     },
     "/integrations/github/webhook": {
       "post": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Github Webhook",
         "operationId": "github_webhook_integrations_github_webhook_post",
         "responses": {
@@ -3232,7 +4145,9 @@
     },
     "/integrations/linear/connections": {
       "get": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "List Linear Connections",
         "operationId": "list_linear_connections_integrations_linear_connections_get",
         "responses": {
@@ -3249,7 +4164,9 @@
         }
       },
       "post": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Create Linear Connection",
         "operationId": "create_linear_connection_integrations_linear_connections_post",
         "requestBody": {
@@ -3288,7 +4205,9 @@
     },
     "/integrations/linear/connections/{conn_id}": {
       "get": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Get Linear Connection",
         "operationId": "get_linear_connection_integrations_linear_connections__conn_id__get",
         "parameters": [
@@ -3327,7 +4246,9 @@
         }
       },
       "patch": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Update Linear Connection",
         "operationId": "update_linear_connection_integrations_linear_connections__conn_id__patch",
         "parameters": [
@@ -3376,7 +4297,9 @@
         }
       },
       "delete": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Delete Linear Connection",
         "operationId": "delete_linear_connection_integrations_linear_connections__conn_id__delete",
         "parameters": [
@@ -3410,7 +4333,9 @@
     },
     "/integrations/linear/connections/{conn_id}/test": {
       "post": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Test Linear Connection",
         "operationId": "test_linear_connection_integrations_linear_connections__conn_id__test_post",
         "parameters": [
@@ -3451,7 +4376,9 @@
     },
     "/integrations/linear/connections/{conn_id}/links": {
       "get": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Get Linear Links",
         "operationId": "get_linear_links_integrations_linear_connections__conn_id__links_get",
         "parameters": [
@@ -3492,7 +4419,9 @@
     },
     "/integrations/linear/webhook": {
       "post": {
-        "tags": ["integrations"],
+        "tags": [
+          "integrations"
+        ],
         "summary": "Linear Webhook",
         "operationId": "linear_webhook_integrations_linear_webhook_post",
         "responses": {
@@ -3511,7 +4440,9 @@
     },
     "/memory": {
       "post": {
-        "tags": ["memory"],
+        "tags": [
+          "memory"
+        ],
         "summary": "Store",
         "operationId": "store_memory_post",
         "requestBody": {
@@ -3548,7 +4479,9 @@
         }
       },
       "get": {
-        "tags": ["memory"],
+        "tags": [
+          "memory"
+        ],
         "summary": "List All",
         "operationId": "list_all_memory_get",
         "parameters": [
@@ -3651,7 +4584,9 @@
     },
     "/memory/search": {
       "get": {
-        "tags": ["memory"],
+        "tags": [
+          "memory"
+        ],
         "summary": "Search",
         "operationId": "search_memory_search_get",
         "parameters": [
@@ -3732,7 +4667,9 @@
     },
     "/memory/contradictions": {
       "get": {
-        "tags": ["memory"],
+        "tags": [
+          "memory"
+        ],
         "summary": "List Contradiction Pairs",
         "operationId": "list_contradiction_pairs_memory_contradictions_get",
         "responses": {
@@ -3751,7 +4688,9 @@
     },
     "/memory/contradictions/{memory_id}/resolve": {
       "post": {
-        "tags": ["memory"],
+        "tags": [
+          "memory"
+        ],
         "summary": "Resolve Contradiction Endpoint",
         "operationId": "resolve_contradiction_endpoint_memory_contradictions__memory_id__resolve_post",
         "parameters": [
@@ -3802,7 +4741,9 @@
     },
     "/memory/{memory_id}": {
       "get": {
-        "tags": ["memory"],
+        "tags": [
+          "memory"
+        ],
         "summary": "Get One",
         "operationId": "get_one_memory__memory_id__get",
         "parameters": [
@@ -3843,7 +4784,9 @@
     },
     "/memory/{memory_id}/feedback": {
       "post": {
-        "tags": ["memory"],
+        "tags": [
+          "memory"
+        ],
         "summary": "Feedback",
         "operationId": "feedback_memory__memory_id__feedback_post",
         "parameters": [
@@ -3894,7 +4837,9 @@
     },
     "/memory/graph/entities": {
       "get": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "List Entities",
         "operationId": "list_entities_memory_graph_entities_get",
         "parameters": [
@@ -3953,7 +4898,9 @@
     },
     "/memory/graph/entities/{entity_id}": {
       "get": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "Get Entity",
         "operationId": "get_entity_memory_graph_entities__entity_id__get",
         "parameters": [
@@ -3994,7 +4941,9 @@
     },
     "/memory/graph/entities/{entity_id}/memories": {
       "get": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "List Entity Memories",
         "operationId": "list_entity_memories_memory_graph_entities__entity_id__memories_get",
         "parameters": [
@@ -4047,7 +4996,9 @@
     },
     "/memory/graph/entities/{entity_id}/agents": {
       "get": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "List Entity Agents",
         "operationId": "list_entity_agents_memory_graph_entities__entity_id__agents_get",
         "parameters": [
@@ -4088,7 +5039,9 @@
     },
     "/memory/graph/entities/{entity_id}/neighbors": {
       "get": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "Get Neighbors",
         "operationId": "get_neighbors_memory_graph_entities__entity_id__neighbors_get",
         "parameters": [
@@ -4141,7 +5094,9 @@
     },
     "/memory/graph/relationships": {
       "get": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "Get Relationships",
         "operationId": "get_relationships_memory_graph_relationships_get",
         "parameters": [
@@ -4192,7 +5147,9 @@
     },
     "/memory/graph/overlap": {
       "get": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "Compute Overlap",
         "operationId": "compute_overlap_memory_graph_overlap_get",
         "parameters": [
@@ -4243,7 +5200,9 @@
     },
     "/memory/graph/overlap/matrix": {
       "get": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "Overlap Matrix",
         "operationId": "overlap_matrix_memory_graph_overlap_matrix_get",
         "responses": {
@@ -4262,7 +5221,9 @@
     },
     "/memory/graph/gaps": {
       "get": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "Find Gaps",
         "operationId": "find_gaps_memory_graph_gaps_get",
         "responses": {
@@ -4281,7 +5242,9 @@
     },
     "/memory/graph/cytoscape": {
       "get": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "Cytoscape Graph",
         "operationId": "cytoscape_graph_memory_graph_cytoscape_get",
         "parameters": [
@@ -4340,7 +5303,9 @@
     },
     "/memory/graph/agent-file/export/{agent_id}": {
       "post": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "Export Agent",
         "operationId": "export_agent_memory_graph_agent_file_export__agent_id__post",
         "parameters": [
@@ -4383,7 +5348,9 @@
     },
     "/memory/graph/agent-file/import": {
       "post": {
-        "tags": ["graph"],
+        "tags": [
+          "graph"
+        ],
         "summary": "Import Agent",
         "operationId": "import_agent_memory_graph_agent_file_import_post",
         "requestBody": {
@@ -4407,6 +5374,180 @@
                   "additionalProperties": true,
                   "type": "object",
                   "title": "Response Import Agent Memory Graph Agent File Import Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/coordination/emit": {
+      "post": {
+        "tags": [
+          "coordination"
+        ],
+        "summary": "Emit Event",
+        "operationId": "emit_event_coordination_emit_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmitEventDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataMessageResponse_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/coordination/subscribe": {
+      "post": {
+        "tags": [
+          "coordination"
+        ],
+        "summary": "Subscribe",
+        "operationId": "subscribe_coordination_subscribe_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/app__coordination__schemas__SubscribeDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_EventSubscriptionResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/coordination/replay": {
+      "post": {
+        "tags": [
+          "coordination"
+        ],
+        "summary": "Replay",
+        "operationId": "replay_coordination_replay_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReplayDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_list_dict__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/coordination/project": {
+      "get": {
+        "tags": [
+          "coordination"
+        ],
+        "summary": "Project",
+        "operationId": "project_coordination_project_get",
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Task Id"
+            }
+          },
+          {
+            "name": "projection_type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Projection Type"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataResponse_dict_"
                 }
               }
             }
@@ -4484,7 +5625,9 @@
           }
         },
         "type": "object",
-        "required": ["capability"],
+        "required": [
+          "capability"
+        ],
         "title": "AddCapabilityDto"
       },
       "AddCommentDto": {
@@ -4507,7 +5650,9 @@
           }
         },
         "type": "object",
-        "required": ["body"],
+        "required": [
+          "body"
+        ],
         "title": "AddCommentDto"
       },
       "AddDependencyDto": {
@@ -4524,7 +5669,9 @@
           }
         },
         "type": "object",
-        "required": ["depends_on_id"],
+        "required": [
+          "depends_on_id"
+        ],
         "title": "AddDependencyDto"
       },
       "AdjustCreditsDto": {
@@ -4549,12 +5696,21 @@
           }
         },
         "type": "object",
-        "required": ["agent_id", "amount", "type", "reason"],
+        "required": [
+          "agent_id",
+          "amount",
+          "type",
+          "reason"
+        ],
         "title": "AdjustCreditsDto"
       },
       "AgentMode": {
         "type": "string",
-        "enum": ["worker", "orchestrator", "observer"],
+        "enum": [
+          "worker",
+          "orchestrator",
+          "observer"
+        ],
         "title": "AgentMode"
       },
       "AgentRegistrationResponse": {
@@ -4568,7 +5724,10 @@
           }
         },
         "type": "object",
-        "required": ["agent", "hmac_secret"],
+        "required": [
+          "agent",
+          "hmac_secret"
+        ],
         "title": "AgentRegistrationResponse"
       },
       "AgentResponse": {
@@ -4783,7 +5942,18 @@
       },
       "AgentRole": {
         "type": "string",
-        "enum": ["worker", "hr", "founder", "admin"],
+        "enum": [
+          "worker",
+          "hr",
+          "founder",
+          "admin",
+          "coo",
+          "talent",
+          "lead",
+          "senior",
+          "manager",
+          "intern"
+        ],
         "title": "AgentRole"
       },
       "AgentSpendingResponse": {
@@ -4806,13 +5976,173 @@
           }
         },
         "type": "object",
-        "required": ["agent_id", "name", "total_spent", "transaction_count"],
+        "required": [
+          "agent_id",
+          "name",
+          "total_spent",
+          "transaction_count"
+        ],
         "title": "AgentSpendingResponse"
       },
       "AgentStatus": {
         "type": "string",
-        "enum": ["pending", "active", "suspended", "revoked"],
+        "enum": [
+          "pending",
+          "active",
+          "idle",
+          "busy",
+          "paused",
+          "suspended",
+          "revoked"
+        ],
         "title": "AgentStatus"
+      },
+      "ArtifactResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "org_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Org Id"
+          },
+          "task_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Task Id"
+          },
+          "producer_agent_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Producer Agent Id"
+          },
+          "artifact_type": {
+            "$ref": "#/components/schemas/ArtifactType"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ArtifactStatus"
+          },
+          "content": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Content"
+          },
+          "content_hash": {
+            "type": "string",
+            "title": "Content Hash"
+          },
+          "metadata_": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          },
+          "source_artifact_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Source Artifact Ids"
+          },
+          "superseded_by_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Superseded By Id"
+          },
+          "approved_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved By"
+          },
+          "approved_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "org_id",
+          "task_id",
+          "producer_agent_id",
+          "artifact_type",
+          "name",
+          "version",
+          "status",
+          "content",
+          "content_hash",
+          "metadata_",
+          "source_artifact_ids",
+          "superseded_by_id",
+          "approved_by",
+          "approved_at",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ArtifactResponse"
+      },
+      "ArtifactStatus": {
+        "type": "string",
+        "enum": [
+          "draft",
+          "published",
+          "superseded"
+        ],
+        "title": "ArtifactStatus"
+      },
+      "ArtifactType": {
+        "type": "string",
+        "enum": [
+          "component",
+          "test_plan",
+          "screenshot",
+          "api_contract",
+          "migration",
+          "schema",
+          "doc_section"
+        ],
+        "title": "ArtifactType"
       },
       "AssignTaskDto": {
         "properties": {
@@ -4823,7 +6153,9 @@
           }
         },
         "type": "object",
-        "required": ["assignee_id"],
+        "required": [
+          "assignee_id"
+        ],
         "title": "AssignTaskDto"
       },
       "BalanceResponse": {
@@ -4834,7 +6166,9 @@
           }
         },
         "type": "object",
-        "required": ["balance"],
+        "required": [
+          "balance"
+        ],
         "title": "BalanceResponse"
       },
       "BudgetResponse": {
@@ -4923,7 +6257,14 @@
           }
         },
         "type": "object",
-        "required": ["id", "org_id", "agent_id", "capability", "proficiency", "created_at"],
+        "required": [
+          "id",
+          "org_id",
+          "agent_id",
+          "capability",
+          "proficiency",
+          "created_at"
+        ],
         "title": "CapabilityResponse"
       },
       "CastVoteDto": {
@@ -4944,7 +6285,9 @@
           }
         },
         "type": "object",
-        "required": ["vote"],
+        "required": [
+          "vote"
+        ],
         "title": "CastVoteDto"
       },
       "ChannelResponse": {
@@ -5009,7 +6352,12 @@
       },
       "ChannelType": {
         "type": "string",
-        "enum": ["task", "agent", "broadcast", "general"],
+        "enum": [
+          "task",
+          "agent",
+          "broadcast",
+          "general"
+        ],
         "title": "ChannelType"
       },
       "ConsensusRequestResponse": {
@@ -5146,7 +6494,13 @@
       },
       "ConsensusStatus": {
         "type": "string",
-        "enum": ["PENDING", "APPROVED", "REJECTED", "EXPIRED", "CANCELLED"],
+        "enum": [
+          "PENDING",
+          "APPROVED",
+          "REJECTED",
+          "EXPIRED",
+          "CANCELLED"
+        ],
         "title": "ConsensusStatus"
       },
       "ConsensusType": {
@@ -5204,7 +6558,15 @@
           }
         },
         "type": "object",
-        "required": ["id", "request_id", "voter_id", "vote", "reason", "voter_level", "created_at"],
+        "required": [
+          "id",
+          "request_id",
+          "voter_id",
+          "vote",
+          "reason",
+          "voter_level",
+          "created_at"
+        ],
         "title": "ConsensusVoteResponse"
       },
       "ContradictionPairResponse": {
@@ -5217,7 +6579,10 @@
           }
         },
         "type": "object",
-        "required": ["older_memory", "newer_memory"],
+        "required": [
+          "older_memory",
+          "newer_memory"
+        ],
         "title": "ContradictionPairResponse"
       },
       "CreateChannelDto": {
@@ -5249,7 +6614,10 @@
           }
         },
         "type": "object",
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "title": "CreateChannelDto"
       },
       "CreateConsensusDto": {
@@ -5317,7 +6685,10 @@
           }
         },
         "type": "object",
-        "required": ["type", "title"],
+        "required": [
+          "type",
+          "title"
+        ],
         "title": "CreateConsensusDto"
       },
       "CreateGitHubConnectionDto": {
@@ -5350,7 +6721,11 @@
           }
         },
         "type": "object",
-        "required": ["installation_id", "name", "webhook_secret"],
+        "required": [
+          "installation_id",
+          "name",
+          "webhook_secret"
+        ],
         "title": "CreateGitHubConnectionDto"
       },
       "CreateLinearConnectionDto": {
@@ -5396,7 +6771,11 @@
           }
         },
         "type": "object",
-        "required": ["team_id", "name", "webhook_secret"],
+        "required": [
+          "team_id",
+          "name",
+          "webhook_secret"
+        ],
         "title": "CreateLinearConnectionDto"
       },
       "CreateTaskDto": {
@@ -5483,7 +6862,9 @@
           }
         },
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "title": "CreateTaskDto"
       },
       "CreditStatsResponse": {
@@ -5506,7 +6887,12 @@
           }
         },
         "type": "object",
-        "required": ["total_credits", "total_debits", "net", "transaction_count"],
+        "required": [
+          "total_credits",
+          "total_debits",
+          "net",
+          "transaction_count"
+        ],
         "title": "CreditStatsResponse"
       },
       "CreditTransactionResponse": {
@@ -5612,7 +6998,10 @@
       },
       "CreditType": {
         "type": "string",
-        "enum": ["credit", "debit"],
+        "enum": [
+          "credit",
+          "debit"
+        ],
         "title": "CreditType"
       },
       "CytoscapeEdge": {
@@ -5624,7 +7013,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "CytoscapeEdge"
       },
       "CytoscapeGraph": {
@@ -5645,7 +7036,10 @@
           }
         },
         "type": "object",
-        "required": ["nodes", "edges"],
+        "required": [
+          "nodes",
+          "edges"
+        ],
         "title": "CytoscapeGraph"
       },
       "CytoscapeNode": {
@@ -5657,7 +7051,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "CytoscapeNode"
       },
       "DataMessageResponse_AgentRegistrationResponse_": {
@@ -5676,7 +7072,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "message"],
+        "required": [
+          "data",
+          "message"
+        ],
         "title": "DataMessageResponse[AgentRegistrationResponse]"
       },
       "DataMessageResponse_AgentResponse_": {
@@ -5695,7 +7094,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "message"],
+        "required": [
+          "data",
+          "message"
+        ],
         "title": "DataMessageResponse[AgentResponse]"
       },
       "DataMessageResponse_ConsensusVoteResponse_": {
@@ -5714,7 +7116,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "message"],
+        "required": [
+          "data",
+          "message"
+        ],
         "title": "DataMessageResponse[ConsensusVoteResponse]"
       },
       "DataMessageResponse_CreditTransactionResponse_": {
@@ -5733,7 +7138,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "message"],
+        "required": [
+          "data",
+          "message"
+        ],
         "title": "DataMessageResponse[CreditTransactionResponse]"
       },
       "DataMessageResponse_EscalationResponse_": {
@@ -5752,7 +7160,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "message"],
+        "required": [
+          "data",
+          "message"
+        ],
         "title": "DataMessageResponse[EscalationResponse]"
       },
       "DataMessageResponse_ReputationSummary_": {
@@ -5771,7 +7182,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "message"],
+        "required": [
+          "data",
+          "message"
+        ],
         "title": "DataMessageResponse[ReputationSummary]"
       },
       "DataMessageResponse_TaskResponse_": {
@@ -5790,7 +7204,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "message"],
+        "required": [
+          "data",
+          "message"
+        ],
         "title": "DataMessageResponse[TaskResponse]"
       },
       "DataMessageResponse_dict_": {
@@ -5811,7 +7228,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "message"],
+        "required": [
+          "data",
+          "message"
+        ],
         "title": "DataMessageResponse[dict]"
       },
       "DataResponse_AgentResponse_": {
@@ -5821,8 +7241,22 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[AgentResponse]"
+      },
+      "DataResponse_ArtifactResponse_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ArtifactResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "DataResponse[ArtifactResponse]"
       },
       "DataResponse_BalanceResponse_": {
         "properties": {
@@ -5831,7 +7265,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[BalanceResponse]"
       },
       "DataResponse_BudgetResponse_": {
@@ -5841,7 +7277,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[BudgetResponse]"
       },
       "DataResponse_CapabilityResponse_": {
@@ -5851,7 +7289,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[CapabilityResponse]"
       },
       "DataResponse_ChannelResponse_": {
@@ -5861,7 +7301,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[ChannelResponse]"
       },
       "DataResponse_ConsensusRequestResponse_": {
@@ -5871,7 +7313,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[ConsensusRequestResponse]"
       },
       "DataResponse_CreditStatsResponse_": {
@@ -5881,7 +7325,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[CreditStatsResponse]"
       },
       "DataResponse_CytoscapeGraph_": {
@@ -5891,7 +7337,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[CytoscapeGraph]"
       },
       "DataResponse_EscalationResponse_": {
@@ -5901,7 +7349,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[EscalationResponse]"
       },
       "DataResponse_EventResponse_": {
@@ -5911,8 +7361,22 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[EventResponse]"
+      },
+      "DataResponse_EventSubscriptionResponse_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/EventSubscriptionResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "DataResponse[EventSubscriptionResponse]"
       },
       "DataResponse_GitHubConnectionResponse_": {
         "properties": {
@@ -5921,7 +7385,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[GitHubConnectionResponse]"
       },
       "DataResponse_GraphEntityResponse_": {
@@ -5931,7 +7397,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[GraphEntityResponse]"
       },
       "DataResponse_HierarchyNode_": {
@@ -5941,7 +7409,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[HierarchyNode]"
       },
       "DataResponse_LinearConnectionResponse_": {
@@ -5951,7 +7421,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[LinearConnectionResponse]"
       },
       "DataResponse_MemoryResponse_": {
@@ -5961,7 +7433,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[MemoryResponse]"
       },
       "DataResponse_MessageResponse_": {
@@ -5971,7 +7445,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[MessageResponse]"
       },
       "DataResponse_OverlapResult_": {
@@ -5981,7 +7457,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[OverlapResult]"
       },
       "DataResponse_ReputationSummary_": {
@@ -5991,8 +7469,22 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[ReputationSummary]"
+      },
+      "DataResponse_SSETokenResponse_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SSETokenResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "DataResponse[SSETokenResponse]"
       },
       "DataResponse_SubGraph_": {
         "properties": {
@@ -6001,8 +7493,22 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[SubGraph]"
+      },
+      "DataResponse_SubscriptionResponse_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SubscriptionResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "DataResponse[SubscriptionResponse]"
       },
       "DataResponse_TaskCommentResponse_": {
         "properties": {
@@ -6011,7 +7517,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[TaskCommentResponse]"
       },
       "DataResponse_TaskDependencyResponse_": {
@@ -6021,7 +7529,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[TaskDependencyResponse]"
       },
       "DataResponse_TaskResponse_": {
@@ -6031,7 +7541,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[TaskResponse]"
       },
       "DataResponse_dict_": {
@@ -6043,7 +7555,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[dict]"
       },
       "DataResponse_list_AgentResponse__": {
@@ -6057,7 +7571,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[AgentResponse]]"
       },
       "DataResponse_list_AgentSpendingResponse__": {
@@ -6071,8 +7587,26 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[AgentSpendingResponse]]"
+      },
+      "DataResponse_list_ArtifactResponse__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ArtifactResponse"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "DataResponse[list[ArtifactResponse]]"
       },
       "DataResponse_list_CapabilityResponse__": {
         "properties": {
@@ -6085,7 +7619,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[CapabilityResponse]]"
       },
       "DataResponse_list_ChannelResponse__": {
@@ -6099,7 +7635,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[ChannelResponse]]"
       },
       "DataResponse_list_ConsensusRequestResponse__": {
@@ -6113,7 +7651,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[ConsensusRequestResponse]]"
       },
       "DataResponse_list_ContradictionPairResponse__": {
@@ -6127,7 +7667,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[ContradictionPairResponse]]"
       },
       "DataResponse_list_EscalationResponse__": {
@@ -6141,7 +7683,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[EscalationResponse]]"
       },
       "DataResponse_list_GapResult__": {
@@ -6155,7 +7699,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[GapResult]]"
       },
       "DataResponse_list_GitHubConnectionResponse__": {
@@ -6169,7 +7715,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[GitHubConnectionResponse]]"
       },
       "DataResponse_list_GraphEntityResponse__": {
@@ -6183,7 +7731,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[GraphEntityResponse]]"
       },
       "DataResponse_list_GraphRelationshipResponse__": {
@@ -6197,7 +7747,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[GraphRelationshipResponse]]"
       },
       "DataResponse_list_IntegrationLinkResponse__": {
@@ -6211,7 +7763,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[IntegrationLinkResponse]]"
       },
       "DataResponse_list_LeaderboardEntry__": {
@@ -6225,7 +7779,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[LeaderboardEntry]]"
       },
       "DataResponse_list_LinearConnectionResponse__": {
@@ -6239,7 +7795,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[LinearConnectionResponse]]"
       },
       "DataResponse_list_MessageResponse__": {
@@ -6253,7 +7811,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[MessageResponse]]"
       },
       "DataResponse_list_OverlapResult__": {
@@ -6267,7 +7827,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[OverlapResult]]"
       },
       "DataResponse_list_SearchResultResponse__": {
@@ -6281,7 +7843,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[SearchResultResponse]]"
       },
       "DataResponse_list_SpendingTrendPoint__": {
@@ -6295,8 +7859,26 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[SpendingTrendPoint]]"
+      },
+      "DataResponse_list_SubscriptionResponse__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionResponse"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "DataResponse[list[SubscriptionResponse]]"
       },
       "DataResponse_list_TaskCommentResponse__": {
         "properties": {
@@ -6309,7 +7891,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[TaskCommentResponse]]"
       },
       "DataResponse_list_UUID__": {
@@ -6324,7 +7908,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[UUID]]"
       },
       "DataResponse_list_dict__": {
@@ -6339,7 +7925,9 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[dict]]"
       },
       "DataResponse_list_str__": {
@@ -6353,8 +7941,46 @@
           }
         },
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "title": "DataResponse[list[str]]"
+      },
+      "EmitEventDto": {
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "title": "Event Type"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Payload"
+          },
+          "task_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Task Id"
+          },
+          "entity_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "event_type",
+          "payload",
+          "task_id"
+        ],
+        "title": "EmitEventDto"
       },
       "EscalateTaskDto": {
         "properties": {
@@ -6374,7 +8000,9 @@
           }
         },
         "type": "object",
-        "required": ["reason"],
+        "required": [
+          "reason"
+        ],
         "title": "EscalateTaskDto"
       },
       "EscalationReason": {
@@ -6545,8 +8173,59 @@
       },
       "EventSeverity": {
         "type": "string",
-        "enum": ["info", "warning", "error"],
+        "enum": [
+          "debug",
+          "info",
+          "success",
+          "warning",
+          "error",
+          "critical"
+        ],
         "title": "EventSeverity"
+      },
+      "EventSubscriptionResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "agent_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Agent Id"
+          },
+          "event_pattern": {
+            "type": "string",
+            "title": "Event Pattern"
+          },
+          "task_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "agent_id",
+          "event_pattern",
+          "task_id",
+          "created_at"
+        ],
+        "title": "EventSubscriptionResponse"
       },
       "GapResult": {
         "properties": {
@@ -6568,7 +8247,12 @@
           }
         },
         "type": "object",
-        "required": ["entity_name", "entity_type", "agent_count", "risk"],
+        "required": [
+          "entity_name",
+          "entity_type",
+          "agent_count",
+          "risk"
+        ],
         "title": "GapResult"
       },
       "GitHubConnectionResponse": {
@@ -6829,7 +8513,14 @@
           }
         },
         "type": "object",
-        "required": ["id", "agent_id", "name", "level", "status", "role"],
+        "required": [
+          "id",
+          "agent_id",
+          "name",
+          "level",
+          "status",
+          "role"
+        ],
         "title": "HierarchyNode"
       },
       "IntegrationLinkResponse": {
@@ -6920,7 +8611,13 @@
           }
         },
         "type": "object",
-        "required": ["agent_id", "name", "trust_score", "tasks_completed", "success_rate"],
+        "required": [
+          "agent_id",
+          "name",
+          "trust_score",
+          "tasks_completed",
+          "success_rate"
+        ],
         "title": "LeaderboardEntry"
       },
       "LinearConnectionResponse": {
@@ -7011,6 +8708,72 @@
         ],
         "title": "LinearConnectionResponse"
       },
+      "LoginRequest": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          },
+          "totp_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Totp Code"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "LoginRequest"
+      },
+      "LoginResponse": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type",
+            "default": "bearer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "access_token",
+          "refresh_token"
+        ],
+        "title": "LoginResponse"
+      },
+      "LogoutRequest": {
+        "properties": {
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "refresh_token"
+        ],
+        "title": "LogoutRequest"
+      },
       "MemoryFeedbackDto": {
         "properties": {
           "helpful": {
@@ -7019,7 +8782,9 @@
           }
         },
         "type": "object",
-        "required": ["helpful"],
+        "required": [
+          "helpful"
+        ],
         "title": "MemoryFeedbackDto"
       },
       "MemoryResponse": {
@@ -7257,7 +9022,12 @@
       },
       "MessageType": {
         "type": "string",
-        "enum": ["text", "handoff", "status_update", "request"],
+        "enum": [
+          "text",
+          "handoff",
+          "status_update",
+          "request"
+        ],
         "title": "MessageType"
       },
       "OverlapResult": {
@@ -7303,6 +9073,26 @@
         ],
         "title": "OverlapResult"
       },
+      "PaginatedResponse_ArtifactResponse_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ArtifactResponse"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "PaginatedResponse[ArtifactResponse]"
+      },
       "PaginatedResponse_CreditTransactionResponse_": {
         "properties": {
           "data": {
@@ -7317,7 +9107,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "meta"],
+        "required": [
+          "data",
+          "meta"
+        ],
         "title": "PaginatedResponse[CreditTransactionResponse]"
       },
       "PaginatedResponse_EventResponse_": {
@@ -7334,7 +9127,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "meta"],
+        "required": [
+          "data",
+          "meta"
+        ],
         "title": "PaginatedResponse[EventResponse]"
       },
       "PaginatedResponse_MemoryResponse_": {
@@ -7351,7 +9147,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "meta"],
+        "required": [
+          "data",
+          "meta"
+        ],
         "title": "PaginatedResponse[MemoryResponse]"
       },
       "PaginatedResponse_ReputationEventResponse_": {
@@ -7368,7 +9167,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "meta"],
+        "required": [
+          "data",
+          "meta"
+        ],
         "title": "PaginatedResponse[ReputationEventResponse]"
       },
       "PaginatedResponse_TaskResponse_": {
@@ -7385,7 +9187,10 @@
           }
         },
         "type": "object",
-        "required": ["data", "meta"],
+        "required": [
+          "data",
+          "meta"
+        ],
         "title": "PaginatedResponse[TaskResponse]"
       },
       "PaginationMeta": {
@@ -7404,13 +9209,144 @@
           }
         },
         "type": "object",
-        "required": ["total", "page", "limit"],
+        "required": [
+          "total",
+          "page",
+          "limit"
+        ],
         "title": "PaginationMeta"
       },
       "Proficiency": {
         "type": "string",
-        "enum": ["basic", "standard", "expert"],
+        "enum": [
+          "basic",
+          "standard",
+          "expert"
+        ],
         "title": "Proficiency"
+      },
+      "PublishArtifactDto": {
+        "properties": {
+          "artifact_type": {
+            "$ref": "#/components/schemas/ArtifactType"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "title": "Name"
+          },
+          "content": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Content"
+          },
+          "task_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Task Id"
+          },
+          "source_artifact_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Source Artifact Ids"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "artifact_type",
+          "name",
+          "content",
+          "task_id"
+        ],
+        "title": "PublishArtifactDto"
+      },
+      "RefreshRequest": {
+        "properties": {
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "refresh_token"
+        ],
+        "title": "RefreshRequest"
+      },
+      "RefreshResponse": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type",
+            "default": "bearer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "access_token",
+          "refresh_token"
+        ],
+        "title": "RefreshResponse"
+      },
+      "ReplayDto": {
+        "properties": {
+          "task_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Task Id"
+          },
+          "since": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Since"
+          },
+          "event_types": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Types"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "default": 500
+          }
+        },
+        "type": "object",
+        "required": [
+          "task_id"
+        ],
+        "title": "ReplayDto"
       },
       "ReputationBonusPenaltyDto": {
         "properties": {
@@ -7427,7 +9363,10 @@
           }
         },
         "type": "object",
-        "required": ["reason", "impact"],
+        "required": [
+          "reason",
+          "impact"
+        ],
         "title": "ReputationBonusPenaltyDto"
       },
       "ReputationEventResponse": {
@@ -7532,7 +9471,13 @@
           }
         },
         "type": "object",
-        "required": ["trust_score", "tasks_completed", "tasks_successful", "success_rate", "level"],
+        "required": [
+          "trust_score",
+          "tasks_completed",
+          "tasks_successful",
+          "success_rate",
+          "level"
+        ],
         "title": "ReputationSummary"
       },
       "ResolveContradictionDto": {
@@ -7544,7 +9489,9 @@
           }
         },
         "type": "object",
-        "required": ["strategy"],
+        "required": [
+          "strategy"
+        ],
         "title": "ResolveContradictionDto"
       },
       "ResolveEscalationDto": {
@@ -7563,6 +9510,24 @@
         },
         "type": "object",
         "title": "ResolveEscalationDto"
+      },
+      "SSETokenResponse": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "expires_in": {
+            "type": "integer",
+            "title": "Expires In"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token",
+          "expires_in"
+        ],
+        "title": "SSETokenResponse"
       },
       "SearchResultResponse": {
         "properties": {
@@ -7695,7 +9660,10 @@
           }
         },
         "type": "object",
-        "required": ["recipient_id", "body"],
+        "required": [
+          "recipient_id",
+          "body"
+        ],
         "title": "SendDirectMessageDto"
       },
       "SendMessageDto": {
@@ -7732,7 +9700,10 @@
           }
         },
         "type": "object",
-        "required": ["channel_id", "body"],
+        "required": [
+          "channel_id",
+          "body"
+        ],
         "title": "SendMessageDto"
       },
       "SetBudgetDto": {
@@ -7809,7 +9780,10 @@
           }
         },
         "type": "object",
-        "required": ["agent_id", "name"],
+        "required": [
+          "agent_id",
+          "name"
+        ],
         "title": "SpawnAgentDto"
       },
       "SpendCreditsDto": {
@@ -7861,7 +9835,10 @@
           }
         },
         "type": "object",
-        "required": ["amount", "reason"],
+        "required": [
+          "amount",
+          "reason"
+        ],
         "title": "SpendCreditsDto"
       },
       "SpendingTrendPoint": {
@@ -7876,7 +9853,10 @@
           }
         },
         "type": "object",
-        "required": ["date", "amount"],
+        "required": [
+          "date",
+          "amount"
+        ],
         "title": "SpendingTrendPoint"
       },
       "StoreMemoryDto": {
@@ -7963,7 +9943,9 @@
           }
         },
         "type": "object",
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "title": "StoreMemoryDto"
       },
       "SubGraph": {
@@ -7984,8 +9966,61 @@
           }
         },
         "type": "object",
-        "required": ["entities", "relationships"],
+        "required": [
+          "entities",
+          "relationships"
+        ],
         "title": "SubGraph"
+      },
+      "SubscriptionResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "org_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Org Id"
+          },
+          "agent_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Agent Id"
+          },
+          "artifact_type": {
+            "type": "string",
+            "title": "Artifact Type"
+          },
+          "task_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "org_id",
+          "agent_id",
+          "artifact_type",
+          "task_id",
+          "created_at"
+        ],
+        "title": "SubscriptionResponse"
       },
       "TaskCommentResponse": {
         "properties": {
@@ -8071,12 +10106,24 @@
           }
         },
         "type": "object",
-        "required": ["id", "task_id", "depends_on_id", "blocking", "created_at"],
+        "required": [
+          "id",
+          "task_id",
+          "depends_on_id",
+          "blocking",
+          "created_at"
+        ],
         "title": "TaskDependencyResponse"
       },
       "TaskPriority": {
         "type": "string",
-        "enum": ["urgent", "high", "normal", "low"],
+        "enum": [
+          "critical",
+          "urgent",
+          "high",
+          "normal",
+          "low"
+        ],
         "title": "TaskPriority"
       },
       "TaskResponse": {
@@ -8263,7 +10310,18 @@
       },
       "TaskStatus": {
         "type": "string",
-        "enum": ["backlog", "todo", "in_progress", "review", "done", "blocked", "cancelled"],
+        "enum": [
+          "backlog",
+          "todo",
+          "pending",
+          "assigned",
+          "in_progress",
+          "review",
+          "done",
+          "blocked",
+          "cancelled",
+          "rejected"
+        ],
         "title": "TaskStatus"
       },
       "TransferCreditsDto": {
@@ -8285,7 +10343,11 @@
           }
         },
         "type": "object",
-        "required": ["to_agent_id", "amount", "reason"],
+        "required": [
+          "to_agent_id",
+          "amount",
+          "reason"
+        ],
         "title": "TransferCreditsDto"
       },
       "TransitionTaskDto": {
@@ -8306,7 +10368,9 @@
           }
         },
         "type": "object",
-        "required": ["status"],
+        "required": [
+          "status"
+        ],
         "title": "TransitionTaskDto"
       },
       "UpdateAgentDto": {
@@ -8405,7 +10469,9 @@
           }
         },
         "type": "object",
-        "required": ["proficiency"],
+        "required": [
+          "proficiency"
+        ],
         "title": "UpdateCapabilityDto"
       },
       "UpdateGitHubConnectionDto": {
@@ -8530,6 +10596,58 @@
         "type": "object",
         "title": "UpdateLinearConnectionDto"
       },
+      "UpdateStatusDto": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ArtifactStatus"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "UpdateStatusDto"
+      },
+      "UserInfoResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "org_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Org Id"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "role": {
+            "type": "string",
+            "title": "Role"
+          },
+          "totp_enabled": {
+            "type": "boolean",
+            "title": "Totp Enabled",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "org_id",
+          "email",
+          "name",
+          "role"
+        ],
+        "title": "UserInfoResponse"
+      },
       "ValidationError": {
         "properties": {
           "loc": {
@@ -8563,13 +10681,72 @@
           }
         },
         "type": "object",
-        "required": ["loc", "msg", "type"],
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
         "title": "ValidationError"
       },
       "VoteValue": {
         "type": "string",
-        "enum": ["APPROVE", "REJECT", "ABSTAIN"],
+        "enum": [
+          "APPROVE",
+          "REJECT",
+          "ABSTAIN"
+        ],
         "title": "VoteValue"
+      },
+      "app__artifacts__schemas__SubscribeDto": {
+        "properties": {
+          "artifact_type": {
+            "type": "string",
+            "title": "Artifact Type",
+            "description": "ArtifactType value or '*' for all"
+          },
+          "task_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "artifact_type"
+        ],
+        "title": "SubscribeDto"
+      },
+      "app__coordination__schemas__SubscribeDto": {
+        "properties": {
+          "event_pattern": {
+            "type": "string",
+            "title": "Event Pattern"
+          },
+          "task_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "event_pattern"
+        ],
+        "title": "SubscribeDto"
       }
     }
   }

--- a/libs/dashboard-data/src/rest/generated/schema.d.ts
+++ b/libs/dashboard-data/src/rest/generated/schema.d.ts
@@ -4,6 +4,113 @@
  */
 
 export interface paths {
+    "/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Login
+         * @description Authenticate user and return access + refresh tokens.
+         *
+         *     Behavior varies by auth mode:
+         *     - mode=none: returns static owner token, any credentials accepted
+         *     - mode=local: validates password against config hash, returns bearer token
+         *     - mode=full: validates credentials against User DB, optional TOTP, returns JWT
+         */
+        post: operations["login_auth_login_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh
+         * @description Exchange refresh token for new access + refresh tokens.
+         *
+         *     In full mode, implements token rotation (old refresh token revoked).
+         */
+        post: operations["refresh_auth_refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Logout
+         * @description Revoke refresh token (logout).
+         */
+        post: operations["logout_auth_logout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Current User Info
+         * @description Return current user profile from bearer token.
+         */
+        get: operations["get_current_user_info_auth_me_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/google": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Google Oauth
+         * @description Google OAuth login — stub for Phase 2.
+         */
+        get: operations["google_oauth_auth_google_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/agents/register": {
         parameters: {
             query?: never;
@@ -948,6 +1055,200 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/artifacts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Artifacts */
+        get: operations["list_artifacts_artifacts_get"];
+        put?: never;
+        /** Publish Artifact */
+        post: operations["publish_artifact_artifacts_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artifacts/batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Publish Batch */
+        post: operations["publish_batch_artifacts_batch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artifacts/latest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Latest Artifact */
+        get: operations["get_latest_artifact_artifacts_latest_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artifacts/subscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Subscription */
+        post: operations["create_subscription_artifacts_subscribe_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artifacts/subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Subscriptions */
+        get: operations["list_subscriptions_artifacts_subscriptions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artifacts/subscriptions/{subscription_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Subscription */
+        delete: operations["delete_subscription_artifacts_subscriptions__subscription_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artifacts/{artifact_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Artifact */
+        get: operations["get_artifact_artifacts__artifact_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artifacts/{artifact_id}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Artifact History */
+        get: operations["get_artifact_history_artifacts__artifact_id__history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artifacts/{artifact_id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update Artifact Status */
+        put: operations["update_artifact_status_artifacts__artifact_id__status_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/events/token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Sse Token
+         * @description Issue short-lived JWT for SSE auth (EventSource can't set headers).
+         */
+        post: operations["create_sse_token_events_token_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/events/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Event Stream
+         * @description SSE stream. Auth via query param token. Supports Last-Event-ID replay.
+         */
+        get: operations["event_stream_events_stream_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/events": {
         parameters: {
             query?: never;
@@ -1465,6 +1766,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/coordination/emit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Emit Event */
+        post: operations["emit_event_coordination_emit_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/coordination/subscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Subscribe */
+        post: operations["subscribe_coordination_subscribe_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/coordination/replay": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Replay */
+        post: operations["replay_coordination_replay_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/coordination/project": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Project */
+        get: operations["project_coordination_project_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -1628,7 +1997,7 @@ export interface components {
          * AgentRole
          * @enum {string}
          */
-        AgentRole: "worker" | "hr" | "founder" | "admin";
+        AgentRole: "worker" | "hr" | "founder" | "admin" | "coo" | "talent" | "lead" | "senior" | "manager" | "intern";
         /** AgentSpendingResponse */
         AgentSpendingResponse: {
             /** Agent Id */
@@ -1644,7 +2013,74 @@ export interface components {
          * AgentStatus
          * @enum {string}
          */
-        AgentStatus: "pending" | "active" | "suspended" | "revoked";
+        AgentStatus: "pending" | "active" | "idle" | "busy" | "paused" | "suspended" | "revoked";
+        /** ArtifactResponse */
+        ArtifactResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Org Id
+             * Format: uuid
+             */
+            org_id: string;
+            /**
+             * Task Id
+             * Format: uuid
+             */
+            task_id: string;
+            /**
+             * Producer Agent Id
+             * Format: uuid
+             */
+            producer_agent_id: string;
+            artifact_type: components["schemas"]["ArtifactType"];
+            /** Name */
+            name: string;
+            /** Version */
+            version: number;
+            status: components["schemas"]["ArtifactStatus"];
+            /** Content */
+            content: {
+                [key: string]: unknown;
+            };
+            /** Content Hash */
+            content_hash: string;
+            /** Metadata */
+            metadata_: {
+                [key: string]: unknown;
+            };
+            /** Source Artifact Ids */
+            source_artifact_ids: string[];
+            /** Superseded By Id */
+            superseded_by_id: string | null;
+            /** Approved By */
+            approved_by: string | null;
+            /** Approved At */
+            approved_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /**
+         * ArtifactStatus
+         * @enum {string}
+         */
+        ArtifactStatus: "draft" | "published" | "superseded";
+        /**
+         * ArtifactType
+         * @enum {string}
+         */
+        ArtifactType: "component" | "test_plan" | "screenshot" | "api_contract" | "migration" | "schema" | "doc_section";
         /** AssignTaskDto */
         AssignTaskDto: {
             /**
@@ -2107,6 +2543,10 @@ export interface components {
         DataResponse_AgentResponse_: {
             data: components["schemas"]["AgentResponse"];
         };
+        /** DataResponse[ArtifactResponse] */
+        DataResponse_ArtifactResponse_: {
+            data: components["schemas"]["ArtifactResponse"];
+        };
         /** DataResponse[BalanceResponse] */
         DataResponse_BalanceResponse_: {
             data: components["schemas"]["BalanceResponse"];
@@ -2143,6 +2583,10 @@ export interface components {
         DataResponse_EventResponse_: {
             data: components["schemas"]["EventResponse"];
         };
+        /** DataResponse[EventSubscriptionResponse] */
+        DataResponse_EventSubscriptionResponse_: {
+            data: components["schemas"]["EventSubscriptionResponse"];
+        };
         /** DataResponse[GitHubConnectionResponse] */
         DataResponse_GitHubConnectionResponse_: {
             data: components["schemas"]["GitHubConnectionResponse"];
@@ -2175,9 +2619,17 @@ export interface components {
         DataResponse_ReputationSummary_: {
             data: components["schemas"]["ReputationSummary"];
         };
+        /** DataResponse[SSETokenResponse] */
+        DataResponse_SSETokenResponse_: {
+            data: components["schemas"]["SSETokenResponse"];
+        };
         /** DataResponse[SubGraph] */
         DataResponse_SubGraph_: {
             data: components["schemas"]["SubGraph"];
+        };
+        /** DataResponse[SubscriptionResponse] */
+        DataResponse_SubscriptionResponse_: {
+            data: components["schemas"]["SubscriptionResponse"];
         };
         /** DataResponse[TaskCommentResponse] */
         DataResponse_TaskCommentResponse_: {
@@ -2207,6 +2659,11 @@ export interface components {
         DataResponse_list_AgentSpendingResponse__: {
             /** Data */
             data: components["schemas"]["AgentSpendingResponse"][];
+        };
+        /** DataResponse[list[ArtifactResponse]] */
+        DataResponse_list_ArtifactResponse__: {
+            /** Data */
+            data: components["schemas"]["ArtifactResponse"][];
         };
         /** DataResponse[list[CapabilityResponse]] */
         DataResponse_list_CapabilityResponse__: {
@@ -2288,6 +2745,11 @@ export interface components {
             /** Data */
             data: components["schemas"]["SpendingTrendPoint"][];
         };
+        /** DataResponse[list[SubscriptionResponse]] */
+        DataResponse_list_SubscriptionResponse__: {
+            /** Data */
+            data: components["schemas"]["SubscriptionResponse"][];
+        };
         /** DataResponse[list[TaskCommentResponse]] */
         DataResponse_list_TaskCommentResponse__: {
             /** Data */
@@ -2309,6 +2771,22 @@ export interface components {
         DataResponse_list_str__: {
             /** Data */
             data: string[];
+        };
+        /** EmitEventDto */
+        EmitEventDto: {
+            /** Event Type */
+            event_type: string;
+            /** Payload */
+            payload: {
+                [key: string]: unknown;
+            };
+            /**
+             * Task Id
+             * Format: uuid
+             */
+            task_id: string;
+            /** Entity Name */
+            entity_name?: string | null;
         };
         /** EscalateTaskDto */
         EscalateTaskDto: {
@@ -2406,7 +2884,29 @@ export interface components {
          * EventSeverity
          * @enum {string}
          */
-        EventSeverity: "info" | "warning" | "error";
+        EventSeverity: "debug" | "info" | "success" | "warning" | "error" | "critical";
+        /** EventSubscriptionResponse */
+        EventSubscriptionResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Agent Id
+             * Format: uuid
+             */
+            agent_id: string;
+            /** Event Pattern */
+            event_pattern: string;
+            /** Task Id */
+            task_id: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
         /** GapResult */
         GapResult: {
             /** Entity Name */
@@ -2654,6 +3154,35 @@ export interface components {
              */
             updated_at: string;
         };
+        /** LoginRequest */
+        LoginRequest: {
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+            /** Password */
+            password: string;
+            /** Totp Code */
+            totp_code?: string | null;
+        };
+        /** LoginResponse */
+        LoginResponse: {
+            /** Access Token */
+            access_token: string;
+            /** Refresh Token */
+            refresh_token: string;
+            /**
+             * Token Type
+             * @default bearer
+             */
+            token_type: string;
+        };
+        /** LogoutRequest */
+        LogoutRequest: {
+            /** Refresh Token */
+            refresh_token: string;
+        };
         /** MemoryFeedbackDto */
         MemoryFeedbackDto: {
             /** Helpful */
@@ -2791,6 +3320,12 @@ export interface components {
             /** Shared Entities */
             shared_entities: components["schemas"]["GraphEntityResponse"][];
         };
+        /** PaginatedResponse[ArtifactResponse] */
+        PaginatedResponse_ArtifactResponse_: {
+            /** Data */
+            data: components["schemas"]["ArtifactResponse"][];
+            meta: components["schemas"]["PaginationMeta"];
+        };
         /** PaginatedResponse[CreditTransactionResponse] */
         PaginatedResponse_CreditTransactionResponse_: {
             /** Data */
@@ -2835,6 +3370,61 @@ export interface components {
          * @enum {string}
          */
         Proficiency: "basic" | "standard" | "expert";
+        /** PublishArtifactDto */
+        PublishArtifactDto: {
+            artifact_type: components["schemas"]["ArtifactType"];
+            /** Name */
+            name: string;
+            /** Content */
+            content: {
+                [key: string]: unknown;
+            };
+            /**
+             * Task Id
+             * Format: uuid
+             */
+            task_id: string;
+            /** Source Artifact Ids */
+            source_artifact_ids?: string[];
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+        };
+        /** RefreshRequest */
+        RefreshRequest: {
+            /** Refresh Token */
+            refresh_token: string;
+        };
+        /** RefreshResponse */
+        RefreshResponse: {
+            /** Access Token */
+            access_token: string;
+            /** Refresh Token */
+            refresh_token: string;
+            /**
+             * Token Type
+             * @default bearer
+             */
+            token_type: string;
+        };
+        /** ReplayDto */
+        ReplayDto: {
+            /**
+             * Task Id
+             * Format: uuid
+             */
+            task_id: string;
+            /** Since */
+            since?: string | null;
+            /** Event Types */
+            event_types?: string[] | null;
+            /**
+             * Limit
+             * @default 500
+             */
+            limit: number;
+        };
         /** ReputationBonusPenaltyDto */
         ReputationBonusPenaltyDto: {
             /** Reason */
@@ -2894,6 +3484,13 @@ export interface components {
         ResolveEscalationDto: {
             /** Notes */
             notes?: string | null;
+        };
+        /** SSETokenResponse */
+        SSETokenResponse: {
+            /** Token */
+            token: string;
+            /** Expires In */
+            expires_in: number;
         };
         /** SearchResultResponse */
         SearchResultResponse: {
@@ -3075,6 +3672,33 @@ export interface components {
             /** Relationships */
             relationships: components["schemas"]["GraphRelationshipResponse"][];
         };
+        /** SubscriptionResponse */
+        SubscriptionResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Org Id
+             * Format: uuid
+             */
+            org_id: string;
+            /**
+             * Agent Id
+             * Format: uuid
+             */
+            agent_id: string;
+            /** Artifact Type */
+            artifact_type: string;
+            /** Task Id */
+            task_id: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
         /** TaskCommentResponse */
         TaskCommentResponse: {
             /**
@@ -3136,7 +3760,7 @@ export interface components {
          * TaskPriority
          * @enum {string}
          */
-        TaskPriority: "urgent" | "high" | "normal" | "low";
+        TaskPriority: "critical" | "urgent" | "high" | "normal" | "low";
         /** TaskResponse */
         TaskResponse: {
             /**
@@ -3201,7 +3825,7 @@ export interface components {
          * TaskStatus
          * @enum {string}
          */
-        TaskStatus: "backlog" | "todo" | "in_progress" | "review" | "done" | "blocked" | "cancelled";
+        TaskStatus: "backlog" | "todo" | "pending" | "assigned" | "in_progress" | "review" | "done" | "blocked" | "cancelled" | "rejected";
         /** TransferCreditsDto */
         TransferCreditsDto: {
             /**
@@ -3270,6 +3894,34 @@ export interface components {
                 [key: string]: unknown;
             } | null;
         };
+        /** UpdateStatusDto */
+        UpdateStatusDto: {
+            status: components["schemas"]["ArtifactStatus"];
+        };
+        /** UserInfoResponse */
+        UserInfoResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Org Id
+             * Format: uuid
+             */
+            org_id: string;
+            /** Email */
+            email: string;
+            /** Name */
+            name: string;
+            /** Role */
+            role: string;
+            /**
+             * Totp Enabled
+             * @default false
+             */
+            totp_enabled: boolean;
+        };
         /** ValidationError */
         ValidationError: {
             /** Location */
@@ -3288,6 +3940,23 @@ export interface components {
          * @enum {string}
          */
         VoteValue: "APPROVE" | "REJECT" | "ABSTAIN";
+        /** SubscribeDto */
+        app__artifacts__schemas__SubscribeDto: {
+            /**
+             * Artifact Type
+             * @description ArtifactType value or '*' for all
+             */
+            artifact_type: string;
+            /** Task Id */
+            task_id?: string | null;
+        };
+        /** SubscribeDto */
+        app__coordination__schemas__SubscribeDto: {
+            /** Event Pattern */
+            event_pattern: string;
+            /** Task Id */
+            task_id?: string | null;
+        };
     };
     responses: never;
     parameters: never;
@@ -3297,6 +3966,145 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    login_auth_login_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LoginRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LoginResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    refresh_auth_refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RefreshRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RefreshResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    logout_auth_logout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LogoutRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_current_user_info_auth_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserInfoResponse"];
+                };
+            };
+        };
+    };
+    google_oauth_auth_google_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+    };
     register_agent_agents_register_post: {
         parameters: {
             query?: never;
@@ -5263,6 +6071,373 @@ export interface operations {
             };
         };
     };
+    list_artifacts_artifacts_get: {
+        parameters: {
+            query?: {
+                artifact_type?: components["schemas"]["ArtifactType"] | null;
+                name?: string | null;
+                task_id?: string | null;
+                status?: components["schemas"]["ArtifactStatus"] | null;
+                producer_agent_id?: string | null;
+                page?: number;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_ArtifactResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    publish_artifact_artifacts_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PublishArtifactDto"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_ArtifactResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    publish_batch_artifacts_batch_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PublishArtifactDto"][];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_list_ArtifactResponse__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_latest_artifact_artifacts_latest_get: {
+        parameters: {
+            query: {
+                name: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_ArtifactResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_subscription_artifacts_subscribe_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["app__artifacts__schemas__SubscribeDto"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_SubscriptionResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_subscriptions_artifacts_subscriptions_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_list_SubscriptionResponse__"];
+                };
+            };
+        };
+    };
+    delete_subscription_artifacts_subscriptions__subscription_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                subscription_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_artifact_artifacts__artifact_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                artifact_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_ArtifactResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_artifact_history_artifacts__artifact_id__history_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                artifact_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_list_ArtifactResponse__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_artifact_status_artifacts__artifact_id__status_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                artifact_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateStatusDto"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_ArtifactResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_sse_token_events_token_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_SSETokenResponse_"];
+                };
+            };
+        };
+    };
+    event_stream_events_stream_get: {
+        parameters: {
+            query: {
+                /** @description SSE JWT from POST /events/token */
+                token: string;
+            };
+            header?: {
+                "Last-Event-ID"?: number | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_events_events_get: {
         parameters: {
             query?: {
@@ -6369,6 +7544,137 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    emit_event_coordination_emit_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EmitEventDto"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataMessageResponse_dict_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    subscribe_coordination_subscribe_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["app__coordination__schemas__SubscribeDto"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_EventSubscriptionResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    replay_coordination_replay_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReplayDto"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_list_dict__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_coordination_project_get: {
+        parameters: {
+            query: {
+                task_id: string;
+                projection_type: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_dict_"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- Add `response_model=None` to SSE stream endpoint — prevents Pydantic from trying to resolve `AsyncIterable[ServerSentEvent]` as a JSON schema
- Regenerate `openapi.json` (107 endpoints, including new coordination endpoints from #666)
- Regenerate `libs/dashboard-data/src/rest/generated/schema.d.ts` via `pnpm run codegen`

Closes #686

## Root cause

The SSE endpoint had `-> AsyncIterable[ServerSentEvent]` return type with `AsyncIterable` imported inside `TYPE_CHECKING` block. At runtime, FastAPI couldn't resolve the forward reference for schema generation.

## Test plan

- [x] All 423 tests pass
- [x] `ruff check`, `ruff format`, `pyright` clean
- [x] `pnpm run codegen` succeeds
- [x] Generated TS types include coordination endpoints