### PR TITLE
docs: layered protocol stack research (#667)

### DIFF
--- a/docs/architecture/layered-protocol-stack.md
+++ b/docs/architecture/layered-protocol-stack.md
@@ -54,6 +54,10 @@ The coordinator broadcasts this to all agents in the same task tree via SSE. No 
 
 **Recommendation:** SSE broadcast. The `EventBus` already supports a `BusBackend` protocol abstraction (`apps/api/app/events/bus.py`). Adding a non-persisted `status.update` SSE event type is ~50 lines of code. The architecture is already designed for this.
 
+### What about "Layer 1.5" — structured gossip?
+
+Issue #667 asked whether there's a useful middle ground between ambient gossip and full A2A structured messages. The answer: **not really, as a distinct layer.** The SSE broadcast recommendation already covers this — a `status.update` event with structured fields (state, progress, blocked_on) is both ambient AND structured. It's gossip with schema. Treating it as a separate layer adds conceptual overhead without adding capability. The `BusBackend` abstraction handles the spectrum from fire-and-forget status pings to persistent coordination events — no need for a separate protocol.
+
 ### Verdict
 
 Gossip is **purely additive** — it requires no architectural changes. The `InMemoryBackend` → `BusBackend` protocol in `bus.py` was designed for exactly this kind of extension. Build it when the dashboard needs real-time progress indicators, or when agents start needing to reason about each other's state. Not before.


### PR DESCRIPTION
## Research: Layered Protocol Stack — Gossip + Structured + CRDTs

Addresses #667 — research-only evaluation of whether OpenSpawn needs a three-layer communication stack beyond the Artifact Bus and Event Mesh.

### Key Findings

| Layer | Verdict |
|-------|---------|
| **Layer 1: Gossip** | Build after MVP launch (~1-2 days, SSE broadcast extension) |
| **Layer 2: Structured** | Already built ✅ (Artifact Bus + Event Mesh + SSE Push) |
| **Layer 3: CRDTs** | Don't build — revisit only if artifact conflicts exceed 5% or we go multi-node |

### Recommendation
Ship the existing Artifact Bus and Event Mesh. Gossip is trivially additive later (~50 lines on existing EventBus). CRDTs solve problems we don't have — our task decomposition model inherently prevents concurrent edits.

### Document
`docs/architecture/layered-protocol-stack.md` — covers all 13 research questions from the issue, competitive landscape analysis, implementation cost estimates, and a decision matrix with trigger signals.

No code changes — research only.

Closes #667