### PR TITLE
chore(cli): add npm publish workflow + bump to 2026.3.18

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,73 @@
+name: Publish CLI
+
+on:
+  push:
+    tags:
+      - "openspawn@*" # e.g. openspawn@2026.3.18
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 2026.3.18). Leave empty to use package.json version."
+        required: false
+        type: string
+      dry_run:
+        description: "Dry run (don't actually publish)"
+        required: false
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    working-directory: packages/openspawn
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Lint
+        run: pnpm exec nx lint openspawn
+        working-directory: .
+
+      - name: Test
+        run: pnpm exec vitest run --config vitest.config.ts
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify CLI runs
+        run: node dist/cli/index.js --version
+
+      - name: Set version (if provided)
+        if: inputs.version
+        run: npm version ${{ inputs.version }} --no-git-tag-version
+
+      - name: Publish
+        if: ${{ !inputs.dry_run }}
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish (dry run)
+        if: inputs.dry_run
+        run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/openspawn/LICENSE
+++ b/packages/openspawn/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 BikiniBottom Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/openspawn/package.json
+++ b/packages/openspawn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openspawn",
-  "version": "2026.3.3",
+  "version": "2026.3.18",
   "description": "Standalone MCP server and CLI for OpenSpawn multi-agent organizations",
   "keywords": [
     "a2a",


### PR DESCRIPTION
## Summary
- Add `publish-cli.yml` workflow for publishing `openspawn` to npm
- Bump version to `2026.3.18` (includes preview, warm-up scenario, config rename)
- Add LICENSE file to package dir (was in `files` but missing)

## Workflow triggers
- **Tag push:** `openspawn@*` (e.g. `git tag openspawn@2026.3.18 && git push --tags`)
- **Manual dispatch:** with optional version override and dry-run flag

## Steps
1. Install + lint + test + build
2. Verify CLI runs (`node dist/cli/index.js --version`)
3. Publish with npm provenance

## Manual step required
- [ ] Add `NPM_TOKEN` secret to repo settings (agentdennis can publish)

## To publish after merge
```bash
git tag openspawn@2026.3.18
git push --tags
```

Closes #692

## Test plan
- [x] Lint/build/test pass
- [x] `node dist/cli/index.js --help` works from compiled output
- [x] Workflow YAML is valid