### PR TITLE
fix: Right sidebar panel width collapsed to ~100px

### DIFF
--- a/apps/team/src/components/layout.tsx
+++ b/apps/team/src/components/layout.tsx
@@ -125,7 +125,7 @@ function SidePanelOverlay() {
   return (
     <>
       <div className="fixed inset-0 z-40 bg-black/30" onClick={closeSidePanel} />
-      <div className="fixed inset-y-0 right-0 z-50 bg-[hsl(var(--background))]">
+      <div className="fixed inset-y-0 right-0 z-50 bg-[hsl(var(--background))]" style={{ width: `${width}px` }}>
         <SidePanelShell
           title={title}
           onClose={closeSidePanel}


### PR DESCRIPTION
Side panel container wasn't applying width from context. Now uses inline style.