### PR TITLE
fix(shared-types): switch package to ESM with .ts source entry

### DIFF
--- a/libs/shared-types/package.json
+++ b/libs/shared-types/package.json
@@ -2,9 +2,9 @@
   "name": "@openspawn/shared-types",
   "version": "0.0.1",
   "private": true,
-  "type": "commonjs",
-  "main": "./src/index.js",
-  "types": "./src/index.d.ts",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "dependencies": {
     "tslib": "^2.3.0"
   }


### PR DESCRIPTION
## Summary
- Fix sandbox crash: `ACPMessageType` import failure from `@openspawn/shared-types`
- Root cause: `package.json` had `type: "commonjs"` pointing at `./src/index.js` which doesn't exist (no compiled JS output)
- Fix: match other libs' pattern (`dashboard-ui`, etc.) — `type: "module"` with `main: "./src/index.ts"`

## Verified
- `openspawn preview` now boots sandbox end-to-end
- Dashboard serves at `localhost:3333/app` (HTTP 200)
- `/api/agents` returns org agents (HTTP 200)
- All 17 projects lint, 11 build, 69+23 TS tests + 438 Python tests pass

## Test plan
- [x] `npx tsx tools/sandbox/src/index.ts` — sandbox boots without import errors
- [x] `openspawn preview --no-open` from scaffolded org — full E2E works
- [x] `curl localhost:3333/app` → 200
- [x] `curl localhost:3333/api/agents` → 200 with agent data
- [x] Lint/build/test all pass