### PR TITLE
fix(deploy): restore api.openspawn.ai vhost in Caddyfile

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -38,6 +38,15 @@ openspawn.ai {
 	import security_headers
 }
 
+# ── api.openspawn.ai — Core API (FastAPI REST + OpenAPI + MCP) ──────────────
+# Dedicated hostname serves FastAPI at the root, so no path prefix is stripped
+# (/health, /docs, /mcp). The openspawn.ai/api/* route above is the same
+# upstream reached via handle_path, which strips the /api prefix.
+api.openspawn.ai {
+	reverse_proxy localhost:8000
+	import security_headers
+}
+
 # ── team.openspawn.ai — Internal team dashboard (basic auth) ────────────────
 team.openspawn.ai {
 	basicauth {


### PR DESCRIPTION
## Problem

`api.openspawn.ai` returns **HTTP 525** (Cloudflare cannot complete the TLS handshake with the origin). It was healthy earlier today.

## Root cause

`deploy.yml` copies `deploy/Caddyfile` → `/etc/caddy/Caddyfile` and reloads Caddy:

```
cp Caddyfile /etc/caddy/Caddyfile 2>/dev/null && systemctl reload caddy 2>/dev/null || true
```

But `deploy/Caddyfile` has **never** contained an `api.openspawn.ai` block — the vhost only ever existed as a hand-edit on the VPS. Deploys had been failing since 2026-03-26, so that hand-edit survived untouched for four months. As soon as a deploy succeeded again (a23282b, the Dockerfile fix from #788), the repo's Caddyfile replaced it, Caddy stopped managing a cert for that hostname, and the handshake started failing.

This is config drift: the file's own header claims it is the *"Source of truth for ALL subdomains"*, and CONTRIBUTING.md lists `api.openspawn.ai` as live, but the vhost was missing.

## Scope of impact

**The API was never down.** `openspawn.ai/api/*` proxies the same upstream (`localhost:8000`) via `handle_path` and returned 200 throughout:

| URL | Before this PR |
| --- | --- |
| `https://api.openspawn.ai/health` | 525 |
| `https://openspawn.ai/api/health` | 200 |
| `https://openspawn.ai/api/docs` | 200 |
| `https://bikinibottom.ai` | 200 |

Only the dedicated hostname was affected.

## Fix

Add the `api.openspawn.ai` block, reverse-proxying to `localhost:8000`. Root-level `reverse_proxy` rather than `handle_path /api/*` — the dedicated hostname serves FastAPI without a prefix to strip, so `/health`, `/docs`, and `/mcp` resolve directly.

Putting it in version control means it survives future deploys instead of living as an undocumented hand-edit.

## Verification

Post-merge: confirm `https://api.openspawn.ai/health` returns `{"status":"ok"}` once Caddy re-provisions the certificate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)