### PR TITLE
feat(cli): add openspawn regenerate command (#693)

### DIFF
--- a/packages/openspawn/src/cli/commands/regenerate.test.ts
+++ b/packages/openspawn/src/cli/commands/regenerate.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { scaffold, defaultAnswers } from "./init.js";
+import { regenerate } from "./regenerate.js";
+import { mkdtempSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function setupScaffold(): string {
+  const dir = mkdtempSync(join(tmpdir(), "os-regen-"));
+  scaffold(dir, defaultAnswers());
+  return dir;
+}
+
+describe("regenerate command", () => {
+  it("regenerate after init produces identical files (all unchanged)", () => {
+    const dir = setupScaffold();
+    const result = regenerate(dir, false);
+
+    expect(result.agentCount).toBeGreaterThan(0);
+    // All files should be unchanged since nothing was edited
+    const changed = result.changes.filter((c) => c.status !== "unchanged");
+    expect(changed).toHaveLength(0);
+  });
+
+  it("regenerate after ORG.md edit updates SOUL.md", () => {
+    const dir = setupScaffold();
+
+    // Read and modify ORG.md — change the mission in Identity section
+    const configPath = join(dir, "openspawn.json");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    config.alignment.mission = "New mission: conquer the world";
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+
+    const result = regenerate(dir, false);
+
+    // SOUL.md files should be updated (they embed the mission)
+    const updated = result.changes.filter((c) => c.status === "updated");
+    expect(updated.length).toBeGreaterThan(0);
+
+    // Verify the new mission is in SOUL.md files
+    const soulFiles = updated.filter((c) => c.path.endsWith("SOUL.md"));
+    expect(soulFiles.length).toBeGreaterThan(0);
+
+    for (const sf of soulFiles) {
+      const content = readFileSync(join(dir, sf.path), "utf-8");
+      expect(content).toContain("New mission: conquer the world");
+    }
+  });
+
+  it("--dry-run does not write files", () => {
+    const dir = setupScaffold();
+
+    // Modify config to trigger changes
+    const configPath = join(dir, "openspawn.json");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    config.alignment.mission = "Dry run mission change";
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+
+    // Read current SOUL.md content before dry run
+    const agentsJson = JSON.parse(readFileSync(join(dir, "openclaw-agents.json"), "utf-8"));
+    const firstWs = agentsJson[0]?.workspace;
+    expect(firstWs).toBeDefined();
+    const soulBefore = readFileSync(join(dir, firstWs, "SOUL.md"), "utf-8");
+
+    // Run dry-run
+    const result = regenerate(dir, true);
+    const updated = result.changes.filter((c) => c.status === "updated");
+    expect(updated.length).toBeGreaterThan(0);
+
+    // Verify files were NOT written
+    const soulAfter = readFileSync(join(dir, firstWs, "SOUL.md"), "utf-8");
+    expect(soulAfter).toBe(soulBefore);
+    expect(soulAfter).not.toContain("Dry run mission change");
+  });
+
+  it("missing ORG.md gives clear error", () => {
+    const dir = mkdtempSync(join(tmpdir(), "os-regen-empty-"));
+    expect(() => regenerate(dir, false)).toThrow("ORG.md not found");
+  });
+
+  it("missing openspawn.json gives clear error", () => {
+    const dir = mkdtempSync(join(tmpdir(), "os-regen-noconfig-"));
+    writeFileSync(join(dir, "ORG.md"), "# Test Org\n");
+    expect(() => regenerate(dir, false)).toThrow("openspawn.json not found");
+  });
+
+  it("creates workspace for new agent added to ORG.md", () => {
+    const dir = setupScaffold();
+
+    // Add a new agent inside the ## Structure section of ORG.md
+    const orgPath = join(dir, "ORG.md");
+    let org = readFileSync(orgPath, "utf-8");
+    // Find the last ### heading in Structure and append after
+    const structureIdx = org.indexOf("## Structure");
+    expect(structureIdx).toBeGreaterThan(-1);
+    // Find the next ## section after Structure (or end of file)
+    const afterStructure = org.indexOf("\n## ", structureIdx + 1);
+    const insertPos = afterStructure > 0 ? afterStructure : org.length;
+    const newAgent = "\n### New Agent — Worker\n\n- **Level:** 3\n- **Domain:** Testing\n\n";
+    org = org.slice(0, insertPos) + newAgent + org.slice(insertPos);
+    writeFileSync(orgPath, org, "utf-8");
+
+    const result = regenerate(dir, false);
+    const created = result.changes.filter((c) => c.status === "created");
+    expect(created.length).toBeGreaterThan(0);
+
+    // New agent workspace should exist
+    expect(existsSync(join(dir, "workspaces", "new-agent", "SOUL.md"))).toBe(true);
+  });
+
+  it("preserves tasks.json and custom workspace files", () => {
+    const dir = setupScaffold();
+
+    // Add a custom file to first agent workspace
+    const agentsJson = JSON.parse(readFileSync(join(dir, "openclaw-agents.json"), "utf-8"));
+    const firstWs = agentsJson[0]?.workspace;
+    const customPath = join(dir, firstWs, "custom-notes.md");
+    writeFileSync(customPath, "my custom notes");
+
+    // Verify tasks.json exists
+    const tasksPath = join(dir, ".openspawn", "tasks.json");
+    expect(existsSync(tasksPath)).toBe(true);
+    const tasksBefore = readFileSync(tasksPath, "utf-8");
+
+    // Regenerate
+    regenerate(dir, false);
+
+    // Custom file preserved
+    expect(readFileSync(customPath, "utf-8")).toBe("my custom notes");
+
+    // Tasks preserved
+    expect(readFileSync(tasksPath, "utf-8")).toBe(tasksBefore);
+  });
+
+  it("updates openclaw-agents.json when model config changes", () => {
+    const dir = setupScaffold();
+
+    const configPath = join(dir, "openspawn.json");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    config.llm.models.default = "gpt-4o-mini";
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+
+    const result = regenerate(dir, false);
+
+    const agentsJsonChange = result.changes.find((c) => c.path === "openclaw-agents.json");
+    expect(agentsJsonChange?.status).toBe("updated");
+
+    const newAgents = JSON.parse(readFileSync(join(dir, "openclaw-agents.json"), "utf-8"));
+    const workerAgents = newAgents.filter(
+      (a: { level: number }) => a.level < config.llm.seniorThreshold,
+    );
+    for (const a of workerAgents) {
+      expect(a.model).toBe("gpt-4o-mini");
+    }
+  });
+});

--- a/packages/openspawn/src/cli/commands/regenerate.ts
+++ b/packages/openspawn/src/cli/commands/regenerate.ts
@@ -1,0 +1,236 @@
+// ── Regenerate Command ──────────────────────────────────────────────────────
+// Re-generates workspace SOUL.md files and openclaw-agents.json from ORG.md
+// and openspawn.json without touching task state or custom workspace files.
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { parseOrgMdContent } from "../../core/org-parser.js";
+import { parseConfig } from "../../core/config.js";
+import type { Agent, OpenSpawnConfig } from "../../core/types.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface AgentConfig {
+  id: string;
+  name: string;
+  role: string;
+  level: number;
+  reportsTo: string;
+  workspace: string;
+  model: string;
+}
+
+interface FileChange {
+  path: string;
+  status: "created" | "updated" | "unchanged";
+  diff?: string;
+}
+
+export interface RegenerateResult {
+  changes: FileChange[];
+  agentCount: number;
+}
+
+// ── Helpers (mirrored from workspace-generator) ─────────────────────────────
+
+function sanitizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+$/, "")
+    .replace(/^-+/, "");
+}
+
+function resolveParentName(agent: Agent, agentsById: Map<string, Agent>): string {
+  if (!agent.parentId) return "";
+  const parent = agentsById.get(agent.parentId);
+  return parent ? parent.name : "";
+}
+
+function buildSoulMd(agent: Agent, config: OpenSpawnConfig, parentName: string): string {
+  const lines: string[] = [
+    `# SOUL.md — ${agent.name}`,
+    "",
+    "## Organizational Alignment",
+    "",
+    `- **Mission:** ${config.alignment.mission}`,
+    `- **Vision:** ${config.alignment.vision}`,
+    `- **Values:** ${config.alignment.values.join(", ")}`,
+    "",
+    "## Identity",
+    "",
+    `**Role:** ${agent.role}`,
+    `**Domain:** ${agent.domain}`,
+    `**Level:** ${agent.level}`,
+  ];
+
+  if (parentName) {
+    lines.push(`**Reports to:** ${parentName}`);
+  }
+
+  lines.push(
+    "",
+    `You are ${agent.name}, a level ${agent.level} agent in the ${agent.domain} domain.`,
+    "Be competent, direct, and focused on your area of expertise.",
+    "",
+  );
+
+  return lines.join("\n");
+}
+
+function resolveModel(agent: Agent, config: OpenSpawnConfig): string {
+  return agent.level >= config.llm.seniorThreshold
+    ? config.llm.models.senior
+    : config.llm.models.default;
+}
+
+// ── Flag parsing ────────────────────────────────────────────────────────────
+
+function hasFlag(args: string[], ...names: string[]): boolean {
+  return names.some((n) => args.includes(n));
+}
+
+// ── Core regeneration logic (pure, testable) ────────────────────────────────
+
+export function regenerate(dir: string, dryRun: boolean): RegenerateResult {
+  const orgPath = join(dir, "ORG.md");
+  if (!existsSync(orgPath)) {
+    throw new Error(
+      "ORG.md not found in current directory. Run `openspawn init` first.",
+    );
+  }
+
+  const configPath = join(dir, "openspawn.json");
+  if (!existsSync(configPath)) {
+    throw new Error(
+      "openspawn.json not found in current directory. Run `openspawn init` first.",
+    );
+  }
+
+  const orgContent = readFileSync(orgPath, "utf-8");
+  const config = parseConfig(dir);
+  const parsed = parseOrgMdContent(orgContent);
+  const agents = parsed.agents;
+
+  const agentsById = new Map<string, Agent>();
+  for (const agent of agents) {
+    agentsById.set(agent.id, agent);
+  }
+
+  const changes: FileChange[] = [];
+  const agentConfigs: AgentConfig[] = [];
+
+  // ── Regenerate per-agent SOUL.md ────────────────────────────────────────
+  for (const agent of agents) {
+    const dirName = sanitizeName(agent.name);
+    const wsPath = join("workspaces", dirName);
+    const fullWsPath = join(dir, wsPath);
+    const soulPath = join(fullWsPath, "SOUL.md");
+
+    const parentName = resolveParentName(agent, agentsById);
+    const newContent = buildSoulMd(agent, config, parentName);
+
+    let status: FileChange["status"];
+
+    if (!existsSync(soulPath)) {
+      status = "created";
+      if (!dryRun) {
+        mkdirSync(join(fullWsPath, "memory"), { recursive: true });
+        writeFileSync(soulPath, newContent, "utf-8");
+      }
+    } else {
+      const existing = readFileSync(soulPath, "utf-8");
+      if (existing === newContent) {
+        status = "unchanged";
+      } else {
+        status = "updated";
+        if (!dryRun) {
+          writeFileSync(soulPath, newContent, "utf-8");
+        }
+      }
+    }
+
+    changes.push({ path: join(wsPath, "SOUL.md"), status });
+
+    agentConfigs.push({
+      id: dirName,
+      name: agent.name,
+      role: agent.role,
+      level: agent.level,
+      reportsTo: parentName,
+      workspace: wsPath,
+      model: resolveModel(agent, config),
+    });
+  }
+
+  // ── Regenerate openclaw-agents.json ─────────────────────────────────────
+  const agentsJsonPath = join(dir, "openclaw-agents.json");
+  const newAgentsJson = JSON.stringify(agentConfigs, null, 2) + "\n";
+
+  let agentsJsonStatus: FileChange["status"];
+  if (!existsSync(agentsJsonPath)) {
+    agentsJsonStatus = "created";
+    if (!dryRun) {
+      writeFileSync(agentsJsonPath, newAgentsJson, "utf-8");
+    }
+  } else {
+    const existing = readFileSync(agentsJsonPath, "utf-8");
+    if (existing === newAgentsJson) {
+      agentsJsonStatus = "unchanged";
+    } else {
+      agentsJsonStatus = "updated";
+      if (!dryRun) {
+        writeFileSync(agentsJsonPath, newAgentsJson, "utf-8");
+      }
+    }
+  }
+  changes.push({ path: "openclaw-agents.json", status: agentsJsonStatus });
+
+  return { changes, agentCount: agents.length };
+}
+
+// ── CLI handler ─────────────────────────────────────────────────────────────
+
+export async function regenerateCommand(args: string[], ctx: { dir: string }) {
+  const dryRun = hasFlag(args, "--dry-run");
+
+  const result = regenerate(ctx.dir, dryRun);
+
+  if (dryRun) {
+    console.log("\n🔍 Dry run — no files written\n");
+  } else {
+    console.log("\n♻️  Regenerated!\n");
+  }
+
+  const created = result.changes.filter((c) => c.status === "created");
+  const updated = result.changes.filter((c) => c.status === "updated");
+  const unchanged = result.changes.filter((c) => c.status === "unchanged");
+
+  if (created.length > 0) {
+    console.log("Created:");
+    for (const c of created) {
+      console.log(`  + ${c.path}`);
+    }
+  }
+
+  if (updated.length > 0) {
+    console.log("Updated:");
+    for (const c of updated) {
+      console.log(`  ~ ${c.path}`);
+    }
+  }
+
+  if (unchanged.length > 0) {
+    console.log("Unchanged:");
+    for (const c of unchanged) {
+      console.log(`  · ${c.path}`);
+    }
+  }
+
+  console.log(`\nAgents: ${result.agentCount}`);
+  console.log(`Files changed: ${created.length + updated.length}`);
+
+  if (dryRun) {
+    console.log("\nRun without --dry-run to apply changes.");
+  }
+}

--- a/packages/openspawn/src/cli/index.ts
+++ b/packages/openspawn/src/cli/index.ts
@@ -3,6 +3,7 @@
 
 import { initCommand } from "./commands/init.js";
 import { previewCommand } from "./commands/preview.js";
+import { regenerateCommand } from "./commands/regenerate.js";
 import { startCommand } from "./commands/start.js";
 
 const HELP = `
@@ -19,6 +20,8 @@ Commands:
     --deploy                     Generate Docker infra
     --low-cost                   Use budget models (GPT-4o-mini)
     -p, --port <n>               Coordinator port (default: 8787)
+  regenerate                      Regenerate workspaces from ORG.md
+    --dry-run                    Show what would change without writing
   preview                        Preview org in local sandbox
     --port <n>                   Dashboard port (default: 3333)
     --no-open                    Don't auto-open browser
@@ -74,6 +77,8 @@ async function main() {
   switch (command) {
     case "init":
       return initCommand(rest, ctx);
+    case "regenerate":
+      return regenerateCommand(rest, ctx);
     case "preview":
       return previewCommand(rest, ctx);
     case "start":


### PR DESCRIPTION
## Summary

Adds `openspawn regenerate [--dry-run]` command that re-generates workspace SOUL.md files and `openclaw-agents.json` from `ORG.md` and `openspawn.json` without touching task state or custom workspace files.

Closes #693

## What it does

1. Reads `ORG.md` and `openspawn.json` from current directory
2. Parses org structure (agents, levels, models, domains)
3. Re-generates `workspaces/{agent}/SOUL.md` files with updated alignment from config
4. Re-generates `openclaw-agents.json` with updated model assignments
5. Prints diff summary showing which files were created/updated/unchanged
6. With `--dry-run`: shows what would change without writing any files

## What it preserves

- `.openspawn/tasks.json` (task state)
- Any custom agent workspace files besides SOUL.md
- `ORG.md` itself
- `openspawn.json` itself

## Files changed

- `packages/openspawn/src/cli/commands/regenerate.ts` — new command implementation
- `packages/openspawn/src/cli/commands/regenerate.test.ts` — 8 tests
- `packages/openspawn/src/cli/index.ts` — command registration + help text

## Tests (8/8 passing)

- Regenerate after init produces identical files (idempotent)
- Regenerate after config edit updates SOUL.md
- `--dry-run` doesn't write files
- Missing ORG.md gives clear error
- Missing openspawn.json gives clear error
- Creates workspace for new agent added to ORG.md
- Preserves tasks.json and custom workspace files
- Updates openclaw-agents.json when model config changes