### PR TITLE
fix: Dashboard data hooks not unwrapping API response

### DIFF
--- a/libs/dashboard-data/src/hooks/use-agents.ts
+++ b/libs/dashboard-data/src/hooks/use-agents.ts
@@ -6,8 +6,15 @@ export type Agent = AgentFields;
 export function useAgents() {
   const rest = useRestAgents();
 
+  const rawData = rest.data;
+  const agents = Array.isArray(rawData)
+    ? rawData
+    : Array.isArray((rawData as Record<string, unknown>)?.data)
+      ? (rawData as Record<string, unknown>).data as AgentFields[]
+      : [];
+
   return {
-    agents: Array.isArray(rest.data) ? rest.data : [],
+    agents,
     loading: rest.isLoading,
     error: rest.error ?? null,
     refetch: rest.refetch,

--- a/libs/dashboard-data/src/hooks/use-events.ts
+++ b/libs/dashboard-data/src/hooks/use-events.ts
@@ -14,7 +14,7 @@ export function useEvents() {
   const rest = useRestEvents();
 
   return {
-    events: Array.isArray(rest.data) ? rest.data : [],
+    events: Array.isArray(rest.data) ? rest.data : Array.isArray((rest.data as any)?.data) ? (rest.data as any).data : [],
     loading: rest.isLoading,
     error: rest.error ?? null,
     refetch: rest.refetch,

--- a/libs/dashboard-data/src/hooks/use-graph.ts
+++ b/libs/dashboard-data/src/hooks/use-graph.ts
@@ -21,7 +21,7 @@ export function useGraphEntities() {
   }
 
   return {
-    entities: Array.isArray(rest.data) ? rest.data : [],
+    entities: Array.isArray(rest.data) ? rest.data : Array.isArray((rest.data as any)?.data) ? (rest.data as any).data : [],
     loading: rest.isLoading,
     error: rest.error ?? null,
     refetch: rest.refetch,
@@ -41,7 +41,7 @@ export function useGraphRelationships() {
   }
 
   return {
-    relationships: Array.isArray(rest.data) ? rest.data : [],
+    relationships: Array.isArray(rest.data) ? rest.data : Array.isArray((rest.data as any)?.data) ? (rest.data as any).data : [],
     loading: rest.isLoading,
     error: rest.error ?? null,
     refetch: rest.refetch,

--- a/libs/dashboard-data/src/hooks/use-memory.ts
+++ b/libs/dashboard-data/src/hooks/use-memory.ts
@@ -21,7 +21,7 @@ export function useMemories() {
   }
 
   return {
-    memories: Array.isArray(rest.data) ? rest.data : [],
+    memories: Array.isArray(rest.data) ? rest.data : Array.isArray((rest.data as any)?.data) ? (rest.data as any).data : [],
     loading: rest.isLoading,
     error: rest.error ?? null,
     refetch: rest.refetch,
@@ -40,7 +40,7 @@ export function useMemorySearch(query: string) {
   }
 
   return {
-    memories: Array.isArray(rest.data) ? rest.data : [],
+    memories: Array.isArray(rest.data) ? rest.data : Array.isArray((rest.data as any)?.data) ? (rest.data as any).data : [],
     loading: rest.isLoading,
     error: rest.error ?? null,
   };
@@ -60,7 +60,7 @@ export function useContradictions() {
   }
 
   return {
-    contradictions: Array.isArray(rest.data) ? rest.data : [],
+    contradictions: Array.isArray(rest.data) ? rest.data : Array.isArray((rest.data as any)?.data) ? (rest.data as any).data : [],
     loading: rest.isLoading,
     error: rest.error ?? null,
     refetch: rest.refetch,

--- a/libs/dashboard-data/src/hooks/use-messages.ts
+++ b/libs/dashboard-data/src/hooks/use-messages.ts
@@ -35,7 +35,7 @@ export function useMessages() {
   const rest = useRestMessages();
 
   return {
-    messages: Array.isArray(rest.data) ? rest.data : [],
+    messages: Array.isArray(rest.data) ? rest.data : Array.isArray((rest.data as any)?.data) ? (rest.data as any).data : [],
     loading: rest.isLoading,
     error: rest.error?.message,
     refetch: rest.refetch,

--- a/libs/dashboard-data/src/hooks/use-tasks.ts
+++ b/libs/dashboard-data/src/hooks/use-tasks.ts
@@ -31,7 +31,7 @@ export function useTasks() {
   const rest = useRestTasks();
 
   return {
-    tasks: Array.isArray(rest.data) ? rest.data : [],
+    tasks: Array.isArray(rest.data) ? rest.data : Array.isArray((rest.data as any)?.data) ? (rest.data as any).data : [],
     loading: rest.isLoading,
     error: rest.error ?? null,
     refetch: rest.refetch,

--- a/tools/a2a-router/demo-agents.json
+++ b/tools/a2a-router/demo-agents.json
@@ -1,0 +1,39 @@
+{
+  "agents": [
+    {
+      "name": "PM",
+      "role": "project-manager",
+      "level": 7,
+      "skills": ["planning", "decomposition", "tracking", "coordination"],
+      "model": "anthropic/claude-sonnet-4-5"
+    },
+    {
+      "name": "Writer",
+      "role": "writer",
+      "level": 5,
+      "skills": ["docs", "markdown", "tutorials", "technical-writing"],
+      "model": "anthropic/claude-haiku-3-5"
+    },
+    {
+      "name": "Reviewer",
+      "role": "editor",
+      "level": 5,
+      "skills": ["review", "quality", "accuracy", "editing"],
+      "model": "anthropic/claude-haiku-3-5"
+    },
+    {
+      "name": "Engineer",
+      "role": "developer",
+      "level": 5,
+      "skills": ["code", "typescript", "astro", "tooling"],
+      "model": "anthropic/claude-haiku-3-5"
+    },
+    {
+      "name": "Designer",
+      "role": "ux-designer",
+      "level": 5,
+      "skills": ["design", "information-architecture", "sitemap", "navigation"],
+      "model": "anthropic/claude-haiku-3-5"
+    }
+  ]
+}


### PR DESCRIPTION
All dashboard pages (agents, tasks, events, messages, memory) were showing empty because the API response wrapping wasn't handled correctly. The API returns `{data: [...]}` but openapi-fetch wraps it again.