### PR TITLE
feat: A2A router → API sync bridge for dashboard visibility

### DIFF
--- a/tools/a2a-router/src/__tests__/sync.test.ts
+++ b/tools/a2a-router/src/__tests__/sync.test.ts
@@ -1,0 +1,269 @@
+// ── Sync Module Tests ────────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Store } from "../store.js";
+import {
+  syncAgentRegistered,
+  syncTaskCreated,
+  syncTaskTransition,
+  initSync,
+  mapStatus,
+} from "../sync.js";
+import type { AgentCard, Task } from "../types.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function mockFetch(status = 200, body = "OK"): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(body),
+  });
+}
+
+const testAgent: AgentCard = {
+  agent_id: "test-agent",
+  name: "Test Agent",
+  skills: ["code"],
+  gateway_url: "http://localhost:9999",
+  hook_path: "/hooks/agent",
+};
+
+const testTask: Task = {
+  id: "task-123",
+  sender_id: "agent-a",
+  target_id: "agent-b",
+  message: "Do something useful",
+  status: "submitted",
+  result: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+// ── Status Mapping ──────────────────────────────────────────────────────────
+
+describe("mapStatus", () => {
+  it("maps A2A statuses to API statuses", () => {
+    expect(mapStatus("submitted")).toBe("backlog");
+    expect(mapStatus("working")).toBe("in_progress");
+    expect(mapStatus("completed")).toBe("done");
+    expect(mapStatus("failed")).toBe("cancelled");
+    expect(mapStatus("canceled")).toBe("cancelled");
+  });
+
+  it("defaults unknown statuses to backlog", () => {
+    expect(mapStatus("unknown")).toBe("backlog");
+  });
+});
+
+// ── Sync Functions (with SYNC_ENABLED) ──────────────────────────────────────
+
+describe("sync functions", () => {
+  // We need to test with SYNC_ENABLED=true. The module reads env at import
+  // time, so we test the internal functions by passing fetchImpl directly
+  // and checking the calls. When SYNC_ENABLED is false, they're no-ops.
+
+  describe("when sync is disabled (default)", () => {
+    it("syncAgentRegistered is a no-op", async () => {
+      const fetch = mockFetch();
+      await syncAgentRegistered(testAgent, fetch as unknown as typeof globalThis.fetch);
+      // SYNC_ENABLED is false in test env, so fetch should NOT be called
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("syncTaskCreated is a no-op", async () => {
+      const fetch = mockFetch();
+      await syncTaskCreated(testTask, fetch as unknown as typeof globalThis.fetch);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("syncTaskTransition is a no-op", async () => {
+      const fetch = mockFetch();
+      await syncTaskTransition("task-123", "completed", "done!", fetch as unknown as typeof globalThis.fetch);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ── initSync wiring ─────────────────────────────────────────────────────────
+
+describe("initSync", () => {
+  let store: Store;
+
+  beforeEach(() => {
+    store = new Store(":memory:");
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it("does not throw when sync is disabled", () => {
+    expect(() => initSync(store)).not.toThrow();
+  });
+
+  it("registers event listeners on the store event bus", () => {
+    // Even though SYNC_ENABLED=false, initSync should not crash
+    initSync(store);
+
+    // The events are registered on store.events — check they exist
+    // When disabled, no listeners should be added
+    const taskStatusListeners = store.events.listenerCount("task-status");
+    const taskCreatedListeners = store.events.listenerCount("task-created");
+    const agentRegisteredListeners = store.events.listenerCount("agent-registered");
+
+    // With SYNC_ENABLED=false, no listeners should be added
+    expect(taskStatusListeners).toBe(0);
+    expect(taskCreatedListeners).toBe(0);
+    expect(agentRegisteredListeners).toBe(0);
+  });
+});
+
+// ── Store event emissions ───────────────────────────────────────────────────
+
+describe("Store event emissions", () => {
+  let store: Store;
+
+  beforeEach(() => {
+    store = new Store(":memory:");
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it("emits agent-registered when an agent is registered", () => {
+    const listener = vi.fn();
+    store.events.on("agent-registered", listener);
+
+    store.registerAgent({
+      agent_id: "test-agent",
+      name: "Test Agent",
+      skills: [],
+      gateway_url: "http://localhost:9999",
+      hook_path: "/hooks/agent",
+    });
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].agent.agent_id).toBe("test-agent");
+  });
+
+  it("emits task-created when a task is created (legacy)", () => {
+    const listener = vi.fn();
+    store.events.on("task-created", listener);
+
+    // Need agents first
+    store.registerAgent({
+      agent_id: "sender",
+      name: "Sender",
+      skills: [],
+      gateway_url: "http://localhost:1",
+      hook_path: "/hooks/agent",
+    });
+    store.registerAgent({
+      agent_id: "target",
+      name: "Target",
+      skills: [],
+      gateway_url: "http://localhost:2",
+      hook_path: "/hooks/agent",
+    });
+
+    store.createTask("sender", "target", "Do something");
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0].task.sender_id).toBe("sender");
+    expect(listener.mock.calls[0][0].task.target_id).toBe("target");
+  });
+
+  it("emits task-status when task status is updated", () => {
+    const listener = vi.fn();
+    store.events.on("task-status", listener);
+
+    store.registerAgent({
+      agent_id: "sender",
+      name: "Sender",
+      skills: [],
+      gateway_url: "http://localhost:1",
+      hook_path: "/hooks/agent",
+    });
+    store.registerAgent({
+      agent_id: "target",
+      name: "Target",
+      skills: [],
+      gateway_url: "http://localhost:2",
+      hook_path: "/hooks/agent",
+    });
+
+    const task = store.createTask("sender", "target", "Do something");
+    store.updateTaskStatus(task.id, "completed", "All done");
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0]).toEqual({
+      taskId: task.id,
+      status: "completed",
+      result: "All done",
+    });
+  });
+
+  it("emits task-created for A2A tasks", () => {
+    const listener = vi.fn();
+    store.events.on("task-created", listener);
+
+    store.registerAgent({
+      agent_id: "sender",
+      name: "Sender",
+      skills: [],
+      gateway_url: "http://localhost:1",
+      hook_path: "/hooks/agent",
+    });
+    store.registerAgent({
+      agent_id: "target",
+      name: "Target",
+      skills: [],
+      gateway_url: "http://localhost:2",
+      hook_path: "/hooks/agent",
+    });
+
+    store.createA2ATask("sender", "target", {
+      role: "user",
+      parts: [{ kind: "text" as const, text: "A2A task" }],
+    });
+
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it("emits task-status for A2A task status updates", () => {
+    const listener = vi.fn();
+    store.events.on("task-status", listener);
+
+    store.registerAgent({
+      agent_id: "sender",
+      name: "Sender",
+      skills: [],
+      gateway_url: "http://localhost:1",
+      hook_path: "/hooks/agent",
+    });
+    store.registerAgent({
+      agent_id: "target",
+      name: "Target",
+      skills: [],
+      gateway_url: "http://localhost:2",
+      hook_path: "/hooks/agent",
+    });
+
+    const task = store.createA2ATask("sender", "target", {
+      role: "user",
+      parts: [{ kind: "text" as const, text: "A2A task" }],
+    });
+
+    store.updateA2ATaskStatus(task.id, "completed", "Done");
+
+    expect(listener).toHaveBeenCalled();
+    const call = listener.mock.calls.find(
+      (c: Array<{ status: string }>) => c[0].status === "completed",
+    );
+    expect(call).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(call![0].taskId).toBe(task.id);
+  });
+});

--- a/tools/a2a-router/src/index.ts
+++ b/tools/a2a-router/src/index.ts
@@ -8,6 +8,7 @@ import { taskRoutes } from "./routes/tasks.js";
 import { jsonrpcRoutes } from "./routes/jsonrpc.js";
 import { streamRoutes } from "./routes/stream.js";
 import { discoveryRoutes } from "./routes/discovery.js";
+import { initSync } from "./sync.js";
 
 const PORT = parseInt(process.env.A2A_PORT ?? "3380", 10);
 const DB_PATH = process.env.A2A_DB_PATH ?? `${process.env.HOME}/.openspawn/a2a/tasks.db`;
@@ -40,6 +41,9 @@ export function createApp(store?: Store) {
 
   // ── SSE Streaming endpoint ────────────────────────────────────────────
   app.use("/a2a/stream", streamRoutes(s));
+
+  // ── API Sync (fire-and-forget) ────────────────────────────────────────
+  initSync(s);
 
   return { app, store: s };
 }

--- a/tools/a2a-router/src/store.ts
+++ b/tools/a2a-router/src/store.ts
@@ -169,6 +169,7 @@ export class Store {
     stmt.run(agent.agent_id, agent.name, skills, agent.gateway_url, agent.gateway_token ?? null, agent.hook_path ?? "/hooks/agent");
     const result = this.getAgent(agent.agent_id);
     if (!result) throw new Error(`Failed to upsert agent ${agent.agent_id}`);
+    this.events.emit("agent-registered", { agent: result });
     return result;
   }
 
@@ -205,6 +206,7 @@ export class Store {
     `).run(id, senderId, targetId, message);
     const task = this.getTask(id);
     if (!task) throw new Error(`Failed to create task ${id}`);
+    this.events.emit("task-created", { task });
     return task;
   }
 
@@ -254,6 +256,7 @@ export class Store {
       kind: "status-update",
       status: { state: status, message: result, timestamp: new Date().toISOString() },
     });
+    this.events.emit("task-status", { taskId, status, result: result ?? null });
     return this.getTask(taskId);
   }
 
@@ -302,6 +305,11 @@ export class Store {
 
     const task = this.getA2ATask(id);
     if (!task) throw new Error(`Failed to create A2A task ${id}`);
+    // Emit for sync — use internal format
+    const internalTask = this.getTask(id);
+    if (internalTask) {
+      this.events.emit("task-created", { task: internalTask });
+    }
     return task;
   }
 
@@ -362,6 +370,7 @@ export class Store {
       kind: "status-update",
       status: { state, message: statusMessage, timestamp: new Date().toISOString() },
     });
+    this.events.emit("task-status", { taskId, status: state, result: statusMessage ?? null });
 
     return this.getA2ATask(taskId);
   }

--- a/tools/a2a-router/src/sync.ts
+++ b/tools/a2a-router/src/sync.ts
@@ -1,0 +1,167 @@
+// ── API Sync Module ──────────────────────────────────────────────────────────
+// Fire-and-forget bridge: pushes A2A router events to the OpenSpawn API
+// (api.openspawn.ai) so they appear on the team dashboard.
+//
+// Design: best-effort, non-blocking. Errors are logged but never thrown.
+// When OPENSPAWN_SYNC_ENABLED is falsy, every method is a silent no-op.
+
+import type { Store } from "./store.js";
+import type { AgentCard, Task } from "./types.js";
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+const API_URL = process.env.OPENSPAWN_API_URL || "https://api.openspawn.ai";
+const API_TOKEN = process.env.OPENSPAWN_API_TOKEN || "owner-static-token-local-dev";
+const SYNC_ENABLED = ["true", "1", "yes"].includes(
+  (process.env.OPENSPAWN_SYNC_ENABLED ?? "").toLowerCase(),
+);
+
+// ── Status mapping ──────────────────────────────────────────────────────────
+
+const STATUS_MAP: Record<string, string> = {
+  submitted: "backlog",
+  working: "in_progress",
+  completed: "done",
+  failed: "cancelled",
+  canceled: "cancelled",
+};
+
+function mapStatus(a2aStatus: string): string {
+  return STATUS_MAP[a2aStatus] ?? "backlog";
+}
+
+// ── HTTP helper ─────────────────────────────────────────────────────────────
+
+type FetchFn = typeof globalThis.fetch;
+
+async function post(
+  path: string,
+  body: Record<string, unknown>,
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<void> {
+  try {
+    const url = `${API_URL}${path}`;
+    const res = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${API_TOKEN}`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(5_000),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.warn(`[sync] POST ${path} → ${res.status}: ${text.slice(0, 200)}`);
+    } else {
+      console.log(`[sync] POST ${path} → ${res.status} OK`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[sync] POST ${path} failed: ${msg}`);
+  }
+}
+
+// ── Sync functions ──────────────────────────────────────────────────────────
+
+export async function syncAgentRegistered(
+  agent: AgentCard,
+  fetchImpl?: FetchFn,
+): Promise<void> {
+  if (!SYNC_ENABLED) return;
+
+  await post(
+    "/agents/register",
+    {
+      agent_id: agent.agent_id,
+      name: agent.name,
+      level: 1,
+      role: "worker",
+      status: "active",
+      model: "unknown",
+      mode: "worker",
+    },
+    fetchImpl,
+  );
+}
+
+export async function syncTaskCreated(
+  task: Task,
+  fetchImpl?: FetchFn,
+): Promise<void> {
+  if (!SYNC_ENABLED) return;
+
+  await post(
+    "/tasks",
+    {
+      title: task.message.slice(0, 500),
+      description: task.message,
+      priority: "normal",
+      assignee_id: null, // API uses UUID; we can't map string agent_id directly
+      status: mapStatus(task.status),
+      metadata: {
+        a2a_task_id: task.id,
+        a2a_sender_id: task.sender_id,
+        a2a_target_id: task.target_id,
+      },
+    },
+    fetchImpl,
+  );
+}
+
+export async function syncTaskTransition(
+  taskId: string,
+  newStatus: string,
+  result?: string | null,
+  fetchImpl?: FetchFn,
+): Promise<void> {
+  if (!SYNC_ENABLED) return;
+
+  const apiStatus = mapStatus(newStatus);
+  // The API transition endpoint uses task UUID — but we only know A2A IDs.
+  // We POST to /tasks with metadata for now; the API side can reconcile.
+  // If we had the API task UUID we'd call /tasks/{uuid}/transition.
+  // For now, log the transition intent.
+  await post(
+    "/tasks/sync-transition",
+    {
+      a2a_task_id: taskId,
+      status: apiStatus,
+      reason: result ?? undefined,
+    },
+    fetchImpl,
+  );
+}
+
+// ── Wiring ──────────────────────────────────────────────────────────────────
+
+/**
+ * Initialize sync listeners on the store's event bus.
+ * Call once at startup. All listeners are fire-and-forget.
+ */
+export function initSync(store: Store, fetchImpl?: FetchFn): void {
+  if (!SYNC_ENABLED) {
+    console.log("[sync] Sync disabled (OPENSPAWN_SYNC_ENABLED is not set)");
+    return;
+  }
+
+  console.log(`[sync] Sync enabled → ${API_URL}`);
+
+  // Listen to all task events from the event bus
+  store.events.on("task-status", (data: { taskId: string; status: string; result?: string | null }) => {
+    syncTaskTransition(data.taskId, data.status, data.result, fetchImpl).catch((_err) => { /* fire-and-forget */ });
+  });
+
+  store.events.on("task-created", (data: { task: Task }) => {
+    syncTaskCreated(data.task, fetchImpl).catch((_err) => { /* fire-and-forget */ });
+  });
+
+  store.events.on("agent-registered", (data: { agent: AgentCard }) => {
+    syncAgentRegistered(data.agent, fetchImpl).catch((_err) => { /* fire-and-forget */ });
+  });
+}
+
+// ── Exports for testing ─────────────────────────────────────────────────────
+
+export { SYNC_ENABLED, API_URL, API_TOKEN, STATUS_MAP, mapStatus, post };


### PR DESCRIPTION
## A2A Router → API Sync Bridge

Syncs A2A tasks and agent registrations to api.openspawn.ai so they appear on the team.openspawn.ai dashboard.

### What's New

**`tools/a2a-router/src/sync.ts`** — Fire-and-forget sync module:
- `syncAgentRegistered()` → POST /agents/register
- `syncTaskCreated()` → POST /tasks
- `syncTaskTransition()` → POST /tasks/sync-transition
- Status mapping: submitted→backlog, working→in_progress, completed→done, failed→cancelled
- All calls are async, non-blocking, with 5s timeout
- Errors logged but never thrown

**`tools/a2a-router/src/store.ts`** — New event emissions:
- `agent-registered` when an agent registers
- `task-created` when a task is created (legacy + A2A)
- `task-status` when task status changes

**`tools/a2a-router/src/index.ts`** — Initializes sync on startup

### Configuration

```
OPENSPAWN_SYNC_ENABLED=true      # Enable sync (default: disabled)
OPENSPAWN_API_URL=...            # API URL (default: https://api.openspawn.ai)
OPENSPAWN_API_TOKEN=...          # Owner token for auth
```

### Tests
- 12 new tests in `sync.test.ts`
- All 137 tests pass
- Lint clean (0 warnings)