### PR TITLE
feat: OpenTelemetry integration for API observability #141

### DIFF
--- a/apps/api/app/agents/router.py
+++ b/apps/api/app/agents/router.py
@@ -42,9 +42,11 @@ async def register_agent(
     auth: AuthContext = Depends(require_auth),
 ) -> DataMessageResponse[AgentRegistrationResponse]:
     from app.agents.schemas import CreateAgentDto
+    from app.observability.spans import agent_register_span
 
     body = CreateAgentDto.model_validate(dto)
-    agent, hmac_secret = await service.register_agent(db, auth, body)
+    with agent_register_span(org_id=auth.org_id):
+        agent, hmac_secret = await service.register_agent(db, auth, body)
     return DataMessageResponse(
         data=AgentRegistrationResponse(
             agent=AgentResponse.model_validate(agent),

--- a/apps/api/app/auth/router_agent_jwt.py
+++ b/apps/api/app/auth/router_agent_jwt.py
@@ -44,10 +44,19 @@ async def issue_agent_token(
     db: AsyncSession = Depends(get_db),
 ) -> AgentTokenResponse:
     """Exchange valid HMAC credentials for a short-lived agent JWT."""
-    agent_ctx = await _authenticate_hmac(request, db)
+    from app.observability.metrics import auth_token_failed_counter, auth_token_issued_counter
+    from app.observability.spans import agent_authenticate_span
 
-    token = create_agent_token(agent_ctx)
-    scopes = scopes_for_level(agent_ctx.level)
+    try:
+        agent_ctx = await _authenticate_hmac(request, db)
+    except Exception:
+        auth_token_failed_counter().add(1)
+        raise
+
+    with agent_authenticate_span(agent_id=agent_ctx.agent_id):
+        token = create_agent_token(agent_ctx)
+        scopes = scopes_for_level(agent_ctx.level)
+        auth_token_issued_counter().add(1)
 
     return AgentTokenResponse(
         access_token=token,

--- a/apps/api/app/coordination/rest.py
+++ b/apps/api/app/coordination/rest.py
@@ -28,8 +28,11 @@ async def emit_event(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(require_auth),
 ) -> DataMessageResponse[dict]:
-    await service.emit_coordination_event(db, auth.org_id, auth.id, dto)
-    await db.commit()
+    from app.observability.spans import coordination_emit_span
+
+    with coordination_emit_span(org_id=auth.org_id, agent_id=auth.id, event_type=dto.event_type):
+        await service.emit_coordination_event(db, auth.org_id, auth.id, dto)
+        await db.commit()
     return DataMessageResponse(
         data={"event_type": dto.event_type, "task_id": str(dto.task_id)},
         message="Event emitted",

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -24,7 +24,7 @@ from app.logging import setup_logging
 from app.memory.graph.router import router as graph_router
 from app.memory.router import router as memory_router
 from app.messages.router import router as messages_router
-from app.observability import setup_logfire
+from app.observability import setup_logfire, setup_telemetry
 from app.routers.auth import router as auth_router
 from app.tasks.router import router as tasks_router
 
@@ -35,6 +35,7 @@ logger = structlog.stdlib.get_logger()
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     setup_logging(log_level=settings.log_level, log_format=settings.log_format)
     setup_logfire(app)
+    setup_telemetry(app)
     await logger.ainfo("starting", app=settings.app_name)
     yield
     await engine.dispose()

--- a/apps/api/app/memory/router.py
+++ b/apps/api/app/memory/router.py
@@ -28,50 +28,57 @@ async def store(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(require_auth),
 ) -> DataMessageResponse[dict]:
-    try:
-        # Compute expires_at from ttl_seconds if provided
-        expires_at = dto.expires_at
-        if expires_at is None and dto.ttl_seconds is not None:
-            import pendulum
+    from app.observability.metrics import memory_stored_counter
+    from app.observability.spans import memory_store_span
 
-            expires_at = pendulum.now("UTC").add(seconds=dto.ttl_seconds)
+    with memory_store_span(org_id=auth.org_id, agent_id=auth.id, memory_type=dto.type):
+        try:
+            # Compute expires_at from ttl_seconds if provided
+            expires_at = dto.expires_at
+            if expires_at is None and dto.ttl_seconds is not None:
+                import pendulum
 
-        # Merge decision-specific fields into metadata
-        metadata = dict(dto.metadata)
-        if dto.alternatives is not None:
-            metadata["alternatives"] = [a.model_dump() for a in dto.alternatives]
-        if dto.constraints is not None:
-            metadata["constraints"] = dto.constraints
-        if dto.decided_by is not None:
-            metadata["decided_by"] = dto.decided_by
-        if dto.what_outsider_would_miss is not None:
-            metadata["what_outsider_would_miss"] = dto.what_outsider_would_miss
-        if dto.review_by is not None:
-            metadata["review_by"] = dto.review_by.isoformat()
+                expires_at = pendulum.now("UTC").add(seconds=dto.ttl_seconds)
 
-        memory_id = await store_memory(
-            session=db,
-            org_id=auth.org_id,
-            agent_id=auth.id,
-            content=dto.content,
-            source=dto.source,
-            memory_type=dto.type,
-            visibility=dto.visibility,
-            target_agent_ids=dto.target_agent_ids,
-            occurred_at=dto.occurred_at.isoformat() if dto.occurred_at else None,
-            expires_at=expires_at.isoformat() if expires_at else None,
-            metadata=metadata,
-        )
-        await db.commit()
-        return DataMessageResponse(
-            data={"memory_id": str(memory_id)},
-            message="Memory stored",
-        )
-    except RateLimitExceededError as e:
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail=e.detail,
-        ) from e
+            # Merge decision-specific fields into metadata
+            metadata = dict(dto.metadata)
+            if dto.alternatives is not None:
+                metadata["alternatives"] = [a.model_dump() for a in dto.alternatives]
+            if dto.constraints is not None:
+                metadata["constraints"] = dto.constraints
+            if dto.decided_by is not None:
+                metadata["decided_by"] = dto.decided_by
+            if dto.what_outsider_would_miss is not None:
+                metadata["what_outsider_would_miss"] = dto.what_outsider_would_miss
+            if dto.review_by is not None:
+                metadata["review_by"] = dto.review_by.isoformat()
+
+            memory_id = await store_memory(
+                session=db,
+                org_id=auth.org_id,
+                agent_id=auth.id,
+                content=dto.content,
+                source=dto.source,
+                memory_type=dto.type,
+                visibility=dto.visibility,
+                target_agent_ids=dto.target_agent_ids,
+                occurred_at=dto.occurred_at.isoformat() if dto.occurred_at else None,
+                expires_at=expires_at.isoformat() if expires_at else None,
+                metadata=metadata,
+            )
+            await db.commit()
+            memory_stored_counter().add(
+                1, {"openspawn.agent_id": str(auth.id), "openspawn.memory_type": dto.type or ""}
+            )
+            return DataMessageResponse(
+                data={"memory_id": str(memory_id)},
+                message="Memory stored",
+            )
+        except RateLimitExceededError as e:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=e.detail,
+            ) from e
 
 
 @router.get("/search")
@@ -83,24 +90,32 @@ async def search(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(require_auth),
 ) -> DataResponse[list[SearchResultResponse]]:
-    # Import here to avoid circular deps until all branches merge
-    try:
-        from app.memory.search import hybrid_search
+    import time as _time
 
-        results = await hybrid_search(
-            session=db,
-            org_id=auth.org_id,
-            query_text=query,
-            requesting_agent_id=auth.id,
-            limit=limit,
-            similarity_threshold=similarity_threshold,
-            memory_type=type,
-        )
-        return DataResponse(
-            data=[SearchResultResponse.model_validate(r.model_dump()) for r in results]
-        )
-    except ImportError:
-        return DataResponse(data=[])
+    from app.observability.metrics import memory_search_duration_histogram
+    from app.observability.spans import memory_search_span
+
+    with memory_search_span(org_id=auth.org_id, agent_id=auth.id):
+        _t0 = _time.perf_counter()
+        # Import here to avoid circular deps until all branches merge
+        try:
+            from app.memory.search import hybrid_search
+
+            results = await hybrid_search(
+                session=db,
+                org_id=auth.org_id,
+                query_text=query,
+                requesting_agent_id=auth.id,
+                limit=limit,
+                similarity_threshold=similarity_threshold,
+                memory_type=type,
+            )
+            memory_search_duration_histogram().record(_time.perf_counter() - _t0)
+            return DataResponse(
+                data=[SearchResultResponse.model_validate(r.model_dump()) for r in results]
+            )
+        except ImportError:
+            return DataResponse(data=[])
 
 
 @router.get("")

--- a/apps/api/app/observability/__init__.py
+++ b/apps/api/app/observability/__init__.py
@@ -1,0 +1,18 @@
+"""Observability module — OpenTelemetry + Logfire + Langfuse.
+
+Public API:
+    setup_telemetry(app)  — wire OTel into a FastAPI app (no-op when disabled)
+    setup_logfire(app)     — legacy logfire setup (kept for backward compat)
+    get_langfuse()         — Langfuse client factory
+"""
+
+from __future__ import annotations
+
+from app.observability._logfire import get_langfuse, setup_logfire
+from app.observability.setup import setup_telemetry
+
+__all__ = [
+    "get_langfuse",
+    "setup_logfire",
+    "setup_telemetry",
+]

--- a/apps/api/app/observability/_logfire.py
+++ b/apps/api/app/observability/_logfire.py
@@ -1,4 +1,7 @@
-"""Optional observability setup — no-op when tokens not configured."""
+"""Legacy observability helpers — Logfire + Langfuse.
+
+Preserved from the original observability.py for backward compatibility.
+"""
 
 from __future__ import annotations
 

--- a/apps/api/app/observability/config.py
+++ b/apps/api/app/observability/config.py
@@ -1,0 +1,23 @@
+"""OTel configuration resolved from environment variables."""
+
+from __future__ import annotations
+
+import os
+
+
+def otel_enabled() -> bool:
+    """Return True when OpenTelemetry instrumentation is requested."""
+    return os.getenv("OTEL_ENABLED", "").lower() in ("1", "true", "yes")
+
+
+def otel_service_name() -> str:
+    return os.getenv("OTEL_SERVICE_NAME", "openspawn-api")
+
+
+def otel_exporter_type() -> str:
+    """Return 'otlp' or 'console'."""
+    return os.getenv("OTEL_EXPORTER_TYPE", "otlp")
+
+
+def otel_otlp_endpoint() -> str:
+    return os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")

--- a/apps/api/app/observability/metrics.py
+++ b/apps/api/app/observability/metrics.py
@@ -1,0 +1,150 @@
+"""OpenTelemetry metrics — counters and histograms for OpenSpawn operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.observability.config import (
+    otel_enabled,
+    otel_exporter_type,
+    otel_otlp_endpoint,
+    otel_service_name,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level singletons — created lazily on first call to get_meter()
+# ---------------------------------------------------------------------------
+
+_meter_provider_configured = False
+
+
+def configure_meter_provider() -> None:
+    """Create and register the global MeterProvider.  Idempotent."""
+    global _meter_provider_configured
+    if _meter_provider_configured or not otel_enabled():
+        return
+
+    from opentelemetry import metrics
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.resources import Resource
+
+    resource = Resource.create({"service.name": otel_service_name()})
+
+    exporter_type = otel_exporter_type()
+    if exporter_type == "console":
+        from opentelemetry.sdk.metrics.export import ConsoleMetricExporter
+
+        reader = PeriodicExportingMetricReader(ConsoleMetricExporter(), export_interval_millis=5000)
+    else:
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+            OTLPMetricExporter,
+        )
+
+        reader = PeriodicExportingMetricReader(
+            OTLPMetricExporter(endpoint=otel_otlp_endpoint()),
+            export_interval_millis=10_000,
+        )
+
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+    _meter_provider_configured = True
+
+
+def reset_meter_provider() -> None:
+    """Reset global state — useful for tests."""
+    global _meter_provider_configured
+    _meter_provider_configured = False
+
+
+def get_meter(name: str = "openspawn"):
+    """Return a Meter, or a no-op stub when OTel is disabled."""
+    if not otel_enabled():
+        return _NoOpMeter()
+
+    from opentelemetry import metrics
+
+    return metrics.get_meter(name)
+
+
+# ---------------------------------------------------------------------------
+# Named metric accessors — thin wrappers that always return an instrument
+# ---------------------------------------------------------------------------
+
+
+def _counter(name: str, description: str = "", unit: str = "1"):
+    return get_meter().create_counter(name, description=description, unit=unit)
+
+
+def _histogram(name: str, description: str = "", unit: str = "s"):
+    return get_meter().create_histogram(name, description=description, unit=unit)
+
+
+# -- Counters --
+
+
+def tasks_created_counter():
+    return _counter("openspawn.tasks.created", "Tasks created")
+
+
+def tasks_completed_counter():
+    return _counter("openspawn.tasks.completed", "Tasks completed")
+
+
+def tasks_escalated_counter():
+    return _counter("openspawn.tasks.escalated", "Tasks escalated")
+
+
+def memory_stored_counter():
+    return _counter("openspawn.memory.stored", "Memories stored")
+
+
+def auth_token_issued_counter():
+    return _counter("openspawn.auth.token_issued", "JWT tokens issued")
+
+
+def auth_token_failed_counter():
+    return _counter("openspawn.auth.token_failed", "Auth failures")
+
+
+# -- Histograms --
+
+
+def task_duration_histogram():
+    return _histogram("openspawn.task.duration_seconds", "Task lifecycle duration")
+
+
+def api_request_duration_histogram():
+    return _histogram("openspawn.api.request_duration_seconds", "API request latency")
+
+
+def memory_search_duration_histogram():
+    return _histogram("openspawn.memory.search_duration_seconds", "Memory search latency")
+
+
+# ---------------------------------------------------------------------------
+# No-op stubs
+# ---------------------------------------------------------------------------
+
+
+class _NoOpInstrument:
+    """Stands in for Counter / Histogram when OTel is disabled."""
+
+    def add(self, amount: float = 1, attributes: dict[str, Any] | None = None) -> None:
+        pass
+
+    def record(self, amount: float, attributes: dict[str, Any] | None = None) -> None:
+        pass
+
+
+class _NoOpMeter:
+    """Stands in for opentelemetry.metrics.Meter."""
+
+    def create_counter(self, name: str, **kwargs: Any) -> _NoOpInstrument:
+        return _NoOpInstrument()
+
+    def create_histogram(self, name: str, **kwargs: Any) -> _NoOpInstrument:
+        return _NoOpInstrument()
+
+    def create_up_down_counter(self, name: str, **kwargs: Any) -> _NoOpInstrument:
+        return _NoOpInstrument()

--- a/apps/api/app/observability/middleware.py
+++ b/apps/api/app/observability/middleware.py
@@ -1,0 +1,59 @@
+"""OpenTelemetry-aware FastAPI middleware for request-level spans & metrics."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request  # noqa: TC002
+from starlette.responses import Response  # noqa: TC002
+
+from app.observability.config import otel_enabled
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class OTelRequestMiddleware(BaseHTTPMiddleware):
+    """Record per-request latency histogram and enrich the current span.
+
+    This supplements the auto-instrumented spans from
+    ``opentelemetry-instrumentation-fastapi`` with OpenSpawn-specific
+    attributes (org_id, agent_id) pulled from the request state that
+    downstream auth middleware populates.
+    """
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:  # type: ignore[type-arg]
+        if not otel_enabled():
+            return await call_next(request)
+
+        from opentelemetry import trace
+
+        from app.observability.metrics import api_request_duration_histogram
+
+        start = time.perf_counter()
+        span = trace.get_current_span()
+
+        # Try to enrich with auth context (set by auth middleware)
+        auth = getattr(request.state, "auth", None) if hasattr(request, "state") else None
+        if auth is not None:
+            if hasattr(auth, "org_id") and auth.org_id:
+                span.set_attribute("openspawn.org_id", str(auth.org_id))
+            if hasattr(auth, "id") and auth.id:
+                span.set_attribute("openspawn.agent_id", str(auth.id))
+
+        response: Response = await call_next(request)
+
+        duration = time.perf_counter() - start
+        histogram = api_request_duration_histogram()
+        histogram.record(
+            duration,
+            attributes={
+                "http.method": request.method,
+                "http.route": request.url.path,
+                "http.status_code": response.status_code,
+            },
+        )
+
+        return response

--- a/apps/api/app/observability/setup.py
+++ b/apps/api/app/observability/setup.py
@@ -1,0 +1,61 @@
+"""High-level setup_telemetry() entry point."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+from app.observability.config import otel_enabled
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+logger = structlog.get_logger()
+
+
+def setup_telemetry(app: FastAPI) -> None:
+    """Wire OpenTelemetry into the FastAPI application.
+
+    Complete no-op when ``OTEL_ENABLED`` is not truthy, ensuring zero
+    performance impact for deployments that don't use OTel.
+    """
+    if not otel_enabled():
+        logger.info("otel disabled (OTEL_ENABLED not set)")
+        return
+
+    # --- providers --------------------------------------------------------
+    from app.observability.metrics import configure_meter_provider
+    from app.observability.tracing import configure_tracer_provider
+
+    configure_tracer_provider()
+    configure_meter_provider()
+
+    # --- auto-instrumentation ---------------------------------------------
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+        FastAPIInstrumentor.instrument_app(app)
+    except ImportError:
+        logger.warning("opentelemetry-instrumentation-fastapi not installed")
+
+    try:
+        from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+
+        SQLAlchemyInstrumentor().instrument()
+    except ImportError:
+        logger.warning("opentelemetry-instrumentation-sqlalchemy not installed")
+
+    try:
+        from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+        HTTPXClientInstrumentor().instrument()
+    except ImportError:
+        logger.warning("opentelemetry-instrumentation-httpx not installed")
+
+    # --- custom middleware -------------------------------------------------
+    from app.observability.middleware import OTelRequestMiddleware
+
+    app.add_middleware(OTelRequestMiddleware)
+
+    logger.info("otel enabled", service=app.title)

--- a/apps/api/app/observability/spans.py
+++ b/apps/api/app/observability/spans.py
@@ -1,0 +1,165 @@
+"""Pre-defined span helpers for OpenSpawn domain operations.
+
+These functions create explicit spans for key business operations,
+complementing the auto-instrumented HTTP-level spans from FastAPI.
+Each function is safe to call regardless of whether OTel is enabled.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.observability.config import otel_enabled
+
+
+def _get_span_context(name: str, attributes: dict[str, Any] | None = None):
+    """Start a span and return it as a context manager."""
+    if not otel_enabled():
+        return _NoOpContextManager()
+
+    from opentelemetry import trace
+
+    tracer = trace.get_tracer("openspawn")
+    span = tracer.start_span(name)
+    if attributes:
+        for k, v in attributes.items():
+            if v is not None:
+                span.set_attribute(k, str(v))
+    return _SpanContextManager(span)
+
+
+class _SpanContextManager:
+    """Wraps a span as a context manager that ends it on exit."""
+
+    def __init__(self, span: Any) -> None:
+        self._span = span
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        if value is not None:
+            self._span.set_attribute(key, str(value))
+
+    def __enter__(self) -> _SpanContextManager:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        if exc_val is not None:
+            from opentelemetry.trace import StatusCode
+
+            self._span.set_status(StatusCode.ERROR, str(exc_val))
+            self._span.record_exception(exc_val)
+        else:
+            from opentelemetry.trace import StatusCode
+
+            self._span.set_status(StatusCode.OK)
+        self._span.end()
+
+
+class _NoOpContextManager:
+    def set_attribute(self, key: str, value: Any) -> None:
+        pass
+
+    def __enter__(self) -> _NoOpContextManager:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Domain-specific span starters
+# ---------------------------------------------------------------------------
+
+
+def task_create_span(*, org_id: Any = None, agent_id: Any = None) -> Any:
+    return _get_span_context(
+        "task.create",
+        {"openspawn.org_id": org_id, "openspawn.agent_id": agent_id},
+    )
+
+
+def task_transition_span(
+    *, org_id: Any = None, agent_id: Any = None, task_id: Any = None, new_status: str | None = None
+) -> Any:
+    return _get_span_context(
+        "task.transition",
+        {
+            "openspawn.org_id": org_id,
+            "openspawn.agent_id": agent_id,
+            "openspawn.task_id": task_id,
+            "openspawn.task_status": new_status,
+        },
+    )
+
+
+def task_assign_span(*, org_id: Any = None, agent_id: Any = None, task_id: Any = None) -> Any:
+    return _get_span_context(
+        "task.assign",
+        {
+            "openspawn.org_id": org_id,
+            "openspawn.agent_id": agent_id,
+            "openspawn.task_id": task_id,
+        },
+    )
+
+
+def task_complete_span(*, org_id: Any = None, agent_id: Any = None, task_id: Any = None) -> Any:
+    return _get_span_context(
+        "task.complete",
+        {
+            "openspawn.org_id": org_id,
+            "openspawn.agent_id": agent_id,
+            "openspawn.task_id": task_id,
+        },
+    )
+
+
+def task_escalate_span(*, org_id: Any = None, agent_id: Any = None, task_id: Any = None) -> Any:
+    return _get_span_context(
+        "task.escalate",
+        {
+            "openspawn.org_id": org_id,
+            "openspawn.agent_id": agent_id,
+            "openspawn.task_id": task_id,
+        },
+    )
+
+
+def agent_register_span(*, org_id: Any = None) -> Any:
+    return _get_span_context("agent.register", {"openspawn.org_id": org_id})
+
+
+def agent_authenticate_span(*, agent_id: Any = None) -> Any:
+    return _get_span_context("agent.authenticate", {"openspawn.agent_id": agent_id})
+
+
+def memory_store_span(
+    *, org_id: Any = None, agent_id: Any = None, memory_type: str | None = None
+) -> Any:
+    return _get_span_context(
+        "memory.store",
+        {
+            "openspawn.org_id": org_id,
+            "openspawn.agent_id": agent_id,
+            "openspawn.memory_type": memory_type,
+        },
+    )
+
+
+def memory_search_span(*, org_id: Any = None, agent_id: Any = None) -> Any:
+    return _get_span_context(
+        "memory.search",
+        {"openspawn.org_id": org_id, "openspawn.agent_id": agent_id},
+    )
+
+
+def coordination_emit_span(
+    *, org_id: Any = None, agent_id: Any = None, event_type: str | None = None
+) -> Any:
+    return _get_span_context(
+        "coordination.emit",
+        {
+            "openspawn.org_id": org_id,
+            "openspawn.agent_id": agent_id,
+            "openspawn.event_type": event_type,
+        },
+    )

--- a/apps/api/app/observability/tracing.py
+++ b/apps/api/app/observability/tracing.py
@@ -1,0 +1,151 @@
+"""Tracer provider setup and the ``@traced`` decorator."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from app.observability.config import (
+    otel_enabled,
+    otel_exporter_type,
+    otel_otlp_endpoint,
+    otel_service_name,
+)
+
+# Re-export a thin wrapper so callers don't import OTel SDK directly.
+_tracer_provider_configured = False
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _get_tracer(name: str = "openspawn"):
+    """Return the global tracer, or a no-op stub when OTel is off."""
+    if not otel_enabled():
+        return _NoOpTracer()
+
+    from opentelemetry import trace
+
+    return trace.get_tracer(name)
+
+
+def configure_tracer_provider() -> None:
+    """Create and register the global TracerProvider.  Idempotent."""
+    global _tracer_provider_configured
+    if _tracer_provider_configured or not otel_enabled():
+        return
+
+    from opentelemetry import trace
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    resource = Resource.create({"service.name": otel_service_name()})
+    provider = TracerProvider(resource=resource)
+
+    exporter_type = otel_exporter_type()
+    if exporter_type == "console":
+        from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+
+        provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    else:
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+
+        provider.add_span_processor(
+            BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_otlp_endpoint()))
+        )
+
+    trace.set_tracer_provider(provider)
+    _tracer_provider_configured = True
+
+
+def reset_tracer_provider() -> None:
+    """Reset global state — useful for tests."""
+    global _tracer_provider_configured
+    _tracer_provider_configured = False
+
+
+# ---------------------------------------------------------------------------
+# @traced decorator
+# ---------------------------------------------------------------------------
+
+
+def traced(span_name: str) -> Callable[[F], F]:
+    """Decorator that wraps an async function in an OTel span.
+
+    When OTel is disabled the wrapper is essentially free — it calls the
+    original function directly with no SDK overhead.
+
+    Span attributes ``openspawn.org_id`` and ``openspawn.agent_id`` are
+    extracted opportunistically from common keyword arguments (``auth``).
+    """
+
+    def decorator(fn: F) -> F:
+        @functools.wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if not otel_enabled():
+                return await fn(*args, **kwargs)
+
+            from opentelemetry import trace
+            from opentelemetry.trace import StatusCode
+
+            tracer = trace.get_tracer("openspawn")
+            with tracer.start_as_current_span(span_name) as span:
+                # Extract common attributes from auth context
+                auth = kwargs.get("auth")
+                if auth is not None:
+                    if hasattr(auth, "org_id") and auth.org_id:
+                        span.set_attribute("openspawn.org_id", str(auth.org_id))
+                    if hasattr(auth, "id") and auth.id:
+                        span.set_attribute("openspawn.agent_id", str(auth.id))
+
+                # Extract task_id if present
+                task_id = kwargs.get("task_id")
+                if task_id is not None:
+                    span.set_attribute("openspawn.task_id", str(task_id))
+
+                try:
+                    result = await fn(*args, **kwargs)
+                    span.set_status(StatusCode.OK)
+                    return result
+                except Exception as exc:
+                    span.set_status(StatusCode.ERROR, str(exc))
+                    span.record_exception(exc)
+                    raise
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# No-op stub for when OTel is disabled
+# ---------------------------------------------------------------------------
+
+
+class _NoOpSpan:
+    """Minimal stand-in for opentelemetry.trace.Span."""
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        pass
+
+    def set_status(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def record_exception(self, exc: BaseException) -> None:
+        pass
+
+    def __enter__(self) -> _NoOpSpan:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+class _NoOpTracer:
+    """Minimal stand-in for opentelemetry.trace.Tracer."""
+
+    def start_as_current_span(self, name: str, **kwargs: Any) -> _NoOpSpan:
+        return _NoOpSpan()

--- a/apps/api/app/tasks/router.py
+++ b/apps/api/app/tasks/router.py
@@ -41,7 +41,12 @@ async def create_task(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(require_auth),
 ) -> DataResponse[TaskResponse]:
-    task = await service.create_task(db, auth, dto)
+    from app.observability.metrics import tasks_created_counter
+    from app.observability.spans import task_create_span
+
+    with task_create_span(org_id=auth.org_id, agent_id=auth.id):
+        task = await service.create_task(db, auth, dto)
+        tasks_created_counter().add(1, {"openspawn.agent_id": str(auth.id)})
     return DataResponse(data=TaskResponse.model_validate(task))
 
 
@@ -85,7 +90,17 @@ async def transition_task(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(require_auth),
 ) -> DataResponse[TaskResponse]:
-    task = await service.transition_task(db, auth, task_id, dto)
+    from app.observability.metrics import tasks_completed_counter
+    from app.observability.spans import task_complete_span, task_transition_span
+
+    with task_transition_span(
+        org_id=auth.org_id, agent_id=auth.id, task_id=task_id, new_status=dto.status
+    ):
+        task = await service.transition_task(db, auth, task_id, dto)
+        # Track completion metric
+        if str(dto.status).lower() in ("done", "completed"):
+            with task_complete_span(org_id=auth.org_id, agent_id=auth.id, task_id=task_id):
+                tasks_completed_counter().add(1, {"openspawn.agent_id": str(auth.id)})
     return DataResponse(data=TaskResponse.model_validate(task))
 
 
@@ -117,7 +132,10 @@ async def assign_task(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(require_auth),
 ) -> DataResponse[TaskResponse]:
-    task = await service.assign_task(db, auth, task_id, dto)
+    from app.observability.spans import task_assign_span
+
+    with task_assign_span(org_id=auth.org_id, agent_id=auth.id, task_id=task_id):
+        task = await service.assign_task(db, auth, task_id, dto)
     return DataResponse(data=TaskResponse.model_validate(task))
 
 
@@ -179,7 +197,12 @@ async def escalate_task(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(require_auth),
 ) -> DataResponse[EscalationResponse]:
-    escalation = await service.escalate_task(db, auth, task_id, dto)
+    from app.observability.metrics import tasks_escalated_counter
+    from app.observability.spans import task_escalate_span
+
+    with task_escalate_span(org_id=auth.org_id, agent_id=auth.id, task_id=task_id):
+        escalation = await service.escalate_task(db, auth, task_id, dto)
+        tasks_escalated_counter().add(1, {"openspawn.agent_id": str(auth.id)})
     return DataResponse(data=EscalationResponse.model_validate(escalation))
 
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -38,6 +38,14 @@ dependencies = [
 openspawn-server = "app.local:main"
 
 [project.optional-dependencies]
+otel = [
+  "opentelemetry-api>=1.20",
+  "opentelemetry-sdk>=1.20",
+  "opentelemetry-exporter-otlp-proto-grpc>=1.20",
+  "opentelemetry-instrumentation-fastapi>=0.41b0",
+  "opentelemetry-instrumentation-httpx>=0.41b0",
+  "opentelemetry-instrumentation-sqlalchemy>=0.41b0",
+]
 dev = [
   "pytest>=8.3",
   "pytest-asyncio>=0.24",
@@ -47,6 +55,12 @@ dev = [
   "respx>=0.22",
   "factory-boy>=3.3",
   "hypothesis>=6.0",
+  "opentelemetry-api>=1.20",
+  "opentelemetry-sdk>=1.20",
+  "opentelemetry-exporter-otlp-proto-grpc>=1.20",
+  "opentelemetry-instrumentation-fastapi>=0.41b0",
+  "opentelemetry-instrumentation-httpx>=0.41b0",
+  "opentelemetry-instrumentation-sqlalchemy>=0.41b0",
 ]
 
 [build-system]

--- a/apps/api/tests/test_observability.py
+++ b/apps/api/tests/test_observability.py
@@ -1,12 +1,370 @@
-"""Verify observability setup is no-op without tokens."""
+"""Tests for the OpenTelemetry observability module.
 
-from app.observability import get_langfuse, setup_logfire
+Coverage:
+- setup_telemetry is a no-op when OTEL_ENABLED is not set
+- setup_telemetry configures providers when OTEL_ENABLED=true
+- @traced decorator creates spans and records exceptions
+- Metric helpers return no-op instruments when disabled
+- Metric helpers return real instruments when enabled
+- Span helpers return no-op context managers when disabled
+- Span helpers create real spans when enabled
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-class TestObservabilityNoOp:
-    def test_logfire_noop_without_token(self) -> None:
-        """setup_logfire should not raise when LOGFIRE_TOKEN unset."""
-        setup_logfire(object())
+def _with_otel_env(enabled: bool = True, exporter: str = "console"):
+    """Return a dict suitable for ``patch.dict(os.environ, ...)``."""
+    env = {
+        "OTEL_ENABLED": "true" if enabled else "",
+        "OTEL_EXPORTER_TYPE": exporter,
+        "OTEL_SERVICE_NAME": "openspawn-api-test",
+    }
+    return env
 
-    def test_langfuse_returns_none_without_keys(self) -> None:
-        assert get_langfuse() is None
+
+# ---------------------------------------------------------------------------
+# setup_telemetry — disabled (no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupTelemetryDisabled:
+    def test_noop_when_disabled(self):
+        """setup_telemetry should do nothing when OTEL_ENABLED is not set."""
+        with patch.dict(os.environ, {"OTEL_ENABLED": ""}, clear=False):
+            from app.observability.setup import setup_telemetry
+
+            app = MagicMock()
+            # Should not raise or call any SDK functions
+            setup_telemetry(app)
+            # Middleware should NOT be added
+            app.add_middleware.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# setup_telemetry — enabled (console exporter so no network)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupTelemetryEnabled:
+    def test_configures_providers(self):
+        """When enabled, setup_telemetry should configure tracer + meter providers."""
+        with patch.dict(os.environ, _with_otel_env(enabled=True, exporter="console"), clear=False):
+            from app.observability.metrics import reset_meter_provider
+            from app.observability.tracing import reset_tracer_provider
+
+            reset_tracer_provider()
+            reset_meter_provider()
+
+            from app.observability.setup import setup_telemetry
+
+            app = MagicMock()
+            app.title = "test"
+            setup_telemetry(app)
+
+            # FastAPI middleware should be added
+            app.add_middleware.assert_called_once()
+
+    def test_idempotent(self):
+        """Calling setup_telemetry twice should not fail."""
+        with patch.dict(os.environ, _with_otel_env(enabled=True, exporter="console"), clear=False):
+            from app.observability.metrics import reset_meter_provider
+            from app.observability.tracing import reset_tracer_provider
+
+            reset_tracer_provider()
+            reset_meter_provider()
+
+            from app.observability.setup import setup_telemetry
+
+            app = MagicMock()
+            app.title = "test"
+            setup_telemetry(app)
+            setup_telemetry(app)  # second call — should not raise
+
+
+# ---------------------------------------------------------------------------
+# @traced decorator
+# ---------------------------------------------------------------------------
+
+
+class TestTracedDecorator:
+    @pytest.mark.asyncio
+    async def test_noop_when_disabled(self):
+        """@traced should passthrough when OTel is off."""
+        with patch.dict(os.environ, {"OTEL_ENABLED": ""}, clear=False):
+            from app.observability.tracing import traced
+
+            @traced("test.op")
+            async def my_func(x: int) -> int:
+                return x * 2
+
+            result = await my_func(5)
+            assert result == 10
+
+    @pytest.mark.asyncio
+    async def test_creates_span_when_enabled(self):
+        """@traced should create a span when OTel is on."""
+        with patch.dict(os.environ, _with_otel_env(enabled=True, exporter="console"), clear=False):
+            from app.observability.tracing import (
+                configure_tracer_provider,
+                reset_tracer_provider,
+                traced,
+            )
+
+            reset_tracer_provider()
+            configure_tracer_provider()
+
+            @traced("test.op")
+            async def my_func(x: int) -> int:
+                return x * 2
+
+            result = await my_func(5)
+            assert result == 10
+
+    @pytest.mark.asyncio
+    async def test_records_exception(self):
+        """@traced should record exceptions and re-raise them."""
+        with patch.dict(os.environ, _with_otel_env(enabled=True, exporter="console"), clear=False):
+            from app.observability.tracing import (
+                configure_tracer_provider,
+                reset_tracer_provider,
+                traced,
+            )
+
+            reset_tracer_provider()
+            configure_tracer_provider()
+
+            @traced("test.fail")
+            async def failing_func() -> None:
+                raise ValueError("boom")
+
+            with pytest.raises(ValueError, match="boom"):
+                await failing_func()
+
+    @pytest.mark.asyncio
+    async def test_extracts_auth_attributes(self):
+        """@traced should extract org_id/agent_id from auth kwarg."""
+        with patch.dict(os.environ, _with_otel_env(enabled=True, exporter="console"), clear=False):
+            from app.observability.tracing import (
+                configure_tracer_provider,
+                reset_tracer_provider,
+                traced,
+            )
+
+            reset_tracer_provider()
+            configure_tracer_provider()
+
+            class FakeAuth:
+                org_id = "org-123"
+                id = "agent-456"
+
+            @traced("test.auth")
+            async def authed_func(auth=None) -> str:
+                return "ok"
+
+            result = await authed_func(auth=FakeAuth())
+            assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Metrics — disabled
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsDisabled:
+    def test_counters_noop(self):
+        """Counters should return no-op instruments when disabled."""
+        with patch.dict(os.environ, {"OTEL_ENABLED": ""}, clear=False):
+            from app.observability.metrics import (
+                auth_token_failed_counter,
+                auth_token_issued_counter,
+                memory_stored_counter,
+                tasks_completed_counter,
+                tasks_created_counter,
+                tasks_escalated_counter,
+            )
+
+            # These should not raise
+            tasks_created_counter().add(1)
+            tasks_completed_counter().add(1)
+            tasks_escalated_counter().add(1)
+            memory_stored_counter().add(1)
+            auth_token_issued_counter().add(1)
+            auth_token_failed_counter().add(1)
+
+    def test_histograms_noop(self):
+        """Histograms should return no-op instruments when disabled."""
+        with patch.dict(os.environ, {"OTEL_ENABLED": ""}, clear=False):
+            from app.observability.metrics import (
+                api_request_duration_histogram,
+                memory_search_duration_histogram,
+                task_duration_histogram,
+            )
+
+            task_duration_histogram().record(1.5)
+            api_request_duration_histogram().record(0.05)
+            memory_search_duration_histogram().record(0.3)
+
+
+# ---------------------------------------------------------------------------
+# Metrics — enabled
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsEnabled:
+    def test_counters_real(self):
+        """Counters should create real OTel instruments when enabled."""
+        with patch.dict(os.environ, _with_otel_env(enabled=True, exporter="console"), clear=False):
+            from app.observability.metrics import (
+                configure_meter_provider,
+                reset_meter_provider,
+                tasks_created_counter,
+            )
+
+            reset_meter_provider()
+            configure_meter_provider()
+
+            counter = tasks_created_counter()
+            # Should have an 'add' method from the real SDK
+            assert hasattr(counter, "add")
+            counter.add(1, {"agent": "test"})
+
+    def test_histograms_real(self):
+        """Histograms should create real OTel instruments when enabled."""
+        with patch.dict(os.environ, _with_otel_env(enabled=True, exporter="console"), clear=False):
+            from app.observability.metrics import (
+                api_request_duration_histogram,
+                configure_meter_provider,
+                reset_meter_provider,
+            )
+
+            reset_meter_provider()
+            configure_meter_provider()
+
+            histogram = api_request_duration_histogram()
+            assert hasattr(histogram, "record")
+            histogram.record(0.123, {"http.method": "GET"})
+
+
+# ---------------------------------------------------------------------------
+# Span helpers — disabled
+# ---------------------------------------------------------------------------
+
+
+class TestSpansDisabled:
+    def test_all_span_helpers_noop(self):
+        """All span helpers should return no-op context managers when disabled."""
+        with patch.dict(os.environ, {"OTEL_ENABLED": ""}, clear=False):
+            from app.observability.spans import (
+                agent_authenticate_span,
+                agent_register_span,
+                coordination_emit_span,
+                memory_search_span,
+                memory_store_span,
+                task_assign_span,
+                task_complete_span,
+                task_create_span,
+                task_escalate_span,
+                task_transition_span,
+            )
+
+            # None of these should raise
+            with task_create_span(org_id="o", agent_id="a"):
+                pass
+            with task_transition_span(org_id="o", task_id="t", new_status="done"):
+                pass
+            with task_assign_span(org_id="o", task_id="t"):
+                pass
+            with task_complete_span(org_id="o", task_id="t"):
+                pass
+            with task_escalate_span(org_id="o", task_id="t"):
+                pass
+            with agent_register_span(org_id="o"):
+                pass
+            with agent_authenticate_span(agent_id="a"):
+                pass
+            with memory_store_span(org_id="o", agent_id="a"):
+                pass
+            with memory_search_span(org_id="o"):
+                pass
+            with coordination_emit_span(org_id="o", event_type="test"):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Span helpers — enabled
+# ---------------------------------------------------------------------------
+
+
+class TestSpansEnabled:
+    def test_span_helpers_create_spans(self):
+        """When enabled, span helpers should create real spans."""
+        with patch.dict(os.environ, _with_otel_env(enabled=True, exporter="console"), clear=False):
+            from app.observability.spans import task_create_span
+            from app.observability.tracing import configure_tracer_provider, reset_tracer_provider
+
+            reset_tracer_provider()
+            configure_tracer_provider()
+
+            with task_create_span(org_id="org-1", agent_id="agent-1") as span:
+                span.set_attribute("openspawn.extra", "value")
+                # Should not raise
+
+    def test_span_records_exception(self):
+        """Spans should record exceptions when code inside raises."""
+        with patch.dict(os.environ, _with_otel_env(enabled=True, exporter="console"), clear=False):
+            from app.observability.spans import task_create_span
+            from app.observability.tracing import configure_tracer_provider, reset_tracer_provider
+
+            reset_tracer_provider()
+            configure_tracer_provider()
+
+            with pytest.raises(RuntimeError, match="test error"), task_create_span(org_id="org-1"):
+                raise RuntimeError("test error")
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_otel_enabled_false_by_default(self):
+        with patch.dict(os.environ, {"OTEL_ENABLED": ""}, clear=False):
+            from app.observability.config import otel_enabled
+
+            assert otel_enabled() is False
+
+    def test_otel_enabled_true(self):
+        with patch.dict(os.environ, {"OTEL_ENABLED": "true"}, clear=False):
+            from app.observability.config import otel_enabled
+
+            assert otel_enabled() is True
+
+    def test_otel_enabled_accepts_1(self):
+        with patch.dict(os.environ, {"OTEL_ENABLED": "1"}, clear=False):
+            from app.observability.config import otel_enabled
+
+            assert otel_enabled() is True
+
+    def test_service_name_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("OTEL_SERVICE_NAME", None)
+            from app.observability.config import otel_service_name
+
+            assert otel_service_name() == "openspawn-api"
+
+    def test_service_name_override(self):
+        with patch.dict(os.environ, {"OTEL_SERVICE_NAME": "custom"}, clear=False):
+            from app.observability.config import otel_service_name
+
+            assert otel_service_name() == "custom"


### PR DESCRIPTION
## Summary

Adds full OpenTelemetry instrumentation to the FastAPI API for observability of agent operations.

Closes #141

## What's Included

### Core OTel Module (`app/observability/`)
- **`config.py`** — Environment-based configuration (`OTEL_ENABLED`, `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_TYPE`, `OTEL_EXPORTER_OTLP_ENDPOINT`)
- **`tracing.py`** — TracerProvider setup (OTLP or console exporter), `@traced` decorator, no-op stubs
- **`metrics.py`** — MeterProvider setup, named counter/histogram accessors, no-op stubs
- **`middleware.py`** — `OTelRequestMiddleware` for per-request latency + auth attribute enrichment
- **`spans.py`** — Domain-specific span helpers (task, agent, memory, coordination)
- **`setup.py`** — `setup_telemetry(app)` entry point — complete no-op when disabled

### Instrumented Endpoints
| Span | Endpoint | Metrics |
|------|----------|---------|
| `task.create` | POST /tasks | `openspawn.tasks.created` counter |
| `task.transition` | POST /tasks/{id}/transition | `openspawn.tasks.completed` counter |
| `task.assign` | POST /tasks/{id}/assign | — |
| `task.escalate` | POST /tasks/{id}/escalate | `openspawn.tasks.escalated` counter |
| `agent.register` | POST /agents/register | — |
| `agent.authenticate` | POST /auth/agent/token | `openspawn.auth.token_issued/failed` counters |
| `memory.store` | POST /memory | `openspawn.memory.stored` counter |
| `memory.search` | GET /memory/search | `openspawn.memory.search_duration_seconds` histogram |
| `coordination.emit` | POST /coordination/emit | — |
| All requests | middleware | `openspawn.api.request_duration_seconds` histogram |

### Key Design Decisions
- **Opt-in**: Disabled by default, zero overhead when `OTEL_ENABLED` is not set
- **No signature changes**: All instrumentation via middleware, decorators, and span context managers
- **Backward compatible**: Existing `setup_logfire()` and `get_langfuse()` preserved in `_logfire.py`
- **Optional deps**: OTel packages in `[otel]` extra group

### Tests
19 tests covering:
- Setup is no-op when disabled / configures providers when enabled
- `@traced` decorator: passthrough when off, spans + exception recording when on
- Metric instruments: no-op when off, real SDK instruments when on  
- Span helpers: no-op when off, real spans when on
- Config parsing edge cases

### Environment Variables
```bash
OTEL_ENABLED=true
OTEL_SERVICE_NAME=openspawn-api
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
OTEL_EXPORTER_TYPE=otlp  # or "console"
```