### PR TITLE
fix: A2A bridge uses /hooks/agent endpoint + deliver:false

### DIFF
--- a/tools/a2a-router/register-agents.sh
+++ b/tools/a2a-router/register-agents.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Auto-register local agents with the A2A router
+# Run after router starts
+
+ROUTER="http://127.0.0.1:3380"
+
+# Wait for router
+for i in {1..10}; do
+  curl -s "$ROUTER/health" > /dev/null 2>&1 && break
+  sleep 2
+done
+
+# Dennis
+curl -s -X POST "$ROUTER/a2a/agents" \
+  -H "Content-Type: application/json" \
+  -d "{\"agentId\":\"dennis\",\"name\":\"Agent Dennis\",\"skills\":[\"openspawn\",\"coding\",\"devops\"],\"gateway_url\":\"http://127.0.0.1:18789\",\"gateway_token\":\"de7a80e75773fcf0bba22349f7bf21498bfb389a6a15283b\",\"hook_path\":\"/hooks/agent\"}" > /dev/null
+
+# Drinkify
+curl -s -X POST "$ROUTER/a2a/agents" \
+  -H "Content-Type: application/json" \
+  -d "{\"agentId\":\"drinkify\",\"name\":\"Agent Drinkify\",\"skills\":[\"drinkify\",\"e-commerce\",\"frontend\"],\"gateway_url\":\"http://127.0.0.1:18810\",\"gateway_token\":\"a2a-drinkify-hook-token-2026\",\"hook_path\":\"/hooks/agent\"}" > /dev/null
+
+echo "Agents registered: $(curl -s $ROUTER/a2a/agents | jq -r '[.[].agent_id] | join(", ")')"

--- a/tools/a2a-router/src/bridge.ts
+++ b/tools/a2a-router/src/bridge.ts
@@ -6,6 +6,8 @@ import type { AgentCard, Task } from "./types.js";
 export interface HookPayload {
   message: string;
   agentId: string;
+  deliver: boolean;
+  timeoutSeconds: number;
 }
 
 /**
@@ -15,6 +17,8 @@ export function buildTaskPayload(task: Task): HookPayload {
   return {
     message: `[a2a:task:${task.id}]\n\n${task.message}`,
     agentId: "main",
+    deliver: false,
+    timeoutSeconds: 300,
   };
 }
 
@@ -29,6 +33,8 @@ export function buildResultPayload(task: Task, targetName: string): HookPayload 
   return {
     message: `[a2a:result:${task.id}]\n\n${statusLine}${resultText}`,
     agentId: "main",
+    deliver: false,
+    timeoutSeconds: 120,
   };
 }
 

--- a/tools/a2a-router/src/store.ts
+++ b/tools/a2a-router/src/store.ts
@@ -28,7 +28,7 @@ export class Store {
         skills TEXT,
         gateway_url TEXT NOT NULL,
         gateway_token TEXT,
-        hook_path TEXT DEFAULT '/hooks/ingest',
+        hook_path TEXT DEFAULT '/hooks/agent',
         registered_at TEXT DEFAULT (datetime('now'))
       );
 
@@ -61,7 +61,7 @@ export class Store {
         hook_path = excluded.hook_path
     `);
     const skills = JSON.stringify(agent.skills ?? []);
-    stmt.run(agent.agent_id, agent.name, skills, agent.gateway_url, agent.gateway_token ?? null, agent.hook_path ?? "/hooks/ingest");
+    stmt.run(agent.agent_id, agent.name, skills, agent.gateway_url, agent.gateway_token ?? null, agent.hook_path ?? "/hooks/agent");
     const result = this.getAgent(agent.agent_id);
     if (!result) throw new Error(`Failed to upsert agent ${agent.agent_id}`);
     return result;


### PR DESCRIPTION
Fixes discovered during first A2A test:
- Default hook_path changed from /hooks/ingest to /hooks/agent (correct OpenClaw endpoint)
- Hook payloads include deliver:false (don't send to Telegram) and timeoutSeconds
- Register script updated with correct paths and tokens