### PR TITLE
feat: openspawn agent create CLI + workspace scaffolding

### DIFF
--- a/packages/openspawn/src/cli/commands/agent.test.ts
+++ b/packages/openspawn/src/cli/commands/agent.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  toAgentId,
+  scaffoldAgent,
+  generateAgentsMd,
+  generateSoulMd,
+  generateIdentityMd,
+  generateUserMd,
+  type AgentConfig,
+  type Teammate,
+} from "../../core/agent-scaffold.js";
+
+// ── Test Helpers ────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `openspawn-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeSkillDir(baseDir: string): string {
+  const skillDir = join(baseDir, "a2a-reporter");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, "SKILL.md"), "# A2A Reporter\nTest skill.");
+  mkdirSync(join(skillDir, "scripts"), { recursive: true });
+  writeFileSync(join(skillDir, "scripts", "report.sh"), "#!/bin/bash\necho test");
+  return skillDir;
+}
+
+const TEST_CONFIG: AgentConfig = {
+  name: "Writer",
+  role: "writer",
+  level: 5,
+  skills: ["docs", "markdown", "tutorials"],
+  model: "anthropic/claude-haiku-3-5",
+};
+
+// ── toAgentId ───────────────────────────────────────────────────────────────
+
+describe("toAgentId", () => {
+  it("converts name to lowercase kebab-case", () => {
+    expect(toAgentId("Writer")).toBe("writer");
+    expect(toAgentId("PM")).toBe("pm");
+    expect(toAgentId("UX Designer")).toBe("ux-designer");
+    expect(toAgentId("Code Review Bot")).toBe("code-review-bot");
+  });
+
+  it("strips leading/trailing hyphens", () => {
+    expect(toAgentId("--test--")).toBe("test");
+  });
+
+  it("handles special characters", () => {
+    expect(toAgentId("agent@123!")).toBe("agent-123");
+  });
+});
+
+// ── Template Generation ─────────────────────────────────────────────────────
+
+describe("generateAgentsMd", () => {
+  it("generates valid AGENTS.md with identity", () => {
+    const md = generateAgentsMd(TEST_CONFIG, "writer");
+    expect(md).toContain("# AGENTS.md — Writer");
+    expect(md).toContain("**Name:** Writer");
+    expect(md).toContain("**Role:** writer");
+    expect(md).toContain("**Level:** 5");
+    expect(md).toContain("**Agent ID:** writer");
+    expect(md).toContain("**Model:** anthropic/claude-haiku-3-5");
+  });
+
+  it("includes A2A protocol instructions", () => {
+    const md = generateAgentsMd(TEST_CONFIG, "writer");
+    expect(md).toContain("A2A Protocol");
+    expect(md).toContain("[a2a:task:<uuid>]");
+    expect(md).toContain("127.0.0.1:3380");
+  });
+
+  it("includes teammates when provided", () => {
+    const teammates: Teammate[] = [
+      { name: "PM", level: 7, role: "project-manager", skills: "planning, tracking" },
+      { name: "Engineer", level: 5, role: "developer", skills: "code, typescript" },
+    ];
+    const md = generateAgentsMd(TEST_CONFIG, "writer", teammates);
+    expect(md).toContain("**PM** (L7, project-manager)");
+    expect(md).toContain("**Engineer** (L5, developer)");
+  });
+
+  it("shows placeholder when no teammates", () => {
+    const md = generateAgentsMd(TEST_CONFIG, "writer", []);
+    expect(md).toContain("No teammates registered yet");
+  });
+});
+
+describe("generateSoulMd", () => {
+  it("generates role-appropriate personality for writer", () => {
+    const soul = generateSoulMd(TEST_CONFIG);
+    expect(soul).toContain("# SOUL.md — Writer");
+    expect(soul).toContain("technical writer");
+  });
+
+  it("generates role-appropriate personality for PM", () => {
+    const soul = generateSoulMd({ ...TEST_CONFIG, name: "PM", role: "project-manager" });
+    expect(soul).toContain("project manager");
+    expect(soul).toContain("Organized, decisive");
+  });
+
+  it("generates role-appropriate personality for developer", () => {
+    const soul = generateSoulMd({ ...TEST_CONFIG, name: "Engineer", role: "developer" });
+    expect(soul).toContain("developer");
+    expect(soul).toContain("clean code");
+  });
+
+  it("falls back for unknown roles", () => {
+    const soul = generateSoulMd({ ...TEST_CONFIG, name: "Custom", role: "custom-role" });
+    expect(soul).toContain("custom-role");
+    expect(soul).toContain("specialty");
+  });
+});
+
+describe("generateIdentityMd", () => {
+  it("includes name, role, and emoji", () => {
+    const identity = generateIdentityMd(TEST_CONFIG, "writer");
+    expect(identity).toContain("# IDENTITY.md — Writer");
+    expect(identity).toContain("**Name:** Writer");
+    expect(identity).toContain("**Role:** writer");
+    expect(identity).toContain("**Emoji:** ✍️");
+  });
+
+  it("uses correct emoji for developer", () => {
+    const identity = generateIdentityMd({ ...TEST_CONFIG, role: "developer" }, "dev");
+    expect(identity).toContain("💻");
+  });
+
+  it("uses fallback emoji for unknown role", () => {
+    const identity = generateIdentityMd({ ...TEST_CONFIG, role: "unknown" }, "x");
+    expect(identity).toContain("🤖");
+  });
+});
+
+describe("generateUserMd", () => {
+  it("includes Adam's details", () => {
+    const user = generateUserMd();
+    expect(user).toContain("Adam");
+    expect(user).toContain("Founder & CEO");
+    expect(user).toContain("Atlantic");
+  });
+});
+
+// ── Workspace Scaffolding ───────────────────────────────────────────────────
+
+describe("scaffoldAgent", () => {
+  let tmpDir: string;
+  let skillDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    skillDir = makeSkillDir(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates workspace with all expected files", () => {
+    const config: AgentConfig = {
+      ...TEST_CONFIG,
+      workspace: join(tmpDir, "workspace"),
+    };
+
+    const result = scaffoldAgent(config, [], { skillSourceDir: skillDir });
+
+    expect(result.agentId).toBe("writer");
+    expect(result.workspace).toBe(join(tmpDir, "workspace"));
+    expect(existsSync(join(result.workspace, "AGENTS.md"))).toBe(true);
+    expect(existsSync(join(result.workspace, "SOUL.md"))).toBe(true);
+    expect(existsSync(join(result.workspace, "IDENTITY.md"))).toBe(true);
+    expect(existsSync(join(result.workspace, "USER.md"))).toBe(true);
+    expect(existsSync(join(result.workspace, ".agent-manifest.json"))).toBe(true);
+  });
+
+  it("creates memory directory", () => {
+    const config: AgentConfig = {
+      ...TEST_CONFIG,
+      workspace: join(tmpDir, "workspace"),
+    };
+
+    const result = scaffoldAgent(config, [], { skillSourceDir: skillDir });
+
+    expect(existsSync(join(result.workspace, "memory"))).toBe(true);
+  });
+
+  it("copies a2a-reporter skill", () => {
+    const config: AgentConfig = {
+      ...TEST_CONFIG,
+      workspace: join(tmpDir, "workspace"),
+    };
+
+    const result = scaffoldAgent(config, [], { skillSourceDir: skillDir });
+
+    expect(result.a2aSkillCopied).toBe(true);
+    expect(existsSync(join(result.workspace, "skills", "a2a-reporter", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(result.workspace, "skills", "a2a-reporter", "scripts", "report.sh"))).toBe(true);
+  });
+
+  it("handles missing skill source gracefully", () => {
+    const config: AgentConfig = {
+      ...TEST_CONFIG,
+      workspace: join(tmpDir, "workspace"),
+    };
+
+    const result = scaffoldAgent(config, [], {
+      skillSourceDir: join(tmpDir, "nonexistent"),
+    });
+
+    expect(result.a2aSkillCopied).toBe(false);
+  });
+
+  it("writes valid manifest JSON", () => {
+    const config: AgentConfig = {
+      ...TEST_CONFIG,
+      workspace: join(tmpDir, "workspace"),
+    };
+
+    const result = scaffoldAgent(config, [], { skillSourceDir: skillDir });
+
+    const manifest = JSON.parse(
+      readFileSync(join(result.workspace, ".agent-manifest.json"), "utf-8"),
+    );
+    expect(manifest.agentId).toBe("writer");
+    expect(manifest.name).toBe("Writer");
+    expect(manifest.role).toBe("writer");
+    expect(manifest.level).toBe(5);
+    expect(manifest.skills).toEqual(["docs", "markdown", "tutorials"]);
+    expect(manifest.model).toBe("anthropic/claude-haiku-3-5");
+    expect(manifest.createdAt).toBeTruthy();
+  });
+
+  it("includes teammates in AGENTS.md", () => {
+    const config: AgentConfig = {
+      ...TEST_CONFIG,
+      workspace: join(tmpDir, "workspace"),
+    };
+    const teammates: Teammate[] = [
+      { name: "PM", level: 7, role: "project-manager", skills: "planning" },
+    ];
+
+    scaffoldAgent(config, teammates, { skillSourceDir: skillDir });
+
+    const agents = readFileSync(join(tmpDir, "workspace", "AGENTS.md"), "utf-8");
+    expect(agents).toContain("**PM** (L7, project-manager)");
+  });
+});
+
+// ── Batch Support ───────────────────────────────────────────────────────────
+
+describe("batch scaffolding", () => {
+  let tmpDir: string;
+  let skillDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    skillDir = makeSkillDir(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates multiple agents with cross-references", () => {
+    const configs: AgentConfig[] = [
+      { name: "PM", role: "project-manager", level: 7, skills: ["planning"], model: "anthropic/claude-sonnet-4-5", workspace: join(tmpDir, "pm") },
+      { name: "Writer", role: "writer", level: 5, skills: ["docs"], model: "anthropic/claude-haiku-3-5", workspace: join(tmpDir, "writer") },
+    ];
+
+    for (const config of configs) {
+      const teammates: Teammate[] = configs
+        .filter((c) => c.name !== config.name)
+        .map((c) => ({ name: c.name, level: c.level, role: c.role, skills: c.skills.join(", ") }));
+
+      scaffoldAgent(config, teammates, { skillSourceDir: skillDir });
+    }
+
+    // PM's AGENTS.md should mention Writer
+    const pmAgents = readFileSync(join(tmpDir, "pm", "AGENTS.md"), "utf-8");
+    expect(pmAgents).toContain("**Writer** (L5, writer)");
+
+    // Writer's AGENTS.md should mention PM
+    const writerAgents = readFileSync(join(tmpDir, "writer", "AGENTS.md"), "utf-8");
+    expect(writerAgents).toContain("**PM** (L7, project-manager)");
+  });
+});

--- a/packages/openspawn/src/cli/commands/agent.ts
+++ b/packages/openspawn/src/cli/commands/agent.ts
@@ -1,0 +1,306 @@
+// ── Agent Command ────────────────────────────────────────────────────────────
+// CLI for creating, listing, and inspecting agents.
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  type AgentConfig,
+  type Teammate,
+  scaffoldAgent,
+  registerWithA2A,
+  listAgents,
+  getAgent,
+} from "../../core/agent-scaffold.js";
+
+const AGENT_HELP = `
+openspawn agent - Manage agents
+
+Usage:
+  openspawn agent create <name> [options]        Create a new agent workspace
+  openspawn agent create-batch <config.json>     Batch create agents from config
+  openspawn agent list                           List all created agents
+  openspawn agent show <agent-id>                Show agent details
+
+Create Options:
+  --role <role>        Agent role (e.g. writer, developer, editor, pm)
+  --level <1-10>       Agent level (default: 5)
+  --skills <list>      Comma-separated skills
+  --model <model>      Model to use (default: anthropic/claude-haiku-3-5)
+  --workspace <path>   Custom workspace path
+  --no-register        Skip A2A router registration
+  --skill-dir <path>   Path to a2a-reporter skill source
+
+Examples:
+  openspawn agent create Writer --role writer --level 5 --skills "docs,markdown"
+  openspawn agent create PM --role project-manager --level 7 --model "anthropic/claude-sonnet-4-5"
+  openspawn agent create-batch agents.json
+  openspawn agent list
+  openspawn agent show writer
+`.trim();
+
+// ── Flag Helpers ────────────────────────────────────────────────────────────
+
+function parseFlag(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx >= 0 && args[idx + 1]) return args[idx + 1];
+  return undefined;
+}
+
+function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function getPositionalArgs(args: string[]): string[] {
+  const result: string[] = [];
+  const flagsWithValue = new Set([
+    "--role",
+    "--level",
+    "--skills",
+    "--model",
+    "--workspace",
+    "--skill-dir",
+  ]);
+  for (let i = 0; i < args.length; i++) {
+    if (flagsWithValue.has(args[i])) {
+      i++; // skip value
+    } else if (!args[i].startsWith("--")) {
+      result.push(args[i]);
+    }
+  }
+  return result;
+}
+
+// ── Create Command ──────────────────────────────────────────────────────────
+
+async function createCommand(args: string[]): Promise<void> {
+  const positional = getPositionalArgs(args);
+  const name = positional[0];
+
+  if (!name) {
+    console.error("Usage: openspawn agent create <name> --role <role>");
+    process.exit(1);
+  }
+
+  const role = parseFlag(args, "--role");
+  if (!role) {
+    console.error("Error: --role is required");
+    process.exit(1);
+  }
+
+  const config: AgentConfig = {
+    name,
+    role,
+    level: parseInt(parseFlag(args, "--level") ?? "5", 10),
+    skills: (parseFlag(args, "--skills") ?? "").split(",").filter(Boolean),
+    model: parseFlag(args, "--model") ?? "anthropic/claude-haiku-3-5",
+    workspace: parseFlag(args, "--workspace"),
+  };
+
+  const skillDir = parseFlag(args, "--skill-dir");
+  const noRegister = hasFlag(args, "--no-register");
+
+  console.log(`\n🤖 Creating agent: ${config.name}`);
+  console.log(`   Role: ${config.role} | Level: ${config.level}`);
+  console.log(`   Model: ${config.model}`);
+  if (config.skills.length > 0) console.log(`   Skills: ${config.skills.join(", ")}`);
+
+  const result = scaffoldAgent(config, [], skillDir ? { skillSourceDir: skillDir } : undefined);
+
+  console.log(`\n✅ Workspace created: ${result.workspace}`);
+  console.log(`   Agent ID: ${result.agentId}`);
+  console.log(`   Files: ${result.filesCreated.length} created`);
+  if (result.a2aSkillCopied) {
+    console.log(`   A2A Reporter: ✅ installed`);
+  } else {
+    console.log(`   A2A Reporter: ⚠️  skill source not found (copy manually)`);
+  }
+
+  // Register with A2A router
+  if (!noRegister) {
+    console.log(`\n📡 Registering with A2A router...`);
+    const reg = await registerWithA2A(result.agentId, config);
+    if (reg.success) {
+      console.log(`   ✅ Registered as "${result.agentId}"`);
+    } else {
+      console.log(`   ⚠️  Registration failed: ${reg.error}`);
+      console.log(`   (You can register later with: openspawn a2a register)`);
+    }
+  }
+
+  console.log(`\n📋 Next steps:`);
+  console.log(`   1. Point an OpenClaw instance at: ${result.workspace}`);
+  console.log(`   2. Start the agent and verify AGENTS.md is loaded`);
+  console.log(`   3. Send a test task: openspawn a2a send ${result.agentId} "Hello!"`);
+  console.log();
+}
+
+// ── Batch Create Command ────────────────────────────────────────────────────
+
+interface BatchConfig {
+  agents: Array<{
+    name: string;
+    role: string;
+    level?: number;
+    skills?: string[];
+    model?: string;
+    workspace?: string;
+  }>;
+}
+
+async function batchCreateCommand(args: string[]): Promise<void> {
+  const configPath = args[0];
+  if (!configPath) {
+    console.error("Usage: openspawn agent create-batch <config.json>");
+    process.exit(1);
+  }
+
+  const fullPath = resolve(configPath);
+  if (!existsSync(fullPath)) {
+    console.error(`❌ Config file not found: ${fullPath}`);
+    process.exit(1);
+  }
+
+  let batch: BatchConfig;
+  try {
+    batch = JSON.parse(readFileSync(fullPath, "utf-8")) as BatchConfig;
+  } catch (err) {
+    console.error(`❌ Invalid JSON: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  if (!Array.isArray(batch.agents) || batch.agents.length === 0) {
+    console.error("❌ Config must have a non-empty 'agents' array");
+    process.exit(1);
+  }
+
+  const noRegister = hasFlag(args, "--no-register");
+  const skillDir = parseFlag(args, "--skill-dir");
+
+  // Build teammate list for cross-referencing
+  const configs: AgentConfig[] = batch.agents.map((a) => ({
+    name: a.name,
+    role: a.role,
+    level: a.level ?? 5,
+    skills: a.skills ?? [],
+    model: a.model ?? "anthropic/claude-haiku-3-5",
+    workspace: a.workspace,
+  }));
+
+  console.log(`\n🚀 Batch creating ${configs.length} agents...\n`);
+
+  for (const config of configs) {
+    // Build teammates (everyone except self)
+    const teammates: Teammate[] = configs
+      .filter((c) => c.name !== config.name)
+      .map((c) => ({
+        name: c.name,
+        level: c.level,
+        role: c.role,
+        skills: c.skills.join(", "),
+      }));
+
+    console.log(`🤖 ${config.name} (${config.role}, L${config.level})`);
+
+    const result = scaffoldAgent(
+      config,
+      teammates,
+      skillDir ? { skillSourceDir: skillDir } : undefined,
+    );
+
+    console.log(`   ✅ ${result.workspace}`);
+    if (!result.a2aSkillCopied) {
+      console.log(`   ⚠️  A2A Reporter skill not found`);
+    }
+
+    // Register with A2A router
+    if (!noRegister) {
+      const reg = await registerWithA2A(result.agentId, config);
+      if (reg.success) {
+        console.log(`   📡 Registered`);
+      } else {
+        console.log(`   ⚠️  Registration: ${reg.error}`);
+      }
+    }
+  }
+
+  console.log(`\n✅ ${configs.length} agents created!`);
+  console.log(`\n📋 Next steps:`);
+  console.log(`   1. Start OpenClaw instances for each agent`);
+  console.log(`   2. Run: openspawn agent list`);
+  console.log(`   3. Test: openspawn a2a send <agent-id> "Hello!"`);
+  console.log();
+}
+
+// ── List Command ────────────────────────────────────────────────────────────
+
+function listCommand(): void {
+  const agents = listAgents();
+
+  if (agents.length === 0) {
+    console.log("\nNo agents found. Create one with: openspawn agent create <name> --role <role>\n");
+    return;
+  }
+
+  console.log(`\n📋 Agents (${agents.length}):\n`);
+  for (const a of agents) {
+    console.log(`  🤖 ${a.name} (${a.agentId})`);
+    console.log(`     Role: ${a.role} | Level: ${a.level} | Model: ${a.model}`);
+    console.log(`     Skills: ${a.skills.join(", ") || "none"}`);
+    console.log(`     Workspace: ${a.workspace}`);
+    console.log();
+  }
+}
+
+// ── Show Command ────────────────────────────────────────────────────────────
+
+function showCommand(args: string[]): void {
+  const agentId = args[0];
+  if (!agentId) {
+    console.error("Usage: openspawn agent show <agent-id>");
+    process.exit(1);
+  }
+
+  const agent = getAgent(agentId);
+  if (!agent) {
+    console.error(`❌ Agent '${agentId}' not found`);
+    console.error("   Run: openspawn agent list");
+    process.exit(1);
+  }
+
+  console.log(`\n🤖 ${agent.name}\n`);
+  console.log(`  Agent ID:  ${agent.agentId}`);
+  console.log(`  Role:      ${agent.role}`);
+  console.log(`  Level:     ${agent.level}`);
+  console.log(`  Model:     ${agent.model}`);
+  console.log(`  Skills:    ${agent.skills.join(", ") || "none"}`);
+  console.log(`  Workspace: ${agent.workspace}`);
+  console.log(`  Created:   ${agent.createdAt}`);
+  console.log();
+}
+
+// ── Router ──────────────────────────────────────────────────────────────────
+
+export async function agentCommand(args: string[]): Promise<void> {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    console.log(AGENT_HELP);
+    return;
+  }
+
+  const sub = args[0];
+  const rest = args.slice(1);
+
+  switch (sub) {
+    case "create":
+      return createCommand(rest);
+    case "create-batch":
+      return batchCreateCommand(rest);
+    case "list":
+      return listCommand();
+    case "show":
+      return showCommand(rest);
+    default:
+      console.error(`Unknown agent subcommand: ${sub}`);
+      console.log(AGENT_HELP);
+      process.exit(1);
+  }
+}

--- a/packages/openspawn/src/cli/index.ts
+++ b/packages/openspawn/src/cli/index.ts
@@ -10,6 +10,7 @@ import { startCommand } from "./commands/start.js";
 import { worktreeCommand } from "./commands/worktree.js";
 import { linearCommand } from "./commands/linear.js";
 import { a2aCommand } from "./commands/a2a.js";
+import { agentCommand } from "./commands/agent.js";
 
 const HELP = `
 openspawn - Multi-agent organization CLI
@@ -31,6 +32,7 @@ Commands:
     --dry-run                    Show what would change without writing
   worktree <subcommand>           Manage git worktrees for agents
   linear <subcommand>             Manage Linear.app integration
+  agent <subcommand>               Manage agent workspaces
   a2a <subcommand>                Agent-to-Agent communication
   preview                        Preview org in local sandbox
     --port <n>                   Dashboard port (default: 3333)
@@ -101,6 +103,8 @@ async function main() {
       return linearCommand(rest);
     case "worktree":
       return worktreeCommand(rest);
+    case "agent":
+      return agentCommand(rest);
     case "a2a":
       return a2aCommand(rest);
     default:

--- a/packages/openspawn/src/core/agent-scaffold.ts
+++ b/packages/openspawn/src/core/agent-scaffold.ts
@@ -1,0 +1,364 @@
+// ── Agent Scaffold ───────────────────────────────────────────────────────────
+// Creates agent workspaces with generated config files for multi-agent orgs.
+
+import { mkdirSync, writeFileSync, cpSync, existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface AgentConfig {
+  name: string;
+  role: string;
+  level: number;
+  skills: string[];
+  model: string;
+  workspace?: string;
+}
+
+export interface AgentManifest {
+  agentId: string;
+  name: string;
+  role: string;
+  level: number;
+  skills: string[];
+  model: string;
+  workspace: string;
+  createdAt: string;
+}
+
+export interface Teammate {
+  name: string;
+  level: number;
+  role: string;
+  skills: string;
+}
+
+// ── ID Generation ───────────────────────────────────────────────────────────
+
+export function toAgentId(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// ── Role → Emoji mapping ───────────────────────────────────────────────────
+
+const ROLE_EMOJI: Record<string, string> = {
+  "project-manager": "📋",
+  pm: "📋",
+  writer: "✍️",
+  editor: "🔍",
+  reviewer: "🔍",
+  developer: "💻",
+  engineer: "💻",
+  "ux-designer": "🎨",
+  designer: "🎨",
+};
+
+function emojiForRole(role: string): string {
+  return ROLE_EMOJI[role] ?? "🤖";
+}
+
+// ── SOUL.md Personalities ───────────────────────────────────────────────────
+
+const SOUL_PERSONALITIES: Record<string, string> = {
+  "project-manager":
+    "You're a project manager. Organized, decisive, tracks progress. You break big projects into tasks and assign them to the right people. You follow up on blockers and report status.",
+  pm: "You're a project manager. Organized, decisive, tracks progress. You break big projects into tasks and assign them to the right people. You follow up on blockers and report status.",
+  writer:
+    "You're a technical writer. Clear, concise, practical. You write docs that developers actually want to read. No fluff, real examples, tested code snippets.",
+  editor:
+    "You're an editor. Sharp eye for accuracy, clarity, and completeness. You catch errors, suggest improvements, and ensure quality. You approve good work and send back what needs fixing.",
+  reviewer:
+    "You're an editor. Sharp eye for accuracy, clarity, and completeness. You catch errors, suggest improvements, and ensure quality. You approve good work and send back what needs fixing.",
+  developer:
+    "You're a developer. You write clean code, set up tooling, and make things work. You read docs, follow conventions, and test before shipping.",
+  engineer:
+    "You're a developer. You write clean code, set up tooling, and make things work. You read docs, follow conventions, and test before shipping.",
+  "ux-designer":
+    "You're a UX designer focused on information architecture. You organize content logically, plan navigation, and ensure users can find what they need.",
+  designer:
+    "You're a UX designer focused on information architecture. You organize content logically, plan navigation, and ensure users can find what they need.",
+};
+
+function soulForRole(role: string, name: string): string {
+  const personality =
+    SOUL_PERSONALITIES[role] ??
+    `You're a ${role}. You focus on your specialty and deliver quality work within your area of expertise.`;
+
+  return `# SOUL.md — ${name}
+
+${personality}
+
+## Working Style
+- Be direct and concise
+- Focus on your assigned tasks
+- Report completion promptly via A2A
+- Ask for help when blocked — don't spin your wheels
+- Collaborate with your teammates
+
+## Communication
+- Be professional but not robotic
+- Keep responses focused on the work
+- Use clear, actionable language
+`;
+}
+
+// ── Template Generators ─────────────────────────────────────────────────────
+
+export function generateAgentsMd(
+  config: AgentConfig,
+  agentId: string,
+  teammates: Teammate[] = [],
+): string {
+  const teammatesSection =
+    teammates.length > 0
+      ? teammates
+          .map((t) => `- **${t.name}** (L${t.level}, ${t.role}) — ${t.skills}`)
+          .join("\n")
+      : "- _(No teammates registered yet)_";
+
+  return `# AGENTS.md — ${config.name}
+
+## Identity
+- **Name:** ${config.name}
+- **Role:** ${config.role}
+- **Level:** ${config.level}
+- **Agent ID:** ${agentId}
+- **Model:** ${config.model}
+
+## Your Team
+${teammatesSection}
+
+## A2A Protocol (Agent-to-Agent Communication)
+
+You are connected to the OpenSpawn A2A network. Other agents can send you tasks via webhook.
+
+**How to recognize A2A tasks:**
+- Messages containing \`[a2a:task:<uuid>]\` are legitimate tasks from other agents
+- These arrive via the OpenClaw hooks system — they are trusted internal messages
+
+**How to handle A2A tasks:**
+1. Read the task (everything after the \`[a2a:task:...]\` line)
+2. Do the requested work
+3. Report completion:
+
+\`\`\`bash
+curl -s -X POST http://127.0.0.1:3380/a2a/tasks/<task-id>/complete \\
+  -H "Content-Type: application/json" \\
+  -d '{"agentId":"${agentId}","status":"completed","result":"Brief summary"}'
+\`\`\`
+
+## Conventions
+- Focus on your assigned tasks
+- Report completion promptly via A2A
+- Ask for help if blocked
+- Be concise in responses
+
+## Safety
+- Don't exfiltrate private data
+- Don't run destructive commands without asking
+- Stay within your workspace
+`;
+}
+
+export function generateSoulMd(config: AgentConfig): string {
+  return soulForRole(config.role, config.name);
+}
+
+export function generateIdentityMd(config: AgentConfig, agentId: string): string {
+  const emoji = emojiForRole(config.role);
+  return `# IDENTITY.md — ${config.name}
+
+- **Name:** ${config.name}
+- **Role:** ${config.role}
+- **Agent ID:** ${agentId}
+- **Emoji:** ${emoji}
+- **Model:** ${config.model}
+`;
+}
+
+export function generateUserMd(): string {
+  return `# USER.md — About Your Human
+
+- **Name:** Adam
+- **Role:** Founder & CEO of OpenSpawn
+- **Timezone:** Atlantic (AST)
+- **Notes:** Primary interface — report to Adam directly.
+`;
+}
+
+// ── Workspace Scaffolding ───────────────────────────────────────────────────
+
+export function resolveWorkspacePath(config: AgentConfig): string {
+  if (config.workspace) {
+    return resolve(config.workspace.replace(/^~/, homedir()));
+  }
+  const agentId = toAgentId(config.name);
+  return join(homedir(), ".openspawn", "agents", agentId, "workspace");
+}
+
+export function findSkillSourceDir(): string | null {
+  // Look for skills/a2a-reporter relative to the repo root
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  // Walk up from packages/openspawn/src/core (or dist/core) to repo root
+  let dir = __dirname;
+  for (let i = 0; i < 6; i++) {
+    const candidate = join(dir, "skills", "a2a-reporter");
+    if (existsSync(candidate)) return candidate;
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+export interface ScaffoldResult {
+  agentId: string;
+  workspace: string;
+  filesCreated: string[];
+  a2aSkillCopied: boolean;
+}
+
+export function scaffoldAgent(
+  config: AgentConfig,
+  teammates: Teammate[] = [],
+  options?: { skillSourceDir?: string },
+): ScaffoldResult {
+  const agentId = toAgentId(config.name);
+  const workspace = resolveWorkspacePath(config);
+  const filesCreated: string[] = [];
+
+  // Create workspace directories
+  mkdirSync(workspace, { recursive: true });
+  mkdirSync(join(workspace, "skills"), { recursive: true });
+  mkdirSync(join(workspace, "memory"), { recursive: true });
+
+  // Generate and write files
+  const files: Array<[string, string]> = [
+    ["AGENTS.md", generateAgentsMd(config, agentId, teammates)],
+    ["SOUL.md", generateSoulMd(config)],
+    ["IDENTITY.md", generateIdentityMd(config, agentId)],
+    ["USER.md", generateUserMd()],
+  ];
+
+  for (const [filename, content] of files) {
+    const filePath = join(workspace, filename);
+    writeFileSync(filePath, content, "utf-8");
+    filesCreated.push(filePath);
+  }
+
+  // Copy a2a-reporter skill
+  let a2aSkillCopied = false;
+  const skillSource = options?.skillSourceDir ?? findSkillSourceDir();
+  if (skillSource && existsSync(skillSource)) {
+    const destDir = join(workspace, "skills", "a2a-reporter");
+    cpSync(skillSource, destDir, { recursive: true });
+    a2aSkillCopied = true;
+    filesCreated.push(destDir);
+  }
+
+  // Write manifest
+  const manifest: AgentManifest = {
+    agentId,
+    name: config.name,
+    role: config.role,
+    level: config.level,
+    skills: config.skills,
+    model: config.model,
+    workspace,
+    createdAt: new Date().toISOString(),
+  };
+  const manifestPath = join(workspace, ".agent-manifest.json");
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), "utf-8");
+  filesCreated.push(manifestPath);
+
+  return { agentId, workspace, filesCreated, a2aSkillCopied };
+}
+
+// ── A2A Registration ────────────────────────────────────────────────────────
+
+const A2A_BASE = process.env.A2A_URL ?? "http://127.0.0.1:3380";
+
+export interface RegisterResult {
+  success: boolean;
+  error?: string;
+}
+
+export async function registerWithA2A(
+  agentId: string,
+  config: AgentConfig,
+  gatewayUrl?: string,
+): Promise<RegisterResult> {
+  try {
+    const res = await fetch(`${A2A_BASE}/a2a/agents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agentId,
+        name: config.name,
+        gateway_url: gatewayUrl ?? `http://127.0.0.1:4140`,
+        skills: config.skills,
+      }),
+    });
+
+    if (res.status === 201 || res.status === 200) {
+      return { success: true };
+    }
+
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    return { success: false, error: (body.error as string) ?? `HTTP ${res.status}` };
+  } catch {
+    return { success: false, error: "Cannot reach A2A router (is it running?)" };
+  }
+}
+
+// ── Agent Discovery (from manifests) ────────────────────────────────────────
+
+import { readdirSync, readFileSync } from "node:fs";
+
+export function listAgents(): AgentManifest[] {
+  const agentsDir = join(homedir(), ".openspawn", "agents");
+  if (!existsSync(agentsDir)) return [];
+
+  const agents: AgentManifest[] = [];
+  try {
+    const entries = readdirSync(agentsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const manifestPath = join(agentsDir, entry.name, "workspace", ".agent-manifest.json");
+      if (existsSync(manifestPath)) {
+        try {
+          const data = JSON.parse(readFileSync(manifestPath, "utf-8")) as AgentManifest;
+          agents.push(data);
+        } catch {
+          // Skip malformed manifests
+        }
+      }
+    }
+  } catch {
+    // Directory doesn't exist or not readable
+  }
+
+  return agents;
+}
+
+export function getAgent(agentId: string): AgentManifest | null {
+  const manifestPath = join(
+    homedir(),
+    ".openspawn",
+    "agents",
+    agentId,
+    "workspace",
+    ".agent-manifest.json",
+  );
+  if (!existsSync(manifestPath)) return null;
+  try {
+    return JSON.parse(readFileSync(manifestPath, "utf-8")) as AgentManifest;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What

Agent creation CLI with auto-generated AGENTS.md, SOUL.md, IDENTITY.md, USER.md. Supports batch creation for multi-agent demos.

## Commands

- `openspawn agent create <name> --role <role> [--level N] [--skills list] [--model m]` — Create single agent
- `openspawn agent create-batch <config.json>` — Batch create with cross-referenced teammates
- `openspawn agent list` — List all created agents
- `openspawn agent show <id>` — Show agent details

## Features

- Role-appropriate SOUL.md personality generation (PM, Writer, Editor, Developer, Designer + fallback)
- A2A Protocol instructions in AGENTS.md with task handling docs
- Copies a2a-reporter skill into each workspace
- Registers with A2A router at localhost:3380 (graceful fallback when offline)
- .agent-manifest.json for agent discovery
- Teammate cross-referencing in batch mode

## Tests

22 new tests covering template generation, workspace scaffolding, and batch creation. All 148 tests pass.