### PR TITLE
fix(api): unbreak python-api CI — a2a lint, format, and type errors

### DIFF
--- a/apps/api/app/a2a/router.py
+++ b/apps/api/app/a2a/router.py
@@ -117,9 +117,7 @@ async def claim_task(
 ) -> A2ATask:
     """Claim an unassigned A2A task."""
     agent_id = _get_agent_id(auth)
-    return await service.claim_task(
-        db=db, task_id=task_id, agent_id=agent_id, org_id=auth.org_id
-    )
+    return await service.claim_task(db=db, task_id=task_id, agent_id=agent_id, org_id=auth.org_id)
 
 
 # --- Heartbeat ---

--- a/apps/api/app/a2a/service.py
+++ b/apps/api/app/a2a/service.py
@@ -14,7 +14,7 @@ from app.models.enums import TaskStatus
 from app.models.organization import Organization
 from app.models.task import Task
 
-from .types import A2AMessage, A2ATask, A2ATaskStatus
+from .types import A2AMessage, A2ATask, A2ATaskState, A2ATaskStatus
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 # State mapping helpers
 # ---------------------------------------------------------------------------
 
-_OPENSPAWN_TO_A2A: dict[str, str] = {
+_OPENSPAWN_TO_A2A: dict[str, A2ATaskState] = {
     TaskStatus.BACKLOG.value: "submitted",
     TaskStatus.TODO.value: "submitted",
     TaskStatus.IN_PROGRESS.value: "working",
@@ -35,7 +35,7 @@ _OPENSPAWN_TO_A2A: dict[str, str] = {
 }
 
 
-def _to_a2a_state(openspawn_status: str) -> str:
+def _to_a2a_state(openspawn_status: str) -> A2ATaskState:
     return _OPENSPAWN_TO_A2A.get(openspawn_status, "submitted")
 
 
@@ -56,7 +56,9 @@ def _task_to_a2a(task: Task) -> A2ATask:
         status=A2ATaskStatus(
             state=_to_a2a_state(task.status),
             message=task.title,
-            timestamp=task.updated_at.isoformat() if task.updated_at else pendulum.now("UTC").isoformat(),
+            timestamp=task.updated_at.isoformat()
+            if task.updated_at
+            else pendulum.now("UTC").isoformat(),
         ),
         messages=messages,
     )
@@ -101,9 +103,7 @@ async def send_message(
     # Get org for task identifier
     org = await db.get(Organization, org_id)
     if not org:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
 
     identifier = f"{org.task_prefix}-{org.next_task_number}"
     org.next_task_number += 1
@@ -161,7 +161,9 @@ async def complete_task(
         )
 
     # Transition state
-    new_status = TaskStatus.DONE.value if completion_status == "completed" else TaskStatus.CANCELLED.value
+    new_status = (
+        TaskStatus.DONE.value if completion_status == "completed" else TaskStatus.CANCELLED.value
+    )
     task.status = new_status
     if new_status == TaskStatus.DONE.value:
         task.completed_at = pendulum.now("UTC")

--- a/apps/api/app/a2a/types.py
+++ b/apps/api/app/a2a/types.py
@@ -29,9 +29,7 @@ class A2AMessage(BaseModel):
 
 
 # A2A task states
-A2ATaskState = Literal[
-    "submitted", "working", "input-required", "completed", "failed", "canceled"
-]
+A2ATaskState = Literal["submitted", "working", "input-required", "completed", "failed", "canceled"]
 
 
 class A2ATaskStatus(BaseModel):

--- a/apps/api/app/a2a/websocket.py
+++ b/apps/api/app/a2a/websocket.py
@@ -112,9 +112,7 @@ async def a2a_websocket(
             return
 
         # Resolve agent to get org_id
-        result = await db.execute(
-            select(Agent).where(Agent.agent_id == agent_id)
-        )
+        result = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
         agent = result.scalar_one_or_none()
         if not agent:
             await websocket.close(code=4004, reason="Agent not found")
@@ -136,10 +134,12 @@ async def a2a_websocket(
                 org_id=org_id,
             )
             for task in pending_tasks:
-                await websocket.send_json({
-                    "type": "task.assigned",
-                    "task": task.model_dump(),
-                })
+                await websocket.send_json(
+                    {
+                        "type": "task.assigned",
+                        "task": task.model_dump(),
+                    }
+                )
 
         # Keep-alive loop
         while True:
@@ -162,15 +162,19 @@ async def a2a_websocket(
                                 result=result,
                                 org_id=org_id,
                             )
-                            await websocket.send_json({
-                                "type": "task.completed",
-                                "task": completed.model_dump(),
-                            })
+                            await websocket.send_json(
+                                {
+                                    "type": "task.completed",
+                                    "task": completed.model_dump(),
+                                }
+                            )
                         except Exception as e:
-                            await websocket.send_json({
-                                "type": "error",
-                                "message": str(e),
-                            })
+                            await websocket.send_json(
+                                {
+                                    "type": "error",
+                                    "message": str(e),
+                                }
+                            )
 
             elif data.get("type") == "ping":
                 await websocket.send_json({"type": "pong"})
@@ -185,7 +189,10 @@ async def a2a_websocket(
 
 async def notify_agent(agent_id: str, task: Any) -> bool:
     """Push a task to an agent via WebSocket if connected."""
-    return await manager.send_to_agent(agent_id, {
-        "type": "task.assigned",
-        "task": task.model_dump(),
-    })
+    return await manager.send_to_agent(
+        agent_id,
+        {
+            "type": "task.assigned",
+            "task": task.model_dump(),
+        },
+    )

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -5,6 +5,9 @@ import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.a2a.router import get_agent_card_router
+from app.a2a.router import router as a2a_router
+from app.a2a.websocket import router as a2a_ws_router
 from app.agents.router import router as agents_router
 from app.apikeys.router import router as hosted_auth_router
 from app.apikeys.usage_middleware import UsageTrackingMiddleware
@@ -26,8 +29,6 @@ from app.memory.router import router as memory_router
 from app.messages.router import router as messages_router
 from app.observability import setup_logfire, setup_telemetry
 from app.routers.auth import router as auth_router
-from app.a2a.router import get_agent_card_router, router as a2a_router
-from app.a2a.websocket import router as a2a_ws_router
 from app.tasks.router import router as tasks_router
 
 logger = structlog.stdlib.get_logger()

--- a/apps/api/app/models/task.py
+++ b/apps/api/app/models/task.py
@@ -62,7 +62,7 @@ class Task(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # A2A fields
     source: Mapped[str] = mapped_column(String(20), nullable=False, server_default="manual")
     a2a_context_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    a2a_messages: Mapped[dict | None] = mapped_column(CompatJSONB(), nullable=True)
+    a2a_messages: Mapped[list[dict] | None] = mapped_column(CompatJSONB(), nullable=True)
 
     organization: Mapped[Organization] = relationship("Organization", back_populates="tasks")
     assignee: Mapped[Agent | None] = relationship(

--- a/apps/api/tests/test_a2a.py
+++ b/apps/api/tests/test_a2a.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import uuid
 
-import pytest
 from httpx import AsyncClient
-
 
 # ---------------------------------------------------------------------------
 # Auth gate tests — verify routes exist and require auth


### PR DESCRIPTION
## Problem

`main` has been red since **2026-03-26**. The `python-api` CI job fails on every PR, including unrelated ones like #788. The failures were introduced by `fd9998c83` (Centralized A2A) and are entirely in `apps/api/app/a2a/`:

- 3 `ruff check` errors (unsorted imports, unused `pytest` import)
- 4 files failing `ruff format --check`
- 2 `pyright` errors

## Fix

Mechanical lint/format, plus two genuine type corrections (no casts, no `type: ignore`):

1. **`_to_a2a_state` returned `str`** where `A2ATaskStatus.state` expects the `A2ATaskState` literal union. Narrowed `_OPENSPAWN_TO_A2A` to `dict[str, A2ATaskState]` and the return type to match.

2. **`Task.a2a_messages` was declared `Mapped[dict | None]`** but every read and write treats it as a **list** — `service.py:128` writes `[message.model_dump()]`, `service.py:182` writes a list, and `service.py:46` has a defensive `isinstance(..., list)` guard that was papering over the contradiction. Corrected to `Mapped[list[dict] | None]`. `CompatJSONB` is already used with `Mapped[list]` elsewhere (`integration.py:23`, `auth.py:72`), so this needs no migration and no decorator change.

No behavior change; no schema change.

## Verification

All four `python-api` job steps run locally against this branch:

| Step | Result |
| --- | --- |
| `ruff check app/ tests/` | All checks passed |
| `ruff format --check app/ tests/` | 211 files already formatted |
| `pyright app/` | 0 errors, 0 warnings |
| `pytest tests/` | 616 passed, 29 skipped, 5 xpassed |

Refs #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)