### PR TITLE
feat: A2A documentation + compliance test suite #743

### DIFF
--- a/docs/guides/a2a-protocol.md
+++ b/docs/guides/a2a-protocol.md
@@ -1,0 +1,676 @@
+# A2A Protocol Guide
+
+OpenSpawn uses the **Agent2Agent (A2A) protocol** for inter-agent communication. This guide covers everything you need to know to get agents talking to each other.
+
+## What is A2A?
+
+[A2A (Agent2Agent)](https://a2a-protocol.org) is an open protocol (v1.0) developed under the Linux Foundation for standardized agent-to-agent communication. It defines how agents discover each other, exchange messages, and track task lifecycle — all over JSON-RPC 2.0.
+
+Key properties:
+- **Framework agnostic** — works with any agent runtime (OpenClaw, LangChain, CrewAI, etc.)
+- **Transport agnostic** — JSON-RPC over HTTP, with optional SSE streaming
+- **Discovery built-in** — agents publish capabilities via AgentCards at well-known URLs
+
+## Why OpenSpawn Uses A2A
+
+OpenSpawn coordinates multiple AI agents. Before A2A, we used a custom REST API. A2A gives us:
+
+1. **Standard protocol** — any A2A-compliant agent can join the network
+2. **Rich task lifecycle** — submitted → working → completed/failed/canceled with proper state tracking
+3. **Structured messages** — typed parts (text, file, data) instead of raw strings
+4. **Agent discovery** — agents describe their capabilities so others know what to ask for
+5. **Push notifications** — senders get notified when tasks complete, with HMAC-signed webhooks
+
+## Architecture
+
+```
+┌─────────────────────┐                            ┌─────────────────────┐
+│   Agent A (Dennis)  │                            │  Agent B (Drinkify) │
+│     OpenClaw        │                            │     OpenClaw        │
+└────────┬────────────┘                            └────────────┬────────┘
+         │                                                      │
+         │  POST /a2a/jsonrpc                                   │
+         │  method: "message/send"                              │
+         │                                                      │
+         ▼                                                      │
+┌─────────────────────────────────────────────────────────────┐ │
+│                  OpenSpawn A2A Router                        │ │
+│                  http://127.0.0.1:3380                       │ │
+│                                                             │ │
+│  ┌─────────┐  ┌──────────┐  ┌───────────┐  ┌───────────┐  │ │
+│  │ Discovery│  │ JSON-RPC │  │ REST API  │  │  SQLite   │  │ │
+│  │ /.well-  │  │ /a2a/    │  │ /a2a/     │  │  Store    │  │ │
+│  │ known/   │  │ jsonrpc  │  │ agents/   │  │           │  │ │
+│  └─────────┘  └──────────┘  └───────────┘  └───────────┘  │ │
+└─────────────────────────────┬───────────────────────────────┘ │
+                              │                                 │
+                              │  Webhook delivery               │
+                              │  POST /hooks/ingest             │
+                              └─────────────────────────────────┘
+```
+
+## Quick Start
+
+Get two agents communicating in 5 steps. See the [A2A Quick Start](./a2a-quickstart.md) for a complete walkthrough.
+
+### 1. Start the Router
+
+```bash
+cd tools/a2a-router && npx tsx src/index.ts
+```
+
+The router starts on `http://127.0.0.1:3380` by default.
+
+### 2. Register Agents
+
+```bash
+# Register sender
+curl -s -X POST http://127.0.0.1:3380/a2a/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "dennis",
+    "name": "Dennis",
+    "gateway_url": "http://127.0.0.1:3381",
+    "skills": ["coding", "devops"]
+  }'
+
+# Register target
+curl -s -X POST http://127.0.0.1:3380/a2a/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "drinkify",
+    "name": "Drinkify",
+    "gateway_url": "http://127.0.0.1:3382",
+    "skills": ["drinks", "inventory"]
+  }'
+```
+
+### 3. Install the a2a-reporter Skill
+
+The target agent needs the `a2a-reporter` skill so it knows how to report task completion. Install it on the target agent's OpenClaw instance:
+
+```bash
+# Copy skills/a2a-reporter/ to the target agent's skills directory
+cp -r skills/a2a-reporter/ ~/.openclaw/workspace/skills/a2a-reporter/
+```
+
+### 4. Send a Message
+
+```bash
+openspawn a2a send drinkify "What are you working on?"
+```
+
+Or via the CLI with async mode:
+
+```bash
+openspawn a2a send drinkify "Deploy staging" --async
+```
+
+### 5. Check Task Status
+
+```bash
+openspawn a2a task <task-id>
+```
+
+---
+
+## JSON-RPC API Reference
+
+All JSON-RPC methods use `POST /a2a/jsonrpc` with standard JSON-RPC 2.0 envelopes.
+
+### `message/send`
+
+Send a message to an agent, creating a new task.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "message/send",
+  "params": {
+    "agentId": "drinkify",
+    "senderId": "dennis",
+    "message": {
+      "kind": "message",
+      "messageId": "msg-001",
+      "role": "user",
+      "parts": [
+        { "kind": "text", "text": "What are you working on?" }
+      ]
+    },
+    "contextId": "optional-conversation-id"
+  }
+}
+```
+
+**Response (success):**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": {
+    "id": "task-uuid",
+    "contextId": "optional-conversation-id",
+    "status": {
+      "state": "working",
+      "timestamp": "2026-03-25T12:00:00.000Z"
+    },
+    "messages": [
+      {
+        "kind": "message",
+        "messageId": "msg-001",
+        "role": "user",
+        "parts": [{ "kind": "text", "text": "What are you working on?" }]
+      }
+    ]
+  }
+}
+```
+
+**Error — agent not found:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "error": {
+    "code": -32002,
+    "message": "Agent not found",
+    "data": { "agentId": "unknown-agent" }
+  }
+}
+```
+
+### `tasks/get`
+
+Retrieve a task by ID.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "2",
+  "method": "tasks/get",
+  "params": {
+    "taskId": "task-uuid"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "2",
+  "result": {
+    "id": "task-uuid",
+    "status": {
+      "state": "completed",
+      "message": "Done",
+      "timestamp": "2026-03-25T12:05:00.000Z"
+    },
+    "messages": [...],
+    "artifacts": [
+      {
+        "parts": [{ "kind": "text", "text": "Here's what I found..." }],
+        "name": "result"
+      }
+    ]
+  }
+}
+```
+
+**Error — task not found:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "2",
+  "error": {
+    "code": -32001,
+    "message": "Task not found",
+    "data": { "taskId": "nonexistent" }
+  }
+}
+```
+
+### `tasks/list`
+
+List tasks with optional filters and pagination.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "3",
+  "method": "tasks/list",
+  "params": {
+    "agentId": "drinkify",
+    "status": "completed",
+    "contextId": "optional-filter",
+    "limit": 10,
+    "offset": 0
+  }
+}
+```
+
+All params are optional. Defaults: `limit=50`, `offset=0`.
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "3",
+  "result": {
+    "tasks": [...],
+    "total": 42,
+    "limit": 10,
+    "offset": 0
+  }
+}
+```
+
+### `tasks/cancel`
+
+Cancel a task that is not yet in a terminal state.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "4",
+  "method": "tasks/cancel",
+  "params": {
+    "taskId": "task-uuid"
+  }
+}
+```
+
+**Response (success):**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "4",
+  "result": {
+    "id": "task-uuid",
+    "status": {
+      "state": "canceled",
+      "timestamp": "2026-03-25T12:10:00.000Z"
+    },
+    "messages": [...]
+  }
+}
+```
+
+**Error — task in terminal state:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "4",
+  "error": {
+    "code": -32602,
+    "message": "Invalid params",
+    "data": { "reason": "Task 'task-uuid' is in state 'completed' and cannot be canceled" }
+  }
+}
+```
+
+### JSON-RPC Error Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| `-32700` | Parse error | Invalid JSON |
+| `-32600` | Invalid Request | Missing jsonrpc version or id |
+| `-32601` | Method not found | Unknown method name |
+| `-32602` | Invalid params | Missing or invalid parameters |
+| `-32603` | Internal error | Server-side error |
+| `-32001` | Task not found | Referenced task doesn't exist |
+| `-32002` | Agent not found | Referenced agent not registered |
+
+---
+
+## REST API Reference (Backward Compatibility)
+
+The REST API predates the JSON-RPC endpoint. Both work; JSON-RPC is preferred for new integrations.
+
+### Agents
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST /a2a/agents` | Register an agent | Body: `{ agentId, name, gateway_url, skills?, gateway_token?, hook_path? }` |
+| `GET /a2a/agents` | List all agents | Returns array of agent objects |
+| `GET /a2a/agents/:id` | Get agent by ID | Returns agent or 404 |
+
+**Register agent:**
+```bash
+curl -s -X POST http://127.0.0.1:3380/a2a/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "dennis",
+    "name": "Dennis",
+    "gateway_url": "http://127.0.0.1:3381",
+    "gateway_token": "optional-secret",
+    "hook_path": "/hooks/ingest",
+    "skills": ["coding", "devops"]
+  }'
+```
+
+### Messages
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST /a2a/message/send` | Send a message (creates task) | Body: `{ agentId, senderId, message }` |
+
+```bash
+curl -s -X POST http://127.0.0.1:3380/a2a/message/send \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "drinkify",
+    "senderId": "dennis",
+    "message": "What are you working on?"
+  }'
+```
+
+### Tasks
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET /a2a/tasks` | List tasks | Optional query: `?agentId=<id>` |
+| `GET /a2a/tasks/:id` | Get task by ID | Returns task or 404 |
+| `POST /a2a/tasks/:id/complete` | Report completion | Body: `{ agentId, status, result }` |
+
+**Complete a task:**
+```bash
+curl -s -X POST http://127.0.0.1:3380/a2a/tasks/<task-id>/complete \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "drinkify",
+    "status": "completed",
+    "result": "Staging deployed successfully"
+  }'
+```
+
+### Health Check
+
+```bash
+curl http://127.0.0.1:3380/health
+# → { "status": "ok", "service": "a2a-router", "version": "0.2.0" }
+```
+
+---
+
+## Agent Discovery
+
+A2A uses well-known URLs for agent discovery.
+
+### Platform-Level Discovery
+
+```
+GET /.well-known/agent.json
+```
+
+Returns the router's AgentCard describing the platform's capabilities:
+
+```json
+{
+  "name": "OpenSpawn A2A Router",
+  "description": "Multi-agent coordination router for OpenSpawn",
+  "protocolVersion": "1.0.0",
+  "version": "0.2.0",
+  "url": "http://127.0.0.1:3380/a2a/jsonrpc",
+  "skills": [
+    { "id": "routing", "name": "Agent Routing", "description": "Route messages between registered agents" },
+    { "id": "task-management", "name": "Task Management", "description": "Track task lifecycle across agents" }
+  ],
+  "capabilities": { "pushNotifications": false, "streaming": false },
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"]
+}
+```
+
+### Per-Agent Discovery
+
+```
+GET /a2a/agents/:id/card
+```
+
+Returns an individual agent's AgentCard:
+
+```json
+{
+  "name": "Drinkify",
+  "description": "Agent drinkify registered with OpenSpawn",
+  "protocolVersion": "1.0.0",
+  "version": "1.0.0",
+  "url": "http://127.0.0.1:3380/a2a/agents/drinkify/jsonrpc",
+  "skills": [
+    { "id": "drinks", "name": "Drinks" },
+    { "id": "inventory", "name": "Inventory" }
+  ],
+  "capabilities": { "pushNotifications": false, "streaming": false },
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"]
+}
+```
+
+---
+
+## AgentCard Schema
+
+The AgentCard is the A2A discovery document. Full schema:
+
+```typescript
+interface AgentCard {
+  name: string;                      // Human-readable agent name
+  description: string;               // What the agent does
+  protocolVersion: "1.0.0";          // A2A protocol version
+  version: string;                   // Agent/router version
+  url: string;                       // JSON-RPC endpoint URL
+  skills: AgentSkill[];              // What the agent can do
+  capabilities: AgentCapabilities;   // Protocol features supported
+  defaultInputModes: string[];       // e.g. ["text", "file"]
+  defaultOutputModes: string[];      // e.g. ["text"]
+  authentication?: AuthenticationInfo;
+  additionalInterfaces?: AdditionalInterface[];
+}
+
+interface AgentSkill {
+  id: string;                        // Unique skill identifier
+  name: string;                      // Human-readable name
+  description?: string;              // What this skill does
+  tags?: string[];                   // Searchable tags
+}
+
+interface AgentCapabilities {
+  pushNotifications: boolean;        // Can receive push notifications
+  streaming: boolean;                // Supports SSE streaming
+}
+```
+
+---
+
+## Task Lifecycle
+
+Tasks follow a strict state machine:
+
+```
+                    ┌──────────────┐
+                    │  submitted   │
+                    └──────┬───────┘
+                           │
+                    ┌──────▼───────┐
+              ┌─────│   working    │─────┐
+              │     └──────┬───────┘     │
+              │            │             │
+       ┌──────▼──────┐    │    ┌────────▼────────┐
+       │   canceled   │    │    │     failed      │
+       └─────────────┘    │    └─────────────────┘
+                   ┌──────▼───────┐
+                   │  completed   │
+                   └──────────────┘
+```
+
+| State | Description |
+|-------|-------------|
+| `submitted` | Task created, pending delivery to target agent |
+| `working` | Target agent received the task and is processing |
+| `input-required` | Target agent needs more info from sender |
+| `completed` | Task finished successfully |
+| `failed` | Task failed |
+| `canceled` | Task canceled before completion |
+
+**Terminal states:** `completed`, `failed`, `canceled` — no further transitions allowed.
+
+---
+
+## Push Notifications
+
+When a task reaches a terminal state (`completed` or `failed`), the router notifies the sender agent via webhook.
+
+### How It Works
+
+1. Task completes → router builds a result payload
+2. Router POSTs to `{sender.gateway_url}{sender.hook_path}` (default: `/hooks/ingest`)
+3. If the sender has a `gateway_token`, the request includes:
+   - `Authorization: Bearer <token>`
+   - `X-A2A-Signature: sha256=<hmac>`
+
+### HMAC Signing
+
+The signature is computed as:
+```
+HMAC-SHA256(gateway_token, JSON.stringify(payload))
+```
+
+Verify on the receiving end:
+```typescript
+import { createHmac } from "crypto";
+const expected = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+if (signature !== expected) reject();
+```
+
+### Retry Policy
+
+| Attempt | Delay |
+|---------|-------|
+| 1st | Immediate |
+| 2nd | 1 second |
+| 3rd | 5 seconds |
+| 4th (final) | 15 seconds |
+
+After 3 retries, the notification is marked as failed. Task status is unaffected — the task is still completed/failed regardless of notification delivery.
+
+Notification attempts are logged in the SQLite store for debugging.
+
+---
+
+## a2a-reporter Skill
+
+The `a2a-reporter` skill teaches agents how to report task completion back to the router.
+
+### How It Works
+
+1. When an agent receives a message containing `[a2a:task:<uuid>]`, it knows this is an A2A task
+2. The agent processes the request normally
+3. On completion, the agent calls:
+
+```bash
+curl -s -X POST http://127.0.0.1:3380/a2a/tasks/<task-id>/complete \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"YOUR_AGENT_ID","status":"completed","result":"Summary of what happened"}'
+```
+
+4. On failure:
+
+```bash
+curl -s -X POST http://127.0.0.1:3380/a2a/tasks/<task-id>/complete \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"YOUR_AGENT_ID","status":"failed","result":"What went wrong"}'
+```
+
+### Installation
+
+Copy the skill to the agent's skills directory:
+```bash
+cp -r skills/a2a-reporter/ ~/.openclaw/workspace/skills/a2a-reporter/
+```
+
+The skill is located at `skills/a2a-reporter/SKILL.md` in the OpenSpawn repo.
+
+---
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `A2A_PORT` | `3380` | Router listen port |
+| `A2A_DB_PATH` | `~/.openspawn/a2a/tasks.db` | SQLite database path |
+| `A2A_BASE_URL` | `http://127.0.0.1:3380` | Base URL for discovery cards |
+| `A2A_URL` | `http://127.0.0.1:3380` | CLI: router URL |
+
+### Agent Registration Fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `agentId` | ✅ | — | Unique agent identifier |
+| `name` | ✅ | — | Human-readable name |
+| `gateway_url` | ✅ | — | Agent's OpenClaw gateway URL |
+| `skills` | ❌ | `[]` | List of skill names |
+| `gateway_token` | ❌ | — | Secret for HMAC-signed webhooks |
+| `hook_path` | ❌ | `/hooks/ingest` | Webhook path on agent's gateway |
+
+---
+
+## Troubleshooting
+
+### Router won't start
+
+```
+Error: SQLITE_CANTOPEN
+```
+The database directory doesn't exist. Create it:
+```bash
+mkdir -p ~/.openspawn/a2a/
+```
+
+### "Cannot reach A2A router"
+
+The CLI can't connect to the router. Check:
+1. Is the router running? `curl http://127.0.0.1:3380/health`
+2. Is `A2A_URL` set correctly?
+3. Is the port blocked by a firewall?
+
+### Message delivery fails (502)
+
+The router can't reach the target agent's gateway. Check:
+1. Is the target agent's OpenClaw gateway running?
+2. Is `gateway_url` correct in the agent registration?
+3. Can the router reach the gateway? `curl <gateway_url>/health`
+
+### Task stays in "submitted"
+
+The webhook delivery to the target agent failed. Check:
+1. Target agent's gateway is running
+2. `hook_path` is correct (default: `/hooks/ingest`)
+3. Check router logs for delivery errors
+
+### Agent not found
+
+The agent isn't registered. Register it first:
+```bash
+curl -s http://127.0.0.1:3380/a2a/agents | jq '.[].agent_id'
+```
+
+### HMAC signature mismatch
+
+Ensure the `gateway_token` used during registration matches the token the agent uses to verify incoming webhooks. The signature is `HMAC-SHA256(token, raw_body)`.
+
+### Compliance testing
+
+Run the built-in compliance test to verify your A2A endpoint:
+```bash
+openspawn a2a test                    # Test default router
+openspawn a2a test http://remote:3380 # Test remote endpoint
+openspawn a2a test --self             # Alias for default
+```

--- a/docs/guides/a2a-quickstart.md
+++ b/docs/guides/a2a-quickstart.md
@@ -1,0 +1,166 @@
+# A2A Quick Start
+
+Get two agents talking in 5 minutes.
+
+## Prerequisites
+
+- Node.js 20+
+- OpenSpawn CLI installed (`npm i -g openspawn`)
+- Two OpenClaw agent instances (or one for testing)
+
+## 1. Start the Router
+
+```bash
+cd tools/a2a-router
+npx tsx src/index.ts
+```
+
+You should see:
+```
+🔄 A2A Router listening on http://127.0.0.1:3380
+   Health: http://127.0.0.1:3380/health
+   JSON-RPC: http://127.0.0.1:3380/a2a/jsonrpc
+   Discovery: http://127.0.0.1:3380/.well-known/agent.json
+```
+
+## 2. Register Your Agents
+
+Register the sender:
+```bash
+curl -s -X POST http://127.0.0.1:3380/a2a/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "dennis",
+    "name": "Dennis",
+    "gateway_url": "http://127.0.0.1:3381",
+    "skills": ["coding", "devops"]
+  }' | jq .
+```
+
+Register the target:
+```bash
+curl -s -X POST http://127.0.0.1:3380/a2a/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "drinkify",
+    "name": "Drinkify",
+    "gateway_url": "http://127.0.0.1:3382",
+    "skills": ["drinks", "inventory"]
+  }' | jq .
+```
+
+Verify they're registered:
+```bash
+openspawn a2a agents
+```
+
+## 3. Install the Reporter Skill
+
+The target agent needs to know how to report results. Copy the `a2a-reporter` skill:
+
+```bash
+cp -r skills/a2a-reporter/ ~/.openclaw/workspace/skills/a2a-reporter/
+```
+
+This teaches the agent to call back the router when it finishes a task.
+
+## 4. Send a Message
+
+```bash
+openspawn a2a send drinkify "What are you working on?"
+```
+
+The CLI will:
+1. Create a task on the router
+2. Router delivers it to drinkify's gateway
+3. Poll until drinkify reports back
+
+For fire-and-forget:
+```bash
+openspawn a2a send drinkify "Deploy staging" --async
+# → 📤 Task created: abc-123
+#    Use: openspawn a2a task abc-123
+```
+
+## 5. Check the Result
+
+```bash
+openspawn a2a task <task-id>
+```
+
+Output:
+```
+✅ Task abc-123
+
+  Status:  completed
+  From:    dennis
+  To:      drinkify
+  Created: 2026-03-25T12:00:00.000Z
+
+  Message: What are you working on?
+
+  Result: Currently working on inventory sync and the new cocktail recommendation engine.
+```
+
+## Using the JSON-RPC API Directly
+
+If you prefer raw API calls over the CLI:
+
+```bash
+# Send a message
+curl -s -X POST http://127.0.0.1:3380/a2a/jsonrpc \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/send",
+    "params": {
+      "agentId": "drinkify",
+      "senderId": "dennis",
+      "message": {
+        "kind": "message",
+        "messageId": "msg-001",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "What are you working on?"}]
+      }
+    }
+  }' | jq .
+
+# Get task status
+curl -s -X POST http://127.0.0.1:3380/a2a/jsonrpc \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "tasks/get",
+    "params": {"taskId": "TASK_ID_HERE"}
+  }' | jq .
+```
+
+## Verify Compliance
+
+Test that the router is A2A v1.0 compliant:
+
+```bash
+openspawn a2a test
+```
+
+```
+A2A Compliance Test — http://127.0.0.1:3380
+✅ Agent discovery (/.well-known/agent.json)
+✅ message/send — creates task
+✅ tasks/get — retrieves task
+✅ tasks/list — pagination works
+✅ tasks/cancel — cancels task
+✅ Error handling — invalid JSON
+✅ Error handling — unknown method
+✅ Error handling — missing params
+
+8/8 tests passed — A2A v1.0 compliant ✓
+```
+
+## Next Steps
+
+- Read the [full A2A Protocol Guide](./a2a-protocol.md) for the complete API reference
+- Set up push notifications with `gateway_token` for HMAC-signed webhooks
+- Explore agent discovery at `/.well-known/agent.json`

--- a/packages/openspawn/src/cli/commands/a2a.test.ts
+++ b/packages/openspawn/src/cli/commands/a2a.test.ts
@@ -34,6 +34,20 @@ describe("a2a CLI", () => {
       const output = logs.join("\n");
       expect(output).toContain("openspawn a2a");
     });
+
+    it("includes test subcommand in help", async () => {
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (msg: string) => logs.push(msg);
+
+      const { a2aCommand } = await import("./a2a.js");
+      await a2aCommand([]);
+
+      console.log = origLog;
+      const output = logs.join("\n");
+      expect(output).toContain("test");
+      expect(output).toContain("compliance");
+    });
   });
 
   describe("register subcommand", () => {
@@ -74,6 +88,94 @@ describe("a2a CLI", () => {
       process.exit = origExit;
 
       expect(errors.some((e) => e.includes("Unknown a2a subcommand"))).toBe(true);
+    });
+  });
+
+  describe("test subcommand", () => {
+    it("exits with error when router is not running", async () => {
+      const errors: string[] = [];
+      const logs: string[] = [];
+      const origError = console.error;
+      const origLog = console.log;
+      const origExit = process.exit;
+      console.error = (msg: string) => errors.push(msg);
+      console.log = (msg: string) => logs.push(msg);
+      process.exit = ((code?: number) => { throw new Error(`exit:${code}`); }) as never;
+
+      // Override A2A_URL to a port that's definitely not running
+      const origEnv = process.env.A2A_URL;
+      process.env.A2A_URL = "http://127.0.0.1:19876";
+
+      // Dynamic import to pick up env change
+      const mod = await import("./a2a.js");
+      try {
+        await mod.a2aCommand(["test", "http://127.0.0.1:19876"]);
+      } catch {
+        // expected — either process.exit or fetch error
+      }
+
+      console.error = origError;
+      console.log = origLog;
+      process.exit = origExit;
+      if (origEnv !== undefined) {
+        process.env.A2A_URL = origEnv;
+      } else {
+        delete process.env.A2A_URL;
+      }
+
+      // Should show compliance test header or error about router
+      const allOutput = [...logs, ...errors].join("\n");
+      expect(allOutput).toMatch(/A2A Compliance Test|Cannot reach|Could not register/);
+    });
+
+    it("accepts --self flag", async () => {
+      const logs: string[] = [];
+      const errors: string[] = [];
+      const origLog = console.log;
+      const origError = console.error;
+      const origExit = process.exit;
+      console.log = (msg: string) => logs.push(msg);
+      console.error = (msg: string) => errors.push(msg);
+      process.exit = ((code?: number) => { throw new Error(`exit:${code}`); }) as never;
+
+      const { a2aCommand } = await import("./a2a.js");
+      try {
+        await a2aCommand(["test", "--self"]);
+      } catch {
+        // expected
+      }
+
+      console.log = origLog;
+      console.error = origError;
+      process.exit = origExit;
+
+      const allOutput = [...logs, ...errors].join("\n");
+      expect(allOutput).toMatch(/A2A Compliance Test|Cannot reach|Could not register/);
+    });
+
+    it("accepts a custom URL argument", async () => {
+      const logs: string[] = [];
+      const errors: string[] = [];
+      const origLog = console.log;
+      const origError = console.error;
+      const origExit = process.exit;
+      console.log = (msg: string) => logs.push(msg);
+      console.error = (msg: string) => errors.push(msg);
+      process.exit = ((code?: number) => { throw new Error(`exit:${code}`); }) as never;
+
+      const { a2aCommand } = await import("./a2a.js");
+      try {
+        await a2aCommand(["test", "http://127.0.0.1:19877"]);
+      } catch {
+        // expected — router not running
+      }
+
+      console.log = origLog;
+      console.error = origError;
+      process.exit = origExit;
+
+      const allOutput = [...logs, ...errors].join("\n");
+      expect(allOutput).toContain("http://127.0.0.1:19877");
     });
   });
 });

--- a/packages/openspawn/src/cli/commands/a2a.ts
+++ b/packages/openspawn/src/cli/commands/a2a.ts
@@ -12,6 +12,8 @@ Usage:
   openspawn a2a tasks                                  List all tasks
   openspawn a2a task <task-id>                         Get task status + result
   openspawn a2a register                               Register this agent
+  openspawn a2a test [url]                             Test A2A endpoint compliance
+  openspawn a2a test --self                            Test own router
 
 Options:
   --async          Return task ID immediately (don't wait for completion)
@@ -23,6 +25,8 @@ Examples:
   openspawn a2a send drinkify "Deploy staging" --async
   openspawn a2a agents
   openspawn a2a task abc-123
+  openspawn a2a test
+  openspawn a2a test http://remote-host:3380
 `.trim();
 
 async function fetchJson(path: string, init?: RequestInit): Promise<{ status: number; body: unknown }> {
@@ -219,6 +223,256 @@ async function taskCommand(args: string[]): Promise<void> {
   console.log();
 }
 
+// ── Compliance Test Command ────────────────────────────────────────────────
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  detail?: string;
+}
+
+async function testCommand(args: string[]): Promise<void> {
+  const isSelf = hasFlag(args, "--self");
+  const positionalUrl = args.find((a) => !a.startsWith("--"));
+  const baseUrl = positionalUrl ?? (isSelf ? A2A_BASE : A2A_BASE);
+
+  console.log(`\nA2A Compliance Test — ${baseUrl}\n`);
+
+  const results: TestResult[] = [];
+
+  // Helper to run a test and collect results
+  async function runTest(name: string, fn: () => Promise<{ passed: boolean; detail?: string }>): Promise<void> {
+    try {
+      const result = await fn();
+      results.push({ name, ...result });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      results.push({ name, passed: false, detail: message });
+    }
+  }
+
+  // We need two test agents for the compliance tests.
+  // Register them temporarily, run tests, then clean up by ignoring errors.
+  const testSenderId = `__a2a_test_sender_${Date.now()}`;
+  const testAgentId = `__a2a_test_target_${Date.now()}`;
+
+  // Register test agents (best effort — they may already exist in some form)
+  async function registerTestAgents(): Promise<boolean> {
+    try {
+      const senderRes = await fetch(`${baseUrl}/a2a/agents`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testSenderId,
+          name: "Test Sender",
+          gateway_url: "http://127.0.0.1:19999",
+          skills: ["test"],
+        }),
+      });
+      const targetRes = await fetch(`${baseUrl}/a2a/agents`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testAgentId,
+          name: "Test Target",
+          gateway_url: "http://127.0.0.1:19998",
+          skills: ["test"],
+        }),
+      });
+      return senderRes.status === 201 && targetRes.status === 201;
+    } catch {
+      return false;
+    }
+  }
+
+  const agentsReady = await registerTestAgents();
+  if (!agentsReady) {
+    console.error("❌ Could not register test agents. Is the router running?");
+    process.exit(1);
+  }
+
+  let createdTaskId: string | undefined;
+
+  // 1. Agent discovery
+  await runTest("Agent discovery (/.well-known/agent.json)", async () => {
+    const res = await fetch(`${baseUrl}/.well-known/agent.json`);
+    if (!res.ok) return { passed: false, detail: `HTTP ${res.status}` };
+    const card = (await res.json()) as Record<string, unknown>;
+    if (card.protocolVersion !== "1.0.0") return { passed: false, detail: `protocolVersion: ${String(card.protocolVersion)}` };
+    if (typeof card.name !== "string") return { passed: false, detail: "missing name" };
+    if (typeof card.url !== "string") return { passed: false, detail: "missing url" };
+    if (!Array.isArray(card.skills)) return { passed: false, detail: "missing skills array" };
+    return { passed: true };
+  });
+
+  // 2. message/send
+  await runTest("message/send — creates task", async () => {
+    const res = await fetch(`${baseUrl}/a2a/jsonrpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "test-1",
+        method: "message/send",
+        params: {
+          agentId: testAgentId,
+          senderId: testSenderId,
+          message: {
+            kind: "message",
+            messageId: `test-msg-${Date.now()}`,
+            role: "user",
+            parts: [{ kind: "text", text: "A2A compliance test message" }],
+          },
+        },
+      }),
+    });
+    if (!res.ok) return { passed: false, detail: `HTTP ${res.status}` };
+    const body = (await res.json()) as Record<string, unknown>;
+    if (body.error) return { passed: false, detail: JSON.stringify(body.error) };
+    const result = body.result as Record<string, unknown> | undefined;
+    if (!result?.id) return { passed: false, detail: "no task id in result" };
+    createdTaskId = result.id as string;
+    return { passed: true };
+  });
+
+  // 3. tasks/get
+  await runTest("tasks/get — retrieves task", async () => {
+    if (!createdTaskId) return { passed: false, detail: "no task created in previous step" };
+    const res = await fetch(`${baseUrl}/a2a/jsonrpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "test-2",
+        method: "tasks/get",
+        params: { taskId: createdTaskId },
+      }),
+    });
+    if (!res.ok) return { passed: false, detail: `HTTP ${res.status}` };
+    const body = (await res.json()) as Record<string, unknown>;
+    if (body.error) return { passed: false, detail: JSON.stringify(body.error) };
+    const result = body.result as Record<string, unknown> | undefined;
+    if (result?.id !== createdTaskId) return { passed: false, detail: "task id mismatch" };
+    return { passed: true };
+  });
+
+  // 4. tasks/list
+  await runTest("tasks/list — pagination works", async () => {
+    const res = await fetch(`${baseUrl}/a2a/jsonrpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "test-3",
+        method: "tasks/list",
+        params: { limit: 5, offset: 0 },
+      }),
+    });
+    if (!res.ok) return { passed: false, detail: `HTTP ${res.status}` };
+    const body = (await res.json()) as Record<string, unknown>;
+    if (body.error) return { passed: false, detail: JSON.stringify(body.error) };
+    const result = body.result as Record<string, unknown> | undefined;
+    if (!Array.isArray(result?.tasks)) return { passed: false, detail: "result.tasks is not an array" };
+    if (typeof result?.total !== "number") return { passed: false, detail: "result.total missing" };
+    if (typeof result?.limit !== "number") return { passed: false, detail: "result.limit missing" };
+    if (typeof result?.offset !== "number") return { passed: false, detail: "result.offset missing" };
+    return { passed: true };
+  });
+
+  // 5. tasks/cancel
+  await runTest("tasks/cancel — cancels task", async () => {
+    if (!createdTaskId) return { passed: false, detail: "no task created" };
+    const res = await fetch(`${baseUrl}/a2a/jsonrpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "test-4",
+        method: "tasks/cancel",
+        params: { taskId: createdTaskId },
+      }),
+    });
+    if (!res.ok) return { passed: false, detail: `HTTP ${res.status}` };
+    const body = (await res.json()) as Record<string, unknown>;
+    if (body.error) return { passed: false, detail: JSON.stringify(body.error) };
+    const result = body.result as Record<string, unknown> | undefined;
+    const status = result?.status as Record<string, unknown> | undefined;
+    if (status?.state !== "canceled") return { passed: false, detail: `state: ${String(status?.state)}` };
+    return { passed: true };
+  });
+
+  // 6. Error handling — invalid JSON
+  await runTest("Error handling — invalid JSON", async () => {
+    const res = await fetch(`${baseUrl}/a2a/jsonrpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{ not valid json",
+    });
+    // The server may return 400 for parse errors, which is acceptable
+    const body = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (body?.error) {
+      const err = body.error as Record<string, unknown>;
+      if (err.code === -32700) return { passed: true };
+    }
+    // Some implementations return 400 status without JSON-RPC error body
+    if (res.status === 400) return { passed: true };
+    return { passed: false, detail: `Expected parse error, got HTTP ${res.status}` };
+  });
+
+  // 7. Error handling — unknown method
+  await runTest("Error handling — unknown method", async () => {
+    const res = await fetch(`${baseUrl}/a2a/jsonrpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "test-5",
+        method: "nonexistent/method",
+        params: {},
+      }),
+    });
+    if (!res.ok && res.status !== 200) {
+      // Some servers return 200 with error in body, some return 404
+      return { passed: false, detail: `HTTP ${res.status}` };
+    }
+    const body = (await res.json()) as Record<string, unknown>;
+    const err = body.error as Record<string, unknown> | undefined;
+    if (err?.code !== -32601) return { passed: false, detail: `Expected -32601, got ${String(err?.code)}` };
+    return { passed: true };
+  });
+
+  // 8. Error handling — missing params
+  await runTest("Error handling — missing params", async () => {
+    const res = await fetch(`${baseUrl}/a2a/jsonrpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "test-6",
+        method: "message/send",
+        params: {},
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    const err = body.error as Record<string, unknown> | undefined;
+    if (err?.code !== -32602) return { passed: false, detail: `Expected -32602, got ${String(err?.code)}` };
+    return { passed: true };
+  });
+
+  // Print results
+  let passed = 0;
+  const total = results.length;
+  for (const r of results) {
+    const icon = r.passed ? "✅" : "❌";
+    const detail = r.detail && !r.passed ? ` (${r.detail})` : "";
+    console.log(`${icon} ${r.name}${detail}`);
+    if (r.passed) passed++;
+  }
+
+  console.log(`\n${passed}/${total} tests passed${passed === total ? " — A2A v1.0 compliant ✓" : ""}`);
+  if (passed < total) process.exit(1);
+}
+
 async function registerCommand(): Promise<void> {
   // Default: register as dennis
   console.log("⚠️  Registration requires agent config. Use the API directly:");
@@ -248,6 +502,8 @@ export async function a2aCommand(args: string[]): Promise<void> {
         return await taskCommand(rest);
       case "register":
         return await registerCommand();
+      case "test":
+        return await testCommand(rest);
       default:
         console.error(`Unknown a2a subcommand: ${sub}`);
         console.log(A2A_HELP);


### PR DESCRIPTION
## What

Full A2A guide, quickstart tutorial, and `openspawn a2a test` CLI command for compliance testing.

### Files
- `docs/guides/a2a-protocol.md` — Comprehensive A2A protocol guide covering architecture, JSON-RPC API, REST API, discovery, task lifecycle, push notifications, configuration, troubleshooting
- `docs/guides/a2a-quickstart.md` — 5-minute quick start tutorial
- `packages/openspawn/src/cli/commands/a2a.ts` — Added `test` subcommand with 8 compliance checks
- `packages/openspawn/src/cli/commands/a2a.test.ts` — Tests for the test subcommand

### Compliance Tests (8/8)
- Agent discovery (`/.well-known/agent.json`)
- `message/send` — creates task
- `tasks/get` — retrieves task
- `tasks/list` — pagination works
- `tasks/cancel` — cancels task
- Error handling — invalid JSON
- Error handling — unknown method
- Error handling — missing params

### Verification
- ✅ Lint clean (`pnpm nx run openspawn:lint -- --max-warnings 0`)
- ✅ All 126 tests pass (`npx vitest run`)

Closes #743