### PR TITLE
feat: A2A SSE streaming for real-time task updates #738

### DIFF
--- a/tools/a2a-router/src/__tests__/events.test.ts
+++ b/tools/a2a-router/src/__tests__/events.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+import { taskEventBus, type TaskEvent } from "../events.js";
+
+describe("TaskEventBus", () => {
+  it("emits and receives task updates", () => {
+    const listener = vi.fn();
+    const taskId = "test-task-1";
+
+    taskEventBus.onTaskUpdate(taskId, listener);
+
+    const event: TaskEvent = {
+      taskId,
+      kind: "status-update",
+      status: { state: "working", timestamp: new Date().toISOString() },
+    };
+
+    taskEventBus.emitTaskUpdate(event);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(event);
+
+    taskEventBus.offTaskUpdate(taskId, listener);
+  });
+
+  it("does not emit to unrelated task listeners", () => {
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
+
+    taskEventBus.onTaskUpdate("task-a", listener1);
+    taskEventBus.onTaskUpdate("task-b", listener2);
+
+    taskEventBus.emitTaskUpdate({
+      taskId: "task-a",
+      kind: "status-update",
+      status: { state: "completed", timestamp: new Date().toISOString() },
+    });
+
+    expect(listener1).toHaveBeenCalledOnce();
+    expect(listener2).not.toHaveBeenCalled();
+
+    taskEventBus.offTaskUpdate("task-a", listener1);
+    taskEventBus.offTaskUpdate("task-b", listener2);
+  });
+
+  it("removes listeners with offTaskUpdate", () => {
+    const listener = vi.fn();
+    const taskId = "test-task-remove";
+
+    taskEventBus.onTaskUpdate(taskId, listener);
+    taskEventBus.offTaskUpdate(taskId, listener);
+
+    taskEventBus.emitTaskUpdate({
+      taskId,
+      kind: "status-update",
+      status: { state: "working", timestamp: new Date().toISOString() },
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("supports artifact-update events", () => {
+    const listener = vi.fn();
+    const taskId = "test-task-artifact";
+
+    taskEventBus.onTaskUpdate(taskId, listener);
+
+    const event: TaskEvent = {
+      taskId,
+      kind: "artifact-update",
+      artifact: { parts: [{ kind: "text", text: "Hello world" }] },
+    };
+
+    taskEventBus.emitTaskUpdate(event);
+
+    expect(listener).toHaveBeenCalledWith(event);
+    expect(listener.mock.calls[0][0].kind).toBe("artifact-update");
+
+    taskEventBus.offTaskUpdate(taskId, listener);
+  });
+
+  it("supports multiple listeners on the same task", () => {
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
+    const taskId = "test-task-multi";
+
+    taskEventBus.onTaskUpdate(taskId, listener1);
+    taskEventBus.onTaskUpdate(taskId, listener2);
+
+    taskEventBus.emitTaskUpdate({
+      taskId,
+      kind: "status-update",
+      status: { state: "working", timestamp: new Date().toISOString() },
+    });
+
+    expect(listener1).toHaveBeenCalledOnce();
+    expect(listener2).toHaveBeenCalledOnce();
+
+    taskEventBus.offTaskUpdate(taskId, listener1);
+    taskEventBus.offTaskUpdate(taskId, listener2);
+  });
+});

--- a/tools/a2a-router/src/__tests__/stream.test.ts
+++ b/tools/a2a-router/src/__tests__/stream.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import request from "supertest";
+import http from "node:http";
+import { createApp } from "../index.js";
+import { Store } from "../store.js";
+// Event bus is accessed through store.events (shared instance)
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Express } from "express";
+
+// Mock fetch for bridge delivery
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function makeStreamPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    jsonrpc: "2.0",
+    id: "stream-1",
+    method: "message/stream",
+    params: {
+      agentId: "drinkify",
+      senderId: "dennis",
+      message: {
+        kind: "message",
+        messageId: "msg-1",
+        role: "user",
+        parts: [{ kind: "text", text: "Hello streaming" }],
+      },
+      ...overrides,
+    },
+  };
+}
+
+function parseSSEEvents(raw: string): Array<{ event: string; data: unknown }> {
+  const events: Array<{ event: string; data: unknown }> = [];
+  let currentEvent = "";
+  for (const line of raw.split("\n")) {
+    if (line.startsWith("event: ")) {
+      currentEvent = line.slice(7);
+    } else if (line.startsWith("data: ")) {
+      try {
+        events.push({ event: currentEvent, data: JSON.parse(line.slice(6)) });
+      } catch {
+        // ignore
+      }
+    }
+  }
+  return events;
+}
+
+/** Collect SSE chunks from a raw HTTP request until connection closes or timeout */
+function collectSSE(
+  server: http.Server,
+  payload: unknown,
+  opts: { timeoutMs?: number } = {},
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; chunks: string[]; events: Array<{ event: string; data: unknown }> }> {
+  const { timeoutMs = 5000 } = opts;
+  return new Promise((resolve) => {
+    const addr = server.address() as { port: number };
+    const body = JSON.stringify(payload);
+    const chunks: string[] = [];
+    let resolved = false;
+
+    function finish(status: number, headers: http.IncomingHttpHeaders) {
+      if (resolved) return;
+      resolved = true;
+      const full = chunks.join("");
+      resolve({ status, headers, chunks, events: parseSSEEvents(full) });
+    }
+
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: addr.port,
+        path: "/a2a/stream",
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(body) },
+      },
+      (res) => {
+        const timer = setTimeout(() => {
+          req.destroy();
+          finish(res.statusCode ?? 0, res.headers);
+        }, timeoutMs);
+
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => {
+          chunks.push(chunk);
+        });
+        res.on("end", () => {
+          clearTimeout(timer);
+          finish(res.statusCode ?? 0, res.headers);
+        });
+      },
+    );
+    req.on("error", () => {
+      finish(0, {});
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+describe("SSE Stream Endpoint", () => {
+  let app: Express;
+  let store: Store;
+  let tempDir: string;
+  let server: http.Server;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "a2a-stream-test-"));
+    const created = createApp(new Store(join(tempDir, "test.db")));
+    app = created.app;
+    store = created.store;
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: true, status: 200, text: async () => "ok" });
+
+    store.registerAgent({
+      agent_id: "dennis",
+      name: "Agent Dennis",
+      skills: ["coding"],
+      gateway_url: "http://127.0.0.1:18789",
+      hook_path: "/hooks/ingest",
+    });
+    store.registerAgent({
+      agent_id: "drinkify",
+      name: "Agent Drinkify",
+      skills: ["ecommerce"],
+      gateway_url: "http://127.0.0.1:18810",
+      gateway_token: "tok",
+      hook_path: "/hooks/ingest",
+    });
+
+    server = app.listen(0);
+    await new Promise<void>((resolve) => server.on("listening", resolve));
+  });
+
+  afterEach(() => {
+    store.close();
+    server.close();
+    rmSync(tempDir, { recursive: true, force: true });
+    store.events.removeAllListeners();
+  });
+
+  // ── Validation (JSON error responses) ─────────────────────────────────
+
+  it("rejects missing jsonrpc version", async () => {
+    const res = await request(app)
+      .post("/a2a/stream")
+      .send({ id: "1", method: "message/stream", params: {} });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe(-32600);
+  });
+
+  it("rejects wrong method", async () => {
+    const res = await request(app)
+      .post("/a2a/stream")
+      .send({ jsonrpc: "2.0", id: "1", method: "message/send", params: {} });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe(-32601);
+  });
+
+  it("rejects missing agentId", async () => {
+    const res = await request(app)
+      .post("/a2a/stream")
+      .send({
+        jsonrpc: "2.0",
+        id: "1",
+        method: "message/stream",
+        params: {
+          senderId: "dennis",
+          message: { kind: "message", messageId: "m1", role: "user", parts: [{ kind: "text", text: "hi" }] },
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe(-32602);
+  });
+
+  it("rejects unknown agent", async () => {
+    const res = await request(app)
+      .post("/a2a/stream")
+      .send({
+        jsonrpc: "2.0",
+        id: "1",
+        method: "message/stream",
+        params: {
+          agentId: "nonexistent",
+          senderId: "dennis",
+          message: { kind: "message", messageId: "m1", role: "user", parts: [{ kind: "text", text: "hi" }] },
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe(-32002);
+  });
+
+  // ── SSE Output ────────────────────────────────────────────────────────
+
+  it("returns SSE content-type and initial status event", async () => {
+    // Mock fetch to complete the task immediately so the SSE stream closes
+    mockFetch.mockImplementation(async (_url: string, init: { body?: string }) => {
+      try {
+        const payload = JSON.parse(init.body ?? "{}");
+        const match = (payload.message as string)?.match(/\[a2a:task:([^\]]+)\]/);
+        const taskId = match?.[1];
+        if (taskId) {
+          // Complete immediately so stream closes
+          setImmediate(() => {
+            store.updateA2ATaskStatus(taskId, "completed", "Done");
+          });
+        }
+      } catch {
+        // ignore
+      }
+      return { ok: true, status: 200, text: async () => "ok" };
+    });
+
+    const result = await collectSSE(server, makeStreamPayload(), { timeoutMs: 3000 });
+
+    expect(result.status).toBe(200);
+    expect(result.headers["content-type"]).toBe("text/event-stream");
+    expect(result.headers["cache-control"]).toBe("no-cache");
+
+    // Should have initial status event
+    const statusEvents = result.events.filter((e) => e.event === "status");
+    expect(statusEvents.length).toBeGreaterThanOrEqual(1);
+    expect(statusEvents[0].data).toHaveProperty("kind", "status-update");
+    expect(statusEvents[0].data).toHaveProperty("taskId");
+  });
+
+  it("streams status updates and closes on terminal state", { timeout: 15000 }, async () => {
+    const taskIdReady = new Promise<string>((resolve) => {
+      mockFetch.mockImplementation(async (_url: string, init: { body?: string }) => {
+        try {
+          const payload = JSON.parse(init.body ?? "{}");
+          const match = (payload.message as string)?.match(/\[a2a:task:([^\]]+)\]/);
+          if (match?.[1]) {
+            resolve(match[1]);
+          }
+        } catch {
+          // ignore
+        }
+        return { ok: true, status: 200, text: async () => "ok" };
+      });
+    });
+
+    // Start collecting SSE (non-blocking)
+    const ssePromise = collectSSE(server, makeStreamPayload(), { timeoutMs: 5000 });
+
+    // Wait for the mock to be called (task created)
+    const taskId = await taskIdReady;
+
+    // Wait for the event listener to be set up (the handler sets it up after writeHead)
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Emit events through the store (uses the same taskEventBus instance as the SSE handler)
+    store.updateA2ATaskStatus(taskId, "working", "Processing...");
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    store.updateA2ATaskStatus(taskId, "completed", "All done!");
+
+    const result = await ssePromise;
+
+    // Should have: initial status, working, completed, done
+    const statusEvents = result.events.filter((e) => e.event === "status");
+    const doneEvents = result.events.filter((e) => e.event === "done");
+
+    expect(statusEvents.length).toBeGreaterThanOrEqual(2); // initial + completed (working may or may not arrive)
+
+    // Should have completed event
+    const completedEvent = statusEvents.find(
+      (e) => ((e.data as Record<string, Record<string, string>>).status)?.state === "completed",
+    );
+    expect(completedEvent).toBeDefined();
+
+    // Should have done event
+    expect(doneEvents.length).toBe(1);
+    expect(doneEvents[0].data).toHaveProperty("taskId");
+
+    // Connection should have closed
+    expect(result.status).toBe(200);
+  });
+
+  it("handles delivery failure gracefully in SSE mode", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, text: async () => "error" });
+
+    // Connection won't close on its own since delivery fails and no terminal event fires
+    const result = await collectSSE(server, makeStreamPayload(), { timeoutMs: 1000 });
+
+    expect(result.status).toBe(200);
+
+    // Should have at least the initial status event
+    const statusEvents = result.events.filter((e) => e.event === "status");
+    expect(statusEvents.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tools/a2a-router/src/events.ts
+++ b/tools/a2a-router/src/events.ts
@@ -1,0 +1,27 @@
+// ── Task Event Bus ───────────────────────────────────────────────────────────
+// In-memory event emitter for real-time task status streaming (SSE).
+
+import { EventEmitter } from "node:events";
+
+export interface TaskEvent {
+  taskId: string;
+  kind: "status-update" | "artifact-update";
+  status?: { state: string; message?: string; timestamp: string };
+  artifact?: { parts: Array<{ kind: string; text?: string }> };
+}
+
+export class TaskEventBus extends EventEmitter {
+  emitTaskUpdate(event: TaskEvent): void {
+    this.emit(`task:${event.taskId}`, event);
+  }
+
+  onTaskUpdate(taskId: string, listener: (event: TaskEvent) => void): void {
+    this.on(`task:${taskId}`, listener);
+  }
+
+  offTaskUpdate(taskId: string, listener: (event: TaskEvent) => void): void {
+    this.off(`task:${taskId}`, listener);
+  }
+}
+
+export const taskEventBus = new TaskEventBus();

--- a/tools/a2a-router/src/index.ts
+++ b/tools/a2a-router/src/index.ts
@@ -6,6 +6,7 @@ import { agentRoutes } from "./routes/agents.js";
 import { messageRoutes } from "./routes/messages.js";
 import { taskRoutes } from "./routes/tasks.js";
 import { jsonrpcRoutes } from "./routes/jsonrpc.js";
+import { streamRoutes } from "./routes/stream.js";
 import { discoveryRoutes } from "./routes/discovery.js";
 
 const PORT = parseInt(process.env.A2A_PORT ?? "3380", 10);
@@ -37,6 +38,9 @@ export function createApp(store?: Store) {
   // ── A2A v1.0 JSON-RPC endpoint ────────────────────────────────────────
   app.use("/a2a/jsonrpc", jsonrpcRoutes(s));
 
+  // ── SSE Streaming endpoint ────────────────────────────────────────────
+  app.use("/a2a/stream", streamRoutes(s));
+
   return { app, store: s };
 }
 
@@ -49,6 +53,7 @@ if (isDirectRun && !isVitest) {
     console.log(`🔄 A2A Router listening on http://127.0.0.1:${PORT}`);
     console.log(`   Health: http://127.0.0.1:${PORT}/health`);
     console.log(`   JSON-RPC: http://127.0.0.1:${PORT}/a2a/jsonrpc`);
+    console.log(`   Stream:   http://127.0.0.1:${PORT}/a2a/stream`);
     console.log(`   Discovery: http://127.0.0.1:${PORT}/.well-known/agent.json`);
     console.log(`   DB: ${DB_PATH}`);
   });

--- a/tools/a2a-router/src/routes/stream.ts
+++ b/tools/a2a-router/src/routes/stream.ts
@@ -1,0 +1,213 @@
+// ── SSE Streaming Endpoint ───────────────────────────────────────────────────
+// POST /a2a/stream — Server-Sent Events for real-time task updates
+
+import { Router, type Request, type Response } from "express";
+import { buildTaskPayload, deliverHook } from "../bridge.js";
+import type { TaskEvent } from "../events.js";
+import type { Store } from "../store.js";
+import {
+  JSON_RPC_ERRORS,
+  type Message,
+  type MessageSendParams,
+  type Part,
+} from "../a2a-types.js";
+
+const SSE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const TERMINAL_STATES = ["completed", "failed", "canceled"];
+
+function isValidPart(part: unknown): part is Part {
+  if (typeof part !== "object" || part === null) return false;
+  const p = part as Record<string, unknown>;
+  if (p.kind === "text") return typeof p.text === "string";
+  if (p.kind === "file") return true;
+  if (p.kind === "data") return typeof p.data === "object" && p.data !== null;
+  return false;
+}
+
+function isValidMessage(msg: unknown): msg is Message {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  if (m.kind !== "message") return false;
+  if (typeof m.messageId !== "string") return false;
+  if (m.role !== "user" && m.role !== "agent") return false;
+  if (!Array.isArray(m.parts) || m.parts.length === 0) return false;
+  return m.parts.every(isValidPart);
+}
+
+function writeSSE(res: Response, event: string, data: unknown): void {
+  res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+export function streamRoutes(store: Store): Router {
+  const router = Router();
+
+  // POST /a2a/stream
+  router.post("/", async (req: Request, res: Response) => {
+    const body = req.body as Record<string, unknown>;
+
+    // Validate JSON-RPC envelope
+    if (body.jsonrpc !== "2.0") {
+      res.status(400).json({
+        jsonrpc: "2.0",
+        id: (body.id as string | number) ?? 0,
+        error: { ...JSON_RPC_ERRORS.INVALID_REQUEST, data: { reason: "Missing or invalid jsonrpc version" } },
+      });
+      return;
+    }
+
+    const id = body.id as string | number;
+    if (id === undefined || id === null) {
+      res.status(400).json({
+        jsonrpc: "2.0",
+        id: 0,
+        error: { ...JSON_RPC_ERRORS.INVALID_REQUEST, data: { reason: "Missing id" } },
+      });
+      return;
+    }
+
+    // Validate method
+    const method = body.method as string;
+    if (method !== "message/stream") {
+      res.status(400).json({
+        jsonrpc: "2.0",
+        id,
+        error: { ...JSON_RPC_ERRORS.METHOD_NOT_FOUND, data: { method, reason: "Stream endpoint only supports message/stream" } },
+      });
+      return;
+    }
+
+    const params = (body.params ?? {}) as Partial<MessageSendParams>;
+
+    // Validate params
+    if (!params.agentId || typeof params.agentId !== "string") {
+      res.status(400).json({
+        jsonrpc: "2.0",
+        id,
+        error: { ...JSON_RPC_ERRORS.INVALID_PARAMS, data: { reason: "agentId is required" } },
+      });
+      return;
+    }
+    if (!params.senderId || typeof params.senderId !== "string") {
+      res.status(400).json({
+        jsonrpc: "2.0",
+        id,
+        error: { ...JSON_RPC_ERRORS.INVALID_PARAMS, data: { reason: "senderId is required" } },
+      });
+      return;
+    }
+    if (!params.message || !isValidMessage(params.message)) {
+      res.status(400).json({
+        jsonrpc: "2.0",
+        id,
+        error: { ...JSON_RPC_ERRORS.INVALID_PARAMS, data: { reason: "message is required and must be a valid A2A Message" } },
+      });
+      return;
+    }
+
+    // Validate agents exist
+    const target = store.getAgent(params.agentId);
+    if (!target) {
+      res.status(400).json({
+        jsonrpc: "2.0",
+        id,
+        error: { ...JSON_RPC_ERRORS.AGENT_NOT_FOUND, data: { agentId: params.agentId } },
+      });
+      return;
+    }
+    const sender = store.getAgent(params.senderId);
+    if (!sender) {
+      res.status(400).json({
+        jsonrpc: "2.0",
+        id,
+        error: { ...JSON_RPC_ERRORS.AGENT_NOT_FOUND, data: { agentId: params.senderId } },
+      });
+      return;
+    }
+
+    // Create A2A task
+    const task = store.createA2ATask(
+      params.senderId,
+      params.agentId,
+      params.message,
+      params.contextId,
+    );
+
+    const taskId = task.id;
+
+    // Set up SSE headers
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+      "X-Accel-Buffering": "no",
+    });
+
+    // Send initial status
+    writeSSE(res, "status", {
+      kind: "status-update",
+      taskId,
+      status: task.status,
+    });
+
+    let closed = false;
+
+    const cleanup = () => {
+      if (closed) return;
+      closed = true;
+      store.events.offTaskUpdate(taskId, listener);
+      clearTimeout(timeout);
+    };
+
+    // Listen for updates
+    const listener = (event: TaskEvent) => {
+      if (closed) return;
+      writeSSE(res, "status", event);
+
+      if (event.status && TERMINAL_STATES.includes(event.status.state)) {
+        writeSSE(res, "done", { taskId });
+        cleanup();
+        res.end();
+      }
+    };
+
+    store.events.onTaskUpdate(taskId, listener);
+
+    // Timeout after 5 minutes
+    const timeout = setTimeout(() => {
+      if (closed) return;
+      writeSSE(res, "timeout", {
+        taskId,
+        message: "SSE connection timed out after 5 minutes",
+      });
+      writeSSE(res, "done", { taskId });
+      cleanup();
+      res.end();
+    }, SSE_TIMEOUT_MS);
+
+    // Handle client disconnect
+    res.on("close", () => {
+      cleanup();
+    });
+
+    // Deliver to target agent (fire and forget for SSE — status updates come via event bus)
+    const internalTask = store.getTask(taskId);
+    if (internalTask) {
+      const payload = buildTaskPayload(internalTask);
+      const result = await deliverHook(target, payload);
+
+      if (!result.ok && !closed) {
+        store.updateA2ATaskStatus(taskId, "submitted", "Delivery to agent gateway failed");
+        const updatedTask = store.getA2ATask(taskId);
+        if (updatedTask) {
+          writeSSE(res, "status", {
+            kind: "status-update",
+            taskId,
+            status: updatedTask.status,
+          });
+        }
+      }
+    }
+  });
+
+  return router;
+}

--- a/tools/a2a-router/src/store.ts
+++ b/tools/a2a-router/src/store.ts
@@ -18,6 +18,7 @@ import type {
   TasksListParams,
   TasksListResult,
 } from "./a2a-types.js";
+import { TaskEventBus } from "./events.js";
 
 const DEFAULT_DB_PATH = `${process.env.HOME}/.openspawn/a2a/tasks.db`;
 
@@ -40,8 +41,10 @@ interface TaskRow {
 
 export class Store {
   private db: Database.Database;
+  public readonly events: TaskEventBus;
 
   constructor(dbPath: string = DEFAULT_DB_PATH) {
+    this.events = new TaskEventBus();
     // Auto-create directory
     mkdirSync(dirname(dbPath), { recursive: true });
     this.db = new Database(dbPath);
@@ -246,6 +249,11 @@ export class Store {
       UPDATE tasks SET status = ?, result = ?, updated_at = datetime('now')
       WHERE id = ?
     `).run(status, result ?? null, taskId);
+    this.events.emitTaskUpdate({
+      taskId,
+      kind: "status-update",
+      status: { state: status, message: result, timestamp: new Date().toISOString() },
+    });
     return this.getTask(taskId);
   }
 
@@ -348,6 +356,12 @@ export class Store {
     if (statusMessage !== undefined) {
       this.db.prepare(`UPDATE tasks SET result = ? WHERE id = ?`).run(statusMessage, taskId);
     }
+
+    this.events.emitTaskUpdate({
+      taskId,
+      kind: "status-update",
+      status: { state, message: statusMessage, timestamp: new Date().toISOString() },
+    });
 
     return this.getA2ATask(taskId);
   }


### PR DESCRIPTION
## Summary

SSE (Server-Sent Events) streaming for real-time A2A task updates.

### What's new

- **`TaskEventBus`** (`events.ts`) — in-memory event emitter scoped per Store instance for task status propagation
- **SSE endpoint** (`POST /a2a/stream`) — accepts `message/stream` JSON-RPC method, returns `text/event-stream`
- **Event wiring** — `store.updateTaskStatus()` and `store.updateA2ATaskStatus()` emit events via the bus
- **5-minute timeout** — SSE connections auto-close with a timeout event if task doesn't reach terminal state
- **Graceful disconnect** — client disconnects are cleaned up via `res.on('close')`

### SSE Event Format
```
event: status
data: {"kind":"status-update","taskId":"abc","status":{"state":"working",...}}

event: done
data: {"taskId":"abc"}
```

### Files changed
- `tools/a2a-router/src/events.ts` — NEW: TaskEventBus class
- `tools/a2a-router/src/routes/stream.ts` — NEW: SSE endpoint
- `tools/a2a-router/src/store.ts` — UPDATE: emit events on state changes
- `tools/a2a-router/src/index.ts` — UPDATE: mount stream route
- `tools/a2a-router/src/__tests__/events.test.ts` — NEW: 5 event bus tests
- `tools/a2a-router/src/__tests__/stream.test.ts` — NEW: 7 SSE endpoint tests

### Verification
- ✅ All 125 tests passing
- ✅ Lint clean (0 warnings)
- ✅ TypeScript strict mode

Closes #738