### PR TITLE
feat: A2A Phase 1 — JSON-RPC server + data model + agent discovery #735 #736 #737

### DIFF
--- a/tools/a2a-router/src/__tests__/discovery.test.ts
+++ b/tools/a2a-router/src/__tests__/discovery.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+import { createApp } from "../index.js";
+import { Store } from "../store.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Express } from "express";
+
+describe("Agent Discovery", () => {
+  let app: Express;
+  let store: Store;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "a2a-discovery-test-"));
+    const created = createApp(new Store(join(tempDir, "test.db")));
+    app = created.app;
+    store = created.store;
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // ── Platform AgentCard ─────────────────────────────────────────────────
+
+  describe("GET /.well-known/agent.json", () => {
+    it("returns platform-level AgentCard", async () => {
+      const res = await request(app).get("/.well-known/agent.json");
+
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe("OpenSpawn A2A Router");
+      expect(res.body.protocolVersion).toBe("1.0.0");
+      expect(res.body.version).toBe("0.2.0");
+      expect(res.body.url).toContain("/a2a/jsonrpc");
+    });
+
+    it("includes required A2A fields", async () => {
+      const res = await request(app).get("/.well-known/agent.json");
+      const card = res.body;
+
+      expect(card.name).toBeTruthy();
+      expect(card.description).toBeTruthy();
+      expect(card.protocolVersion).toBe("1.0.0");
+      expect(card.version).toBeTruthy();
+      expect(card.url).toBeTruthy();
+      expect(Array.isArray(card.skills)).toBe(true);
+      expect(card.capabilities).toBeDefined();
+      expect(typeof card.capabilities.pushNotifications).toBe("boolean");
+      expect(typeof card.capabilities.streaming).toBe("boolean");
+      expect(Array.isArray(card.defaultInputModes)).toBe(true);
+      expect(Array.isArray(card.defaultOutputModes)).toBe(true);
+    });
+
+    it("includes router skills", async () => {
+      const res = await request(app).get("/.well-known/agent.json");
+
+      expect(res.body.skills).toHaveLength(2);
+      expect(res.body.skills[0].id).toBe("routing");
+      expect(res.body.skills[1].id).toBe("task-management");
+    });
+
+    it("reports no push notifications or streaming", async () => {
+      const res = await request(app).get("/.well-known/agent.json");
+
+      expect(res.body.capabilities.pushNotifications).toBe(false);
+      expect(res.body.capabilities.streaming).toBe(false);
+    });
+  });
+
+  // ── Agent-Specific Cards ───────────────────────────────────────────────
+
+  describe("GET /a2a/agents/:id/card", () => {
+    beforeEach(() => {
+      store.registerAgent({
+        agent_id: "dennis",
+        name: "Agent Dennis",
+        skills: ["coding", "devops"],
+        gateway_url: "http://127.0.0.1:18789",
+        gateway_token: "secret",
+        hook_path: "/hooks/ingest",
+      });
+    });
+
+    it("returns agent's A2A-compliant AgentCard", async () => {
+      const res = await request(app).get("/a2a/agents/dennis/card");
+
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe("Agent Dennis");
+      expect(res.body.protocolVersion).toBe("1.0.0");
+      expect(res.body.version).toBe("1.0.0");
+      expect(res.body.url).toContain("/a2a/agents/dennis/jsonrpc");
+    });
+
+    it("includes required A2A fields", async () => {
+      const res = await request(app).get("/a2a/agents/dennis/card");
+      const card = res.body;
+
+      expect(card.name).toBeTruthy();
+      expect(card.description).toBeTruthy();
+      expect(card.protocolVersion).toBe("1.0.0");
+      expect(card.version).toBeTruthy();
+      expect(card.url).toBeTruthy();
+      expect(Array.isArray(card.skills)).toBe(true);
+      expect(card.capabilities).toBeDefined();
+      expect(Array.isArray(card.defaultInputModes)).toBe(true);
+      expect(Array.isArray(card.defaultOutputModes)).toBe(true);
+    });
+
+    it("converts string skills to AgentSkill objects", async () => {
+      const res = await request(app).get("/a2a/agents/dennis/card");
+
+      expect(res.body.skills).toHaveLength(2);
+      expect(res.body.skills[0]).toEqual({ id: "coding", name: "Coding" });
+      expect(res.body.skills[1]).toEqual({ id: "devops", name: "Devops" });
+    });
+
+    it("returns 404 for unknown agent", async () => {
+      const res = await request(app).get("/a2a/agents/unknown/card");
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain("unknown");
+    });
+
+    it("does not expose gateway_token", async () => {
+      const res = await request(app).get("/a2a/agents/dennis/card");
+
+      const body = JSON.stringify(res.body);
+      expect(body).not.toContain("secret");
+      expect(body).not.toContain("gateway_token");
+    });
+
+    it("handles agent with empty skills", async () => {
+      store.registerAgent({
+        agent_id: "noskills",
+        name: "No Skills Agent",
+        skills: [],
+        gateway_url: "http://localhost",
+        hook_path: "/",
+      });
+
+      const res = await request(app).get("/a2a/agents/noskills/card");
+
+      expect(res.status).toBe(200);
+      expect(res.body.skills).toEqual([]);
+    });
+  });
+
+  // ── Coexistence with REST routes ───────────────────────────────────────
+
+  describe("coexistence with REST routes", () => {
+    it("REST GET /a2a/agents/:id still works alongside /card", async () => {
+      store.registerAgent({
+        agent_id: "test",
+        name: "Test",
+        skills: [],
+        gateway_url: "http://test",
+        hook_path: "/",
+      });
+
+      // REST route
+      const restRes = await request(app).get("/a2a/agents/test");
+      expect(restRes.status).toBe(200);
+      expect(restRes.body.agent_id).toBe("test");
+
+      // Discovery route
+      const cardRes = await request(app).get("/a2a/agents/test/card");
+      expect(cardRes.status).toBe(200);
+      expect(cardRes.body.protocolVersion).toBe("1.0.0");
+    });
+
+    it("REST GET /a2a/agents still lists agents", async () => {
+      store.registerAgent({ agent_id: "a", name: "A", skills: [], gateway_url: "http://a", hook_path: "/" });
+
+      const res = await request(app).get("/a2a/agents");
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+  });
+});

--- a/tools/a2a-router/src/__tests__/jsonrpc.test.ts
+++ b/tools/a2a-router/src/__tests__/jsonrpc.test.ts
@@ -1,0 +1,534 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import request from "supertest";
+import { createApp } from "../index.js";
+import { Store } from "../store.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Express } from "express";
+
+// Mock fetch for bridge delivery tests
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function rpc(app: Express, method: string, params: Record<string, unknown>, id: string | number = "1") {
+  return request(app)
+    .post("/a2a/jsonrpc")
+    .send({ jsonrpc: "2.0", id, method, params });
+}
+
+describe("JSON-RPC 2.0 Endpoint", () => {
+  let app: Express;
+  let store: Store;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "a2a-jsonrpc-test-"));
+    const created = createApp(new Store(join(tempDir, "test.db")));
+    app = created.app;
+    store = created.store;
+    mockFetch.mockReset();
+
+    // Register test agents
+    store.registerAgent({ agent_id: "dennis", name: "Agent Dennis", skills: ["coding"], gateway_url: "http://127.0.0.1:18789", hook_path: "/hooks/ingest" });
+    store.registerAgent({ agent_id: "drinkify", name: "Agent Drinkify", skills: ["ecommerce"], gateway_url: "http://127.0.0.1:18810", gateway_token: "tok", hook_path: "/hooks/ingest" });
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // ── Envelope Validation ────────────────────────────────────────────────
+
+  describe("envelope validation", () => {
+    it("rejects missing jsonrpc version", async () => {
+      const res = await request(app)
+        .post("/a2a/jsonrpc")
+        .send({ id: "1", method: "tasks/get", params: {} });
+
+      expect(res.status).toBe(200);
+      expect(res.body.error.code).toBe(-32600);
+      expect(res.body.error.data.reason).toContain("jsonrpc");
+    });
+
+    it("rejects wrong jsonrpc version", async () => {
+      const res = await request(app)
+        .post("/a2a/jsonrpc")
+        .send({ jsonrpc: "1.0", id: "1", method: "tasks/get", params: {} });
+
+      expect(res.status).toBe(200);
+      expect(res.body.error.code).toBe(-32600);
+    });
+
+    it("rejects missing id", async () => {
+      const res = await request(app)
+        .post("/a2a/jsonrpc")
+        .send({ jsonrpc: "2.0", method: "tasks/get", params: {} });
+
+      expect(res.status).toBe(200);
+      expect(res.body.error.code).toBe(-32600);
+      expect(res.body.id).toBe(0);
+    });
+
+    it("rejects missing method", async () => {
+      const res = await request(app)
+        .post("/a2a/jsonrpc")
+        .send({ jsonrpc: "2.0", id: "1", params: {} });
+
+      expect(res.status).toBe(200);
+      expect(res.body.error.code).toBe(-32600);
+      expect(res.body.error.data.reason).toContain("method");
+    });
+
+    it("rejects empty method string", async () => {
+      const res = await request(app)
+        .post("/a2a/jsonrpc")
+        .send({ jsonrpc: "2.0", id: "1", method: "", params: {} });
+
+      expect(res.status).toBe(200);
+      expect(res.body.error.code).toBe(-32600);
+    });
+
+    it("rejects unknown method", async () => {
+      const res = await rpc(app, "unknown/method", {});
+
+      expect(res.body.error.code).toBe(-32601);
+      expect(res.body.error.data.method).toBe("unknown/method");
+    });
+
+    it("preserves request id in response", async () => {
+      const res = await rpc(app, "tasks/get", { taskId: "nonexistent" }, 42);
+      expect(res.body.id).toBe(42);
+    });
+
+    it("preserves string id in response", async () => {
+      const res = await rpc(app, "tasks/get", { taskId: "nonexistent" }, "req-abc");
+      expect(res.body.id).toBe("req-abc");
+    });
+
+    it("works without explicit params", async () => {
+      const res = await request(app)
+        .post("/a2a/jsonrpc")
+        .send({ jsonrpc: "2.0", id: "1", method: "tasks/list" });
+
+      expect(res.body.jsonrpc).toBe("2.0");
+      expect(res.body.result).toBeDefined();
+    });
+  });
+
+  // ── message/send ───────────────────────────────────────────────────────
+
+  describe("message/send", () => {
+    const validMessage = {
+      kind: "message",
+      messageId: "msg-1",
+      role: "user",
+      parts: [{ kind: "text", text: "Status update please" }],
+    };
+
+    it("sends a message and creates a task", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => "ok" });
+
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+        message: validMessage,
+      });
+
+      expect(res.body.error).toBeUndefined();
+      expect(res.body.result.id).toBeTruthy();
+      expect(res.body.result.status.state).toBe("working");
+      expect(res.body.result.messages).toHaveLength(1);
+      expect(res.body.result.messages[0].parts[0].text).toBe("Status update please");
+    });
+
+    it("includes contextId when provided", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => "ok" });
+
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+        message: validMessage,
+        contextId: "project-drinkify",
+      });
+
+      expect(res.body.result.contextId).toBe("project-drinkify");
+    });
+
+    it("handles multi-part messages", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => "ok" });
+
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+        message: {
+          kind: "message",
+          messageId: "msg-multi",
+          role: "user",
+          parts: [
+            { kind: "text", text: "Check this out" },
+            { kind: "data", data: { foo: "bar" } },
+          ],
+        },
+      });
+
+      expect(res.body.result.messages[0].parts).toHaveLength(2);
+    });
+
+    it("rejects missing agentId", async () => {
+      const res = await rpc(app, "message/send", {
+        senderId: "dennis",
+        message: validMessage,
+      });
+
+      expect(res.body.error.code).toBe(-32602);
+      expect(res.body.error.data.reason).toContain("agentId");
+    });
+
+    it("rejects missing senderId", async () => {
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        message: validMessage,
+      });
+
+      expect(res.body.error.code).toBe(-32602);
+      expect(res.body.error.data.reason).toContain("senderId");
+    });
+
+    it("rejects missing message", async () => {
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+      });
+
+      expect(res.body.error.code).toBe(-32602);
+      expect(res.body.error.data.reason).toContain("message");
+    });
+
+    it("rejects invalid message — missing kind", async () => {
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+        message: { messageId: "m", role: "user", parts: [{ kind: "text", text: "hi" }] },
+      });
+
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    it("rejects invalid message — missing messageId", async () => {
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+        message: { kind: "message", role: "user", parts: [{ kind: "text", text: "hi" }] },
+      });
+
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    it("rejects invalid message — empty parts", async () => {
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+        message: { kind: "message", messageId: "m", role: "user", parts: [] },
+      });
+
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    it("rejects invalid message — invalid part kind", async () => {
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+        message: { kind: "message", messageId: "m", role: "user", parts: [{ kind: "unknown" }] },
+      });
+
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    it("returns AGENT_NOT_FOUND for unknown target agent", async () => {
+      const res = await rpc(app, "message/send", {
+        agentId: "unknown",
+        senderId: "dennis",
+        message: validMessage,
+      });
+
+      expect(res.body.error.code).toBe(-32002);
+      expect(res.body.error.data.agentId).toBe("unknown");
+    });
+
+    it("returns AGENT_NOT_FOUND for unknown sender agent", async () => {
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "unknown",
+        message: validMessage,
+      });
+
+      expect(res.body.error.code).toBe(-32002);
+      expect(res.body.error.data.agentId).toBe("unknown");
+    });
+
+    it("reverts to submitted when gateway delivery fails", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+        message: validMessage,
+      });
+
+      // Still returns the task but with submitted status
+      expect(res.body.result.status.state).toBe("submitted");
+      expect(res.body.result.status.message).toContain("Delivery");
+    });
+  });
+
+  // ── tasks/get ──────────────────────────────────────────────────────────
+
+  describe("tasks/get", () => {
+    it("returns a task by ID", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => "ok" });
+
+      const createRes = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+        message: { kind: "message", messageId: "m1", role: "user", parts: [{ kind: "text", text: "hi" }] },
+      });
+      const taskId = createRes.body.result.id;
+
+      const res = await rpc(app, "tasks/get", { taskId });
+
+      expect(res.body.result.id).toBe(taskId);
+      expect(res.body.result.messages).toHaveLength(1);
+    });
+
+    it("returns TASK_NOT_FOUND for unknown task", async () => {
+      const res = await rpc(app, "tasks/get", { taskId: "nonexistent" });
+
+      expect(res.body.error.code).toBe(-32001);
+      expect(res.body.error.data.taskId).toBe("nonexistent");
+    });
+
+    it("rejects missing taskId", async () => {
+      const res = await rpc(app, "tasks/get", {});
+
+      expect(res.body.error.code).toBe(-32602);
+      expect(res.body.error.data.reason).toContain("taskId");
+    });
+  });
+
+  // ── tasks/list ─────────────────────────────────────────────────────────
+
+  describe("tasks/list", () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200, text: async () => "ok" });
+    });
+
+    it("lists all tasks", async () => {
+      await rpc(app, "message/send", {
+        agentId: "drinkify", senderId: "dennis",
+        message: { kind: "message", messageId: "m1", role: "user", parts: [{ kind: "text", text: "t1" }] },
+      });
+      await rpc(app, "message/send", {
+        agentId: "drinkify", senderId: "dennis",
+        message: { kind: "message", messageId: "m2", role: "user", parts: [{ kind: "text", text: "t2" }] },
+      });
+
+      const res = await rpc(app, "tasks/list", {});
+
+      expect(res.body.result.total).toBe(2);
+      expect(res.body.result.tasks).toHaveLength(2);
+    });
+
+    it("filters by agentId", async () => {
+      store.registerAgent({ agent_id: "other", name: "Other", skills: [], gateway_url: "http://o", hook_path: "/" });
+
+      await rpc(app, "message/send", {
+        agentId: "drinkify", senderId: "dennis",
+        message: { kind: "message", messageId: "m1", role: "user", parts: [{ kind: "text", text: "t1" }] },
+      });
+
+      // Create a task via legacy store to have different agents
+      store.createTask("other", "drinkify", "other task");
+
+      const res = await rpc(app, "tasks/list", { agentId: "other" });
+      expect(res.body.result.total).toBe(1);
+    });
+
+    it("filters by status", async () => {
+      await rpc(app, "message/send", {
+        agentId: "drinkify", senderId: "dennis",
+        message: { kind: "message", messageId: "m1", role: "user", parts: [{ kind: "text", text: "t1" }] },
+      });
+
+      // All tasks should be "working" after successful delivery
+      const res = await rpc(app, "tasks/list", { status: "working" });
+      expect(res.body.result.total).toBeGreaterThan(0);
+
+      const res2 = await rpc(app, "tasks/list", { status: "completed" });
+      expect(res2.body.result.total).toBe(0);
+    });
+
+    it("filters by contextId", async () => {
+      await rpc(app, "message/send", {
+        agentId: "drinkify", senderId: "dennis",
+        message: { kind: "message", messageId: "m1", role: "user", parts: [{ kind: "text", text: "t1" }] },
+        contextId: "project-a",
+      });
+      await rpc(app, "message/send", {
+        agentId: "drinkify", senderId: "dennis",
+        message: { kind: "message", messageId: "m2", role: "user", parts: [{ kind: "text", text: "t2" }] },
+        contextId: "project-b",
+      });
+
+      const res = await rpc(app, "tasks/list", { contextId: "project-a" });
+      expect(res.body.result.total).toBe(1);
+    });
+
+    it("supports pagination with limit and offset", async () => {
+      for (let i = 0; i < 5; i++) {
+        await rpc(app, "message/send", {
+          agentId: "drinkify", senderId: "dennis",
+          message: { kind: "message", messageId: `m${i}`, role: "user", parts: [{ kind: "text", text: `t${i}` }] },
+        });
+      }
+
+      const res = await rpc(app, "tasks/list", { limit: 2, offset: 0 });
+      expect(res.body.result.tasks).toHaveLength(2);
+      expect(res.body.result.total).toBe(5);
+      expect(res.body.result.limit).toBe(2);
+      expect(res.body.result.offset).toBe(0);
+
+      const res2 = await rpc(app, "tasks/list", { limit: 2, offset: 4 });
+      expect(res2.body.result.tasks).toHaveLength(1);
+    });
+
+    it("returns empty result for offset beyond total", async () => {
+      const res = await rpc(app, "tasks/list", { offset: 100 });
+      expect(res.body.result.tasks).toHaveLength(0);
+      expect(res.body.result.total).toBe(0);
+    });
+
+    it("rejects negative limit", async () => {
+      const res = await rpc(app, "tasks/list", { limit: -1 });
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    it("rejects negative offset", async () => {
+      const res = await rpc(app, "tasks/list", { offset: -1 });
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    it("rejects invalid status value", async () => {
+      const res = await rpc(app, "tasks/list", { status: "invalid" });
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    it("defaults limit to 50", async () => {
+      const res = await rpc(app, "tasks/list", {});
+      expect(res.body.result.limit).toBe(50);
+    });
+  });
+
+  // ── tasks/cancel ───────────────────────────────────────────────────────
+
+  describe("tasks/cancel", () => {
+    let taskId: string;
+
+    beforeEach(async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200, text: async () => "ok" });
+
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify", senderId: "dennis",
+        message: { kind: "message", messageId: "m1", role: "user", parts: [{ kind: "text", text: "do it" }] },
+      });
+      taskId = res.body.result.id;
+    });
+
+    it("cancels a working task", async () => {
+      const res = await rpc(app, "tasks/cancel", { taskId });
+
+      expect(res.body.result.status.state).toBe("canceled");
+    });
+
+    it("cancels a submitted task", async () => {
+      // Create a task that fails delivery (stays submitted)
+      mockFetch.mockRejectedValueOnce(new Error("fail"));
+      const createRes = await rpc(app, "message/send", {
+        agentId: "drinkify", senderId: "dennis",
+        message: { kind: "message", messageId: "m2", role: "user", parts: [{ kind: "text", text: "test" }] },
+      });
+      const submittedTaskId = createRes.body.result.id;
+
+      const res = await rpc(app, "tasks/cancel", { taskId: submittedTaskId });
+      expect(res.body.result.status.state).toBe("canceled");
+    });
+
+    it("rejects canceling a completed task", async () => {
+      store.updateA2ATaskStatus(taskId, "completed");
+
+      const res = await rpc(app, "tasks/cancel", { taskId });
+      expect(res.body.error.code).toBe(-32602);
+      expect(res.body.error.data.reason).toContain("completed");
+    });
+
+    it("rejects canceling a failed task", async () => {
+      store.updateA2ATaskStatus(taskId, "failed");
+
+      const res = await rpc(app, "tasks/cancel", { taskId });
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    it("rejects canceling an already canceled task", async () => {
+      store.updateA2ATaskStatus(taskId, "canceled");
+
+      const res = await rpc(app, "tasks/cancel", { taskId });
+      expect(res.body.error.code).toBe(-32602);
+    });
+
+    it("returns TASK_NOT_FOUND for unknown task", async () => {
+      const res = await rpc(app, "tasks/cancel", { taskId: "nonexistent" });
+      expect(res.body.error.code).toBe(-32001);
+    });
+
+    it("rejects missing taskId", async () => {
+      const res = await rpc(app, "tasks/cancel", {});
+      expect(res.body.error.code).toBe(-32602);
+    });
+  });
+
+  // ── Edge Cases ─────────────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("handles numeric id = 0", async () => {
+      const res = await request(app)
+        .post("/a2a/jsonrpc")
+        .send({ jsonrpc: "2.0", id: 0, method: "tasks/list", params: {} });
+
+      // id=0 is falsy but valid in JSON-RPC
+      expect(res.body.jsonrpc).toBe("2.0");
+    });
+
+    it("handles empty params object", async () => {
+      const res = await rpc(app, "tasks/list", {});
+      expect(res.body.result).toBeDefined();
+    });
+
+    it("handles file parts in messages", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => "ok" });
+
+      const res = await rpc(app, "message/send", {
+        agentId: "drinkify",
+        senderId: "dennis",
+        message: {
+          kind: "message",
+          messageId: "m-file",
+          role: "user",
+          parts: [{ kind: "file", name: "test.txt", mimeType: "text/plain", uri: "file:///tmp/test.txt" }],
+        },
+      });
+
+      expect(res.body.result.messages[0].parts[0].kind).toBe("file");
+    });
+  });
+});

--- a/tools/a2a-router/src/a2a-types.ts
+++ b/tools/a2a-router/src/a2a-types.ts
@@ -1,0 +1,165 @@
+// ── A2A v1.0 Canonical Types ─────────────────────────────────────────────────
+// Reference: https://a2a-protocol.org/latest/specification/
+
+// ── Agent Discovery ──────────────────────────────────────────────────────────
+
+export interface AgentCard {
+  name: string;
+  description: string;
+  protocolVersion: "1.0.0";
+  version: string;
+  url: string;
+  skills: AgentSkill[];
+  capabilities: AgentCapabilities;
+  defaultInputModes: string[];
+  defaultOutputModes: string[];
+  authentication?: AuthenticationInfo;
+  additionalInterfaces?: AdditionalInterface[];
+}
+
+export interface AgentSkill {
+  id: string;
+  name: string;
+  description?: string;
+  tags?: string[];
+}
+
+export interface AgentCapabilities {
+  pushNotifications: boolean;
+  streaming: boolean;
+}
+
+export interface AuthenticationInfo {
+  schemes: string[];
+}
+
+export interface AdditionalInterface {
+  url: string;
+  transport: "JSONRPC" | "HTTP+JSON" | "GRPC";
+}
+
+// ── Task Lifecycle ───────────────────────────────────────────────────────────
+
+export type TaskState =
+  | "submitted"
+  | "working"
+  | "input-required"
+  | "completed"
+  | "failed"
+  | "canceled";
+
+export interface Task {
+  id: string;
+  contextId?: string;
+  status: TaskStatus;
+  messages: Message[];
+  artifacts?: Artifact[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface TaskStatus {
+  state: TaskState;
+  message?: string;
+  timestamp: string;
+}
+
+// ── Messages & Parts ─────────────────────────────────────────────────────────
+
+export interface Message {
+  kind: "message";
+  messageId: string;
+  role: "user" | "agent";
+  parts: Part[];
+  contextId?: string;
+}
+
+export type Part = TextPart | FilePart | DataPart;
+
+export interface TextPart {
+  kind: "text";
+  text: string;
+}
+
+export interface FilePart {
+  kind: "file";
+  name?: string;
+  mimeType?: string;
+  uri?: string;
+  bytes?: string; // base64
+}
+
+export interface DataPart {
+  kind: "data";
+  data: Record<string, unknown>;
+}
+
+export interface Artifact {
+  parts: Part[];
+  name?: string;
+  description?: string;
+}
+
+// ── JSON-RPC 2.0 ────────────────────────────────────────────────────────────
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number;
+  result?: unknown;
+  error?: JsonRpcError;
+}
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+// Standard JSON-RPC error codes
+export const JSON_RPC_ERRORS = {
+  PARSE_ERROR: { code: -32700, message: "Parse error" },
+  INVALID_REQUEST: { code: -32600, message: "Invalid Request" },
+  METHOD_NOT_FOUND: { code: -32601, message: "Method not found" },
+  INVALID_PARAMS: { code: -32602, message: "Invalid params" },
+  INTERNAL_ERROR: { code: -32603, message: "Internal error" },
+  TASK_NOT_FOUND: { code: -32001, message: "Task not found" },
+  AGENT_NOT_FOUND: { code: -32002, message: "Agent not found" },
+} as const;
+
+// ── Method Params & Results ──────────────────────────────────────────────────
+
+export interface MessageSendParams {
+  agentId: string;
+  senderId: string;
+  message: Message;
+  contextId?: string;
+}
+
+export interface TasksGetParams {
+  taskId: string;
+}
+
+export interface TasksListParams {
+  agentId?: string;
+  status?: TaskState;
+  contextId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface TasksCancelParams {
+  taskId: string;
+}
+
+export interface TasksListResult {
+  tasks: Task[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/tools/a2a-router/src/index.ts
+++ b/tools/a2a-router/src/index.ts
@@ -5,9 +5,12 @@ import { Store } from "./store.js";
 import { agentRoutes } from "./routes/agents.js";
 import { messageRoutes } from "./routes/messages.js";
 import { taskRoutes } from "./routes/tasks.js";
+import { jsonrpcRoutes } from "./routes/jsonrpc.js";
+import { discoveryRoutes } from "./routes/discovery.js";
 
 const PORT = parseInt(process.env.A2A_PORT ?? "3380", 10);
 const DB_PATH = process.env.A2A_DB_PATH ?? `${process.env.HOME}/.openspawn/a2a/tasks.db`;
+const BASE_URL = process.env.A2A_BASE_URL ?? `http://127.0.0.1:${PORT}`;
 
 export function createApp(store?: Store) {
   const s = store ?? new Store(DB_PATH);
@@ -17,13 +20,22 @@ export function createApp(store?: Store) {
 
   // Health check
   app.get("/health", (_req, res) => {
-    res.json({ status: "ok", service: "a2a-router", version: "0.1.0" });
+    res.json({ status: "ok", service: "a2a-router", version: "0.2.0" });
   });
 
-  // Mount routes
+  // ── Agent Discovery ───────────────────────────────────────────────────
+  // Mount discovery BEFORE REST agent routes so /:id/card doesn't get caught by /:id
+  const { wellKnown, agentCards } = discoveryRoutes(s, { baseUrl: BASE_URL });
+  app.use("/.well-known", wellKnown);
+  app.use("/a2a/agents", agentCards);
+
+  // ── Legacy REST routes (backward compatibility) ────────────────────────
   app.use("/a2a/agents", agentRoutes(s));
   app.use("/a2a/message", messageRoutes(s));
   app.use("/a2a/tasks", taskRoutes(s));
+
+  // ── A2A v1.0 JSON-RPC endpoint ────────────────────────────────────────
+  app.use("/a2a/jsonrpc", jsonrpcRoutes(s));
 
   return { app, store: s };
 }
@@ -36,6 +48,8 @@ if (isDirectRun && !isVitest) {
   app.listen(PORT, () => {
     console.log(`🔄 A2A Router listening on http://127.0.0.1:${PORT}`);
     console.log(`   Health: http://127.0.0.1:${PORT}/health`);
+    console.log(`   JSON-RPC: http://127.0.0.1:${PORT}/a2a/jsonrpc`);
+    console.log(`   Discovery: http://127.0.0.1:${PORT}/.well-known/agent.json`);
     console.log(`   DB: ${DB_PATH}`);
   });
 }

--- a/tools/a2a-router/src/routes/discovery.ts
+++ b/tools/a2a-router/src/routes/discovery.ts
@@ -1,0 +1,73 @@
+// ── Agent Discovery Routes ───────────────────────────────────────────────────
+// GET /.well-known/agent.json — Platform-level AgentCard
+// GET /a2a/agents/:id/card    — Individual agent's A2A-compliant AgentCard
+
+import { Router, type Request, type Response } from "express";
+import type { Store } from "../store.js";
+import type { AgentCard } from "../a2a-types.js";
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:3380";
+
+export interface DiscoveryOptions {
+  baseUrl?: string;
+  routerVersion?: string;
+}
+
+export function discoveryRoutes(store: Store, options?: DiscoveryOptions): { wellKnown: Router; agentCards: Router } {
+  const baseUrl = options?.baseUrl ?? DEFAULT_BASE_URL;
+  const routerVersion = options?.routerVersion ?? "0.2.0";
+
+  const wellKnown = Router();
+  const agentCards = Router();
+
+  // GET /.well-known/agent.json — Platform-level AgentCard for the router
+  wellKnown.get("/agent.json", (_req: Request, res: Response) => {
+    const card: AgentCard = {
+      name: "OpenSpawn A2A Router",
+      description: "Multi-agent coordination router for OpenSpawn",
+      protocolVersion: "1.0.0",
+      version: routerVersion,
+      url: `${baseUrl}/a2a/jsonrpc`,
+      skills: [
+        { id: "routing", name: "Agent Routing", description: "Route messages between registered agents" },
+        { id: "task-management", name: "Task Management", description: "Track task lifecycle across agents" },
+      ],
+      capabilities: { pushNotifications: false, streaming: false },
+      defaultInputModes: ["text"],
+      defaultOutputModes: ["text"],
+    };
+    res.json(card);
+  });
+
+  // GET /a2a/agents/:id/card — Individual agent's A2A-compliant AgentCard
+  agentCards.get("/:id/card", (req: Request, res: Response) => {
+    const agent = store.getAgent(req.params.id);
+    if (!agent) {
+      res.status(404).json({ error: `Agent '${req.params.id}' not found` });
+      return;
+    }
+
+    const skills = (agent.skills ?? []).map((skill, idx) => {
+      if (typeof skill === "string") {
+        return { id: skill, name: skill.charAt(0).toUpperCase() + skill.slice(1) };
+      }
+      return { id: `skill-${idx}`, name: String(skill) };
+    });
+
+    const card: AgentCard = {
+      name: agent.name,
+      description: `Agent ${agent.agent_id} registered with OpenSpawn`,
+      protocolVersion: "1.0.0",
+      version: "1.0.0",
+      url: `${baseUrl}/a2a/agents/${agent.agent_id}/jsonrpc`,
+      skills,
+      capabilities: { pushNotifications: false, streaming: false },
+      defaultInputModes: ["text"],
+      defaultOutputModes: ["text"],
+    };
+
+    res.json(card);
+  });
+
+  return { wellKnown, agentCards };
+}

--- a/tools/a2a-router/src/routes/jsonrpc.ts
+++ b/tools/a2a-router/src/routes/jsonrpc.ts
@@ -1,0 +1,225 @@
+// ── JSON-RPC 2.0 Endpoint ────────────────────────────────────────────────────
+// POST /a2a/jsonrpc — A2A v1.0 compliant JSON-RPC server
+
+import { Router, type Request, type Response } from "express";
+import { buildTaskPayload, deliverHook } from "../bridge.js";
+import type { Store } from "../store.js";
+import {
+  JSON_RPC_ERRORS,
+  type JsonRpcResponse,
+  type JsonRpcError,
+  type Message,
+  type MessageSendParams,
+  type TasksGetParams,
+  type TasksListParams,
+  type TasksCancelParams,
+  type Part,
+} from "../a2a-types.js";
+
+type MethodHandler = (params: Record<string, unknown>, id: string | number) => Promise<JsonRpcResponse>;
+
+function makeResponse(id: string | number, result: unknown): JsonRpcResponse {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function makeError(id: string | number, error: { code: number; message: string }, data?: unknown): JsonRpcResponse {
+  const rpcError: JsonRpcError = { code: error.code, message: error.message };
+  if (data !== undefined) {
+    rpcError.data = data;
+  }
+  return { jsonrpc: "2.0", id, error: rpcError };
+}
+
+function isValidPart(part: unknown): part is Part {
+  if (typeof part !== "object" || part === null) return false;
+  const p = part as Record<string, unknown>;
+  if (p.kind === "text") return typeof p.text === "string";
+  if (p.kind === "file") return true;
+  if (p.kind === "data") return typeof p.data === "object" && p.data !== null;
+  return false;
+}
+
+function isValidMessage(msg: unknown): msg is Message {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  if (m.kind !== "message") return false;
+  if (typeof m.messageId !== "string") return false;
+  if (m.role !== "user" && m.role !== "agent") return false;
+  if (!Array.isArray(m.parts) || m.parts.length === 0) return false;
+  return m.parts.every(isValidPart);
+}
+
+export function jsonrpcRoutes(store: Store): Router {
+  const router = Router();
+
+  const methods: Record<string, MethodHandler> = {
+    "message/send": handleMessageSend,
+    "tasks/get": handleTasksGet,
+    "tasks/list": handleTasksList,
+    "tasks/cancel": handleTasksCancel,
+  };
+
+  // POST /a2a/jsonrpc
+  router.post("/", async (req: Request, res: Response) => {
+    // Validate JSON-RPC envelope
+    const body = req.body as Record<string, unknown>;
+
+    if (body.jsonrpc !== "2.0") {
+      res.json(makeError(
+        (body.id as string | number) ?? 0,
+        JSON_RPC_ERRORS.INVALID_REQUEST,
+        { reason: "Missing or invalid jsonrpc version, must be '2.0'" },
+      ));
+      return;
+    }
+
+    if (body.id === undefined || body.id === null) {
+      res.json(makeError(0, JSON_RPC_ERRORS.INVALID_REQUEST, { reason: "Missing id" }));
+      return;
+    }
+
+    const id = body.id as string | number;
+
+    if (typeof body.method !== "string" || body.method.length === 0) {
+      res.json(makeError(id, JSON_RPC_ERRORS.INVALID_REQUEST, { reason: "Missing or invalid method" }));
+      return;
+    }
+
+    const method = body.method;
+    const handler = methods[method];
+    if (!handler) {
+      res.json(makeError(id, JSON_RPC_ERRORS.METHOD_NOT_FOUND, { method }));
+      return;
+    }
+
+    const params = (body.params ?? {}) as Record<string, unknown>;
+
+    try {
+      const result = await handler(params, id);
+      res.json(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.json(makeError(id, JSON_RPC_ERRORS.INTERNAL_ERROR, { message }));
+    }
+  });
+
+  // ── Method Handlers ────────────────────────────────────────────────────
+
+  async function handleMessageSend(params: Record<string, unknown>, id: string | number): Promise<JsonRpcResponse> {
+    const p = params as Partial<MessageSendParams>;
+
+    if (!p.agentId || typeof p.agentId !== "string") {
+      return makeError(id, JSON_RPC_ERRORS.INVALID_PARAMS, { reason: "agentId is required" });
+    }
+    if (!p.senderId || typeof p.senderId !== "string") {
+      return makeError(id, JSON_RPC_ERRORS.INVALID_PARAMS, { reason: "senderId is required" });
+    }
+    if (!p.message || !isValidMessage(p.message)) {
+      return makeError(id, JSON_RPC_ERRORS.INVALID_PARAMS, {
+        reason: "message is required and must be a valid A2A Message with kind, messageId, role, and parts",
+      });
+    }
+
+    // Validate agents exist
+    const target = store.getAgent(p.agentId);
+    if (!target) {
+      return makeError(id, JSON_RPC_ERRORS.AGENT_NOT_FOUND, { agentId: p.agentId });
+    }
+    const sender = store.getAgent(p.senderId);
+    if (!sender) {
+      return makeError(id, JSON_RPC_ERRORS.AGENT_NOT_FOUND, { agentId: p.senderId });
+    }
+
+    // Create A2A task
+    const task = store.createA2ATask(
+      p.senderId,
+      p.agentId,
+      p.message,
+      p.contextId,
+    );
+
+    // Build hook payload from the internal task and deliver
+    const internalTask = store.getTask(task.id);
+    if (internalTask) {
+      const payload = buildTaskPayload(internalTask);
+      const result = await deliverHook(target, payload);
+
+      if (!result.ok) {
+        // Revert to submitted if delivery fails
+        store.updateA2ATaskStatus(task.id, "submitted", "Delivery to agent gateway failed");
+        const updatedTask = store.getA2ATask(task.id);
+        return makeResponse(id, updatedTask);
+      }
+    }
+
+    return makeResponse(id, task);
+  }
+
+  async function handleTasksGet(params: Record<string, unknown>, id: string | number): Promise<JsonRpcResponse> {
+    const p = params as Partial<TasksGetParams>;
+
+    if (!p.taskId || typeof p.taskId !== "string") {
+      return makeError(id, JSON_RPC_ERRORS.INVALID_PARAMS, { reason: "taskId is required" });
+    }
+
+    const task = store.getA2ATask(p.taskId);
+    if (!task) {
+      return makeError(id, JSON_RPC_ERRORS.TASK_NOT_FOUND, { taskId: p.taskId });
+    }
+
+    return makeResponse(id, task);
+  }
+
+  async function handleTasksList(params: Record<string, unknown>, id: string | number): Promise<JsonRpcResponse> {
+    const p = params as Partial<TasksListParams>;
+
+    // Validate types if provided
+    if (p.limit !== undefined && (typeof p.limit !== "number" || p.limit < 0)) {
+      return makeError(id, JSON_RPC_ERRORS.INVALID_PARAMS, { reason: "limit must be a non-negative number" });
+    }
+    if (p.offset !== undefined && (typeof p.offset !== "number" || p.offset < 0)) {
+      return makeError(id, JSON_RPC_ERRORS.INVALID_PARAMS, { reason: "offset must be a non-negative number" });
+    }
+
+    const validStates = ["submitted", "working", "input-required", "completed", "failed", "canceled"];
+    if (p.status !== undefined && !validStates.includes(p.status)) {
+      return makeError(id, JSON_RPC_ERRORS.INVALID_PARAMS, { reason: `status must be one of: ${validStates.join(", ")}` });
+    }
+
+    const result = store.listA2ATasks({
+      agentId: typeof p.agentId === "string" ? p.agentId : undefined,
+      status: p.status,
+      contextId: typeof p.contextId === "string" ? p.contextId : undefined,
+      limit: p.limit,
+      offset: p.offset,
+    });
+
+    return makeResponse(id, result);
+  }
+
+  async function handleTasksCancel(params: Record<string, unknown>, id: string | number): Promise<JsonRpcResponse> {
+    const p = params as Partial<TasksCancelParams>;
+
+    if (!p.taskId || typeof p.taskId !== "string") {
+      return makeError(id, JSON_RPC_ERRORS.INVALID_PARAMS, { reason: "taskId is required" });
+    }
+
+    const task = store.getA2ATask(p.taskId);
+    if (!task) {
+      return makeError(id, JSON_RPC_ERRORS.TASK_NOT_FOUND, { taskId: p.taskId });
+    }
+
+    // Can only cancel tasks that are not already in a terminal state
+    const terminalStates = ["completed", "failed", "canceled"];
+    if (terminalStates.includes(task.status.state)) {
+      return makeError(id, JSON_RPC_ERRORS.INVALID_PARAMS, {
+        reason: `Task '${p.taskId}' is in state '${task.status.state}' and cannot be canceled`,
+      });
+    }
+
+    const updated = store.updateA2ATaskStatus(p.taskId, "canceled");
+    return makeResponse(id, updated);
+  }
+
+  return router;
+}

--- a/tools/a2a-router/src/store.ts
+++ b/tools/a2a-router/src/store.ts
@@ -4,9 +4,39 @@ import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { v4 as uuidv4 } from "uuid";
-import type { AgentCard, AgentRow, CompleteTaskRequest, Task, TaskStatus } from "./types.js";
+import type {
+  AgentCard as InternalAgentCard,
+  AgentRow,
+  CompleteTaskRequest,
+  Task as InternalTask,
+  TaskStatus as InternalTaskStatus,
+} from "./types.js";
+import type {
+  Message as A2AMessage,
+  Task as A2ATask,
+  TaskState as A2ATaskState,
+  TasksListParams,
+  TasksListResult,
+} from "./a2a-types.js";
 
 const DEFAULT_DB_PATH = `${process.env.HOME}/.openspawn/a2a/tasks.db`;
+
+// ── Internal DB row types ────────────────────────────────────────────────────
+
+interface TaskRow {
+  id: string;
+  sender_id: string;
+  target_id: string;
+  message: string;
+  status: string;
+  result: string | null;
+  context_id: string | null;
+  messages_json: string | null;
+  artifacts_json: string | null;
+  metadata_json: string | null;
+  created_at: string;
+  updated_at: string;
+}
 
 export class Store {
   private db: Database.Database;
@@ -39,17 +69,37 @@ export class Store {
         message TEXT NOT NULL,
         status TEXT NOT NULL DEFAULT 'submitted',
         result TEXT,
+        context_id TEXT,
+        messages_json TEXT,
+        artifacts_json TEXT,
+        metadata_json TEXT,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now')),
         FOREIGN KEY (sender_id) REFERENCES agents(agent_id),
         FOREIGN KEY (target_id) REFERENCES agents(agent_id)
       );
     `);
+
+    // Migration: add columns if they don't exist (for existing databases)
+    const cols = this.db.prepare("PRAGMA table_info(tasks)").all() as Array<{ name: string }>;
+    const colNames = new Set(cols.map((c) => c.name));
+    if (!colNames.has("context_id")) {
+      this.db.exec("ALTER TABLE tasks ADD COLUMN context_id TEXT");
+    }
+    if (!colNames.has("messages_json")) {
+      this.db.exec("ALTER TABLE tasks ADD COLUMN messages_json TEXT");
+    }
+    if (!colNames.has("artifacts_json")) {
+      this.db.exec("ALTER TABLE tasks ADD COLUMN artifacts_json TEXT");
+    }
+    if (!colNames.has("metadata_json")) {
+      this.db.exec("ALTER TABLE tasks ADD COLUMN metadata_json TEXT");
+    }
   }
 
   // ── Agents ───────────────────────────────────────────────────────────────
 
-  registerAgent(agent: AgentCard): AgentCard {
+  registerAgent(agent: InternalAgentCard): InternalAgentCard {
     const stmt = this.db.prepare(`
       INSERT INTO agents (agent_id, name, skills, gateway_url, gateway_token, hook_path)
       VALUES (?, ?, ?, ?, ?, ?)
@@ -67,18 +117,18 @@ export class Store {
     return result;
   }
 
-  getAgent(agentId: string): AgentCard | null {
+  getAgent(agentId: string): InternalAgentCard | null {
     const row = this.db.prepare("SELECT * FROM agents WHERE agent_id = ?").get(agentId) as AgentRow | undefined;
     if (!row) return null;
     return this.rowToAgent(row);
   }
 
-  listAgents(): AgentCard[] {
+  listAgents(): InternalAgentCard[] {
     const rows = this.db.prepare("SELECT * FROM agents ORDER BY registered_at DESC").all() as AgentRow[];
     return rows.map((r) => this.rowToAgent(r));
   }
 
-  private rowToAgent(row: AgentRow): AgentCard {
+  private rowToAgent(row: AgentRow): InternalAgentCard {
     return {
       agent_id: row.agent_id,
       name: row.name,
@@ -90,9 +140,9 @@ export class Store {
     };
   }
 
-  // ── Tasks ────────────────────────────────────────────────────────────────
+  // ── Tasks (Legacy REST interface) ────────────────────────────────────────
 
-  createTask(senderId: string, targetId: string, message: string): Task {
+  createTask(senderId: string, targetId: string, message: string): InternalTask {
     const id = uuidv4();
     this.db.prepare(`
       INSERT INTO tasks (id, sender_id, target_id, message, status)
@@ -103,20 +153,43 @@ export class Store {
     return task;
   }
 
-  getTask(taskId: string): Task | null {
-    return this.db.prepare("SELECT * FROM tasks WHERE id = ?").get(taskId) as Task | null ?? null;
+  getTask(taskId: string): InternalTask | null {
+    const row = this.db.prepare("SELECT * FROM tasks WHERE id = ?").get(taskId) as TaskRow | undefined;
+    if (!row) return null;
+    return {
+      id: row.id,
+      sender_id: row.sender_id,
+      target_id: row.target_id,
+      message: row.message,
+      status: row.status as InternalTaskStatus,
+      result: row.result,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    };
   }
 
-  listTasks(agentId?: string): Task[] {
+  listTasks(agentId?: string): InternalTask[] {
+    let rows: TaskRow[];
     if (agentId) {
-      return this.db.prepare(
+      rows = this.db.prepare(
         "SELECT * FROM tasks WHERE sender_id = ? OR target_id = ? ORDER BY created_at DESC"
-      ).all(agentId, agentId) as Task[];
+      ).all(agentId, agentId) as TaskRow[];
+    } else {
+      rows = this.db.prepare("SELECT * FROM tasks ORDER BY created_at DESC").all() as TaskRow[];
     }
-    return this.db.prepare("SELECT * FROM tasks ORDER BY created_at DESC").all() as Task[];
+    return rows.map((r) => ({
+      id: r.id,
+      sender_id: r.sender_id,
+      target_id: r.target_id,
+      message: r.message,
+      status: r.status as InternalTaskStatus,
+      result: r.result,
+      created_at: r.created_at,
+      updated_at: r.updated_at,
+    }));
   }
 
-  updateTaskStatus(taskId: string, status: TaskStatus, result?: string): Task | null {
+  updateTaskStatus(taskId: string, status: InternalTaskStatus, result?: string): InternalTask | null {
     this.db.prepare(`
       UPDATE tasks SET status = ?, result = ?, updated_at = datetime('now')
       WHERE id = ?
@@ -124,11 +197,141 @@ export class Store {
     return this.getTask(taskId);
   }
 
-  completeTask(taskId: string, req: CompleteTaskRequest): Task | null {
+  completeTask(taskId: string, req: CompleteTaskRequest): InternalTask | null {
     const task = this.getTask(taskId);
     if (!task) return null;
     if (task.target_id !== req.agentId) return null;
     return this.updateTaskStatus(taskId, req.status, req.result);
+  }
+
+  // ── A2A Tasks (JSON-RPC interface) ───────────────────────────────────────
+
+  createA2ATask(
+    senderId: string,
+    targetId: string,
+    message: A2AMessage,
+    contextId?: string,
+    metadata?: Record<string, unknown>,
+  ): A2ATask {
+    const id = uuidv4();
+    const plainText = message.parts
+      .filter((p): p is { kind: "text"; text: string } => p.kind === "text")
+      .map((p) => p.text)
+      .join("\n");
+
+    const messagesJson = JSON.stringify([message]);
+
+    this.db.prepare(`
+      INSERT INTO tasks (id, sender_id, target_id, message, status, context_id, messages_json, metadata_json)
+      VALUES (?, ?, ?, ?, 'submitted', ?, ?, ?)
+    `).run(
+      id,
+      senderId,
+      targetId,
+      plainText || "(structured message)",
+      contextId ?? null,
+      messagesJson,
+      metadata ? JSON.stringify(metadata) : null,
+    );
+
+    // Transition to working immediately
+    this.db.prepare(`
+      UPDATE tasks SET status = 'working', updated_at = datetime('now')
+      WHERE id = ?
+    `).run(id);
+
+    const task = this.getA2ATask(id);
+    if (!task) throw new Error(`Failed to create A2A task ${id}`);
+    return task;
+  }
+
+  getA2ATask(taskId: string): A2ATask | null {
+    const row = this.db.prepare("SELECT * FROM tasks WHERE id = ?").get(taskId) as TaskRow | undefined;
+    if (!row) return null;
+    return this.rowToA2ATask(row);
+  }
+
+  listA2ATasks(params: TasksListParams): TasksListResult {
+    const conditions: string[] = [];
+    const values: (string | number)[] = [];
+
+    if (params.agentId) {
+      conditions.push("(sender_id = ? OR target_id = ?)");
+      values.push(params.agentId, params.agentId);
+    }
+    if (params.status) {
+      conditions.push("status = ?");
+      values.push(params.status);
+    }
+    if (params.contextId) {
+      conditions.push("context_id = ?");
+      values.push(params.contextId);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const limit = params.limit ?? 50;
+    const offset = params.offset ?? 0;
+
+    const countRow = this.db.prepare(`SELECT COUNT(*) as cnt FROM tasks ${where}`).get(...values) as { cnt: number };
+    const total = countRow.cnt;
+
+    const rows = this.db.prepare(
+      `SELECT * FROM tasks ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`
+    ).all(...values, limit, offset) as TaskRow[];
+
+    return {
+      tasks: rows.map((r) => this.rowToA2ATask(r)),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  updateA2ATaskStatus(taskId: string, state: A2ATaskState, statusMessage?: string): A2ATask | null {
+    this.db.prepare(`
+      UPDATE tasks SET status = ?, updated_at = datetime('now')
+      WHERE id = ?
+    `).run(state, taskId);
+
+    if (statusMessage !== undefined) {
+      this.db.prepare(`UPDATE tasks SET result = ? WHERE id = ?`).run(statusMessage, taskId);
+    }
+
+    return this.getA2ATask(taskId);
+  }
+
+  appendA2AMessage(taskId: string, message: A2AMessage): A2ATask | null {
+    const row = this.db.prepare("SELECT messages_json FROM tasks WHERE id = ?").get(taskId) as { messages_json: string | null } | undefined;
+    if (!row) return null;
+
+    const messages: A2AMessage[] = row.messages_json ? JSON.parse(row.messages_json) : [];
+    messages.push(message);
+
+    this.db.prepare(`
+      UPDATE tasks SET messages_json = ?, updated_at = datetime('now')
+      WHERE id = ?
+    `).run(JSON.stringify(messages), taskId);
+
+    return this.getA2ATask(taskId);
+  }
+
+  private rowToA2ATask(row: TaskRow): A2ATask {
+    const messages: A2AMessage[] = row.messages_json ? JSON.parse(row.messages_json) : [];
+    const artifacts = row.artifacts_json ? JSON.parse(row.artifacts_json) : undefined;
+    const metadata = row.metadata_json ? JSON.parse(row.metadata_json) : undefined;
+
+    return {
+      id: row.id,
+      contextId: row.context_id ?? undefined,
+      status: {
+        state: row.status as A2ATaskState,
+        message: row.result ?? undefined,
+        timestamp: row.updated_at,
+      },
+      messages,
+      artifacts,
+      metadata,
+    };
   }
 
   close(): void {


### PR DESCRIPTION
## A2A Phase 1: Core Infrastructure

Implements A2A v1.0 compliant JSON-RPC 2.0 server with proper data model and agent discovery.

### What's New

**A2A v1.0 Data Model** (`a2a-types.ts`)
- Canonical types: AgentCard, Task, Message, Part, Artifact, TaskStatus
- JSON-RPC 2.0 request/response/error types
- All A2A TaskState values: submitted, working, input-required, completed, failed, canceled

**JSON-RPC 2.0 Server** (`routes/jsonrpc.ts`)
- `POST /a2a/jsonrpc` — single endpoint for all A2A methods
- `message/send` — send structured A2A messages, creates tasks
- `tasks/get` — retrieve task by ID with full A2A message history
- `tasks/list` — filter by agentId, status, contextId + pagination (limit/offset)
- `tasks/cancel` — cancel non-terminal tasks
- Full JSON-RPC 2.0 error handling (parse error, invalid request, method not found, etc.)

**Agent Discovery** (`routes/discovery.ts`)
- `GET /.well-known/agent.json` — platform-level AgentCard for the router
- `GET /a2a/agents/:id/card` — per-agent A2A-compliant AgentCard
- Cards built from registration data, no gateway tokens exposed

**Store Upgrades**
- A2A message storage (full Message with Parts, not just plain text)
- `context_id` column for task grouping
- Pagination support (limit, offset, total count)
- Filter support (by status, agentId, contextId)
- Backward-compatible migrations for existing databases

### Backward Compatibility
All existing REST routes preserved. JSON-RPC is additive.

### Tests
100 tests passing (57 new + 43 existing):
- JSON-RPC envelope validation (missing/invalid jsonrpc, id, method)
- All 4 methods with success + error cases
- Message validation (kind, messageId, role, parts)
- Pagination boundaries
- Terminal state cancel rejection
- Agent discovery card generation
- REST + discovery route coexistence

Closes #735, #736, #737