### PR TITLE
feat(api): agent JWT tokens — Phase 1.5 auth (#648)

### DIFF
--- a/apps/api/app/auth/dependencies.py
+++ b/apps/api/app/auth/dependencies.py
@@ -23,6 +23,26 @@ from app.models.enums import AgentStatus
 
 type AuthContext = AuthenticatedAgent | AuthenticatedUser
 
+def _try_agent_jwt(token: str) -> AuthenticatedAgent | None:
+    """Attempt to decode *token* as an agent JWT.
+
+    Returns AuthenticatedAgent on success, None if the token is not
+    an agent JWT (so the caller can fall through to user JWT logic).
+    Raises HTTPException only for *expired* agent tokens (clear signal).
+    """
+    try:
+        from app.auth.jwt_agent import decode_agent_token, authenticated_agent_from_jwt
+
+        payload = decode_agent_token(token)
+        return authenticated_agent_from_jwt(payload)
+    except HTTPException as exc:
+        # If it is an expired agent token, surface immediately
+        if "expired" in str(exc.detail).lower():
+            raise
+        # Otherwise it is not an agent token -- fall through
+        return None
+
+
 
 async def _authenticate_hmac(
     request: Request,
@@ -183,12 +203,18 @@ async def require_auth(
     if request.headers.get("x-agent-id") or request.headers.get("x-signature"):
         return await _authenticate_hmac(request, db)
 
-    # JWT bearer token (full mode user auth from dashboard)
+    # Bearer token -- try agent JWT first, then user JWT / local token
     if auth_header and auth_header.startswith("Bearer "):
         token = auth_header[7:]
+
+        # Attempt agent JWT (token_type=agent claim distinguishes it)
+        agent_ctx = _try_agent_jwt(token)
+        if agent_ctx is not None:
+            return agent_ctx
+
         if cfg.auth.mode == AuthMode.FULL:
             return await _authenticate_jwt(token, db)
-        # local mode — accept any valid local token via middleware
+        # local mode -- accept any valid local token via middleware
         from app.auth.middleware import _authenticate_local
 
         return await _authenticate_local(token)

--- a/apps/api/app/auth/jwt_agent.py
+++ b/apps/api/app/auth/jwt_agent.py
@@ -1,0 +1,111 @@
+"""Agent JWT token issuance and validation.
+
+Agents exchange HMAC credentials for short-lived JWTs, avoiding the overhead
+of per-request HMAC computation and nonce tracking.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import jwt
+import pendulum
+from fastapi import HTTPException, status
+
+from app.auth.schemas import AuthenticatedAgent
+
+# ---------------------------------------------------------------------------
+# Scope constants derived from agent level
+# ---------------------------------------------------------------------------
+
+_BASE_SCOPES = ["read:channels", "read:tasks"]
+_MID_SCOPES = _BASE_SCOPES + ["write:messages", "transition:task"]
+_HIGH_SCOPES = _MID_SCOPES + ["create:task", "spawn:agent", "manage:credits"]
+_ALL_SCOPES = ["*"]
+
+AGENT_JWT_TTL_MINUTES = 15
+AGENT_JWT_ALGORITHM = "HS256"
+
+
+def _get_agent_jwt_secret() -> str:
+    secret = os.environ.get("AUTH_JWT_SECRET")
+    if not secret:
+        raise RuntimeError("AUTH_JWT_SECRET not configured")
+    return secret
+
+
+def scopes_for_level(level: int) -> list[str]:
+    """Return the scope list for a given agent level (1-10)."""
+    if level >= 10:
+        return list(_ALL_SCOPES)
+    if level >= 7:
+        return list(_HIGH_SCOPES)
+    if level >= 4:
+        return list(_MID_SCOPES)
+    return list(_BASE_SCOPES)
+
+
+def create_agent_token(agent: AuthenticatedAgent) -> str:
+    """Create a signed JWT for an authenticated agent."""
+    secret = _get_agent_jwt_secret()
+    now = pendulum.now("UTC")
+    expire = now.add(minutes=AGENT_JWT_TTL_MINUTES)
+
+    payload: dict[str, Any] = {
+        "sub": str(agent.agent_id),
+        "agent_uuid": str(agent.id),
+        "org_id": str(agent.org_id),
+        "level": agent.level,
+        "role": agent.role,
+        "mode": agent.mode,
+        "scopes": scopes_for_level(agent.level),
+        "state": "active",
+        "token_type": "agent",
+        "iat": int(now.timestamp()),
+        "exp": int(expire.timestamp()),
+    }
+
+    return jwt.encode(payload, secret, algorithm=AGENT_JWT_ALGORITHM)
+
+
+def decode_agent_token(token: str) -> dict[str, Any]:
+    """Decode and validate an agent JWT. Raises HTTPException on failure."""
+    secret = _get_agent_jwt_secret()
+
+    try:
+        payload: dict[str, Any] = jwt.decode(
+            token, secret, algorithms=[AGENT_JWT_ALGORITHM]
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Agent token expired",
+        ) from exc
+    except jwt.InvalidTokenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid agent token",
+        ) from exc
+
+    if payload.get("token_type") != "agent":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid agent token",
+        )
+
+    return payload
+
+
+def authenticated_agent_from_jwt(payload: dict[str, Any]) -> AuthenticatedAgent:
+    """Build an AuthenticatedAgent from decoded JWT claims."""
+    return AuthenticatedAgent(
+        id=uuid.UUID(str(payload["agent_uuid"])),
+        org_id=uuid.UUID(str(payload["org_id"])),
+        agent_id=str(payload["sub"]),
+        name="",  # not stored in JWT -- lightweight claim set
+        role=str(payload["role"]),
+        mode=str(payload["mode"]),
+        level=int(payload["level"]),
+    )

--- a/apps/api/app/auth/router_agent_jwt.py
+++ b/apps/api/app/auth/router_agent_jwt.py
@@ -1,0 +1,118 @@
+"""Router for agent JWT token endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import _authenticate_hmac
+from app.auth.jwt_agent import (
+    AGENT_JWT_TTL_MINUTES,
+    authenticated_agent_from_jwt,
+    create_agent_token,
+    decode_agent_token,
+    scopes_for_level,
+)
+from app.database import get_db
+from app.models.agent import Agent
+from app.models.enums import AgentStatus
+
+router = APIRouter(prefix="/auth/agent", tags=["agent-jwt"])
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class AgentTokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int  # seconds
+    scopes: list[str]
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/agent/token -- exchange HMAC creds for JWT
+# ---------------------------------------------------------------------------
+
+
+@router.post("/token", response_model=AgentTokenResponse)
+async def issue_agent_token(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> AgentTokenResponse:
+    """Exchange valid HMAC credentials for a short-lived agent JWT."""
+    agent_ctx = await _authenticate_hmac(request, db)
+
+    token = create_agent_token(agent_ctx)
+    scopes = scopes_for_level(agent_ctx.level)
+
+    return AgentTokenResponse(
+        access_token=token,
+        expires_in=AGENT_JWT_TTL_MINUTES * 60,
+        scopes=scopes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/agent/refresh -- refresh an existing agent JWT
+# ---------------------------------------------------------------------------
+
+
+class RefreshRequest(BaseModel):
+    token: str
+
+
+@router.post("/refresh", response_model=AgentTokenResponse)
+async def refresh_agent_token(
+    body: RefreshRequest,
+    db: AsyncSession = Depends(get_db),
+) -> AgentTokenResponse:
+    """Refresh an agent JWT. Only ACTIVE agents may refresh."""
+    payload = decode_agent_token(body.token)
+
+    # Verify agent is still active in DB
+    agent_id = payload["sub"]
+    org_id = payload["org_id"]
+
+    result = await db.execute(
+        select(Agent).where(Agent.agent_id == agent_id, Agent.org_id == org_id)
+    )
+    agent = result.scalar_one_or_none()
+
+    if not agent:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Agent not found",
+        )
+
+    if agent.status != AgentStatus.ACTIVE:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Agent is not active",
+        )
+
+    # Re-derive from current DB state (level/role may have changed)
+    from app.auth.schemas import AuthenticatedAgent
+
+    agent_ctx = AuthenticatedAgent(
+        id=agent.id,
+        org_id=agent.org_id,
+        agent_id=agent.agent_id,
+        name=agent.name,
+        role=agent.role,
+        mode=agent.mode,
+        level=agent.level,
+    )
+
+    token = create_agent_token(agent_ctx)
+    scopes = scopes_for_level(agent_ctx.level)
+
+    return AgentTokenResponse(
+        access_token=token,
+        expires_in=AGENT_JWT_TTL_MINUTES * 60,
+        scopes=scopes,
+    )

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -21,6 +21,7 @@ from app.memory.graph.router import router as graph_router
 from app.memory.router import router as memory_router
 from app.messages.router import router as messages_router
 from app.observability import setup_logfire
+from app.auth.router_agent_jwt import router as agent_jwt_router
 from app.routers.auth import router as auth_router
 from app.tasks.router import router as tasks_router
 
@@ -53,6 +54,7 @@ app.add_middleware(
 )
 
 app.include_router(auth_router)
+app.include_router(agent_jwt_router)
 app.include_router(agents_router)
 app.include_router(tasks_router)
 app.include_router(credits_router)

--- a/apps/api/tests/test_agent_jwt.py
+++ b/apps/api/tests/test_agent_jwt.py
@@ -1,0 +1,398 @@
+"""Tests for agent JWT token issuance, refresh, scope derivation, and require_auth integration."""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt
+import pendulum
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.auth.jwt_agent import (
+    AGENT_JWT_ALGORITHM,
+    AGENT_JWT_TTL_MINUTES,
+    authenticated_agent_from_jwt,
+    create_agent_token,
+    decode_agent_token,
+    scopes_for_level,
+)
+from app.auth.schemas import AuthenticatedAgent
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+TEST_JWT_SECRET = "test-agent-jwt-secret-do-not-use-in-prod"
+
+
+@pytest.fixture(autouse=True)
+def _jwt_env():
+    with patch.dict(os.environ, {"AUTH_JWT_SECRET": TEST_JWT_SECRET}):
+        yield
+
+
+def _make_agent(
+    level: int = 5,
+    status: str = "active",
+    agent_id: str = "agent-007",
+) -> AuthenticatedAgent:
+    return AuthenticatedAgent(
+        id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        agent_id=agent_id,
+        name="Test Agent",
+        role="worker",
+        mode="worker",
+        level=level,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scope derivation
+# ---------------------------------------------------------------------------
+
+
+class TestScopeDerivation:
+    def test_level_1_base_scopes(self):
+        scopes = scopes_for_level(1)
+        assert scopes == ["read:channels", "read:tasks"]
+
+    def test_level_3_base_scopes(self):
+        scopes = scopes_for_level(3)
+        assert scopes == ["read:channels", "read:tasks"]
+
+    def test_level_4_mid_scopes(self):
+        scopes = scopes_for_level(4)
+        assert "write:messages" in scopes
+        assert "transition:task" in scopes
+        assert "read:channels" in scopes
+
+    def test_level_6_mid_scopes(self):
+        scopes = scopes_for_level(6)
+        assert "write:messages" in scopes
+        assert "spawn:agent" not in scopes
+
+    def test_level_7_high_scopes(self):
+        scopes = scopes_for_level(7)
+        assert "create:task" in scopes
+        assert "spawn:agent" in scopes
+        assert "manage:credits" in scopes
+
+    def test_level_9_high_scopes(self):
+        scopes = scopes_for_level(9)
+        assert "spawn:agent" in scopes
+
+    def test_level_10_all_scopes(self):
+        scopes = scopes_for_level(10)
+        assert scopes == ["*"]
+
+
+# ---------------------------------------------------------------------------
+# Token creation and decoding
+# ---------------------------------------------------------------------------
+
+
+class TestTokenLifecycle:
+    def test_create_and_decode(self):
+        agent = _make_agent(level=5)
+        token = create_agent_token(agent)
+        payload = decode_agent_token(token)
+
+        assert payload["sub"] == agent.agent_id
+        assert payload["org_id"] == str(agent.org_id)
+        assert payload["level"] == 5
+        assert payload["role"] == "worker"
+        assert payload["mode"] == "worker"
+        assert payload["token_type"] == "agent"
+        assert "write:messages" in payload["scopes"]
+
+    def test_expired_token_rejected(self):
+        agent = _make_agent()
+        secret = TEST_JWT_SECRET
+        now = pendulum.now("UTC")
+        payload = {
+            "sub": agent.agent_id,
+            "agent_uuid": str(agent.id),
+            "org_id": str(agent.org_id),
+            "level": agent.level,
+            "role": agent.role,
+            "mode": agent.mode,
+            "scopes": scopes_for_level(agent.level),
+            "state": "active",
+            "token_type": "agent",
+            "iat": int(now.subtract(minutes=20).timestamp()),
+            "exp": int(now.subtract(minutes=5).timestamp()),
+        }
+        token = jwt.encode(payload, secret, algorithm=AGENT_JWT_ALGORITHM)
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            decode_agent_token(token)
+        assert exc_info.value.status_code == 401
+        assert "expired" in exc_info.value.detail.lower()
+
+    def test_invalid_token_rejected(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            decode_agent_token("not.a.valid.token")
+        assert exc_info.value.status_code == 401
+
+    def test_wrong_token_type_rejected(self):
+        """A JWT without token_type=agent should be rejected."""
+        secret = TEST_JWT_SECRET
+        now = int(time.time())
+        payload = {
+            "sub": "user-123",
+            "token_type": "user",
+            "iat": now,
+            "exp": now + 900,
+        }
+        token = jwt.encode(payload, secret, algorithm=AGENT_JWT_ALGORITHM)
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            decode_agent_token(token)
+        assert exc_info.value.status_code == 401
+
+    def test_roundtrip_authenticated_agent(self):
+        agent = _make_agent(level=8)
+        token = create_agent_token(agent)
+        payload = decode_agent_token(token)
+        restored = authenticated_agent_from_jwt(payload)
+
+        assert restored.id == agent.id
+        assert restored.org_id == agent.org_id
+        assert restored.agent_id == agent.agent_id
+        assert restored.role == agent.role
+        assert restored.mode == agent.mode
+        assert restored.level == agent.level
+
+
+# ---------------------------------------------------------------------------
+# Router integration tests
+# ---------------------------------------------------------------------------
+
+
+def _mock_agent_row(
+    agent_id: str = "agent-007",
+    status: str = "active",
+    level: int = 5,
+    org_id: uuid.UUID | None = None,
+):
+    """Create a mock Agent ORM row."""
+    row = MagicMock()
+    row.id = uuid.uuid4()
+    row.org_id = org_id or uuid.uuid4()
+    row.agent_id = agent_id
+    row.name = "Test Agent"
+    row.role = "worker"
+    row.mode = "worker"
+    row.level = level
+    row.status = status
+    row.hmac_secret_enc = b""
+    return row
+
+
+class TestTokenEndpoint:
+    """Test POST /auth/agent/token via HMAC exchange."""
+
+    @pytest.mark.anyio
+    async def test_token_issued_for_valid_hmac(self, client: AsyncClient):
+        """Valid HMAC headers -> JWT returned."""
+        agent = _make_agent(level=6)
+
+        with patch("app.auth.router_agent_jwt._authenticate_hmac", new_callable=AsyncMock) as mock_hmac:
+            mock_hmac.return_value = agent
+            resp = await client.post(
+                "/auth/agent/token",
+                headers={
+                    "x-agent-id": agent.agent_id,
+                    "x-timestamp": str(int(time.time())),
+                    "x-nonce": "nonce123",
+                    "x-signature": "fake-sig",
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+        assert data["expires_in"] == AGENT_JWT_TTL_MINUTES * 60
+        assert "write:messages" in data["scopes"]
+
+    @pytest.mark.anyio
+    async def test_token_rejected_for_invalid_hmac(self, client: AsyncClient):
+        """Missing HMAC headers -> 401."""
+        resp = await client.post("/auth/agent/token")
+        assert resp.status_code == 401
+
+
+class TestRefreshEndpoint:
+    """Test POST /auth/agent/refresh."""
+
+    @pytest.mark.anyio
+    async def test_refresh_active_agent(self, client: AsyncClient):
+        agent = _make_agent(level=5)
+        token = create_agent_token(agent)
+
+        mock_row = _mock_agent_row(
+            agent_id=agent.agent_id,
+            status="active",
+            level=5,
+            org_id=agent.org_id,
+        )
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_row
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        from app.main import app
+        from app.database import get_db
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            resp = await client.post(
+                "/auth/agent/refresh",
+                json={"token": token},
+            )
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data
+        assert data["access_token"] != token
+
+    @pytest.mark.anyio
+    async def test_refresh_rejected_for_suspended_agent(self, client: AsyncClient):
+        agent = _make_agent(level=5)
+        token = create_agent_token(agent)
+
+        mock_row = _mock_agent_row(
+            agent_id=agent.agent_id,
+            status="suspended",
+            org_id=agent.org_id,
+        )
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_row
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        from app.main import app
+        from app.database import get_db
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            resp = await client.post(
+                "/auth/agent/refresh",
+                json={"token": token},
+            )
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+        assert resp.status_code == 401
+        assert "not active" in resp.json()["detail"].lower()
+
+    @pytest.mark.anyio
+    async def test_refresh_rejected_for_expired_token(self, client: AsyncClient):
+        """Expired JWT -> 401 on refresh."""
+        agent = _make_agent()
+        secret = TEST_JWT_SECRET
+        now = pendulum.now("UTC")
+        payload = {
+            "sub": agent.agent_id,
+            "agent_uuid": str(agent.id),
+            "org_id": str(agent.org_id),
+            "level": agent.level,
+            "role": agent.role,
+            "mode": agent.mode,
+            "scopes": scopes_for_level(agent.level),
+            "state": "active",
+            "token_type": "agent",
+            "iat": int(now.subtract(minutes=20).timestamp()),
+            "exp": int(now.subtract(minutes=5).timestamp()),
+        }
+        expired_token = jwt.encode(payload, secret, algorithm=AGENT_JWT_ALGORITHM)
+
+        resp = await client.post(
+            "/auth/agent/refresh",
+            json={"token": expired_token},
+        )
+
+        assert resp.status_code == 401
+        assert "expired" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# require_auth integration — _try_agent_jwt unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRequireAuthAcceptsAgentJWT:
+    def test_agent_jwt_parsed_by_try_agent_jwt(self):
+        """_try_agent_jwt should return AuthenticatedAgent for valid agent JWT."""
+        from app.auth.dependencies import _try_agent_jwt
+
+        agent = _make_agent(level=7)
+        token = create_agent_token(agent)
+
+        result = _try_agent_jwt(token)
+        assert result is not None
+        assert isinstance(result, AuthenticatedAgent)
+        assert result.agent_id == agent.agent_id
+        assert result.level == 7
+
+    def test_try_agent_jwt_returns_none_for_user_token(self):
+        """_try_agent_jwt should return None for non-agent JWTs."""
+        from app.auth.dependencies import _try_agent_jwt
+
+        secret = TEST_JWT_SECRET
+        now = int(time.time())
+        payload = {
+            "sub": "user-123",
+            "org_id": str(uuid.uuid4()),
+            "email": "test@example.com",
+            "role": "admin",
+            "iat": now,
+            "exp": now + 900,
+        }
+        token = jwt.encode(payload, secret, algorithm=AGENT_JWT_ALGORITHM)
+
+        result = _try_agent_jwt(token)
+        assert result is None
+
+    def test_try_agent_jwt_raises_for_expired_agent_token(self):
+        """_try_agent_jwt should raise for expired agent tokens."""
+        from app.auth.dependencies import _try_agent_jwt
+        from fastapi import HTTPException
+
+        agent = _make_agent()
+        secret = TEST_JWT_SECRET
+        now = pendulum.now("UTC")
+        payload = {
+            "sub": agent.agent_id,
+            "agent_uuid": str(agent.id),
+            "org_id": str(agent.org_id),
+            "level": agent.level,
+            "role": agent.role,
+            "mode": agent.mode,
+            "scopes": scopes_for_level(agent.level),
+            "state": "active",
+            "token_type": "agent",
+            "iat": int(now.subtract(minutes=20).timestamp()),
+            "exp": int(now.subtract(minutes=5).timestamp()),
+        }
+        expired_token = jwt.encode(payload, secret, algorithm=AGENT_JWT_ALGORITHM)
+
+        with pytest.raises(HTTPException) as exc_info:
+            _try_agent_jwt(expired_token)
+        assert exc_info.value.status_code == 401


### PR DESCRIPTION
## Summary

Adds JWT-based authentication for agents (Phase 1.5), issued by the API as a lightweight alternative to per-request HMAC.

### What's New

**New files:**
- `apps/api/app/auth/jwt_agent.py` — Token creation, decode, scope derivation
- `apps/api/app/auth/router_agent_jwt.py` — Two endpoints:
  - `POST /auth/agent/token` — Exchange HMAC credentials for a 15-min JWT
  - `POST /auth/agent/refresh` — Refresh JWT (active agents only)
- `apps/api/tests/test_agent_jwt.py` — 20 tests

**Modified files:**
- `apps/api/app/auth/dependencies.py` — `require_auth()` now accepts agent JWTs via Bearer header (additive, HMAC still works)
- `apps/api/app/main.py` — Router registration

### Design Decisions

- **HS256 signing** using existing `AUTH_JWT_SECRET` env var (same config as user JWTs)
- **15-minute TTL** — short-lived, refresh endpoint for renewal
- **Level-based scopes:**
  - L1-L3: `read:channels`, `read:tasks`
  - L4-L6: + `write:messages`, `transition:task`
  - L7-L9: + `create:task`, `spawn:agent`, `manage:credits`
  - L10: `*` (all scopes)
- **token_type=agent** claim distinguishes agent JWTs from user JWTs
- Expired agent tokens raise immediately; non-agent tokens fall through to user JWT logic
- Refresh checks DB for active status (catches suspensions between token issues)

### Testing

All 20 new tests pass. All 23 existing auth tests pass unchanged.

Closes #648